### PR TITLE
Add react intl to compliance tab

### DIFF
--- a/src/components/inventory/Compliance.js
+++ b/src/components/inventory/Compliance.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import Compliance from '@redhat-cloud-services/frontend-components-inventory-compliance';
+import { IntlProvider } from 'react-intl';
+
+const ComplianceTab = () => (
+    <IntlProvider locale={navigator.language}>
+        <Compliance />
+    </IntlProvider>
+);
+
+export default ComplianceTab;

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -5,9 +5,9 @@ import GeneralInformation, {
     systemProfileStore
 } from '@redhat-cloud-services/frontend-components-inventory-general-info';
 import Vulnerabilities from '@redhat-cloud-services/frontend-components-inventory-vulnerabilities';
-import Compliance from '@redhat-cloud-services/frontend-components-inventory-compliance';
 import Advisor from '@redhat-cloud-services/frontend-components-inventory-insights';
 import { notifications } from '@redhat-cloud-services/frontend-components-notifications';
+import ComplianceTab from '../components/inventory/Compliance';
 
 const defaultState = { loaded: false };
 
@@ -42,7 +42,7 @@ function entityLoaded(state, { payload: { entitlements } } = { payload: {} }) {
             isEntitled(entitlements && entitlements.smart_management) && {
                 title: 'Compliance',
                 name: 'compliance',
-                component: Compliance
+                component: ComplianceTab
             }
         ].filter(Boolean)
     };


### PR DESCRIPTION
Fixed Compliance tab problem with missing react intl provider so it will not throw arror when rendered.