### PR TITLE
Move permissions to redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2628,9 +2628,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-inventory-general-info": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-general-info/-/frontend-components-inventory-general-info-2.2.3.tgz",
-      "integrity": "sha512-ZxG4Bie+5FWyWsgmZq/Vpd8iFTNJDy0TlrX0TdidYfK6HJHiQ7DafVvxwTd+GZ7hv0LVXWl4Ly5Oa012Vt79tg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-inventory-general-info/-/frontend-components-inventory-general-info-2.2.4.tgz",
+      "integrity": "sha512-qzi48pxJXSpNrmdg14IBWM/9GUe5/35BvK+AoBNYIRMx2kYycVLwqIK6LTmWj0CbGGvzEc4sezNVnvVR+5Mc0g==",
       "requires": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-inventory": "*",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@patternfly/react-table": "4.16.20",
     "@redhat-cloud-services/frontend-components": "2.4.9",
     "@redhat-cloud-services/frontend-components-inventory-compliance": "2.2.9",
-    "@redhat-cloud-services/frontend-components-inventory-general-info": "2.2.3",
+    "@redhat-cloud-services/frontend-components-inventory-general-info": "2.2.4",
     "@redhat-cloud-services/frontend-components-inventory-insights": "2.6.4",
     "@redhat-cloud-services/frontend-components-inventory-patchman": "0.25.2",
     "@redhat-cloud-services/frontend-components-inventory-vulnerabilities": "^1.49.0",

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import routerParams from '@redhat-cloud-services/frontend-components-utilities/f
 import registryDecorator from '@redhat-cloud-services/frontend-components-utilities/files/Registry';
 import { reducers } from './store';
 import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-notifications';
+import PermissionLoader from './components/PermissionsLoader';
 
 @registryDecorator()
 class App extends Component {
@@ -33,6 +34,7 @@ class App extends Component {
         return (
             <React.Fragment>
                 <NotificationsPortal />
+                {!insights.chrome.isProd && <PermissionLoader />}
                 <Routes childProps={this.props} />
             </React.Fragment>
         );

--- a/src/components/PermissionsLoader.js
+++ b/src/components/PermissionsLoader.js
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import useInventoryWritePermissions from '../hooks/useInventoryWritePermissions';
+import { ACTION_TYPES } from '../constants';
+
+const PermissionLoader = () => {
+    const { isLoading, hasAccess } = useInventoryWritePermissions();
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        dispatch({ type: `${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_PENDING` });
+    }, []);
+
+    useEffect(() => {
+        if (!isLoading) {
+            dispatch({ type: `${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_FULFILLED`, payload: { writePermissions: hasAccess } });
+        }
+    }, [isLoading]);
+
+    return null;
+};
+
+export default PermissionLoader;

--- a/src/components/PermissionsLoader.test.js
+++ b/src/components/PermissionsLoader.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import * as redux from 'react-redux';
+
+import { init } from '../store';
+import PermissionLoader from './PermissionsLoader';
+
+jest.mock('../hooks/useInventoryWritePermissions', () => ({
+    __esModule: true,
+    default: () => ({ hasAccess: true, isLoading: false })
+}));
+
+describe('PermissionsLoader', () => {
+    it('loads permissions on mount', async () => {
+        const actionSpy = jest.fn();
+
+        const testMiddleware = () => (next) => (action) => {
+            actionSpy(action);
+            next(action);
+        };
+
+        const store = init(testMiddleware).getStore();
+
+        await act(async () => {
+            mount(<redux.Provider store={store}>
+                <PermissionLoader />
+            </redux.Provider>);
+        });
+
+        expect(actionSpy.mock.calls[0][0]).toEqual({
+            type: 'LOAD_WRITE_PERMISSIONS_PENDING'
+        });
+        expect(actionSpy.mock.calls[1][0]).toEqual({
+            type: 'LOAD_WRITE_PERMISSIONS_FULFILLED',
+            payload: { writePermissions: true }
+        });
+    });
+});

--- a/src/components/inventory/GeneralInfo.js
+++ b/src/components/inventory/GeneralInfo.js
@@ -1,9 +1,13 @@
 import React from 'react';
