### PR TITLE
fix(ESSNTL-2194) Use compact table

### DIFF
--- a/src/components/InventoryTable/EntityTable.js
+++ b/src/components/InventoryTable/EntityTable.js
@@ -7,7 +7,8 @@ import {
     Table as PfTable,
     TableBody,
     TableHeader,
-    TableGridBreakpoint
+    TableGridBreakpoint,
+    TableVariant
 } from '@patternfly/react-table';
 import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/helpers/helpers';
 import { SkeletonTable } from '@redhat-cloud-services/frontend-components/SkeletonTable';
@@ -199,6 +200,7 @@ EntityTable.defaultProps = {
     hasCheckbox: true,
     showActions: false,
     rows: [],
+    variant: TableVariant.compact,
     onExpandClick: () => undefined,
     tableProps: {}
 };

--- a/src/components/InventoryTable/InventoryList.scss
+++ b/src/components/InventoryTable/InventoryList.scss
@@ -68,6 +68,9 @@
 }
 
 .ins-c-entity-table.pf-c-table {
+    td {
+        vertical-align: middle;
+    }
 
     .pf-c-table__check input { cursor: pointer; }
     .ins-health-status div {

--- a/src/components/InventoryTable/__snapshots__/EntityTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTable.test.js.snap
@@ -216,7 +216,7 @@ exports[`EntityTable DOM should render correctly - grid breakpoints 1`] = `
       "index": 0,
     }
   }
-  variant={null}
+  variant="compact"
 />
 `;
 
@@ -296,7 +296,7 @@ exports[`EntityTable DOM should render correctly - is expandable 1`] = `
       "index": 1,
     }
   }
-  variant={null}
+  variant="compact"
 />
 `;
 
@@ -311,13 +311,14 @@ exports[`EntityTable DOM should render correctly - no data 1`] = `
   showActions={false}
   showHealth={false}
   tableProps={Object {}}
+  variant="compact"
 />
 `;
 
 exports[`EntityTable DOM should render correctly - no rows 1`] = `
 <table
   aria-label="Host inventory"
-  class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-sticky-header"
+  class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
   data-ouia-component-id="OUIA-Generated-Table-4"
   data-ouia-component-type="PF4/Table"
   data-ouia-safe="true"
@@ -458,14 +459,14 @@ exports[`EntityTable DOM should render correctly - with actions 1`] = `
       "index": 0,
     }
   }
-  variant={null}
+  variant="compact"
 />
 `;
 
 exports[`EntityTable DOM should render correctly - with customNoSystemsTable 1`] = `
 <table
   aria-label="Host inventory"
-  class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-sticky-header"
+  class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
   data-ouia-component-id="OUIA-Generated-Table-6"
   data-ouia-component-type="PF4/Table"
   data-ouia-safe="true"
@@ -586,14 +587,14 @@ exports[`EntityTable DOM should render correctly - without checkbox 1`] = `
       "index": -1,
     }
   }
-  variant={null}
+  variant="compact"
 />
 `;
 
 exports[`EntityTable DOM should render correctly 1`] = `
 <table
   aria-label="Host inventory"
-  class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-sticky-header"
+  class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
   data-ouia-component-id="OUIA-Generated-Table-26"
   data-ouia-component-type="PF4/Table"
   data-ouia-safe="true"
@@ -784,7 +785,7 @@ exports[`EntityTable DOM sort by should render correctly - is expandable 1`] = `
       "index": 2,
     }
   }
-  variant={null}
+  variant="compact"
 />
 `;
 
@@ -860,7 +861,7 @@ exports[`EntityTable DOM sort by should render correctly - without checkbox 1`] 
       "index": 0,
     }
   }
-  variant={null}
+  variant="compact"
 />
 `;
 
@@ -937,6 +938,6 @@ exports[`EntityTable DOM sort by should render correctly 1`] = `
       "index": 1,
     }
   }
-  variant={null}
+  variant="compact"
 />
 `;

--- a/src/components/InventoryTable/__snapshots__/InventoryList.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/InventoryList.test.js.snap
@@ -54,7 +54,7 @@ exports[`InventoryList should render correctly 1`] = `
   >
     <table
       aria-label="Host inventory"
-      class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-sticky-header"
+      class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
       data-ouia-component-id="OUIA-Generated-Table-2"
       data-ouia-component-type="PF4/Table"
       data-ouia-safe="true"


### PR DESCRIPTION
Request was to change the table to compact version. I've centered the content as well.

In my opinion the name should be a bit smaller maybe md or even sm. Open for changes.

Before:
![image](https://user-images.githubusercontent.com/20592948/157480017-e0482239-79c7-461a-be41-e548d05234d2.png)

After:
![image](https://user-images.githubusercontent.com/20592948/157479858-b566d87d-d0c0-466f-9a88-05e02520d937.png)
