### PR TITLE
Add data label to OS column

### DIFF
--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -50,6 +50,7 @@ export const defaultColumns = [
     {
         key: 'system_profile',
         sortKey: 'operating_system',
+        dataLabel: 'OS',
         title: <Tooltip content={<span>Operating system</span>}><span>OS</span></Tooltip>,
         // eslint-disable-next-line react/display-name
         renderFunc: (systemProfile) => <OperatingSystemFormatter operatingSystem={systemProfile?.operating_system} />,


### PR DESCRIPTION
Fixes [ESSNTL-2777](https://issues.redhat.com/browse/ESSNTL-2777).

For mobile view OS column did not have the correct label.

Before:
![before](https://user-images.githubusercontent.com/8426204/168848508-f07c2caa-1b5f-4438-9375-c1ed36f462ca.png)

After:
![after](https://user-images.githubusercontent.com/8426204/168848525-0134d93f-49ec-4ea1-a182-52430d86f325.png)