### PR TITLE
Add table v2

### DIFF
--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -11,7 +11,7 @@ import AccessDenied from '../../Utilities/AccessDenied';
 import { loadSystems } from '../../Utilities/index';
 import isEqual from 'lodash/isEqual';
 import { entitiesLoading } from '../../store/actions';
-
+import InventoryTableV2 from '../TableNew';
 /**
  * A helper function to store props and to always return the latest state.
  * For example, EntityTableToolbar wraps OnRefreshData in a callback, so we need this
@@ -261,4 +261,10 @@ InventoryTable.propTypes = {
     showTagModal: PropTypes.bool
 };
 
-export default InventoryTable;
+const TablesWrapper = ({ v2, ...props }) => v2 ? <InventoryTableV2 {...props} /> : <InventoryTable {...props} />;
+
+TablesWrapper.propTypes = {
+    v2: PropTypes.bool
+};
+
+export default TablesWrapper;

--- a/src/components/TableNew/InventoryTable.js
+++ b/src/components/TableNew/InventoryTable.js
@@ -1,0 +1,308 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useHistory, useLocation } from 'react-router-dom';
+
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
+import { SkeletonTable } from '@redhat-cloud-services/frontend-components/SkeletonTable';
+import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
+
+import {
+    Table as PfTable,
+    TableBody,
+    TableHeader,
+    TableGridBreakpoint
+} from '@patternfly/react-table';
+
+import useColumns from './useColumns';
+import useCallbackReducer from './useCallbackReducer';
+import { getEntities as apiGetEntities } from './api';
+import { getEnabledFilters } from './helpers';
+import TableToolbar from './TableToolbar';
+import NoSystemsTable from '../InventoryTable/NoSystemsTable';
+import AccessDenied from '../../Utilities/AccessDenied';
+import { createColumns, createRows } from '../InventoryTable/helpers';
+
+const initialStateReducer = {
+    orderBy: 'updated',
+    orderDirection: 'DESC',
+    page: 1,
+    perPage: 50,
+    filters: {},
+    entities: [],
+    total: 0,
+    loadingCounter: 0,
+    isLoaded: false,
+    error: false,
+    selected: []
+};
+
+const reducer = (state, action) => {
+    console.log(action.type, action);
+    switch (action.type) {
+        case 'setFilter':
+            return { ...state, filters: { ...state.filters, [action.payload.key]: action.payload.value } };
+        case 'selectAll':
+            return { ...state, selected: action.payload.selected };
+        case 'selectNone':
+            return { ...state, selected: [] };
+        case 'selectPage':
+            return {
+                ...state,
+                selected:
+                [
+                    ...state.selected,
+                    ...state.entities.map(entity => !state.selected.includes(entity.id) && entity.id).filter(Boolean)
+                ]
+            };
+        case 'unselectPage':
+            return { ...state, selected: state.selected.filter(id => !state.entities.find((entity) => entity.id === id)) };
+        case 'selectEntity':
+            return {
+                ...state,
+                selected: action.payload.checked ?
+                    [...state.selected, action.payload.id]
+                    : state.selected.filter((item) => item !== action.payload.id)
+            };
+        case 'setLoaded':
+            return { ...state, isLoaded: false, ...action.payload.options };
+        case 'setResults':
+            return { ...state, total: action.payload.results.total, entities: action.payload.results.results, isLoaded: true };
+        case 'setError':
+            return { ...state, error: true };
+        default:
+            return state;
+    }
+};
+
+const InventoryTable = ({
+    hasAccess,
+    isFullView,
+    errorState = <ErrorState />,
+    paginationProps = {},
+    tableProps = {},
+    columns,
+    noSystemsTable = <NoSystemsTable />,
+    onRowClick,
+    showTags,
+    disableDefaultColumns,
+    columnsCounter,
+    bulkSelect,
+    hasCheckbox,
+    expandable,
+    actions,
+    noDetail,
+    getEntities,
+    selectAll,
+    children,
+    hideFilters,
+    actionsConfig
+}) => {
+    const enabledFilters = useMemo(() => getEnabledFilters(hideFilters), [hideFilters]);
+
+    const [state, dispatch] = useCallbackReducer(reducer, initialStateReducer);
+    const columnsRef = useColumns({ columns, showTags, disableDefaultColumns, columnsCounter });
+
+    const history = useHistory();
+    const location = useLocation();
+
+    const refreshData = async (options) => {
+        dispatch({ type: 'setLoaded', payload: { options } }, async (newState) => {
+            try {
+                console.log({ newState });
+                const params = {
+                    filters: newState.filters,
+                    perPage: newState.perPage,
+                    page: newState.page,
+                    orderBy: newState.orderBy,
+                    orderDirection: newState.orderDirection,
+                    tags: [], // ?
+                    filter: {}, // ?
+                    showTags
+                };
+
+                const results = !getEntities ? await apiGetEntities(params) : await getEntities(params, apiGetEntities);
+
+                dispatch({ type: 'setResults', payload: { results } });
+            } catch (e) {
+                console.error(e);
+                dispatch({ type: 'setError' });
+            }
+        });
+    };
+
+    useState(() => {
+        !state.isLoaded && refreshData();
+    }, []);
+
+    const noAccess = hasAccess === false;
+
+    if (noAccess && isFullView) {
+        return <AccessDenied
+            title="This application requires Inventory permissions"
+            description={<div>
+            To view the content of this page, you must be granted
+            a minimum of inventory permissions from your Organization Administrator.
+            </div>}
+        />;
+    }
+
+    if (state.error) {
+        return errorState;
+    }
+
+    const paginationConfig = {
+        itemCount: state.total,
+        page: state.page,
+        perPage: state.perPage,
+        onSetPage: (_e, newPage) => refreshData({ page: newPage }),
+        onPerPageSelect: (_e, newPerPage) => refreshData({ page: 1, perPage: newPerPage }),
+        ...paginationProps
+    };
+
+    const paginationConfigBottom = {
+        ...paginationConfig,
+        dropDirection: 'up',
+        variant: 'bottom',
+        isCompact: false
+    };
+
+    const cells = state.isLoaded && createColumns(columnsRef.current, false, state.entities, expandable);
+
+    const defaultRowClick = (_event, key) => {
+        history.push(`${location.pathname}${location.pathname.slice(-1) === '/' ? '' : '/'}${key}`);
+    };
+
+    const rows = createRows(
+        state.entities,
+        columnsRef.current,
+        {
+            actions,
+            expandable,
+            loaded: state.isLoaded,
+            onRowClick: onRowClick || defaultRowClick,
+            noDetail,
+            sortBy: state.orderBy,
+            noSystemsTable
+        });
+
+    state.selected.forEach(id => {
+        const index = rows.findIndex(row => row.id === id);
+        if (index >= 0) {
+            rows[index].selected = true;
+        }
+    });
+
+    const onItemSelect = (_event, checked, rowId) => {
+        const row = expandable ? state.entities[rowId / 2] : state.entities[rowId];
+        dispatch({ type: 'selectEntity', payload: { id: rowId === -1 ? 0 : row.id, checked } });
+    };
+
+    const onExpandClick = () => null;
+
+    const onSortChange = (orderBy, orderDirection) => refreshData({ orderBy, orderDirection: orderDirection.toUpperCase() });
+
+    return (<React.Fragment>
+        <TableToolbar
+            state={state}
+            paginationConfig={paginationConfig}
+            actionsConfig={actionsConfig}
+            dispatch={dispatch}
+            enabledFilters={enabledFilters}
+            bulkSelect={bulkSelect}
+            rows={rows}
+            selectAll={selectAll}
+            noAccess={noAccess}
+        >{children}</TableToolbar>
+        {!state.isLoaded && <SkeletonTable colSize={ columnsRef.current?.length || 3 } rowSize={ 15 } />}
+        {state.isLoaded && noAccess && <div className="ins-c-inventory__no-access">
+            <AccessDenied showReturnButton={false} />
+        </div>}
+        { state.isLoaded && !noAccess &&
+            <PfTable
+                aria-label="Host inventory"
+                className="ins-c-entity-table"
+                cells={ cells }
+                rows={ rows }
+                gridBreakPoint={
+                    columnsRef.current?.length > 5 ? TableGridBreakpoint.gridLg : TableGridBreakpoint.gridMd
+                }
+                onSort={ (_event, index, direction) => {
+                    onSortChange(
+                        cells[index - Boolean(hasCheckbox) - Boolean(expandable)]?.key,
+                        direction
+                    );
+                } }
+                sortBy={ {
+                    index: cells.findIndex(item => state.orderBy === item.key) + Boolean(hasCheckbox) + Boolean(expandable),
+                    direction: state.orderDirection.toLowerCase()
+                } }
+                { ...tableProps }
+                { ...{
+                    ...hasCheckbox && state.entities.length !== 0 ? { onSelect: onItemSelect } : {},
+                    ...expandable ? { onCollapse: onExpandClick } : {},
+                    ...actions && state.entities.length > 0 && { actions }
+                } }
+            >
+                <TableHeader />
+                <TableBody />
+            </PfTable>
+        }
+        {state.isLoaded && <PrimaryToolbar pagination={paginationConfigBottom} />}
+    </React.Fragment>);
+};
+
+/*
+        <TagsModal
+            customFilters={customFilters}
+            filterTagsBy={filterTagsBy}
+            onApply={(selected) => setSelectedTags(arrayToSelection(selected))}
+            onToggleModal={() => seFilterTagsBy('')}
+        />
+        */
+
+InventoryTable.propTypes = {
+    // autoRefresh: PropTypes.bool,
+    // onRefresh: PropTypes.func,
+    // children: PropTypes.node,
+    // inventoryRef: PropTypes.object,
+    // items: PropTypes.array,
+    // total: PropTypes.number,
+    // page: PropTypes.number,
+    // perPage: PropTypes.number,
+    // filters: PropTypes.any,
+    // sortBy: PropTypes.object,
+    showTags: PropTypes.bool,
+    customFilters: PropTypes.any,
+    hasAccess: PropTypes.bool,
+    isFullView: PropTypes.bool,
+    getEntities: PropTypes.func,
+    hideFilters: PropTypes.shape({
+        tags: PropTypes.bool,
+        name: PropTypes.bool,
+        registeredWith: PropTypes.bool,
+        stale: PropTypes.bool,
+        all: PropTypes.bool
+    }),
+    paginationProps: PropTypes.object,
+    errorState: PropTypes.node,
+    tableProps: PropTypes.object,
+    columns: PropTypes.any,
+    noSystemsTable: PropTypes.node,
+    onRowClick: PropTypes.func,
+    disableDefaultColumns: PropTypes.oneOfType([PropTypes.bool, PropTypes.arrayOf(PropTypes.string)]),
+    columnsCounter: PropTypes.number,
+    bulkSelect: PropTypes.object,
+    hasCheckbox: PropTypes.bool,
+    expandable: PropTypes.bool,
+    actions: PropTypes.node,
+    noDetail: PropTypes.bool,
+    selectAll: PropTypes.func,
+    children: PropTypes.node,
+    actionsConfig: PrimaryToolbar.propTypes.actionsConfig
+    // isLoaded: PropTypes.bool,
+    // initialLoading: PropTypes.bool,
+    // ignoreRefresh: PropTypes.bool,
+    // showTagModal: PropTypes.bool
+};
+
+export default InventoryTable;

