### PR TITLE
Rename Source filter; add data collector options

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -12,8 +12,8 @@ export const staleness = [
     { label: 'Stale warning', value: 'stale_warning' }
 ];
 export const registered = [
-    { label: 'Insights-client', value: 'puptoo' },
-    { label: 'Subscription-manager', value: 'rhsm-conduit' },
+    { label: 'insights-client', value: 'puptoo' },
+    { label: 'subscription-manager', value: 'rhsm-conduit' },
     { label: 'Satellite/Discovery', value: 'yupana' },
     { label: 'Insights not connected', value: 'nil' }
 ];

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -11,7 +11,12 @@ export const staleness = [
     { label: 'Stale', value: 'stale' },
     { label: 'Stale warning', value: 'stale_warning' }
 ];
-export const registered = [{ label: 'Insights', value: 'insights' }, { label: 'Insights not connected', value: 'nil' }];
+export const registered = [
+    { label: 'Insights-client', value: 'puptoo' },
+    { label: 'Subscription-manager', value: 'rhsm-conduit' },
+    { label: 'Satellite/Discovery', value: 'yupana' },
+    { label: 'Insights not connected', value: 'nil' }
+];
 export const InventoryContext = createContext({});
 export const defaultFilters = {
     staleFilter: ['fresh', 'stale']

--- a/src/components/InventoryDetail/InsightsPrompt.js
+++ b/src/components/InventoryDetail/InsightsPrompt.js
@@ -5,7 +5,7 @@ import {
 
 const InsightsPrompt = () => {
     return (
-        <Alert variant="info" isInline title="Your insights-client is not repotring">
+        <Alert variant="info" isInline title="Your insights-client is not reporting">
             <Grid>
                 <GridItem>
                     <Grid hasGutter>

--- a/src/components/InventoryDetail/InsightsPrompt.js
+++ b/src/components/InventoryDetail/InsightsPrompt.js
@@ -5,7 +5,7 @@ import {
 
 const InsightsPrompt = () => {
     return (
-        <Alert variant="info" isInline title="Your Insights-client is not repotring">
+        <Alert variant="info" isInline title="Your insights-client is not repotring">
             <Grid>
                 <GridItem>
                     <Grid hasGutter>

--- a/src/components/InventoryTable/InventoryTable.test.js
+++ b/src/components/InventoryTable/InventoryTable.test.js
@@ -227,7 +227,7 @@ describe('InventoryTable', () => {
             </Provider>);
 
             expect(wrapper.find(ConditionalFilter).props().items.map(({ label }) => label)).toEqual(
-                ['Status', 'Operating System', 'Source', 'Tags']
+                ['Status', 'Operating System', 'Data Collector', 'Tags']
             );
         });
 

--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -242,11 +242,11 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights-client",
+                "label": "insights-client",
                 "value": "puptoo",
               },
               Object {
-                "label": "Subscription-manager",
+                "label": "subscription-manager",
                 "value": "rhsm-conduit",
               },
               Object {
@@ -519,11 +519,11 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights-client",
+                "label": "insights-client",
                 "value": "puptoo",
               },
               Object {
-                "label": "Subscription-manager",
+                "label": "subscription-manager",
                 "value": "rhsm-conduit",
               },
               Object {
@@ -812,11 +812,11 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights-client",
+                "label": "insights-client",
                 "value": "puptoo",
               },
               Object {
-                "label": "Subscription-manager",
+                "label": "subscription-manager",
                 "value": "rhsm-conduit",
               },
               Object {
@@ -1124,11 +1124,11 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights-client",
+                "label": "insights-client",
                 "value": "puptoo",
               },
               Object {
-                "label": "Subscription-manager",
+                "label": "subscription-manager",
                 "value": "rhsm-conduit",
               },
               Object {
@@ -1408,11 +1408,11 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights-client",
+                "label": "insights-client",
                 "value": "puptoo",
               },
               Object {
-                "label": "Subscription-manager",
+                "label": "subscription-manager",
                 "value": "rhsm-conduit",
               },
               Object {
@@ -1690,11 +1690,11 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights-client",
+                "label": "insights-client",
                 "value": "puptoo",
               },
               Object {
-                "label": "Subscription-manager",
+                "label": "subscription-manager",
                 "value": "rhsm-conduit",
               },
               Object {
@@ -1974,11 +1974,11 @@ exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
             "isDisabled": true,
             "items": Array [
               Object {
-                "label": "Insights-client",
+                "label": "insights-client",
                 "value": "puptoo",
               },
               Object {
-                "label": "Subscription-manager",
+                "label": "subscription-manager",
                 "value": "rhsm-conduit",
               },
               Object {
@@ -2264,11 +2264,11 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights-client",
+                "label": "insights-client",
                 "value": "puptoo",
               },
               Object {
-                "label": "Subscription-manager",
+                "label": "subscription-manager",
                 "value": "rhsm-conduit",
               },
               Object {
@@ -2584,11 +2584,11 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights-client",
+                "label": "insights-client",
                 "value": "puptoo",
               },
               Object {
-                "label": "Subscription-manager",
+                "label": "subscription-manager",
                 "value": "rhsm-conduit",
               },
               Object {

--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -242,8 +242,16 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights",
-                "value": "insights",
+                "label": "Insights-client",
+                "value": "puptoo",
+              },
+              Object {
+                "label": "Subscription-manager",
+                "value": "rhsm-conduit",
+              },
+              Object {
+                "label": "Satellite/Discovery",
+                "value": "yupana",
               },
               Object {
                 "label": "Insights not connected",
@@ -251,12 +259,12 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
               },
             ],
             "onChange": [Function],
-            "placeholder": "Filter by source",
+            "placeholder": "Filter by data collector",
             "value": undefined,
           },
-          "label": "Source",
+          "label": "Data Collector",
           "type": "checkbox",
-          "value": "source-registered-with",
+          "value": "data-collector-registered-with",
         },
       ],
     }
@@ -511,8 +519,16 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights",
-                "value": "insights",
+                "label": "Insights-client",
+                "value": "puptoo",
+              },
+              Object {
+                "label": "Subscription-manager",
+                "value": "rhsm-conduit",
+              },
+              Object {
+                "label": "Satellite/Discovery",
+                "value": "yupana",
               },
               Object {
                 "label": "Insights not connected",
@@ -520,12 +536,12 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
               },
             ],
             "onChange": [Function],
