### PR TITLE
Fix cockpit linking to wrong page in inventory

### DIFF
--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -29,6 +29,8 @@ const Inventory = ({ entity, currentApp, clearNotifications, loadEntity }) => {
         insights.chrome.appAction('system-detail');
         clearNotifications();
 
+        // BZ: RHEL cockpit is linking to crc/insights/inventory/{}/insights - which results in a page error, catch that and redirect
+        // TODO Remove me when BZ is fixed
         const splitUrl = window.location.href.split('/insights');
         if(splitUrl.length === 3) {
             window.location = `${splitUrl[0]}/insights${splitUrl[1]}`;

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -28,6 +28,11 @@ const Inventory = ({ entity, currentApp, clearNotifications, loadEntity }) => {
         insights.chrome?.hideGlobalFilter?.(true);
         insights.chrome.appAction('system-detail');
         clearNotifications();
+
+        const splitUrl = window.location.href.split('/insights');
+        if(splitUrl.length === 3) {
+            window.location = `${splitUrl[0]}/insights${splitUrl[1]}`;
+        }
     }, []);
 
     const additionalClasses = {

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -29,10 +29,11 @@ const Inventory = ({ entity, currentApp, clearNotifications, loadEntity }) => {
         insights.chrome.appAction('system-detail');
         clearNotifications();
 
-        // BZ: RHEL cockpit is linking to crc/insights/inventory/{}/insights - which results in a page error, catch that and redirect
+        // BZ: RHEL cockpit is linking to crc/insights/inventory/{}/insights
+        // which results in a page error, catch that and redirect
         // TODO Remove me when BZ is fixed
         const splitUrl = window.location.href.split('/insights');
-        if(splitUrl.length === 3) {
+        if (splitUrl.length === 3) {
             window.location = `${splitUrl[0]}/insights${splitUrl[1]}`;
         }
     }, []);


### PR DESCRIPTION
Customer is using the RHEL cockpit web console(http://example.com:9090/system) to access the insights host.

- Go to http://127.0.0.1:9090/system
- Under "Health" tile, Click on hyperlink "Insights:1 moderate hit"
- It will redirect user to the wrong url "https://cloud.redhat.com/insights/inventory/xx-xxx-xxx/insights" which results into this error.

Cockpit is incorrectly linking to this page and adding an additional `/insights` at the end. They're a shipped product so it could take a bit before this is fixed on their end.

BZ will be updated when made.