### PR TITLE
Use default values for pagination

### DIFF
--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -109,10 +109,12 @@ function onSetFilter(state, { payload }) {
 }
 
 function onSetPagination(state, { payload }) {
+    const perPage = parseInt(payload.perPage, 10);
+    const page = parseInt(payload.page, 10);
     return {
         ...state,
-        perPage: payload.perPage,
-        page: payload.page
+        perPage: isNaN(perPage) ? 50 : perPage,
+        page: isNaN(page) ? 1 : page
     };
 }
 


### PR DESCRIPTION
### Do not use NaN in pagination

When user types in URL some strange page or pagination it can break the UI. There is even report that user can somehow enter this state trough selecting systems. This PR fixes such issue by using default values when NaN is passed in the URL.