-            "placeholder": "Filter by source",
+            "placeholder": "Filter by data collector",
             "value": undefined,
           },
-          "label": "Source",
+          "label": "Data Collector",
           "type": "checkbox",
-          "value": "source-registered-with",
+          "value": "data-collector-registered-with",
         },
       ],
     }
@@ -796,8 +812,16 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights",
-                "value": "insights",
+                "label": "Insights-client",
+                "value": "puptoo",
+              },
+              Object {
+                "label": "Subscription-manager",
+                "value": "rhsm-conduit",
+              },
+              Object {
+                "label": "Satellite/Discovery",
+                "value": "yupana",
               },
               Object {
                 "label": "Insights not connected",
@@ -805,12 +829,12 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
               },
             ],
             "onChange": [Function],
-            "placeholder": "Filter by source",
+            "placeholder": "Filter by data collector",
             "value": undefined,
           },
-          "label": "Source",
+          "label": "Data Collector",
           "type": "checkbox",
-          "value": "source-registered-with",
+          "value": "data-collector-registered-with",
         },
         Object {
           "filterValues": Object {
@@ -1100,8 +1124,16 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights",
-                "value": "insights",
+                "label": "Insights-client",
+                "value": "puptoo",
+              },
+              Object {
+                "label": "Subscription-manager",
+                "value": "rhsm-conduit",
+              },
+              Object {
+                "label": "Satellite/Discovery",
+                "value": "yupana",
               },
               Object {
                 "label": "Insights not connected",
@@ -1109,12 +1141,12 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
               },
             ],
             "onChange": [Function],
-            "placeholder": "Filter by source",
+            "placeholder": "Filter by data collector",
             "value": undefined,
           },
-          "label": "Source",
+          "label": "Data Collector",
           "type": "checkbox",
