### PR TITLE
Use same filter generator as on load

### DIFF
--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -121,6 +121,15 @@ const Inventory = ({
             options.filters = defaultFilters;
         }
 
+        const { status, source, tagsFilter, filterbyName } = options?.filters.reduce((acc, curr) => ({
+            ...acc,
+            ...curr?.staleFilter && { status: curr.staleFilter },
+            ...curr?.registeredWithFilter && { source: curr.registeredWithFilter },
+            ...curr?.tagFilters && { tagsFilter: curr.tagFilters },
+            ...curr?.value === 'hostname_or_id' && { filterbyName: curr.filter }
+        }), { status: undefined, source: undefined, tagsFilter: undefined, filterbyName: undefined });
+        options.filters = generateFilter(status, source, tagsFilter, filterbyName);
+
         onSetfilters(options?.filters);
         const searchParams = new URLSearchParams();
         calculateFilters(searchParams, options?.filters);


### PR DESCRIPTION
### Use same filter generator

While changing filters they can be wrongly generated under certain scenarios, like clearing out all filters and applying just filter by name. This PR fixes such issue by using same logic as for generating the filters in URL.

Fixes: RHCLOUD-10465