### PR TITLE
Update NODE_BUILD_VERSION

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -7,7 +7,7 @@
 export COMPONENT="insights-inventory"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=12
+export NODE_BUILD_VERSION=15
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 set -exv

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -7,7 +7,7 @@
 export COMPONENT="insights-inventory"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=12
+export NODE_BUILD_VERSION=15
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------


### PR DESCRIPTION
`@redhat-cloud-services/frontend-components-config` uses optional chaining, which Node added support for in v14. We also specify in `package.json` that it needs node version 15 or newer. However, our Jenkins builds are using node 12, which is causing build errors. This PR rectifies that by upping this to version 15.