-          "value": "source-registered-with",
+          "value": "data-collector-registered-with",
         },
         Object {
           "filterValues": Object {
@@ -1376,8 +1408,16 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights",
-                "value": "insights",
+                "label": "Insights-client",
+                "value": "puptoo",
+              },
+              Object {
+                "label": "Subscription-manager",
+                "value": "rhsm-conduit",
+              },
+              Object {
+                "label": "Satellite/Discovery",
+                "value": "yupana",
               },
               Object {
                 "label": "Insights not connected",
@@ -1385,12 +1425,12 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
               },
             ],
             "onChange": [Function],
-            "placeholder": "Filter by source",
+            "placeholder": "Filter by data collector",
             "value": undefined,
           },
-          "label": "Source",
+          "label": "Data Collector",
           "type": "checkbox",
-          "value": "source-registered-with",
+          "value": "data-collector-registered-with",
         },
       ],
     }
@@ -1650,8 +1690,16 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights",
-                "value": "insights",
+                "label": "Insights-client",
+                "value": "puptoo",
+              },
+              Object {
+                "label": "Subscription-manager",
+                "value": "rhsm-conduit",
+              },
+              Object {
+                "label": "Satellite/Discovery",
+                "value": "yupana",
               },
               Object {
                 "label": "Insights not connected",
@@ -1659,12 +1707,12 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
               },
             ],
             "onChange": [Function],
-            "placeholder": "Filter by source",
+            "placeholder": "Filter by data collector",
             "value": undefined,
           },
-          "label": "Source",
+          "label": "Data Collector",
           "type": "checkbox",
-          "value": "source-registered-with",
+          "value": "data-collector-registered-with",
         },
       ],
     }
@@ -1926,8 +1974,16 @@ exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
             "isDisabled": true,
             "items": Array [
               Object {
-                "label": "Insights",
-                "value": "insights",
+                "label": "Insights-client",
+                "value": "puptoo",
+              },
+              Object {
+                "label": "Subscription-manager",
+                "value": "rhsm-conduit",
+              },
+              Object {
+                "label": "Satellite/Discovery",
+                "value": "yupana",
               },
               Object {
                 "label": "Insights not connected",
@@ -1935,12 +1991,12 @@ exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
               },
             ],
             "onChange": [Function],
-            "placeholder": "Filter by source",
+            "placeholder": "Filter by data collector",
             "value": undefined,
           },
-          "label": "Source",
+          "label": "Data Collector",
           "type": "checkbox",
-          "value": "source-registered-with",
+          "value": "data-collector-registered-with",
         },
       ],
     }
@@ -2208,8 +2264,16 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights",
-                "value": "insights",
+                "label": "Insights-client",
+                "value": "puptoo",
+              },
+              Object {
+                "label": "Subscription-manager",
+                "value": "rhsm-conduit",
+              },
+              Object {
+                "label": "Satellite/Discovery",
+                "value": "yupana",
               },
               Object {
                 "label": "Insights not connected",
@@ -2217,12 +2281,12 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
               },
             ],
             "onChange": [Function],
-            "placeholder": "Filter by source",
+            "placeholder": "Filter by data collector",
             "value": undefined,
           },
-          "label": "Source",
+          "label": "Data Collector",
           "type": "checkbox",
-          "value": "source-registered-with",
+          "value": "data-collector-registered-with",
         },
         Object {
           "filterValues": Object {
@@ -2520,8 +2584,16 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
             "isDisabled": false,
             "items": Array [
               Object {
-                "label": "Insights",
-                "value": "insights",
+                "label": "Insights-client",
+                "value": "puptoo",
+              },
+              Object {
+                "label": "Subscription-manager",
+                "value": "rhsm-conduit",
+              },
+              Object {
+                "label": "Satellite/Discovery",
+                "value": "yupana",
               },
               Object {
                 "label": "Insights not connected",
@@ -2529,12 +2601,12 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
               },
             ],
             "onChange": [Function],
-            "placeholder": "Filter by source",
+            "placeholder": "Filter by data collector",
             "value": undefined,
           },
-          "label": "Source",
+          "label": "Data Collector",
           "type": "checkbox",
-          "value": "source-registered-with",
+          "value": "data-collector-registered-with",
         },
       ],
     }

