### PR TITLE
Enable RBAC everywhere

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ class App extends Component {
         return (
             <React.Fragment>
                 <NotificationsPortal />
-                {!insights.chrome.isProd && <PermissionLoader />}
+                <PermissionLoader />
                 <Routes childProps={this.props} />
             </React.Fragment>
         );

--- a/src/hooks/useInventoryWritePermissions.js
+++ b/src/hooks/useInventoryWritePermissions.js
@@ -7,7 +7,7 @@ const useInventoryWritePermissions = () => {
         'inventory:*:write'
     ]);
 
-    return { ...rest, hasAccess: insights.chrome.isProd || hasAccess };
+    return { ...rest, hasAccess };
 };
 
 export default useInventoryWritePermissions;

--- a/src/store/permissions/reducer.js
+++ b/src/store/permissions/reducer.js
@@ -4,8 +4,8 @@ import { ACTION_TYPES } from '../../constants';
 const loadWritePermissionsPending = (state) => ({
     ...state,
     loadingFailed: false,
-    loading: !window.insights?.chrome?.isProd,
-    writePermissions: window.insights?.chrome?.isProd
+    loading: true,
+    writePermissions: false
 });
 
 const loadWritePermissionsFulfilled = (state, { payload }) => ({
@@ -22,8 +22,8 @@ const loadWritePermissionsFailed = (state) => ({
 });
 
 const defaultPermissionState = {
-    loading: !window.insights?.chrome?.isProd,
-    writePermissions: window.insights?.chrome?.isProd,
+    loading: true,
+    writePermissions: false,
     loadingFailed: false
 };
 

--- a/src/store/permissions/reducer.js
+++ b/src/store/permissions/reducer.js
@@ -5,7 +5,7 @@ const loadWritePermissionsPending = (state) => ({
     ...state,
     loadingFailed: false,
     loading: true,
-    writePermissions: false
+    writePermissions: undefined
 });
 
 const loadWritePermissionsFulfilled = (state, { payload }) => ({

--- a/src/store/permissions/reducer.test.js
+++ b/src/store/permissions/reducer.test.js
@@ -11,16 +11,6 @@ describe('permissionsReducer', () => {
         });
     });
 
-    it('pending write permission - on prod', () => {
-
-        expect(permissionsReducer({}, { type: `${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_PENDING` }))
-        .toEqual({
-            loading: false,
-            loadingFailed: false,
-            writePermissions: true
-        });
-    });
-
     it('fulfilled write permission - true', () => {
         expect(permissionsReducer(
             {},

--- a/src/store/permissions/reducer.test.js
+++ b/src/store/permissions/reducer.test.js
@@ -12,8 +12,6 @@ describe('permissionsReducer', () => {
     });
 
     it('pending write permission - on prod', () => {
-        const tmp = insights.chrome.isProd;
-        insights.chrome.isProd = true;
 
         expect(permissionsReducer({}, { type: `${ACTION_TYPES.LOAD_WRITE_PERMISSIONS}_PENDING` }))
         .toEqual({
@@ -21,8 +19,6 @@ describe('permissionsReducer', () => {
             loadingFailed: false,
             writePermissions: true
         });
-
-        insights.chrome.isProd = tmp;
     });
 
     it('fulfilled write permission - true', () => {


### PR DESCRIPTION
Since we are enabling RBAC for profuction no need to have RBAC gated behind `isProd` flag from chrome.