### PR TITLE
Fix path to inventory.md doc in inventory_header.md

### DIFF
--- a/doc/inventory_header.md
+++ b/doc/inventory_header.md
@@ -1,5 +1,5 @@
 # Inventory detail
-If you want to learn how to comunicate with inventory check out [Inventory](doc/components/inventory/inventory.md), this documentation is for showing how to include inventory information at top and app info in bottom screen of inventory detail.
+If you want to learn how to comunicate with inventory check out [Inventory](/inventory.md), this documentation is for showing how to include inventory information at top and app info in bottom screen of inventory detail.
 
 ### Usage
 1) Import correct components


### PR DESCRIPTION
The path takes you to a 404 right now. I assume the directory structure used to be different. Updating to take you to what I presume is the correct doc.