### PR TITLE
[WIP] Make inventory table sortable by OS

### DIFF
--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -26,6 +26,11 @@ export const defaultState = {
     tagsLoaded: false,
     allTagsLoaded: false,
     invConfig: {},
+    //TODO: change back
+    // sortBy: {
+    //     key: 'updated',
+    //     direction: 'desc'
+    // }
     sortBy: {
         key: 'updated',
         direction: 'desc'
@@ -50,7 +55,7 @@ export const defaultColumns = [
         title: <Tooltip content={<span>Operating system</span>}><span>OS</span></Tooltip>,
         // eslint-disable-next-line react/display-name
         renderFunc: (systemProfile) => <OperatingSystemFormatter operatingSystem={systemProfile?.operating_system} />,
-        props: { width: 10, isStatic: true }
+        props: { width: 10 }
     },
     {
         key: 'updated',


### PR DESCRIPTION
Resolves [this Jira](https://issues.redhat.com/browse/ESSNTL-1441) feature request.

Simply makes the table orderable/sortable by the OS column the same way that `hostname` and `updated` are now.

![sortable_by_os_not_selected](https://user-images.githubusercontent.com/26419550/149539536-a9087600-0dc8-4475-b2de-5b0ab1be807f.png)

Here is an example of the generated query

Right now this change is blocked on [ESSNTL-1879](https://issues.redhat.com/browse/ESSNTL-1879). There is a bug in the `/hosts/{host_id_list}` endpoint that makes it return a `400` when ordered by `operating_system`.