--- a/src/components/TableNew/TableToolbar.js
+++ b/src/components/TableNew/TableToolbar.js
@@ -1,0 +1,118 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+
+import { generateFilters, generateChips } from './filters';
+import { useTagsFilter } from '../filters';
+import { arrayToSelection, TagsModal } from '../../Utilities';
+
+const TableToolbar = ({
+    state,
+    paginationConfig,
+    actionsConfig,
+    dispatch,
+    enabledFilters,
+    bulkSelect,
+    rows,
+    selectAll,
+    children,
+    noAccess
+}) => {
+    const [tagModal, toggleTagModal] = useState();
+    const [{ allTags, allTagsLoaded, additionalTagsCount }, setTagsState] = useState({});
+    const [filters, setFilter] = useState(state.filters);
+    const {
+        tagsFilter,
+        tagsChip,
+        selectedTags,
+        setSelectedTags,
+        filterTagsBy,
+        seFilterTagsBy
+    } = useTagsFilter(
+        allTags,
+        allTagsLoaded,
+        additionalTagsCount,
+        () => toggleTagModal(true),
+        [{ tagsFilter: state.filters.tags }]
+    );
+
+    const updateTextFilter = (key, value) => {
+        setFilter({ ...filters, [key]: value });
+        // debounce dispatch({ type: 'setFilter', payload: { key, value } })
+    };
+
+    const bulkSelectConfig = useMemo(() => (
+        {
+            count: state.selected.length,
+            isDisabled: (state.total === 0 && state.selected.length === 0) || !state.isLoaded || noAccess,
+            checked: rows.every(({ selected }) => selected) || (rows.some(({ selected }) => selected) && null),
+            onSelect: () => rows.some(({ selected }) => selected)
+                ? dispatch({ type: 'unselectPage' })
+                : dispatch({ type: 'selectPage' }),
+            items: [
+                {
+                    title: 'Select none (0)',
+                    onClick: () => dispatch({ type: 'selectNone' })
+                },
+                ...state.isLoaded && rows?.length > 0 ? [{
+                    title: `Select page (${ rows.length })`,
+                    onClick: () => dispatch({ type: 'selectPage' })
+                }] : [{}],
+                ...selectAll && state.isLoaded && rows?.length > 0 ? [{
+                    title: `Select all (${ state.total })`,
+                    onClick: () => selectAll((selected) => dispatch({ type: 'selectAll', payload: { selected } }))
+                }] : [{}]
+            ]
+        }
+    ), [state.selected, state.total, state.isLoaded, noAccess, rows.length, Boolean(selectAll)]);
+
+    console.log(tagsFilter, enabledFilters);
+
+    return (
+        <React.Fragment>
+            <PrimaryToolbar
+                pagination={state.isLoaded ? paginationConfig : <Skeleton size={SkeletonSize.lg} /> }
+                filterConfig={
+                    generateFilters(
+                        enabledFilters,
+                        {},
+                        filters,
+                        updateTextFilter,
+                        tagsFilter
+                    )
+                }
+                {...actionsConfig && { actionsConfig }}
+                {...bulkSelect && {
+                    bulkSelect: bulkSelectConfig
+                }}
+                activeFiltersConfig={{
+                    filters: [...generateChips(filters), tagsChip],
+                    onDelete: console.log
+                }}
+            >{children}</PrimaryToolbar>
+            {tagModal && <TagsModal
+                customFilters={state.customFilters}
+                filterTagsBy={filterTagsBy}
+                onApply={(selected) => setSelectedTags(arrayToSelection(selected))}
+                onToggleModal={() => seFilterTagsBy('')}
+            />}
+        </React.Fragment>
+    );
+};
+
+TableToolbar.propTypes = {
+    state: PropTypes.object,
+    paginationConfig: PropTypes.object,
+    actionsConfig: PropTypes.object,
+    dispatch: PropTypes.func,
+    enabledFilters: PropTypes.object,
+    bulkSelect: PropTypes.bool,
+    rows: PropTypes.array,
+    selectAll: PropTypes.func,
+    children: PropTypes.node,
+    noAccess: PropTypes.bool
+};
+
+export default TableToolbar;

