### PR TITLE
Apply default filters on page load

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -1,0 +1,31 @@
+export const defaultFilters = [
+    {
+        staleFilter: ['fresh', 'stale']
+    }, {
+        registeredWithFilter: ['insights']
+    }
+];
+
+export const isEmpty = (check) => !check || check?.length === 0;
+
+export const generateFilter = (status, source, tagsFilter, filterbyName) => ([
+    !isEmpty(status) && {
+        staleFilter: Array.isArray(status) ? status : [status]
+    },
+    !isEmpty(tagsFilter) && {
+        tagFilters: Array.isArray(tagsFilter) ? tagsFilter : [tagsFilter]
+    },
+    !isEmpty(source) && {
+        registeredWithFilter: Array.isArray(source) ? source : [source]
+    },
+    !isEmpty(filterbyName) && {
+        value: 'hostname_or_id',
+        filter: Array.isArray(filterbyName) ? filterbyName[0] : filterbyName
+    },
+    (!isEmpty(status) || !isEmpty(tagsFilter) || !isEmpty(filterbyName)) && isEmpty(source) && {
+        registeredWithFilter: []
+    },
+    (!isEmpty(source) || !isEmpty(tagsFilter) || !isEmpty(filterbyName)) && isEmpty(status) && {
+        staleFilter: []
+    }
+].filter(Boolean));

--- a/src/Utilities/constants.test.js
+++ b/src/Utilities/constants.test.js
@@ -1,0 +1,131 @@
+import { generateFilter, isEmpty } from './constants';
+
+describe('generateFilter', () => {
+    it('should generate empty array', () => {
+        const result = generateFilter();
+        expect(result.length).toBe(0);
+    });
+
+    describe('status filter', () => {
+        it('should generate filter with empty source - string', () => {
+            const result = generateFilter('something');
+            expect(result.length).toBe(2);
+            expect(result).toMatchObject([
+                { staleFilter: ['something'] },
+                { registeredWithFilter: [] }
+            ]);
+        });
+
+        it('should generate filter with empty source - array', () => {
+            const result = generateFilter(['something']);
+            expect(result.length).toBe(2);
+            expect(result).toMatchObject([
+                { staleFilter: ['something'] },
+                { registeredWithFilter: [] }
+            ]);
+        });
+    });
+
+    describe('source filter', () => {
+        it('should generate filter with empty status - string', () => {
+            const result = generateFilter(undefined, 'something');
+            expect(result.length).toBe(2);
+            expect(result).toMatchObject([
+                { registeredWithFilter: ['something'] },
+                { staleFilter: [] }
+            ]);
+        });
+
+        it('should generate filter with empty status - array', () => {
+            const result = generateFilter(undefined, ['something']);
+            expect(result.length).toBe(2);
+            expect(result).toMatchObject([
+                { registeredWithFilter: ['something'] },
+                { staleFilter: [] }
+            ]);
+        });
+    });
+
+    describe('tags filter', () => {
+        it('should generate filter and rest empty - string', () => {
+            const result = generateFilter(undefined, undefined, 'something');
+            expect(result.length).toBe(3);
+            expect(result).toMatchObject([
+                { tagFilters: ['something'] },
+                { registeredWithFilter: [] },
+                { staleFilter: [] }
+            ]);
+        });
+
+        it('should generate filter and rest empty - array', () => {
+            const result = generateFilter(undefined, undefined, ['something']);
+            expect(result.length).toBe(3);
+            expect(result).toMatchObject([
+                { tagFilters: ['something'] },
+                { registeredWithFilter: [] },
+                { staleFilter: [] }
+            ]);
+        });
+    });
+
+    describe('filter by name or id', () => {
+        it('should generate filter and rest empty - string', () => {
+            const result = generateFilter(undefined, undefined, undefined, 'something');
+            expect(result.length).toBe(3);
+            expect(result).toMatchObject([
+                {
+                    value: 'hostname_or_id',
+                    filter: 'something'
+                },
+                { registeredWithFilter: [] },
+                { staleFilter: [] }
+            ]);
+        });
+
+        it('should generate filter and rest empty - array', () => {
+            const result = generateFilter(undefined, undefined, undefined, ['something']);
+            expect(result.length).toBe(3);
+            expect(result).toMatchObject([
+                {
+                    value: 'hostname_or_id',
+                    filter: 'something'
+                },
+                { registeredWithFilter: [] },
+                { staleFilter: [] }
+            ]);
+        });
+    });
+
+    it('should generate stale and source filter', () => {
+        const result = generateFilter('test', 'something');
+        expect(result.length).toBe(2);
+        expect(result).toMatchObject([
+            { staleFilter: ['test'] },
+            { registeredWithFilter: ['something'] }
+        ]);
+    });
+
+    it('should generate full filter', () => {
+        const result = generateFilter('one', 'two', 'three', 'four');
+        expect(result).toMatchObject([
+            { staleFilter: ['one'] },
+            { tagFilters: ['three'] },
+            { registeredWithFilter: ['two'] },
+            {
+                value: 'hostname_or_id',
+                filter: 'four'
+            }
+        ]);
+    });
+});
+
+describe('isEmpty', () => {
+    it('should return true', () => {
+        expect(isEmpty()).toBe(true);
+        expect(isEmpty([])).toBe(true);
+    });
+
+    it('should return false', () => {
+        expect(isEmpty(['test'])).toBe(false);
+    });
+});


### PR DESCRIPTION
### Populate filters on load

if user navigates to inventory default filters are not stored in URL, this causes an error with sorting and user is not able to save partial filters in URL. This PR fixes such issue by computing active filters on load and if no filters (`undefined`! Not empty array) are passed from inventory it will use default filters as fallback.