### PR TITLE
Fix Back to previous page button in empty state.

### DIFF
--- a/src/components/InventoryDetail/AppInfo.js
+++ b/src/components/InventoryDetail/AppInfo.js
@@ -15,7 +15,7 @@ const AppInfo = ({ componentMapper, appList }) => {
     const { search } = useLocation();
     const searchParams = new URLSearchParams(search);
     const loaded = useSelector(({ entityDetails }) => entityDetails?.loaded);
-    const entity = useSelector(({ entityDetails }) => entityDetails?. entity);
+    const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
     const activeApp = useSelector(({ entityDetails }) => {
         if (entityDetails?.loaded) {
             return (appList || entityDetails?.activeApps)?.find?.(item => item?.name === (
@@ -24,6 +24,11 @@ const AppInfo = ({ componentMapper, appList }) => {
         }
     });
     const Cmp = componentMapper || activeApp?.component;
+
+    if (loaded === true && !entity) {
+        return null;
+    }
+
     return (
         <Fragment>
             {

--- a/src/components/InventoryDetail/InventoryDetail.js
+++ b/src/components/InventoryDetail/InventoryDetail.js
@@ -91,8 +91,7 @@ InventoryDetail.propTypes = {
 InventoryDetail.defaultProps = {
     actions: [],
     hideInvLink: false,
-    showTags: false,
-    onBackToListClick: () => undefined
+    showTags: false
 };
 
 export default InventoryDetail;

--- a/src/components/InventoryDetail/InventoryDetail.js
+++ b/src/components/InventoryDetail/InventoryDetail.js
@@ -64,7 +64,9 @@ const InventoryDetail = ({
             {children}
         </Fragment>
         }
-        <ApplicationDetails onTabSelect={ onTabSelect } appList={ appList } />
+        {loaded && entity && (
+            <ApplicationDetails onTabSelect={ onTabSelect } appList={ appList } />
+        )}
     </div>;
 };
 

--- a/src/components/InventoryDetail/helpers.js
+++ b/src/components/InventoryDetail/helpers.js
@@ -4,7 +4,10 @@ export const redirectToInventoryList = (id, onBackToListClick) => {
     if (onBackToListClick) {
         onBackToListClick();
     } else {
-        if (document.referrer) {
+        /**
+         * Prevent the case that refferer has the same URL as current browser URL is
+         */
+        if (document.referrer && document.referrer !== `${document.location.origin}${document.location.pathname}`) {
             history.back();
         } else {
             location.href = location.pathname.replace(new RegExp(`${[id]}.*`, 'g'), '');

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect, useSelector, shallowEqual, useStore } from 'react-redux';
+import { useRouteMatch } from 'react-router-dom';
 import './inventory.scss';
 import { Link, useHistory } from 'react-router-dom';
 import { entitesDetailReducer, RegistryContext } from '../store';
@@ -18,12 +19,14 @@ import DetailWrapper from '../modules/DetailWrapper';
 const Inventory = ({ entity, currentApp, clearNotifications }) => {
     const store = useStore();
     const history = useHistory();
+    const { params: { inventoryId } } = useRouteMatch('/:inventoryId');
     const { getRegistry } = useContext(RegistryContext);
     const { loading, writePermissions } = useSelector(
         ({ permissionsReducer }) =>
             ({ loading: permissionsReducer?.loading, writePermissions: permissionsReducer?.writePermissions }),
         shallowEqual
     );
+    const entityLoaded = useSelector(({ entityDetails }) => entityDetails?.loaded);
 
     useEffect(() => {
         insights.chrome?.hideGlobalFilter?.(true);
@@ -71,7 +74,8 @@ const Inventory = ({ entity, currentApp, clearNotifications }) => {
                             {
                                 entity ?
                                     entity.display_name :
-                                    <Skeleton size={SkeletonSize.xs} />
+                                    entityLoaded !== true ?
+                                        <Skeleton size={SkeletonSize.xs} /> : inventoryId
                             }
                         </div>
                     </BreadcrumbItem>


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-12979

### Changes
- remove default prop for `onBackToListClick`
- add an additional check for the back to the previous page to choose the correct URL.

@karelhala I've also noticed that the tabs are still trying to render when the system is not found. As it is passed as a child to the detail wrapper, it should be handled from the parent component. ~~Could you point me in~~ Found it.

### Before

![screenshot-ci cloud redhat com-2021 08 23-12_58_59](https://user-images.githubusercontent.com/22619452/130439418-eedf9670-f296-464c-a2b5-66c89432a0b5.png)


### After
![screenshot-ci foo redhat com_1337-2021 08 23-13_37_39](https://user-images.githubusercontent.com/22619452/130441064-5ce5d546-e543-42ed-a4d1-dfbcba4a6cfd.png)
