### PR TITLE
ESSNTL-8: ability to filter w/o Insights (needs test)

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -11,11 +11,10 @@ export const staleness = [
     { label: 'Stale', value: 'stale' },
     { label: 'Stale warning', value: 'stale_warning' }
 ];
-export const registered = [{ label: 'Insights', value: 'insights' }];
+export const registered = [{ label: 'Insights', value: 'insights' }, { label: 'Insights not connected', value: 'nil' }];
 export const InventoryContext = createContext({});
 export const defaultFilters = {
-    staleFilter: ['fresh', 'stale'],
-    registeredWithFilter: ['insights']
+    staleFilter: ['fresh', 'stale']
 };
 
 export const operatingSystems = [

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -61,6 +61,26 @@ export const constructTags = (tagFilters) => {
     ) || '';
 };
 
+export const calculateSystemProfile = (osFilter, nonInsights) => {
+    let systemProfile = {};
+
+    if (osFilter?.length > 0) {
+        systemProfile.operating_system = {
+            RHEL: {
+                version: {
+                    eq: osFilter
+                }
+            }
+        };
+    }
+
+    if (nonInsights) {
+        systemProfile.insights_client_version = 'nil';
+    }
+
+    return generateFilter({ system_profile: systemProfile });
+};
+
 export const filtersReducer = (acc, filter = {}) => ({
     ...acc,
     ...filter.value === 'hostname_or_id' && { hostnameOrId: filter.filter },
@@ -133,6 +153,9 @@ export async function getEntities(items, {
 
         return data;
     } else if (!hasItems) {
+        const insightsConnectedFilter = filters?.registeredWithFilter.filter(filter => filter !== 'nil');
+        const hasNonInsightHostFilter = filters?.registeredWithFilter.filter(filter => filter === 'nil').length > 0;
+
         return hosts.apiHostGetHostList(
             undefined,
             undefined,
@@ -148,23 +171,14 @@ export async function getEntities(items, {
                 ...constructTags(filters.tagFilters),
                 ...options.tags || []
             ],
-            filters.registeredWithFilter,
+            insightsConnectedFilter,
             undefined,
             undefined,
             {
                 cancelToken: controller && controller.token,
                 query: {
                     ...(options.filter && Object.keys(options.filter).length && generateFilter(options.filter)),
-                    ...(filters.osFilter?.length > 0 && generateFilter({ system_profile: {
-                        operating_system: {
-                            RHEL: {
-                                version: {
-                                    eq: filters.osFilter
-                                }
-                            }
-                        }
-                    } }
-                    )),
+                    ...(calculateSystemProfile(filters.osFilter, hasNonInsightHostFilter)),
                     ...(fields && Object.keys(fields).length && generateFilter(fields, 'fields'))
                 }
             }
@@ -205,6 +219,9 @@ export function getAllTags(search, { filters, pagination, ...options } = { pagin
         registeredWithFilter,
         osFilter
     } = filters ? filters.reduce(filtersReducer, defaultFilters) : defaultFilters;
+    const insightsConnectedFilter = registeredWithFilter?.filter(filter => filter !== 'nil');
+    const hasNonInsightHostFilter = registeredWithFilter?.filter(filter => filter === 'nil').length > 0;
+
     return tags.apiTagGetTags(
         [
             ...tagFilters ? constructTags(tagFilters) : [],
@@ -216,20 +233,11 @@ export function getAllTags(search, { filters, pagination, ...options } = { pagin
         (pagination && pagination.page) || 1,
         staleFilter,
         search,
-        registeredWithFilter,
+        insightsConnectedFilter,
         undefined,
         {
             query: {
-                ...(osFilter?.length > 0 && generateFilter({ system_profile: {
-                    operating_system: {
-                        RHEL: {
-                            version: {
-                                eq: osFilter
-                            }
-                        }
-                    }
-                } }
-                ))
+                ...(calculateSystemProfile(osFilter, hasNonInsightHostFilter))
             }
         }
     );

--- a/src/api/tagsApi.test.js
+++ b/src/api/tagsApi.test.js
@@ -4,7 +4,7 @@ import MockAdapter from 'axios-mock-adapter';
 describe('getAllTags', () => {
     const mockedTags = new MockAdapter(tags.axios);
     it('should generate get all tags call', async () => {
-        const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&registered_with=insights';
+        const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale';
         mockedTags.onGet(
             `/api/inventory/v1/tags${params}`
         ).replyOnce(200, { test: 'test' });
@@ -14,7 +14,7 @@ describe('getAllTags', () => {
 
     it('should generate get all tags call with search', async () => {
         // eslint-disable-next-line max-len
-        const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&search=something&registered_with=insights';
+        const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&search=something';
         mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
         const data = await getAllTags('something');
         expect(data).toMatchObject({ test: 'test' });
@@ -23,7 +23,7 @@ describe('getAllTags', () => {
     describe('tagFilters', () => {
         it('should generate get all tags call with tagFilters', async () => {
             // eslint-disable-next-line max-len
-            const params = '?tags=namespace%2Fsome%20key%3Dsome%20value&tags=some%20key&order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&registered_with=insights';
+            const params = '?tags=namespace%2Fsome%20key%3Dsome%20value&tags=some%20key&order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale';
             mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
             const data = await getAllTags(undefined, {
                 filters: [{
@@ -47,7 +47,7 @@ describe('getAllTags', () => {
         });
 
         it('should generate get all tags call with staleFilter', async () => {
-            const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=something&registered_with=insights';
+            const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=something';
             mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
             const data = await getAllTags(undefined, {
                 filters: [{
@@ -59,8 +59,8 @@ describe('getAllTags', () => {
 
         it('should generate get all tags call with osFilter', async () => {
             mockedTags.resetHistory();
-            const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&registered_with='
-            + 'insights&filter%5Bsystem_profile%5D%5Boperating_system%5D%5BRHEL%5D%5Bversion%5D%5Beq%5D=something';
+            const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&'
+            + 'filter%5Bsystem_profile%5D%5Boperating_system%5D%5BRHEL%5D%5Bversion%5D%5Beq%5D=something';
             mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
             const data = await getAllTags(undefined, {
                 filters: [{
@@ -86,7 +86,7 @@ describe('getAllTags', () => {
     describe('pagination', () => {
         it('should generate get all tags call with perPage', async () => {
             // eslint-disable-next-line max-len
-            const params = '?order_by=tag&order_how=ASC&per_page=50&page=1&staleness=fresh&staleness=stale&registered_with=insights';
+            const params = '?order_by=tag&order_how=ASC&per_page=50&page=1&staleness=fresh&staleness=stale';
             mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
             const data = await getAllTags(undefined, {
                 pagination: {
@@ -98,7 +98,7 @@ describe('getAllTags', () => {
 
         it('should generate get all tags call with page', async () => {
             // eslint-disable-next-line max-len
-            const params = '?order_by=tag&order_how=ASC&per_page=10&page=20&staleness=fresh&staleness=stale&registered_with=insights';
+            const params = '?order_by=tag&order_how=ASC&per_page=10&page=20&staleness=fresh&staleness=stale';
             mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
             const data = await getAllTags(undefined, {
                 pagination: {

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -229,7 +229,7 @@ describe('EntityTableToolbar', () => {
                 });
                 wrapper.update();
                 expect(onRefreshData).toHaveBeenCalledWith(
-                    { filters: [{}, { filter: '', value: 'hostname_or_id' }, { registeredWithFilter: [] }], page: 1, perPage: 50 }
+                    { filters: [{}, { filter: '', value: 'hostname_or_id' }, { staleFilter: [] }], page: 1, perPage: 50 }
                 );
             });
 

--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -20,16 +20,6 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
           ],
           "type": "staleness",
         },
-        Object {
-          "category": "Source",
-          "chips": Array [
-            Object {
-              "name": "Insights",
-              "value": "insights",
-            },
-          ],
-          "type": "registered_with",
-        },
       ],
       "onDelete": [Function],
     }
@@ -214,12 +204,14 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
                 "label": "Insights",
                 "value": "insights",
               },
+              Object {
+                "label": "Insights not connected",
+                "value": "nil",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by source",
-            "value": Array [
-              "insights",
-            ],
+            "value": undefined,
           },
           "label": "Source",
           "type": "checkbox",
@@ -257,16 +249,6 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
           ],
           "type": "staleness",
         },
-        Object {
-          "category": "Source",
-          "chips": Array [
-            Object {
-              "name": "Insights",
-              "value": "insights",
-            },
-          ],
-          "type": "registered_with",
-        },
       ],
       "onDelete": [Function],
     }
@@ -451,12 +433,14 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
                 "label": "Insights",
                 "value": "insights",
               },
+              Object {
+                "label": "Insights not connected",
+                "value": "nil",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by source",
-            "value": Array [
-              "insights",
-            ],
+            "value": undefined,
           },
           "label": "Source",
           "type": "checkbox",
@@ -497,16 +481,6 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
             },
           ],
           "type": "staleness",
-        },
-        Object {
-          "category": "Source",
-          "chips": Array [
-            Object {
-              "name": "Insights",
-              "value": "insights",
-            },
-          ],
-          "type": "registered_with",
         },
         Object {
           "category": "Some",
@@ -703,12 +677,14 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
                 "label": "Insights",
                 "value": "insights",
               },
+              Object {
+                "label": "Insights not connected",
+                "value": "nil",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by source",
-            "value": Array [
-              "insights",
-            ],
+            "value": undefined,
           },
           "label": "Source",
           "type": "checkbox",
@@ -780,16 +756,6 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
           ],
           "type": "staleness",
         },
-        Object {
-          "category": "Source",
-          "chips": Array [
-            Object {
-              "name": "Insights",
-              "value": "insights",
-            },
-          ],
-          "type": "registered_with",
-        },
       ],
       "onDelete": [Function],
     }
@@ -974,12 +940,14 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
                 "label": "Insights",
                 "value": "insights",
               },
+              Object {
+                "label": "Insights not connected",
+                "value": "nil",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by source",
-            "value": Array [
-              "insights",
-            ],
+            "value": undefined,
           },
           "label": "Source",
           "type": "checkbox",
@@ -1024,16 +992,6 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
           ],
           "type": "staleness",
         },
-        Object {
-          "category": "Source",
-          "chips": Array [
-            Object {
-              "name": "Insights",
-              "value": "insights",
-            },
-          ],
-          "type": "registered_with",
-        },
       ],
       "onDelete": [Function],
     }
@@ -1217,12 +1175,14 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
                 "label": "Insights",
                 "value": "insights",
               },
+              Object {
+                "label": "Insights not connected",
+                "value": "nil",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by source",
-            "value": Array [
-              "insights",
-            ],
+            "value": undefined,
           },
           "label": "Source",
           "type": "checkbox",
@@ -1263,16 +1223,6 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
             },
           ],
           "type": "staleness",
-        },
-        Object {
-          "category": "Source",
-          "chips": Array [
-            Object {
-              "name": "Insights",
-              "value": "insights",
-            },
-          ],
-          "type": "registered_with",
         },
       ],
       "onDelete": [Function],
@@ -1458,12 +1408,14 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
                 "label": "Insights",
                 "value": "insights",
               },
+              Object {
+                "label": "Insights not connected",
+                "value": "nil",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by source",
-            "value": Array [
-              "insights",
-            ],
+            "value": undefined,
           },
           "label": "Source",
           "type": "checkbox",
@@ -1691,12 +1643,14 @@ exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
                 "label": "Insights",
                 "value": "insights",
               },
+              Object {
+                "label": "Insights not connected",
+                "value": "nil",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by source",
-            "value": Array [
-              "insights",
-            ],
+            "value": undefined,
           },
           "label": "Source",
           "type": "checkbox",
@@ -1745,16 +1699,6 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
             },
           ],
           "type": "staleness",
-        },
-        Object {
-          "category": "Source",
-          "chips": Array [
-            Object {
-              "name": "Insights",
-              "value": "insights",
-            },
-          ],
-          "type": "registered_with",
         },
       ],
       "onDelete": [Function],
@@ -1940,12 +1884,14 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
                 "label": "Insights",
                 "value": "insights",
               },
+              Object {
+                "label": "Insights not connected",
+                "value": "nil",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by source",
-            "value": Array [
-              "insights",
-            ],
+            "value": undefined,
           },
           "label": "Source",
           "type": "checkbox",
@@ -2025,16 +1971,6 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
           ],
           "type": "staleness",
         },
-        Object {
-          "category": "Source",
-          "chips": Array [
-            Object {
-              "name": "Insights",
-              "value": "insights",
-            },
-          ],
-          "type": "registered_with",
-        },
       ],
       "onDelete": [Function],
     }
@@ -2219,12 +2155,14 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
                 "label": "Insights",
                 "value": "insights",
               },
+              Object {
+                "label": "Insights not connected",
+                "value": "nil",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by source",
-            "value": Array [
-              "insights",
-            ],
+            "value": undefined,
           },
           "label": "Source",
           "type": "checkbox",

--- a/src/components/filters/useRegisteredWithFilter.test.js
+++ b/src/components/filters/useRegisteredWithFilter.test.js
@@ -26,7 +26,10 @@ describe('useRegisteredWithFilter', () => {
                 type: 'checkbox'
             });
             expect(filter.filterValues.value.length).toBe(0);
-            expect(filter.filterValues.items).toMatchObject([{ label: 'Insights', value: 'insights' }]);
+            expect(filter.filterValues.items).toMatchObject([
+                { label: 'Insights', value: 'insights' },
+                { label: 'Insights not connected', value: 'nil' }
+            ]);
         };
 
         mount(<HookRender hookAccessor={hookAccessor} />);


### PR DESCRIPTION
This PR is intented to enable filtering hosts withour insights client  connection. 
To test locally:

1. Open inventory list table.
2. Use filters dropdown and click on 'Source' filter and choose 'Insights not connected.
3. You should expect that the table is not broke.

There is a bug in the APi thus the request is not getting correct result. The Inventory engine team told me that I can make a request with the syntax: `api/inventory/v1/hosts?filter[system_profile][insights_client_version]=nil` and they will fix the bug . So the improtant thing to test is that the request syntax is correct.