### PR TITLE
Remove inventory CI URL

### DIFF
--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,5 +1,5 @@
 /* global exports */
 
 exports.routes = {
-    '/hosts': { host: 'https://insights-inventory-platform-ci.5a9f.insights-dev.openshiftapps.com/api' }
+    '/hosts': { host: 'https://insights-inventory-platform-ci/api' }
 };


### PR DESCRIPTION
It's probably not a good idea to keep the CI inventory URL out in the open, so that it may not be abused