### PR TITLE
'Filter by" sentence case fix

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -5,3 +5,10 @@ table.ins-entity-table th {
     padding: 1rem;
     padding-left: 2rem;
 }
+
+.pf-c-select__toggle-text {
+	text-transform: lowercase;
+	&:first-letter{
+        text-transform: capitalize
+    }
+}


### PR DESCRIPTION
Force sentence case for 'Filter by" dropdown using css
Jira: https://issues.redhat.com/browse/RHCLOUD-12823

Old
![Screen Shot 2021-05-12 at 10 21 29 AM](https://user-images.githubusercontent.com/1287144/117991240-dc7b1c80-b30b-11eb-864a-61cc709985d3.png)

New
![Screen Shot 2021-05-12 at 10 20 43 AM](https://user-images.githubusercontent.com/1287144/117991238-dc7b1c80-b30b-11eb-9a02-210c28329df9.png)