--- a/src/components/TableNew/api.js
+++ b/src/components/TableNew/api.js
@@ -1,0 +1,98 @@
+/* eslint-disable camelcase */
+import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
+
+import { generateFilter, mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/helpers';
+import { constructTags, hosts, mapData, mapTags } from '../../api';
+
+export async function getEntities({
+    controller,
+    items,
+    filters,
+    perPage,
+    page,
+    orderBy,
+    orderDirection,
+    fields = { system_profile: ['operating_system'] },
+    tags, // ?
+    filter, // ?
+    showTags
+}) {
+    let data;
+
+    if (items) {
+        data = await hosts.apiHostGetHostById(
+            items,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { cancelToken: controller && controller.token }
+        );
+
+        if (fields && Object.keys(fields).length) {
+            const result = await hosts.apiHostGetHostSystemProfileById(
+                items,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                {
+                    cancelToken: controller && controller.token,
+                    query: generateFilter(fields, 'fields')
+                }
+            );
+
+            data = {
+                ...data,
+                results: mergeArraysByKey([
+                    data?.results,
+                    result?.results || []
+                ], 'id')
+            };
+
+        }
+    } else {
+        data = await hosts.apiHostGetHostList(
+            undefined,
+            undefined,
+            filters.hostnameOrId,
+            undefined,
+            undefined,
+            perPage,
+            page,
+            orderBy,
+            orderDirection,
+            filters.staleFilter,
+            [
+                ...constructTags(filters.tagFilters || []),
+                ...tags || []
+            ],
+            filters.registeredWithFilter,
+            undefined,
+            undefined,
+            {
+                cancelToken: controller && controller.token,
+                query: {
+                    ...(filter && Object.keys(filter).length && generateFilter(filter)),
+                    ...(fields && Object.keys(fields).length && generateFilter(fields, 'fields'))
+                }
+            }
+        );
+    }
+
+    data = showTags ? await mapTags(data, { orderBy, orderDirection }) : data;
+
+    data = {
+        ...data,
+        filters,
+        results: data.results.map(result => mapData({
+            ...result,
+            display_name: result.display_name || result.fqdn || result.id
+        }))
+    };
+
+    return data;
+}

--- a/src/components/TableNew/filters.js
+++ b/src/components/TableNew/filters.js
@@ -1,0 +1,73 @@
+import { registered, REGISTERED_CHIP, staleness, STALE_CHIP, TEXTUAL_CHIP } from '../../Utilities';
+
+const textFilter = (value, onChange) => ({
+    label: 'Name',
+    value: 'name-filter',
+    filterValues: {
+        placeholder: 'Filter by name',
+        value,
+        onChange: (_e, value) => onChange('name', value)
+    }
+});
+
+const textChipFormatter = (value) => ({
+    category: 'Display name',
+    type: TEXTUAL_CHIP,
+    chips: [
+        { name: value }
+    ]
+});
+
+const stalenessFilter = (value, onChange) => ({
+    label: 'Status',
+    value: 'stale-status',
+    type: 'checkbox',
+    filterValues: {
+        value,
+        onChange: (_e, value) => onChange('stale', value),
+        items: staleness
+    }
+});
+
+const stalenessChipFormatter = (stalenessValue) => ({
+    category: 'Status',
+    type: STALE_CHIP,
+    chips: staleness.filter(({ value }) => stalenessValue.includes(value))
+    .map(({ label, ...props }) => ({ name: label, ...props }))
+});
+
+const registeredWithFilter = (value, onChange) => ({
+    label: 'Source',
+    value: 'source-registered-with',
+    type: 'checkbox',
+    filterValues: {
+        value,
+        onChange: (_e, value) => onChange('registeredWith', value),
+        items: registered
+    }
+});
+
+const registeredWithChipFormatter = (registeredWithValue) => ({
+    category: 'Source',
+    type: REGISTERED_CHIP,
+    chips: registered.filter(({ value }) => registeredWithValue.includes(value))
+    .map(({ label, ...props }) => ({ name: label, ...props }))
+});
+
+export const generateFilters = (enabledFilters, customFilters, filter, onChange, tagsFilter) => ({ items: [
+    ...(enabledFilters.name ? [textFilter(filter.name, onChange)] : []),
+    ...(enabledFilters.stale ? [stalenessFilter(filter.stale, onChange)] : []),
+    ...(enabledFilters.registeredWith ? [registeredWithFilter(filter.registeredWith, onChange)] : []),
+    ...(enabledFilters.tags ? [tagsFilter] : [])
+] });
+
+const formatters = {
+    name: textChipFormatter,
+    stale: stalenessChipFormatter,
+    registeredWith: registeredWithChipFormatter
+};
+
+export const generateChips = (filters) => Object.keys(filters).map((filter) =>
+    (filters[filter] && !(Array.isArray(filters[filter]) && filters[filter].length === 0))
+    && formatters[filter](filters[filter]))
+.filter(Boolean);

--- a/src/components/TableNew/helpers.js
+++ b/src/components/TableNew/helpers.js
@@ -1,0 +1,6 @@
+export const getEnabledFilters = (hideFilters = {}) => ({
+    name: !(hideFilters.all && hideFilters.name !== false) && !hideFilters.name,
+    stale: !(hideFilters.all && hideFilters.stale !== false) && !hideFilters.stale,
+    registeredWith: !(hideFilters.all && hideFilters.registeredWith !== false) && !hideFilters.registeredWith,
+    tags: !(hideFilters.all && hideFilters.tags !== false) && !hideFilters.tags
+});

--- a/src/components/TableNew/index.js
+++ b/src/components/TableNew/index.js
@@ -1,0 +1,1 @@
+export { default } from './InventoryTable';

--- a/src/components/TableNew/useCallbackReducer.js
+++ b/src/components/TableNew/useCallbackReducer.js
@@ -1,0 +1,29 @@
+import { useReducer, useRef } from 'react';
+import cloneDeep from 'lodash/cloneDeep';
+
+const useCallbackReducer = (reducer, initialState, initFn) => {
+    const stateRef = useRef(initialState);
+
+    const enhancedReducer = (...args) => {
+        const newState = reducer(...args);
+
+        stateRef.current = newState;
+
+        return newState;
+    };
+
+    const [state, originalDispatch] = useReducer(enhancedReducer, initialState, initFn);
+
+    const enhancedDispatch = async (args, callback) => {
+        if (callback) {
+            await originalDispatch(args);
+            await callback(cloneDeep(stateRef.current));
+        } else {
+            originalDispatch(args);
+        }
+    };
+
+    return [state, enhancedDispatch];
+};
+
+export default useCallbackReducer;

--- a/src/components/TableNew/useColumns.js
+++ b/src/components/TableNew/useColumns.js
@@ -1,0 +1,31 @@
+import { useMemo, useRef } from 'react';
+
+import { defaultColumns } from '../../store/entities';
+
+const useColumns = ({ columns: columnsProp, showTags, disableDefaultColumns, columnsCounter }) => {
+    const columns = useRef([]);
+    useMemo(() => {
+        if (typeof columnsProp === 'function') {
+            columns.current = columnsProp(defaultColumns);
+        } else if (columnsProp) {
+            columns.current = columnsProp;
+        } else {
+            const disabledColumns = Array.isArray(disableDefaultColumns) ? disableDefaultColumns : [];
+            const defaultColumnsFiltered = defaultColumns.filter(({ key }) =>
+                (key === 'tags' && showTags) || (key !== 'tags' && !disabledColumns.includes(key))
+            );
+            columns.current = defaultColumnsFiltered;
+        }
+    }, [
+        showTags,
+        Array.isArray(disableDefaultColumns) ? disableDefaultColumns.join() : disableDefaultColumns,
+        Array.isArray(columnsProp)
+            ? columnsProp.map(({ key }) => key).join()
+            : typeof columnsProp === 'function' ? 'function' : columnsProp,
+        columnsCounter
+    ]);
+
+    return columns;
+};
+
+export default useColumns;

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -178,17 +178,14 @@ const Inventory = ({
                 <Grid gutter="md">
                     <GridItem span={12}>
                         {
-                            !loading && InvCmp && <InvCmp
-                                history={history}
-                                store={store}
+                            !loading && <InvCmp
+                                v2
                                 customFilters={globalFilter}
                                 isFullView
-                                ref={inventory}
                                 showTags
-                                onRefresh={onRefresh}
                                 hasCheckbox={writePermissions}
-                                autoRefresh
-                                initialLoading={initialLoading}
+                                bulkSelect
+                                selectAll={(select) => select(['49467873-b8de-4a8a-a18b-d5f501e88d5c'])}
                                 {...(writePermissions && {
                                     actions: [
                                         {
@@ -220,28 +217,6 @@ const Inventory = ({
                                                 }
                                             }
                                         }]
-                                    },
-                                    bulkSelect: {
-                                        count: calculateSelected(),
-                                        id: 'bulk-select-systems',
-                                        items: [{
-                                            title: 'Select none (0)',
-                                            onClick: () => {
-                                                onSelectRows(-1, false);
-                                            }
-                                        },
-                                        {
-                                            ...loaded && rows && rows.length > 0 ? {
-                                                title: `Select page (${ rows.length })`,
-                                                onClick: () => {
-                                                    onSelectRows(0, true);
-                                                }
-                                            } : {}
-                                        }],
-                                        checked: calculateChecked(rows, selected),
-                                        onSelect: (value) => {
-                                            onSelectRows(0, value);
-                                        }
                                     }
                                 })}
                                 tableProps={{


### PR DESCRIPTION
Port of https://github.com/RedHatInsights/frontend-components/pull/1200

This a draft proposal to introduce version 2 of the inventory table:

- no redux
- simplified data flow
- less props

todo:
- [x] data fetching
    - [x] missing functionality (pagination, sort)
    - [x] custom getEntities
- [ ] filters
  - [x] chips
  - [ ] remove chips
- [ ] custom filters
- [x] children
- [x] bulkSelect
- [ ] tags
- [ ] expanded support