### PR TITLE
Improve build to release automatically to beta

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+set -x
+
+if [[ "${TRAVIS_BRANCH}" = "master" ]]; then
+    .travis/release.sh "ci-beta"
+    .travis/release.sh "qa-beta"
+    
+elif [[ "${TRAVIS_BRANCH}" = "master-stable" ]]; then
+    .travis/release.sh "ci-stable"
+    .travis/release.sh "qa-stable"
+
+# If current dev branch is deployment branch, push to build repo
+elif [[ "${TRAVIS_BRANCH}" = "ci-stable"  || "${TRAVIS_BRANCH}" = "qa-beta" || "${TRAVIS_BRANCH}" = "qa-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+    .travis/release.sh "${TRAVIS_BRANCH}"
+fi

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -10,7 +10,6 @@ elif [[ "${TRAVIS_BRANCH}" = "master-stable" ]]; then
     .travis/release.sh "ci-stable"
     .travis/release.sh "qa-stable"
 
-# If current dev branch is deployment branch, push to build repo
-elif [[ "${TRAVIS_BRANCH}" = "ci-stable"  || "${TRAVIS_BRANCH}" = "qa-beta" || "${TRAVIS_BRANCH}" = "qa-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+elif [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
     .travis/release.sh "${TRAVIS_BRANCH}"
 fi


### PR DESCRIPTION
* on `master` it will automatically release to `ci-beta` and `qa-beta`
* on `master-stable` it will automatically release to `ci-stable` and `qa-stable`
* on any other branch listed as build branch it will automatically push to this branch as a way how to promote specific env