### PR TITLE
Fixes for operating_system's display issues

### DIFF
--- a/src/Utilities/OperatingSystemFormatter.js
+++ b/src/Utilities/OperatingSystemFormatter.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const OperatingSystemFormatter = ({ systemProfile }) => {
-    if (systemProfile?.operating_system?.name === 'RHEL') {
-        const version = (systemProfile.operating_system.major && systemProfile.operating_system.minor !== null)
-        && `${systemProfile.operating_system.major}.${systemProfile.operating_system?.minor}` || null;
+const OperatingSystemFormatter = ({ operatingSystem }) => {
+    if (operatingSystem?.name === 'RHEL') {
+        const version = (operatingSystem.major && operatingSystem.minor !== null)
+        && `${operatingSystem.major}.${operatingSystem?.minor}` || null;
 
         return <span>
             RHEL {version}
@@ -12,17 +12,15 @@ const OperatingSystemFormatter = ({ systemProfile }) => {
     }
 
     return <span>
-        {systemProfile?.operating_system?.name || 'Not available'}
+        {operatingSystem?.name || 'Not available'}
     </span>;
 };
 
 OperatingSystemFormatter.propTypes = {
-    systemProfile: PropTypes.shape({
+    operatingSystem: PropTypes.shape({
         name: PropTypes.string,
         major: PropTypes.number,
-        minor: PropTypes.number,
-        // eslint-disable-next-line camelcase
-        operating_system: PropTypes.shape({ name: PropTypes.string, major: PropTypes.number, minor: PropTypes.number })
+        minor: PropTypes.number
     })
 };
 

--- a/src/Utilities/OperatingSystemFormatter.js
+++ b/src/Utilities/OperatingSystemFormatter.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const OperatingSystemFormatter = ({ systemProfile }) => {
     if (systemProfile?.operating_system?.name === 'RHEL') {
-        const version = (systemProfile.operating_system.major && systemProfile.operating_system.minor)
+        const version = (systemProfile.operating_system.major && systemProfile.operating_system.minor !== null)
         && `${systemProfile.operating_system.major}.${systemProfile.operating_system?.minor}` || null;
 
         return <span>

--- a/src/Utilities/OperatingSystemFormatter.test.js
+++ b/src/Utilities/OperatingSystemFormatter.test.js
@@ -35,6 +35,20 @@ describe('OperatingSystemFormatter', () => {
         expect(wrapper.text()).toEqual('RHEL ');
     });
 
+    it('should render correctly with RHEL and minor version set to 0', () => {
+        systemProfile = {
+            operating_system: {
+                name: 'RHEL',
+                major: 7,
+                minor: 0
+            }
+        };
+
+        const wrapper = mount(<OperatingSystemFormatter systemProfile={systemProfile}/>);
+
+        expect(wrapper.text()).toEqual('RHEL 7.0');
+    });
+
     it('should render with different system', () => {
         systemProfile = {
             operating_system: {

--- a/src/Utilities/OperatingSystemFormatter.test.js
+++ b/src/Utilities/OperatingSystemFormatter.test.js
@@ -5,78 +5,68 @@ import { mount } from 'enzyme';
 import OperatingSystemFormatter from './OperatingSystemFormatter';
 
 describe('OperatingSystemFormatter', () => {
-    let systemProfile;
+    let operatingSystem;
 
     it('should render correctly with RHEL and version', () => {
-        systemProfile = {
-            operating_system: {
-                name: 'RHEL',
-                major: 7,
-                minor: 4
-            }
+        operatingSystem = {
+            name: 'RHEL',
+            major: 7,
+            minor: 4
         };
 
-        const wrapper = mount(<OperatingSystemFormatter systemProfile={systemProfile}/>);
+        const wrapper = mount(<OperatingSystemFormatter operatingSystem={operatingSystem}/>);
 
         expect(wrapper.text()).toEqual('RHEL 7.4');
     });
 
     it('should render correctly with RHEL and no version', () => {
-        systemProfile = {
-            operating_system: {
-                name: 'RHEL',
-                major: 7,
-                minor: null
-            }
+        operatingSystem = {
+            name: 'RHEL',
+            major: 7,
+            minor: null
         };
 
-        const wrapper = mount(<OperatingSystemFormatter systemProfile={systemProfile}/>);
+        const wrapper = mount(<OperatingSystemFormatter operatingSystem={operatingSystem}/>);
 
         expect(wrapper.text()).toEqual('RHEL ');
     });
 
     it('should render correctly with RHEL and minor version set to 0', () => {
-        systemProfile = {
-            operating_system: {
-                name: 'RHEL',
-                major: 7,
-                minor: 0
-            }
+        operatingSystem = {
+            name: 'RHEL',
+            major: 7,
+            minor: 0
         };
 
-        const wrapper = mount(<OperatingSystemFormatter systemProfile={systemProfile}/>);
+        const wrapper = mount(<OperatingSystemFormatter operatingSystem={operatingSystem}/>);
 
         expect(wrapper.text()).toEqual('RHEL 7.0');
     });
 
     it('should render with different system', () => {
-        systemProfile = {
-            operating_system: {
-                name: 'Windows'
-            }
+        operatingSystem = {
+            name: 'Windows'
         };
 
-        const wrapper = mount(<OperatingSystemFormatter systemProfile={systemProfile}/>);
+        const wrapper = mount(<OperatingSystemFormatter operatingSystem={operatingSystem}/>);
 
         expect(wrapper.text()).toEqual('Windows');
     });
 
     it('missing name', () => {
-        systemProfile = {
-            operating_system: {
-                name: null
-            }
+        operatingSystem = {
+            name: null
         };
 
-        const wrapper = mount(<OperatingSystemFormatter systemProfile={systemProfile}/>);
+        const wrapper = mount(<OperatingSystemFormatter operatingSystem={operatingSystem}/>);
 
         expect(wrapper.text()).toEqual('Not available');
     });
 
     it('missing operating system', () => {
-        systemProfile = {};
+        operatingSystem = {};
 
-        const wrapper = mount(<OperatingSystemFormatter systemProfile={systemProfile}/>);
+        const wrapper = mount(<OperatingSystemFormatter operatingSystem={operatingSystem}/>);
 
         expect(wrapper.text()).toEqual('Not available');
     });

--- a/src/__mocks__/selectors.js
+++ b/src/__mocks__/selectors.js
@@ -11,7 +11,9 @@ export const testProperties = {
 export const osTest = {
     arch: 'test-arch',
     operating_system: {
-        name: 'test-release'
+        name: 'test-release',
+        major: 1,
+        minor: 0
     },
     os_kernel_version: 'test-kernel',
     last_boot_time: 'test-boot',

--- a/src/__mocks__/selectors.js
+++ b/src/__mocks__/selectors.js
@@ -10,7 +10,9 @@ export const testProperties = {
 
 export const osTest = {
     arch: 'test-arch',
-    os_release: 'test-release',
+    operating_system: {
+        name: 'test-release'
+    },
     os_kernel_version: 'test-kernel',
     last_boot_time: 'test-boot',
     kernel_modules: []

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -306,7 +306,9 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -995,7 +997,9 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -1646,7 +1650,9 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -2307,7 +2313,9 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -3369,7 +3377,9 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -4132,7 +4142,9 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -4828,7 +4840,9 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -5486,7 +5500,9 @@ exports[`GeneralInformation custom components should render custom Configuration
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -6154,7 +6170,9 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -7237,7 +7255,9 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""
@@ -8826,7 +8846,9 @@ exports[`GeneralInformation should render correctly 1`] = `
                 class=""
                 data-pf-content="true"
               >
-                test-release
+                <span>
+                  test-release
+                </span>
               </dd>
               <dt
                 class=""

--- a/src/components/GeneralInfo/OperatingSystemCard/OperatingSystemCard.js
+++ b/src/components/GeneralInfo/OperatingSystemCard/OperatingSystemCard.js
@@ -6,6 +6,7 @@ import { generalMapper } from '../dataMapper';
 import { operatingSystem } from '../selectors';
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import { extraShape, isDate } from '../../../constants';
+import OperatingSystemFormatter from '../../../Utilities/OperatingSystemFormatter';
 
 const OperatingSystemCard = ({
     systemInfo,
@@ -22,7 +23,7 @@ const OperatingSystemCard = ({
         title="Operating system"
         isLoading={ !detailLoaded }
         items={ [
-            ...hasRelease ? [{ title: 'Release', value: systemInfo.release }] : [],
+            ...hasRelease ? [{ title: 'Release', value: <OperatingSystemFormatter operatingSystem={systemInfo.release} /> }] : [],
             ...hasKernelRelease ? [{ title: 'Kernel release', value: systemInfo.kernelRelease }] : [],
             ...hasArchitecture ? [{ title: 'Architecture', value: systemInfo.architecture }] : [],
             ...hasLastBoot ? [{ title: 'Last boot time', value: (isDate(systemInfo.bootTime) ?

--- a/src/components/GeneralInfo/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
+++ b/src/components/GeneralInfo/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
@@ -41,7 +41,9 @@ exports[`OperatingSystemCard should not render hasArchitecture 1`] = `
           class=""
           data-pf-content="true"
         >
-          test-release
+          <span>
+            test-release
+          </span>
         </dd>
         <dt
           class=""
@@ -126,7 +128,9 @@ exports[`OperatingSystemCard should not render hasKernelModules 1`] = `
           class=""
           data-pf-content="true"
         >
-          test-release
+          <span>
+            test-release
+          </span>
         </dd>
         <dt
           class=""
@@ -211,7 +215,9 @@ exports[`OperatingSystemCard should not render hasKernelRelease 1`] = `
           class=""
           data-pf-content="true"
         >
-          test-release
+          <span>
+            test-release
+          </span>
         </dd>
         <dt
           class=""
@@ -296,7 +302,9 @@ exports[`OperatingSystemCard should not render hasLastBoot 1`] = `
           class=""
           data-pf-content="true"
         >
-          test-release
+          <span>
+            test-release
+          </span>
         </dd>
         <dt
           class=""
@@ -583,7 +591,9 @@ exports[`OperatingSystemCard should render correctly with data 1`] = `
           class=""
           data-pf-content="true"
         >
-          test-release
+          <span>
+            test-release
+          </span>
         </dd>
         <dt
           class=""
@@ -680,7 +690,9 @@ exports[`OperatingSystemCard should render correctly with rhsm facts 1`] = `
           class=""
           data-pf-content="true"
         >
-          Not available
+          <span>
+            Not available
+          </span>
         </dd>
         <dt
           class=""
@@ -777,7 +789,9 @@ exports[`OperatingSystemCard should render enabled/disabled 1`] = `
           class=""
           data-pf-content="true"
         >
-          test-release
+          <span>
+            test-release
+          </span>
         </dd>
         <dt
           class=""
@@ -874,7 +888,9 @@ exports[`OperatingSystemCard should render extra 1`] = `
           class=""
           data-pf-content="true"
         >
-          test-release
+          <span>
+            test-release
+          </span>
         </dd>
         <dt
           class=""

--- a/src/components/GeneralInfo/selectors/selectors.js
+++ b/src/components/GeneralInfo/selectors/selectors.js
@@ -39,12 +39,12 @@ export const propertiesSelector = ({
 
 export const operatingSystem = ({
     arch,
-    os_release,
+    operating_system,
     os_kernel_version,
     last_boot_time,
     kernel_modules
 } = {}, { facts } = {}) => ({
-    release: os_release,
+    release: operating_system,
     kernelRelease: os_kernel_version,
     architecture: arch || facts?.rhsm?.ARCHITECTURE,
     bootTime: last_boot_time,

--- a/src/components/GeneralInfo/selectors/selectors.test.js
+++ b/src/components/GeneralInfo/selectors/selectors.test.js
@@ -39,7 +39,9 @@ it('propertiesSelector - no data', () => {
 
 it('operatingSystem should return correct data', () => {
     expect(operatingSystem(osTest)).toEqual({
-        release: 'test-release',
+        release: {
+            name: 'test-release'
+        },
         kernelRelease: 'test-kernel',
         architecture: 'test-arch',
         bootTime: 'test-boot',

--- a/src/components/GeneralInfo/selectors/selectors.test.js
+++ b/src/components/GeneralInfo/selectors/selectors.test.js
@@ -40,7 +40,9 @@ it('propertiesSelector - no data', () => {
 it('operatingSystem should return correct data', () => {
     expect(operatingSystem(osTest)).toEqual({
         release: {
-            name: 'test-release'
+            name: 'test-release',
+            major: 1,
+            minor: 0
         },
         kernelRelease: 'test-kernel',
         architecture: 'test-arch',

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -49,7 +49,7 @@ export const defaultColumns = [
         key: 'system_profile',
         title: <Tooltip content={<span>Operating system</span>}><span>OS</span></Tooltip>,
         // eslint-disable-next-line react/display-name
-        renderFunc: (systemProfile) => <OperatingSystemFormatter systemProfile={systemProfile} />,
+        renderFunc: (systemProfile) => <OperatingSystemFormatter operatingSystem={systemProfile?.operating_system} />,
         props: { width: 10, isStatic: true }
     },
     {


### PR DESCRIPTION
This addresses two issues:

- [ESSNTL-1725](https://issues.redhat.com/browse/ESSNTL-1725): When the operating_system's minor version is set to 0, it won't display "RHEL 8.0", for instance; it will just say "RHEL". That's because the component does not differentiate between falsy values.
- [ESSNTL-1717](https://issues.redhat.com/browse/ESSNTL-1717): The "Release" field on the host detail page uses the deprecated system_profile.os_version field, instead of system_profile.operating_system.

I was going to make separate PRs for these, but they ended up being too tightly coupled. I refactored a bit so that we could reuse `OperatingSystemFormatter`; this added a `<span>` around the Release value, so I had to update the snapshots as well. There isn't isn't a visible change in the formatting, though the Release field now includes the name, e.g. "RHEL 8.0" instead of "8.0". Is that an issue?