### PR TITLE
Use only the latest request to reload state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "insights-inventory-frontend",
       "version": "0.0.1",
       "dependencies": {
         "@patternfly/react-core": "4.135.0",

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -182,7 +182,7 @@ const EntityTableToolbar = ({
         refresh({ page: 1, perPage, filters: newFilters });
     };
 
-    const shouldReload = page && perPage && filters && (!hasItems || items) && loaded;
+    const shouldReload = page && perPage && filters && (!hasItems || items);
 
     useEffect(() => {
         if (shouldReload && showTags && enabledFilters.tags) {

--- a/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
@@ -152,6 +152,10 @@ exports[`InventoryTable should render correctly 1`] = `
       activeFilters={
         Array [
           Object {},
+          Object {
+            "filter": "",
+            "value": "hostname_or_id",
+          },
         ]
       }
       hasItems={false}
@@ -271,6 +275,10 @@ exports[`InventoryTable should render correctly with items 1`] = `
       activeFilters={
         Array [
           Object {},
+          Object {
+            "filter": "",
+            "value": "hostname_or_id",
+          },
         ]
       }
       hasItems={true}
@@ -374,6 +382,10 @@ exports[`InventoryTable should render correctly with items no totla 1`] = `
       activeFilters={
         Array [
           Object {},
+          Object {
+            "filter": "",
+            "value": "hostname_or_id",
+          },
         ]
       }
       hasItems={true}

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -91,7 +91,7 @@ function entitiesPending(state, { meta }) {
         ], 'key'),
         rows: [],
         loaded: false,
-        currentDate: meta.currentDate
+        lastDateRequest: meta.lastDateRequest
     };
 }
 
@@ -105,7 +105,7 @@ function clearFilters(state) {
 // eslint-disable-next-line camelcase
 function entitiesLoaded(state, { payload: { results, per_page: perPage, page, count, total, loaded, filters }, meta }) {
     // Older requests should not rewrite the state
-    if (meta.currentDate < state.currentDate) {
+    if (meta.lastDateRequest < state.lastDateRequest) {
         return state;
     }
 
@@ -223,9 +223,9 @@ export function toggleTagModalReducer(state, { payload: { isOpen } }) {
     };
 }
 
-export function allTags(state, { payload: { results, total, page, per_page: perPage }, meta: { currentDateTags } }) {
+export function allTags(state, { payload: { results, total, page, per_page: perPage }, meta: { lastDateRequestTags } }) {
     // only the latest request can change state
-    if (currentDateTags < state.currentDateTags) {
+    if (lastDateRequestTags < state.lastDateRequestTags) {
         return state;
     }
 
@@ -249,7 +249,7 @@ export function allTags(state, { payload: { results, total, page, per_page: perP
 export default {
     [ACTION_TYPES.ALL_TAGS_FULFILLED]: allTags,
     [ACTION_TYPES.ALL_TAGS_PENDING]: (state, { meta }) => (
-        { ...state, allTagsLoaded: false, tagModalLoaded: false, currentDateTags: meta.currentDateTags }
+        { ...state, allTagsLoaded: false, tagModalLoaded: false, lastDateRequestTags: meta.lastDateRequestTags }
     ),
     [ACTION_TYPES.LOAD_ENTITIES_PENDING]: entitiesPending,
     [ACTION_TYPES.LOAD_ENTITIES_FULFILLED]: entitiesLoaded,

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -223,7 +223,12 @@ export function toggleTagModalReducer(state, { payload: { isOpen } }) {
     };
 }
 
-export function allTags(state, { payload: { results, total, page, per_page: perPage } }) {
+export function allTags(state, { payload: { results, total, page, per_page: perPage }, meta: { currentDateTags } }) {
+    // only the latest request can change state
+    if (currentDateTags < state.currentDateTags) {
+        return state;
+    }
+
     return {
         ...state,
         allTags: Object.entries(groupBy(results, ({ tag: { namespace } }) => namespace)).map(([key, value]) => ({
@@ -243,7 +248,9 @@ export function allTags(state, { payload: { results, total, page, per_page: perP
 
 export default {
     [ACTION_TYPES.ALL_TAGS_FULFILLED]: allTags,
-    [ACTION_TYPES.ALL_TAGS_PENDING]: (state) => ({ ...state, allTagsLoaded: false, tagModalLoaded: false }),
+    [ACTION_TYPES.ALL_TAGS_PENDING]: (state, { meta }) => (
+        { ...state, allTagsLoaded: false, tagModalLoaded: false, currentDateTags: meta.currentDateTags }
+    ),
     [ACTION_TYPES.LOAD_ENTITIES_PENDING]: entitiesPending,
     [ACTION_TYPES.LOAD_ENTITIES_FULFILLED]: entitiesLoaded,
     [ACTION_TYPES.LOAD_ENTITIES_REJECTED]: loadingRejected,

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -90,7 +90,8 @@ function entitiesPending(state, { meta }) {
             state.columns
         ], 'key'),
         rows: [],
-        loaded: false
+        loaded: false,
+        currentDate: meta.currentDate
     };
 }
 
@@ -102,7 +103,12 @@ function clearFilters(state) {
 }
 
 // eslint-disable-next-line camelcase
-function entitiesLoaded(state, { payload: { results, per_page: perPage, page, count, total, loaded, filters } }) {
+function entitiesLoaded(state, { payload: { results, per_page: perPage, page, count, total, loaded, filters }, meta }) {
+    // Older requests should not rewrite the state
+    if (meta.currentDate < state.currentDate) {
+        return state;
+    }
+
     // Data are loaded and APi returned malicious data
     if (loaded === undefined && (page === undefined || perPage === undefined)) {
         return state;

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -46,6 +46,8 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
     const orderBy = config.orderBy || 'updated';
     const orderDirection = config.orderDirection || 'DESC';
 
+    const currentDate = Date.now();
+
     return {
         type: ACTION_TYPES.LOAD_ENTITIES,
         payload: getEntities(itemIds, {
@@ -67,7 +69,8 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
             hideFilters: config.hideFilters
         })),
         meta: {
-            showTags
+            showTags,
+            currentDate
         }
     };
 };

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -46,7 +46,7 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
     const orderBy = config.orderBy || 'updated';
     const orderDirection = config.orderDirection || 'DESC';
 
-    const currentDate = Date.now();
+    const lastDateRequest = Date.now();
 
     return {
         type: ACTION_TYPES.LOAD_ENTITIES,
@@ -70,7 +70,7 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
         })),
         meta: {
             showTags,
-            currentDate
+            lastDateRequest
         }
     };
 };
@@ -174,7 +174,7 @@ export const toggleTagModal = (isOpen) => ({
 export const fetchAllTags = (search, options) => ({
     type: ACTION_TYPES.ALL_TAGS,
     payload: getAllTags(search, options),
-    meta: { currentDateTags: Date.now() }
+    meta: { lastDateRequestTags: Date.now() }
 });
 
 export const deleteEntity = (systems, displayName) => ({

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -173,7 +173,8 @@ export const toggleTagModal = (isOpen) => ({
 
 export const fetchAllTags = (search, options) => ({
     type: ACTION_TYPES.ALL_TAGS,
-    payload: getAllTags(search, options)
+    payload: getAllTags(search, options),
+    meta: { currentDateTags: Date.now() }
 });
 
 export const deleteEntity = (systems, displayName) => ({

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -105,7 +105,11 @@ function entityDeleted(state, { meta }) {
     };
 }
 
-function onEntitiesLoaded(state, { payload }) {
+function onEntitiesLoaded(state, { payload, meta }) {
+    if (meta?.lastDateRequest < state?.lastDateRequest) {
+        return state;
+    }
+
     return {
         ...state,
         rows: mergeArraysByKey([state.rows, payload.results.map(result => {

--- a/src/store/reducers.test.js
+++ b/src/store/reducers.test.js
@@ -1,8 +1,50 @@
+import { INVENTORY_ACTION_TYPES } from './action-types';
 import { tableReducer, entitesDetailReducer } from './reducers';
 
 describe('tableReducer', () => {
     test('should show default state', () => {
         expect(tableReducer(undefined, {})).toMatchObject({ loaded: false });
+    });
+
+    it('by default merges results', () => {
+        expect(
+            tableReducer(
+                {},
+                { type: INVENTORY_ACTION_TYPES.LOAD_ENTITIES_FULFILLED, payload: { results: [{ id: '123' }] } }
+            ))
+        .toEqual(
+            { rows: [{ id: '123', selected: undefined }]  }
+        );
+    });
+
+    it('merges results when the request is newer than state', () => {
+        expect(
+            tableReducer(
+                { lastDateRequest: 1 },
+                {
+                    type: INVENTORY_ACTION_TYPES.LOAD_ENTITIES_FULFILLED,
+                    payload: { results: [{ id: '123' }] },
+                    meta: { lastDateRequest: 1 }
+                }
+            ))
+        .toEqual(
+            { lastDateRequest: 1, rows: [{ id: '123', selected: undefined }] }
+        );
+    });
+
+    it('does not merge results when the request is older than state', () => {
+        expect(
+            tableReducer(
+                { lastDateRequest: 2 },
+                {
+                    type: INVENTORY_ACTION_TYPES.LOAD_ENTITIES_FULFILLED,
+                    payload: { results: [{ id: '123' }] },
+                    meta: { lastDateRequest: 1 }
+                }
+            ))
+        .toEqual(
+            { lastDateRequest: 2 }
+        );
     });
 });
 


### PR DESCRIPTION
When changing filters during loading, filters are not being updated - because useEffect hooks are disabled when `loaded` is false.

I removed this condition and make a new condition in reducer so only the latest request will rewrite the store. This means that there can be multiple requests at the same time, but only the latest will change the state.

**Before** (notice the different total)

![Kapture 2021-09-10 at 11 01 03](https://user-images.githubusercontent.com/32869456/132829017-a8fed50f-92cc-42a8-94df-ebff661a01e9.gif)

**After**

![Kapture 2021-09-10 at 10 59 50](https://user-images.githubusercontent.com/32869456/132828852-8b301d22-783e-4a73-9199-f0df49e20db8.gif)

cc @leSamo
