### PR TITLE
Remove "RHEL machine id" from collection card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4441,7 +4441,7 @@
     },
     "discontinuous-range": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
       "dev": true
     },
@@ -6544,7 +6544,7 @@
     },
     "is-subset": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/is-subset/-/is-subset-0.1.1.tgz",
       "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
@@ -8234,7 +8234,7 @@
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
@@ -9924,13 +9924,13 @@
     },
     "railroad-diagrams": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
       "dev": true
     },
     "randexp": {
       "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/randexp/-/randexp-0.4.6.tgz",
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "dev": true,
       "requires": {
@@ -10473,7 +10473,7 @@
     },
     "rst-selector-parser": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "resolved": "https://insights:d985c03594f5f476782b0eb66d7458cd@insights-npm-cache-nginx-insights-npm-cache.1b13.insights.openshiftapps.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
       "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
       "dev": true,
       "requires": {

--- a/src/components/GeneralInfo/CollectionCard/CollectionCard.js
+++ b/src/components/GeneralInfo/CollectionCard/CollectionCard.js
@@ -38,7 +38,6 @@ const CollectionCard = ({
     hasRegistered,
     hasInsightsId,
     hasReporter,
-    hasMachineId,
     extra
 }) => (<LoadingCard
     title="Collection information"
@@ -60,7 +59,6 @@ const CollectionCard = ({
         ) }] : [],
         ...hasInsightsId ? [{ title: 'Insights id', value: entity && entity.insights_id }] : [],
         ...hasReporter ? [{ title: 'Reporter', value: entity && entity.reporter }] : [],
-        ...hasMachineId ? [{ title: 'RHEL machine id', value: entity && entity.rhel_machine_id }] : [],
         ...extra.map(({ onClick, ...item }) => ({
             ...item,
             ...onClick && { onClick: (e) => onClick(e, handleClick) }
@@ -74,8 +72,7 @@ CollectionCard.propTypes = {
         updated: PropTypes.string,
         created: PropTypes.string,
         insights_id: PropTypes.string,
-        reporter: PropTypes.string,
-        rhel_machine_id: PropTypes.string
+        reporter: PropTypes.string
     }),
     handleClick: PropTypes.func,
     collectionInformation: PropTypes.shape({
@@ -87,7 +84,6 @@ CollectionCard.propTypes = {
     hasRegistered: PropTypes.bool,
     hasInsightsId: PropTypes.bool,
     hasReporter: PropTypes.bool,
-    hasMachineId: PropTypes.bool,
     extra: PropTypes.arrayOf(extraShape)
 };
 CollectionCard.defaultProps = {
@@ -99,7 +95,6 @@ CollectionCard.defaultProps = {
     hasRegistered: true,
     hasInsightsId: true,
     hasReporter: true,
-    hasMachineId: true,
     extra: []
 };
 

--- a/src/components/GeneralInfo/CollectionCard/CollectionCard.test.js
+++ b/src/components/GeneralInfo/CollectionCard/CollectionCard.test.js
@@ -58,8 +58,7 @@ describe('CollectionCard', () => {
         'hasLastCheckIn',
         'hasRegistered',
         'hasInsightsId',
-        'hasReporter',
-        'hasMachineId'
+        'hasReporter'
     ].map((item) => it(`should not render ${item}`, () => {
         const store = mockStore(initialState);
         const wrapper = render(<CollectionCard store={ store } {...{ [item]: false }} />);

--- a/src/components/GeneralInfo/CollectionCard/__snapshots__/CollectionCard.test.js.snap
+++ b/src/components/GeneralInfo/CollectionCard/__snapshots__/CollectionCard.test.js.snap
@@ -79,18 +79,6 @@ exports[`CollectionCard should not render hasClient 1`] = `
         >
           Not available
         </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RHEL machine id
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
       </dl>
     </div>
   </div>
@@ -178,18 +166,6 @@ exports[`CollectionCard should not render hasInsightsId 1`] = `
         >
           Not available
         </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RHEL machine id
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
       </dl>
     </div>
   </div>
@@ -240,117 +216,6 @@ exports[`CollectionCard should not render hasLastCheckIn 1`] = `
           <span>
             test-client
           </span>
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          Registered
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          01 Apr 2014
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          Insights id
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          Reporter
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RHEL machine id
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
-      </dl>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`CollectionCard should not render hasMachineId 1`] = `
-<div
-  class="pf-l-stack pf-m-gutter"
->
-  <div
-    class="pf-l-stack__item"
-  >
-    <div
-      class="pf-c-content"
-    >
-      <h1
-        class=""
-        data-ouia-component-id="OUIA-Generated-Text-9"
-        data-ouia-component-type="PF4/Text"
-        data-ouia-safe="true"
-        data-pf-content="true"
-      >
-        Collection information
-      </h1>
-    </div>
-  </div>
-  <div
-    class="pf-l-stack__item pf-m-fill"
-  >
-    <div
-      class="pf-c-content"
-    >
-      <dl
-        class=""
-        data-pf-content="true"
-      >
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          Insights client
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          <span>
-            test-client
-          </span>
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          Last check-in
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          01 Jun 2014
         </dd>
         <dt
           class=""
@@ -475,18 +340,6 @@ exports[`CollectionCard should not render hasRegistered 1`] = `
         >
           Not available
         </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RHEL machine id
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
       </dl>
     </div>
   </div>
@@ -567,18 +420,6 @@ exports[`CollectionCard should not render hasReporter 1`] = `
           data-pf-content="true"
         >
           Insights id
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RHEL machine id
         </dt>
         <dd
           class=""
@@ -713,24 +554,6 @@ exports[`CollectionCard should render correctly - no data 1`] = `
             />
           </div>
         </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RHEL machine id
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          <div
-            class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
-          >
-            <span
-              class="pf-u-screen-reader"
-            />
-          </div>
-        </dd>
       </dl>
     </div>
   </div>
@@ -830,18 +653,6 @@ exports[`CollectionCard should render correctly with data 1`] = `
         >
           Not available
         </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RHEL machine id
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
       </dl>
     </div>
   </div>
@@ -860,7 +671,7 @@ exports[`CollectionCard should render extra 1`] = `
     >
       <h1
         class=""
-        data-ouia-component-id="OUIA-Generated-Text-10"
+        data-ouia-component-id="OUIA-Generated-Text-9"
         data-ouia-component-type="PF4/Text"
         data-ouia-safe="true"
         data-pf-content="true"
@@ -934,18 +745,6 @@ exports[`CollectionCard should render extra 1`] = `
           data-pf-content="true"
         >
           Reporter
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RHEL machine id
         </dt>
         <dd
           class=""

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -670,18 +670,6 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
               >
                 Not available
               </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
             </dl>
           </div>
         </div>
@@ -1986,18 +1974,6 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
               >
                 Not available
               </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
             </dl>
           </div>
         </div>
@@ -2634,18 +2610,6 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                 data-pf-content="true"
               >
                 Reporter
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
               </dt>
               <dd
                 class=""
@@ -3306,18 +3270,6 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
               >
                 Not available
               </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
             </dl>
           </div>
         </div>
@@ -3808,18 +3760,6 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                 data-pf-content="true"
               >
                 Reporter
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
               </dt>
               <dd
                 class=""
@@ -4506,18 +4446,6 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                 data-pf-content="true"
               >
                 Reporter
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
               </dt>
               <dd
                 class=""
@@ -5843,18 +5771,6 @@ exports[`GeneralInformation custom components should render custom Configuration
               >
                 Not available
               </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
             </dl>
           </div>
         </div>
@@ -6498,18 +6414,6 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                 data-pf-content="true"
               >
                 Reporter
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
               </dt>
               <dd
                 class=""
@@ -7177,18 +7081,6 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
               >
                 Not available
               </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
             </dl>
           </div>
         </div>
@@ -7686,18 +7578,6 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                 data-pf-content="true"
               >
                 Reporter
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
               </dt>
               <dd
                 class=""
@@ -8577,24 +8457,6 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                   />
                 </div>
               </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                <div
-                  class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
-                >
-                  <span
-                    class="pf-u-screen-reader"
-                  />
-                </div>
-              </dd>
             </dl>
           </div>
         </div>
@@ -9341,18 +9203,6 @@ exports[`GeneralInformation should render correctly 1`] = `
                 data-pf-content="true"
               >
                 Reporter
-              </dt>
-              <dd
-                class=""
-                data-pf-content="true"
-              >
-                Not available
-              </dd>
-              <dt
-                class=""
-                data-pf-content="true"
-              >
-                RHEL machine id
               </dt>
               <dd
                 class=""

--- a/src/routes/InventoryTable.test.js
+++ b/src/routes/InventoryTable.test.js
@@ -31,7 +31,6 @@ describe('InventoryTable', () => {
         mac_addresses: ['fa:16:3e:72:a6:99', '00:00:00:00:00:00'],
         rawFacts: [],
         reporter: 'puptoo',
-        rhel_machine_id: null,
         satellite_id: null,
         stale_timestamp: '2020-10-28T12:07:14.263615+00:00',
         stale_warning_timestamp: '2020-11-04T12:07:14.263615+00:00',


### PR DESCRIPTION
This PR addresses [ESSNTL-1996](https://issues.redhat.com/browse/ESSNTL-1996).
Basically, "RHEL machine id" maps to the "rhel_machine_id" field on host records; that field no longer exists, and is not returned by the API, so this removes it from the UI.