-import { useStore } from 'react-redux';
+import { useStore, useSelector } from 'react-redux';
 import GeneralInformation from '@redhat-cloud-services/frontend-components-inventory-general-info/cjs';
 
 const GeneralInformationTab = () => {
-    return <GeneralInformation store={useStore()} />;
+    const writePermissions  = useSelector(
+        ({ permissionsReducer: { writePermissions } }) => writePermissions
+    );
+
+    return <GeneralInformation store={useStore()} writePermissions={writePermissions} />;
 };
 
 export default GeneralInformationTab;

--- a/src/components/inventory/GeneralInfo.js
+++ b/src/components/inventory/GeneralInfo.js
@@ -3,8 +3,8 @@ import { useStore, useSelector } from 'react-redux';
 import GeneralInformation from '@redhat-cloud-services/frontend-components-inventory-general-info/cjs';
 
 const GeneralInformationTab = () => {
-    const writePermissions  = useSelector(
-        ({ permissionsReducer: { writePermissions } }) => writePermissions
+    const writePermissions = useSelector(
+        ({ permissionsReducer }) => permissionsReducer?.writePermissions
     );
 
     return <GeneralInformation store={useStore()} writePermissions={writePermissions} />;

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,7 +10,8 @@ const actions = [
 const asyncActions = flatMap([
     'GET_ENTITIES',
     'GET_ENTITY',
-    'UPDATE_DISPLAY_NAME'
+    'UPDATE_DISPLAY_NAME',
+    'LOAD_WRITE_PERMISSIONS'
 ], a => [a, `${a}_PENDING`, `${a}_FULFILLED`, `${a}_REJECTED`]);
 
 export const ACTION_TYPES = keyBy([...actions, ...asyncActions], k => k);

--- a/src/hooks/useInventoryWritePermissions.js
+++ b/src/hooks/useInventoryWritePermissions.js
@@ -1,13 +1,13 @@
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/files/RBACHook';
 
 const useInventoryWritePermissions = () => {
-    const { hasAccess } = usePermissions('inventory', [
+    const { hasAccess, ...rest } = usePermissions('inventory', [
         'inventory:*:*',
         'inventory:hosts:write',
         'inventory:*:write'
     ]);
 
-    return insights.chrome.isProd || hasAccess;
+    return { ...rest, hasAccess: insights.chrome.isProd || hasAccess };
 };
 
 export default useInventoryWritePermissions;

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -24,7 +24,8 @@ const Inventory = ({ entity, currentApp, clearNotifications, loadEntity }) => {
     const store = useStore();
     const { InventoryDetail, AppInfo, DetailWrapper } = ConnectedInventory;
     const { loading, writePermissions } = useSelector(
-        ({ permissionsReducer: { loading, writePermissions } }) => ({ loading, writePermissions }),
+        ({ permissionsReducer }) =>
+            ({ loading: permissionsReducer?.loading, writePermissions: permissionsReducer?.writePermissions }),
         shallowEqual
     );
 

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -1,6 +1,6 @@
 import React, { useState, Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect, useStore } from 'react-redux';
+import { connect, useStore, shallowEqual, useSelector } from 'react-redux';
 import './inventory.scss';
 import { Link } from 'react-router-dom';
 import { entitesDetailReducer, addNewListener } from '../store';
@@ -16,7 +16,6 @@ import '@redhat-cloud-services/frontend-components-inventory-insights/index.css'
 import '@redhat-cloud-services/frontend-components-inventory-vulnerabilities/dist/cjs/index.css';
 import { SystemCvesStore } from '@redhat-cloud-services/frontend-components-inventory-vulnerabilities/dist/cjs/SystemCvesStore';
 import { SystemAdvisoryListStore } from '@redhat-cloud-services/frontend-components-inventory-patchman/dist/esm';
-import useInventoryWritePermissions from '../hooks/useInventoryWritePermissions';
 import classnames from 'classnames';
 import { routes } from '../Routes';
 
@@ -24,7 +23,10 @@ const Inventory = ({ entity, currentApp, clearNotifications, loadEntity }) => {
     const [ConnectedInventory, setInventory] = useState({});
     const store = useStore();
     const { InventoryDetail, AppInfo, DetailWrapper } = ConnectedInventory;
-    const canPerformActions = useInventoryWritePermissions();
+    const { loading, writePermissions } = useSelector(
+        ({ permissionsReducer: { loading, writePermissions } }) => ({ loading, writePermissions }),
+        shallowEqual
+    );
 
     const loadInventory = async () => {
         clearNotifications();
@@ -92,12 +94,12 @@ const Inventory = ({ entity, currentApp, clearNotifications, loadEntity }) => {
                     </BreadcrumbItem>
                 </Breadcrumb>
                 {
-                    InventoryDetail &&
+                    !loading && InventoryDetail &&
                     <InventoryDetail
                         hideBack
                         showTags
                         hideInvLink
-                        showDelete={canPerformActions}
+                        showDelete={writePermissions}
                         hideInvDrawer
                     />
                 }

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect, shallowEqual, useSelector } from 'react-redux';
 import './inventory.scss';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import { PageHeader, PageHeaderTitle, Main } from '@redhat-cloud-services/frontend-components';
@@ -15,7 +15,6 @@ import { useStore } from 'react-redux';
 import DeleteModal from '../components/DeleteModal';
 import TextInputModal from '@redhat-cloud-services/frontend-components-inventory-general-info/TextInputModal';
 import flatMap from 'lodash/flatMap';
-import useInventoryWritePermissions from '../hooks/useInventoryWritePermissions';
 
 const calculateChecked = (rows = [], selected) => (
     rows.every(({ id }) => selected && selected.has(id))
@@ -85,7 +84,10 @@ const Inventory = ({
     const [filters, onSetfilters] = useState([]);
     const [ediOpen, onEditOpen] = useState(false);
     const [globalFilter, setGlobalFilter] = useState();
-    const canPerformActions = useInventoryWritePermissions();
+    const { loading, writePermissions } = useSelector(
+        ({ permissionsReducer: { loading, writePermissions } }) => ({ loading, writePermissions }),
+        shallowEqual
+    );
     const store = useStore();
 
     const loadInventory = async () => {
@@ -182,7 +184,7 @@ const Inventory = ({
                 <Grid gutter="md">
                     <GridItem span={12}>
                         {
-                            ConnectedInventory &&
+                            !loading && ConnectedInventory &&
                                 <ConnectedInventory
                                     customFilters={globalFilter}
                                     isFullView
@@ -190,8 +192,8 @@ const Inventory = ({
                                     ref={inventory}
                                     showTags
                                     onRefresh={onRefresh}
-                                    hasCheckbox={canPerformActions}
-                                    {...(canPerformActions && {
+                                    hasCheckbox={writePermissions}
+                                    {...(writePermissions && {
                                         actions: [
                                             {
                                                 title: 'Delete',

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -85,7 +85,8 @@ const Inventory = ({
     const [ediOpen, onEditOpen] = useState(false);
     const [globalFilter, setGlobalFilter] = useState();
     const { loading, writePermissions } = useSelector(
-        ({ permissionsReducer: { loading, writePermissions } }) => ({ loading, writePermissions }),
+        ({ permissionsReducer }) =>
+            ({ loading: permissionsReducer?.loading, writePermissions: permissionsReducer?.writePermissions }),
         shallowEqual
     );
     const store = useStore();

--- a/src/store/permissions/reducer.js
+++ b/src/store/permissions/reducer.js
@@ -11,6 +11,7 @@ const loadWritePermissionsPending = (state) => ({
 const loadWritePermissionsFulfilled = (state, { payload }) => ({
     ...state,
     loading: false,
+    loadingFailed: false,
     writePermissions: payload.writePermissions
 });
 
@@ -21,8 +22,8 @@ const loadWritePermissionsFailed = (state) => ({
 });
 
 const defaultPermissionState = {
-    writePermissions: false,
-    loading: true,
+    loading: !insights.chrome.isProd,
+    writePermissions: insights.chrome.isProd,
     loadingFailed: false
 };
 

--- a/src/store/permissions/reducer.js
+++ b/src/store/permissions/reducer.js
@@ -1,0 +1,38 @@
+import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
+import { ACTION_TYPES } from '../../constants';
+
+const loadWritePermissionsPending = (state) => ({
+    ...state,
+    loadingFailed: false,
+    loading: !insights.chrome.isProd,
+    writePermissions: insights.chrome.isProd
+});
+
+const loadWritePermissionsFulfilled = (state, { payload }) => ({
+    ...state,
+    loading: false,
+    writePermissions: payload.writePermissions
+});
+
+const loadWritePermissionsFailed = (state) => ({
+    ...state,
+    loading: false,
+    loadingFailed: true
+});
+
+const defaultPermissionState = {
+    writePermissions: false,
+    loading: true,
+    loadingFailed: false
+};
+
+const permissionsReducer = applyReducerHash(
+    {
+        [`${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_PENDING`]: loadWritePermissionsPending,
+        [`${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_FULFILLED`]: loadWritePermissionsFulfilled,
+        [`${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_FAILED`]: loadWritePermissionsFailed
+    },
+    defaultPermissionState
+);
+
+export default permissionsReducer;

--- a/src/store/permissions/reducer.test.js
+++ b/src/store/permissions/reducer.test.js
@@ -1,0 +1,59 @@
+import permissionsReducer from './reducer';
+import { ACTION_TYPES } from '../../constants';
+
+describe('permissionsReducer', () => {
+    it('pending write permission', () => {
+        expect(permissionsReducer({}, { type: `${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_PENDING` }))
+        .toEqual({
+            loading: true,
+            loadingFailed: false,
+            writePermissions: undefined
+        });
+    });
+
+    it('pending write permission - on prod', () => {
+        const tmp = insights.chrome.isProd;
+        insights.chrome.isProd = true;
+
+        expect(permissionsReducer({}, { type: `${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_PENDING` }))
+        .toEqual({
+            loading: false,
+            loadingFailed: false,
+            writePermissions: true
+        });
+
+        insights.chrome.isProd = tmp;
+    });
+
+    it('fulfilled write permission - true', () => {
+        expect(permissionsReducer(
+            {},
+            { type: `${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_FULFILLED`, payload: { writePermissions: true } }
+        ))
+        .toEqual({
+            loading: false,
+            loadingFailed: false,
+            writePermissions: true
+        });
+    });
+
+    it('fulfilled write permission - false', () => {
+        expect(permissionsReducer(
+            {},
+            { type: `${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_FULFILLED`, payload: { writePermissions: false } }
+        ))
+        .toEqual({
+            loading: false,
+            loadingFailed: false,
+            writePermissions: false
+        });
+    });
+
+    it('failed write permission', () => {
+        expect(permissionsReducer({}, { type: `${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_FAILED` }))
+        .toEqual({
+            loading: false,
+            loadingFailed: true
+        });
+    });
+});

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -8,6 +8,8 @@ import { applyReducerHash } from '@redhat-cloud-services/frontend-components-uti
 import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 import { notifications } from '@redhat-cloud-services/frontend-components-notifications';
 
+import permissionsReducer from './permissions/reducer';
+
 const defaultState = { loaded: false, selected: new Map() };
 
 const isEntitled = (service) => {
@@ -116,7 +118,8 @@ function onSetPagination(state, { payload }) {
 
 let reducers = {
     notifications,
-    systemProfileStore
+    systemProfileStore,
+    permissionsReducer
 };
 
 export const entitiesReducer = ({ LOAD_ENTITIES_FULFILLED }) => applyReducerHash(


### PR DESCRIPTION
closes https://issues.redhat.com/browse/RHCLOUD-9754

**Description**

If not on prod, the `PermissionLoader` component will load up `writePermissions` to redux. `InventoryTable` and `InventoryDetail` are not shown until the permissions are loaded (to prevent pop-in). Also, `writePermissions` are passed to `InventoryDetail` > `SystemCard` to also prevent pop-in and to not load permission multiple times.

**TODO**
- [x] test
- [x] generic-info update https://github.com/RedHatInsights/frontend-components/pull/769