### PR TITLE
chore: handle undefined registeredWithFilter

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -153,8 +153,8 @@ export async function getEntities(items, {
 
         return data;
     } else if (!hasItems) {
-        const insightsConnectedFilter = filters?.registeredWithFilter.filter(filter => filter !== 'nil');
-        const hasNonInsightHostFilter = filters?.registeredWithFilter.filter(filter => filter === 'nil').length > 0;
+        const insightsConnectedFilter = filters?.registeredWithFilter?.filter(filter => filter !== 'nil');
+        const hasNonInsightHostFilter = filters?.registeredWithFilter?.filter(filter => filter === 'nil').length > 0;
 
         return hosts.apiHostGetHostList(
             undefined,


### PR DESCRIPTION
Intended to fix `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'filter')` error in Drift app.