### PR TITLE
Call onRefreshData after render cycle to get the latest props

### DIFF
--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -87,7 +87,7 @@ const Inventory = ({
     const [currentSytem, activateSystem] = useState({});
     const [filters, onSetfilters] = useState([]);
     const [ediOpen, onEditOpen] = useState(false);
-    const [globalFilter, setGlobalFilter] = useState();
+    const [{ globalFilterChanged, ...globalFilter }, setGlobalFilter] = useState({ globalFilterChanged: 0 });
     const { loading, writePermissions } = useSelector(
         ({ permissionsReducer }) =>
             ({ loading: permissionsReducer?.loading, writePermissions: permissionsReducer?.writePermissions }),
@@ -132,7 +132,8 @@ const Inventory = ({
         insights.chrome.appObjectId();
         insights.chrome.on('GLOBAL_FILTER_UPDATE', ({ data }) => {
             const [workloads, SID, tags] = insights.chrome?.mapGlobalFilter?.(data, false, true);
-            setGlobalFilter(() => ({
+            setGlobalFilter(({ globalFilterChanged }) => ({
+                globalFilterChanged: globalFilterChanged + 1,
                 tags,
                 filter: {
                     ...globalFilter?.filter,
@@ -143,12 +144,15 @@ const Inventory = ({
                     }
                 }
             }));
-            if (inventory.current) {
-                inventory.current.onRefreshData({});
-            }
         });
         clearNotifications();
     }, []);
+
+    useEffect(() => {
+        if (inventory.current && globalFilterChanged) {
+            inventory.current.onRefreshData({});
+        }
+    }, [globalFilterChanged]);
 
     const calculateSelected = () => selected ? selected.size : 0;
 


### PR DESCRIPTION
`onRefreshUpdate` is called before the state is updated, but we need to update the props first and then call the `onRefreshUpdate`. We could also call the `onRefreshUpdate` with the correct options, however, I think it's better to let the inventoryTable handle it.

**Before**

![Kapture 2021-04-28 at 10 39 26](https://user-images.githubusercontent.com/32869456/116373851-0a416b00-a80e-11eb-859a-20892c9f26d0.gif)

**After**

![Kapture 2021-04-28 at 10 37 02](https://user-images.githubusercontent.com/32869456/116373737-ec740600-a80d-11eb-8e69-54f1d397c9d3.gif)
