### PR TITLE
feat(InventoryTable): RHICOMPL-2377 - Add and call getTags for custom tags list

### DIFF
--- a/doc/custom_fetch.md
+++ b/doc/custom_fetch.md
@@ -7,16 +7,26 @@
       - [results](#results)
       - [total](#total)
       - [loaded](#loaded)
-  - [Example](#example)
+    - [Example](#example)
+  - [getTags](#gettags)
 
 # Custom fetch
 
-Inventory components provides a simple way for changing its loading function. This function replaces the internal `getEntities` function and allows customers to handle the whole data loading.
+The InventoryTable component allows replacing the default functions that load entities for the table and tags for the filters with custom async functions to provide results.
 
 ```jsx
+const getEntities = () => {
+  return {...}
+};
+
+const getTags = () => {
+  return {...}
+};
+
 <InventoryTable
     {...otherProps}
     getEntities={getEntities}
+    getTags={getTags}
 />
 ```
 
@@ -116,7 +126,7 @@ Total number of all entities based on the filters.
 
 Set loaded to `false`, when loading was not successful.
 
-## Example
+### Example
 
 ```jsx
 <InventoryTable
@@ -134,3 +144,50 @@ Set loaded to `false`, when loading was not successful.
     }}
 />
 ```
+
+## getTags
+
+```tsx
+getTags = (search: array, config: Config) => result as Result
+```
+
+### search
+
+Search string to filter tags by
+
+### config
+
+See getEntities config.
+
+### result
+
+```js
+{
+  page: 1,
+  per_page: 1,
+  total: 1,
+  results: [
+    {
+      tag: { key: 'XUyiWeFmoF', namespace: 'BDFiKe', value: 'miAOoMthvR' },
+      count: 1,
+    },
+  ],
+}
+```
+
+#### page
+
+Current page to fetch
+
+#### per_page
+
+Tags per page
+
+#### total
+
+Overall count of tags
+
+#### results
+
+An array of objects with a tag object and count.
+

--- a/src/Utilities/TagsModal.js
+++ b/src/Utilities/TagsModal.js
@@ -11,7 +11,8 @@ const TagsModal = ({
     customFilters,
     filterTagsBy,
     onToggleModal,
-    onApply
+    onApply,
+    getTags
 }) => {
     const dispatch = useDispatch();
     const [filterBy, setFilterBy] = useState('');
@@ -61,7 +62,7 @@ const TagsModal = ({
 
     const fetchTags = (pagination, filterBy) => {
         if (!activeSystemTag) {
-            dispatch(fetchAllTags(filterBy, { ...customFilters, pagination, filters }));
+            dispatch(fetchAllTags(filterBy, { ...customFilters, pagination, filters }, getTags));
         } else {
             setStatePagination(() => pagination);
         }
@@ -139,7 +140,8 @@ TagsModal.propTypes = {
             PropTypes.object,
             PropTypes.arrayOf(PropTypes.string)
         ])
-    })
+    }),
+    getTags: PropTypes.func
 };
 
 TagsModal.defaultProps = {

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -49,6 +49,7 @@ const EntityTableToolbar = ({
     actionsConfig,
     activeFiltersConfig,
     showTags,
+    getTags,
     items,
     sortBy,
     customFilters,
@@ -97,7 +98,7 @@ const EntityTableToolbar = ({
             dispatch(fetchAllTags(config, {
                 ...customFilters,
                 ...options
-            }));
+            },  getTags));
         }
     }, 800), [customFilters?.tags]);
 
@@ -108,7 +109,7 @@ const EntityTableToolbar = ({
         if (hasAccess) {
             onRefreshData(options);
             if (showTags && !hasItems) {
-                dispatch(fetchAllTags(filterTagsBy, { ...customFilters, filters: options?.filters || filters }));
+                dispatch(fetchAllTags(filterTagsBy, { ...customFilters, filters: options?.filters || filters }, getTags));
             }
         }
     }, [customFilters?.tags]);
@@ -332,6 +333,7 @@ const EntityTableToolbar = ({
                 filterTagsBy={filterTagsBy}
                 onApply={(selected) => setSelectedTags(arrayToSelection(selected))}
                 onToggleModal={() => seFilterTagsBy('')}
+                getTags={getTags}
             />
         }
     </Fragment>;
@@ -339,6 +341,7 @@ const EntityTableToolbar = ({
 
 EntityTableToolbar.propTypes = {
     showTags: PropTypes.bool,
+    getTags: PropTypes.func,
     hasAccess: PropTypes.bool,
     filterConfig: PrimaryToolbar.propTypes.filterConfig,
     total: PropTypes.number,

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -51,6 +51,7 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
     hasAccess = true,
     isFullView = false,
     getEntities,
+    getTags,
     hideFilters,
     paginationProps,
     errorState = <ErrorState />,
@@ -195,6 +196,7 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
                     page={ pagination.page }
                     perPage={ pagination.perPage }
                     showTags={ showTags }
+                    getTags={ getTags }
                     onRefreshData={onRefreshData}
                     sortBy={ sortBy }
                     hideFilters={hideFilters}
@@ -248,6 +250,7 @@ InventoryTable.propTypes = {
     perPage: PropTypes.number,
     filters: PropTypes.any,
     showTags: PropTypes.bool,
+    getTags: PropTypes.func,
     sortBy: PropTypes.object,
     customFilters: PropTypes.any,
     hasAccess: PropTypes.bool,

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -16,7 +16,7 @@ import {
     getEntities as defaultGetEntities,
     getEntitySystemProfile,
     hosts,
-    getAllTags,
+    getAllTags as defaultGetAllTags,
     getTags,
     filtersReducer
 } from '../api';
@@ -171,9 +171,9 @@ export const toggleTagModal = (isOpen) => ({
     payload: { isOpen }
 });
 
-export const fetchAllTags = (search, options) => ({
+export const fetchAllTags = (search, options, getTags = defaultGetAllTags) => ({
     type: ACTION_TYPES.ALL_TAGS,
-    payload: getAllTags(search, options),
+    payload: getTags(search, options),
     meta: { lastDateRequestTags: Date.now() }
 });
 


### PR DESCRIPTION
A `getTags` prop would allow apps to provide a function to be called in order to query a custom API providing the list of tags.

(See https://github.com/RedHatInsights/compliance-frontend/pull/1415/files#diff-d41389c1e49b96059af8df5c978c229a8cc521008bd0ac86a8f71a43ae620473R203 and below for an example)