### PR TITLE
Downgrade inventory-compliance to 0.0.33 to support current prod-API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2432,9 +2432,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-inventory-compliance": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-compliance/-/frontend-components-inventory-compliance-0.0.35.tgz",
-      "integrity": "sha512-UT1GWYegzWaDs5C/Tnw0SPm5b8IcIvL1GspYafToJ9w/a6jZYuJmVT5CpatTHFtSP5hgQUhwXODol+dxL1dd0A==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-compliance/-/frontend-components-inventory-compliance-0.0.33.tgz",
+      "integrity": "sha512-mXioRaADkjq13bX17CEB0nEUxJRQp6ZYrM9HgrJM65ugLu7ofGe3O4rqon3iQSkk8Dl5c/1C6wgXHiQK7IHMvw==",
       "requires": {
         "@redhat-cloud-services/frontend-components": ">=0.0.21",
         "@redhat-cloud-services/frontend-components-notifications": "*",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@patternfly/react-icons": "3.14.24",
     "@patternfly/react-table": "^2.24.64",
     "@redhat-cloud-services/frontend-components": "0.0.48",
-    "@redhat-cloud-services/frontend-components-inventory-compliance": "0.0.35",
+    "@redhat-cloud-services/frontend-components-inventory-compliance": "0.0.33",
     "@redhat-cloud-services/frontend-components-inventory-general-info": "0.0.15",
     "@redhat-cloud-services/frontend-components-inventory-insights": "0.4.2",
     "@redhat-cloud-services/frontend-components-inventory-vulnerabilities": "1.25.0",


### PR DESCRIPTION
Notice this is going to prod-beta, it should probably be cherry-picked to any QA env where the 0.0.34 or higher is used. 

The changes in the API in:
https://github.com/RedHatInsights/frontend-components/commit/a2a009a2ddccc004f044473887dcbcf8b717516b#diff-dbd2a0d59c0484c28f333a4bc8891abd 
are only available in CI, but not in QA, prod.., so using the 0.0.36 version will result in the whole page not being able to render as GQL won't respond with these fields. 