### PR TITLE
Downgrade inventory-compliance to 0.0.33 to support current prod-API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,19 +1963,33 @@
       }
     },
     "@redhat-cloud-services/frontend-components-inventory-compliance": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-compliance/-/frontend-components-inventory-compliance-1.0.0.tgz",
-      "integrity": "sha512-xwnuhMPAFA9j0pMXKwEVVIvof28tdHsSYpnimHxwMuSl0HTGPnMswt4kkVSi+/7cRg3E0kSJeWSOtpRHxpe0EQ==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-compliance/-/frontend-components-inventory-compliance-0.0.33.tgz",
+      "integrity": "sha512-mXioRaADkjq13bX17CEB0nEUxJRQp6ZYrM9HgrJM65ugLu7ofGe3O4rqon3iQSkk8Dl5c/1C6wgXHiQK7IHMvw==",
       "requires": {
-        "@redhat-cloud-services/frontend-components": "*",
+        "@redhat-cloud-services/frontend-components": ">=0.0.21",
         "@redhat-cloud-services/frontend-components-notifications": "*",
         "@redhat-cloud-services/frontend-components-remediations": "*",
-        "@redhat-cloud-services/frontend-components-utilities": "*",
+        "@redhat-cloud-services/frontend-components-utilities": "~0.0.7",
         "apollo-boost": "^0.1.23",
         "graphql-tag": "^2.10.0",
         "react-apollo": "^2.3.3",
         "react-intl": "^2.8.0",
         "react-truncate": "^2.4.0"
+      },
+      "dependencies": {
+        "@redhat-cloud-services/frontend-components-utilities": {
+          "version": "0.0.15",
+          "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-0.0.15.tgz",
+          "integrity": "sha512-aZnDN7CiPK7MLSt+Kp9KbTGShhivk65i99RB9YQu/z0iKh6yNxjQhg/HK+/zTNha8atpr+emvPsHEu9bgY045A==",
+          "requires": {
+            "@sentry/browser": "^5.4.0",
+            "awesome-debounce-promise": "^2.1.0",
+            "axios": "^0.19.0",
+            "commander": "^2.20.0",
+            "react-content-loader": "^3.4.1"
+          }
+        }
       }
     },
     "@redhat-cloud-services/frontend-components-inventory-general-info": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@patternfly/react-icons": "3.15.3",
     "@patternfly/react-table": "^2.27.11",
     "@redhat-cloud-services/frontend-components": "1.0.8",
-    "@redhat-cloud-services/frontend-components-inventory-compliance": "1.0.0",
+    "@redhat-cloud-services/frontend-components-inventory-compliance": "0.0.33",
     "@redhat-cloud-services/frontend-components-inventory-general-info": "1.0.0",
     "@redhat-cloud-services/frontend-components-inventory-insights": "1.0.2",
     "@redhat-cloud-services/frontend-components-inventory-vulnerabilities": "1.25.2",


### PR DESCRIPTION
See the reasons in https://github.com/RedHatInsights/insights-inventory-frontend/pull/291