### PR TITLE
extend OUIA IDs in delete/edit modals

### DIFF
--- a/src/components/DeleteModal.js
+++ b/src/components/DeleteModal.js
@@ -27,6 +27,7 @@ const DeleteModal = ({ handleModalToggle, isModalOpen, currentSytem, onConfirm }
         variant="small"
         title="Remove from inventory"
         className="ins-c-inventory__table--remove"
+        ouiaId="inventory-delete-modal"
         isOpen={isModalOpen}
         onClose={() => handleModalToggle(false)}
         appendTo={document.getElementsByClassName('inventory')[0]}
@@ -54,7 +55,7 @@ const DeleteModal = ({ handleModalToggle, isModalOpen, currentSytem, onConfirm }
                 <Button variant="danger" onClick={onConfirm} ouiaId="confirm-delete">
                     Remove
                 </Button>
-                <Button variant="link" onClick={() => handleModalToggle(false)}>Cancel</Button>
+                <Button variant="link" onClick={() => handleModalToggle(false)} ouiaId="cancel-delete">Cancel</Button>
             </LevelItem>
         </Level>
     </Modal>;

--- a/src/components/inventory/GeneralInfo/SystemCard/SystemCard.js
+++ b/src/components/inventory/GeneralInfo/SystemCard/SystemCard.js
@@ -163,6 +163,10 @@ class SystemCard extends Component {
                     title='Edit display name'
                     value={ entity && entity.display_name }
                     ariaLabel='Host inventory display name'
+                    modalOuiaId="edit-display-name-modal"
+                    cancelOuiaId="cancel-edit-display-name"
+                    confirmOuiaId="confirm-edit-display-name"
+                    inputOuiaId="input-edit-display-name"
                     onCancel={ this.onCancel }
                     onSubmit={ this.onSubmit(setDisplayName) }
                 />
@@ -171,6 +175,10 @@ class SystemCard extends Component {
                     title='Edit Ansible host'
                     value={ entity && this.getAnsibleHost() }
                     ariaLabel='Ansible host'
+                    modalOuiaId="edit-ansible-name-modal"
+                    cancelOuiaId="cancel-edit-ansible-name"
+                    confirmOuiaId="confirm-edit-ansible-name"
+                    inputOuiaId="input-edit-ansible-name"
                     onCancel={ this.onCancel }
                     onSubmit={ this.onSubmit(setAnsibleHost) }
                 />

--- a/src/components/inventory/GeneralInfo/TextInputModal/TextInputModal.js
+++ b/src/components/inventory/GeneralInfo/TextInputModal/TextInputModal.js
@@ -50,7 +50,8 @@ export default class TextInputModal extends Component {
                         key="confirm"
                         data-action="confirm"
                         variant="primary"
-                        onClick={ () => onSubmit(this.state.value) } ouiaId={ confirmOuiaId }
+                        onClick={ () => onSubmit(this.state.value) }
+                        ouiaId={ confirmOuiaId }
                     >
                         Save
                     </Button>
@@ -88,4 +89,3 @@ TextInputModal.defaultProps = {
     title: '',
     ariaLabel: 'input text'
 };
-

--- a/src/components/inventory/GeneralInfo/TextInputModal/TextInputModal.js
+++ b/src/components/inventory/GeneralInfo/TextInputModal/TextInputModal.js
@@ -28,7 +28,7 @@ export default class TextInputModal extends Component {
     };
 
     render () {
-        const { title, isOpen, onCancel, onSubmit, ariaLabel } = this.props;
+        const { title, isOpen, onCancel, onSubmit, ariaLabel, modalOuiaId, cancelOuiaId, confirmOuiaId, inputOuiaId } = this.props;
         const { value } = this.state;
 
         return (
@@ -37,13 +37,14 @@ export default class TextInputModal extends Component {
                 title={ title }
                 className="ins-c-inventory__detail--edit"
                 aria-label={ ariaLabel ? `${ariaLabel} - modal` : 'input modal' }
+                ouiaId={ modalOuiaId }
                 isOpen={ isOpen }
                 onClose={ event => onCancel(event) }
                 actions={ [
-                    <Button key="cancel" data-action="cancel" variant="secondary" onClick={ onCancel }>
+                    <Button key="cancel" data-action="cancel" variant="secondary" onClick={ onCancel } ouiaId={ cancelOuiaId }>
                         Cancel
                     </Button>,
-                    <Button key="confirm" data-action="confirm" variant="primary" onClick={ () => onSubmit(this.state.value) }>
+                    <Button key="confirm" data-action="confirm" variant="primary" onClick={ () => onSubmit(this.state.value) } ouiaId={ confirmOuiaId }>
                         Save
                     </Button>
                 ] }
@@ -51,6 +52,7 @@ export default class TextInputModal extends Component {
                 <TextInput
                     value={ value }
                     type="text"
+                    ouiaId={ inputOuiaId }
                     onChange={ value => this.setState({ value }) }
                     aria-label={ ariaLabel  }
                 />

--- a/src/components/inventory/GeneralInfo/TextInputModal/TextInputModal.js
+++ b/src/components/inventory/GeneralInfo/TextInputModal/TextInputModal.js
@@ -28,7 +28,9 @@ export default class TextInputModal extends Component {
     };
 
     render () {
-        const { title, isOpen, onCancel, onSubmit, ariaLabel, modalOuiaId, cancelOuiaId, confirmOuiaId, inputOuiaId } = this.props;
+        const {
+            title, isOpen, onCancel, onSubmit, ariaLabel, modalOuiaId, cancelOuiaId, confirmOuiaId, inputOuiaId
+        } = this.props;
         const { value } = this.state;
 
         return (
@@ -44,7 +46,12 @@ export default class TextInputModal extends Component {
                     <Button key="cancel" data-action="cancel" variant="secondary" onClick={ onCancel } ouiaId={ cancelOuiaId }>
                         Cancel
                     </Button>,
-                    <Button key="confirm" data-action="confirm" variant="primary" onClick={ () => onSubmit(this.state.value) } ouiaId={ confirmOuiaId }>
+                    <Button
+                        key="confirm"
+                        data-action="confirm"
+                        variant="primary"
+                        onClick={ () => onSubmit(this.state.value) } ouiaId={ confirmOuiaId }
+                    >
                         Save
                     </Button>
                 ] }
@@ -67,6 +74,10 @@ TextInputModal.propTypes = {
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func,
     ariaLabel: PropTypes.string,
+    modalOuiaId: PropTypes.string,
+    cancelOuiaId: PropTypes.string,
+    confirmOuiaId: PropTypes.string,
+    inputOuiaId: PropTypes.string,
     value: PropTypes.string
 };
 


### PR DESCRIPTION
Extended OUIA ids in delete modal, and added some optional parameters for TextInputModal so that OUIA ID's can be optionally inserted and added them to edit modals in inventory.

cc @karelhala 