--- a/src/components/filters/useRegisteredWithFilter.js
+++ b/src/components/filters/useRegisteredWithFilter.js
@@ -15,8 +15,8 @@ export const useRegisteredWithFilter = ([state, dispatch] = [registeredWithFilte
     const setValue = dispatch ? (newValue) => dispatch({ type: REGISTERED_WITH_FILTER, payload: newValue }) : setStateValue;
 
     const filter = {
-        label: 'Source',
-        value: 'source-registered-with',
+        label: 'Data Collector',
+        value: 'data-collector-registered-with',
         type: 'checkbox',
         filterValues: {
             value: registeredWithValue,
@@ -25,7 +25,7 @@ export const useRegisteredWithFilter = ([state, dispatch] = [registeredWithFilte
         }
     };
     const chip = registeredWithValue?.length > 0 ? [{
-        category: 'Source',
+        category: 'Data Collector',
         type: REGISTERED_CHIP,
         chips: registered.filter(({ value }) => registeredWithValue.includes(value))
         .map(({ label, ...props }) => ({ name: label, ...props }))

--- a/src/components/filters/useRegisteredWithFilter.test.js
+++ b/src/components/filters/useRegisteredWithFilter.test.js
@@ -27,8 +27,8 @@ describe('useRegisteredWithFilter', () => {
             });
             expect(filter.filterValues.value.length).toBe(0);
             expect(filter.filterValues.items).toMatchObject([
-                { label: 'Insights-client', value: 'puptoo' },
-                { label: 'Subscription-manager', value: 'rhsm-conduit' },
+                { label: 'insights-client', value: 'puptoo' },
+                { label: 'subscription-manager', value: 'rhsm-conduit' },
                 { label: 'Satellite/Discovery', value: 'yupana' },
                 { label: 'Insights not connected', value: 'nil' }
             ]);
@@ -47,7 +47,7 @@ describe('useRegisteredWithFilter', () => {
             expect(filter.filterValues.value.length).toBe(1);
             expect(chip).toMatchObject([{
                 category: 'Data Collector',
-                chips: [{ name: 'Insights-client', value: 'puptoo' }],
+                chips: [{ name: 'insights-client', value: 'puptoo' }],
                 type: 'registered_with'
             }]);
         };

--- a/src/components/filters/useRegisteredWithFilter.test.js
+++ b/src/components/filters/useRegisteredWithFilter.test.js
@@ -21,13 +21,15 @@ describe('useRegisteredWithFilter', () => {
     it('should create filter', () => {
         const hookAccessor = ([filter]) => {
             expect(filter).toMatchObject({
-                label: 'Source',
-                value: 'source-registered-with',
+                label: 'Data Collector',
+                value: 'data-collector-registered-with',
                 type: 'checkbox'
             });
             expect(filter.filterValues.value.length).toBe(0);
             expect(filter.filterValues.items).toMatchObject([
-                { label: 'Insights', value: 'insights' },
+                { label: 'Insights-client', value: 'puptoo' },
+                { label: 'Subscription-manager', value: 'rhsm-conduit' },
+                { label: 'Satellite/Discovery', value: 'yupana' },
                 { label: 'Insights not connected', value: 'nil' }
             ]);
         };
@@ -37,15 +39,15 @@ describe('useRegisteredWithFilter', () => {
 
     it('should create chip', () => {
         const hookAccessor = ([, , , setValue]) => {
-            setValue(['insights']);
+            setValue(['puptoo']);
         };
 
         const hookNotify = ([filter, chip, registeredWithValue]) => {
-            expect(registeredWithValue).toMatchObject(['insights']);
+            expect(registeredWithValue).toMatchObject(['puptoo']);
             expect(filter.filterValues.value.length).toBe(1);
             expect(chip).toMatchObject([{
-                category: 'Source',
-                chips: [{ name: 'Insights', value: 'insights' }],
+                category: 'Data Collector',
+                chips: [{ name: 'Insights-client', value: 'puptoo' }],
                 type: 'registered_with'
             }]);
         };


### PR DESCRIPTION
This addresses [ESSNTL-2449](https://issues.redhat.com/browse/ESSNTL-2449), using the information decided upon by [ESSNTL-2443](https://issues.redhat.com/browse/ESSNTL-2443).

This renames "Source" to "Data Collector", and adds more options to the list. Here is the association of data collectors to reporters:

- insights-client -> puptoo
- subscription-manager -> rhsm-conduit
- Satellite/Discovery -> yupana
