### PR TITLE
Fix for ESSNTL-2787

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -8,7 +8,6 @@ import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/Prima
 import { fetchAllTags, clearFilters, toggleTagModal, setFilter } from '../../store/actions';
 import { defaultFilters } from '../../Utilities/constants';
 import debounce from 'lodash/debounce';
-import flatMap from 'lodash/flatMap';
 import {
     TagsModal,
     TEXT_FILTER,
@@ -291,20 +290,6 @@ const EntityTableToolbar = ({
         };
     };
 
-    /**
-     * Function to calculate if any filter is applied.
-     */
-    const isFilterSelected = () => {
-        return textFilter.length > 0 || flatMap(
-            Object.values(selectedTags),
-            (value) => Object.values(value).filter(Boolean)
-        ).filter(Boolean).length > 0 ||
-        (staleFilter?.length > 0) ||
-        (registeredWithFilter?.length > 0) ||
-        (osFilter?.length > 0) ||
-        (activeFiltersConfig?.filters?.length > 0);
-    };
-
     const inventoryFilters = [
         ...!hasItems ? [
             ...enabledFilters.name ? [nameFilter] : [],
@@ -342,7 +327,7 @@ const EntityTableToolbar = ({
                     }))
                 }
             }}
-            { ...isFilterSelected() && hasAccess && { activeFiltersConfig: constructFilters() } }
+            { ...hasAccess && { activeFiltersConfig: constructFilters() } }
             actionsConfig={ loaded ? actionsConfig : null }
             pagination={loaded ? {
                 page,

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -201,7 +201,7 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
                     paginationProps={paginationProps}
                     loaded={loaded}
                     showTagModal={showTagModal}
-                    activeFiltersConfig={{ deleteTitle: 'Reset filters', ...props.activeFiltersConfig }}
+                    activeFiltersConfig={{ deleteTitle: 'Reset filters', ...props.activeFiltersConfig, showDeleteButton: true }}
                 >
                     { children }
                 </EntityTableToolbar>

--- a/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
@@ -6,6 +6,7 @@ exports[`InventoryTable should render correctly - no data 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
+        "showDeleteButton": true,
       }
     }
     filters={Array []}
@@ -47,6 +48,7 @@ exports[`InventoryTable should render correctly - with no access 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
+        "showDeleteButton": true,
       }
     }
     filters={Array []}
@@ -125,6 +127,7 @@ exports[`InventoryTable should render correctly 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
+        "showDeleteButton": true,
       }
     }
     filters={Array []}
@@ -236,6 +239,7 @@ exports[`InventoryTable should render correctly with items 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
+        "showDeleteButton": true,
       }
     }
     filters={Array []}
@@ -347,6 +351,7 @@ exports[`InventoryTable should render correctly with items no totla 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
+        "showDeleteButton": true,
       }
     }
     filters={Array []}

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -107,6 +107,7 @@ const Inventory = ({
             options.filters = Object.entries(defaultFilters).map(([key, val]) => ({ [key]: val }));
         }
 
+        let results = options?.filters.filter(({ osFilter }) => osFilter);
         const { status, source, tagsFilter, filterbyName, operatingSystem } = (options?.filters || []).reduce((acc, curr) => ({
             ...acc,
             ...curr?.staleFilter && { status: curr.staleFilter },
@@ -114,11 +115,12 @@ const Inventory = ({
             ...curr?.tagFilters && { tagsFilter: curr.tagFilters },
             ...curr?.value === 'hostname_or_id' && { filterbyName: curr.filter },
             ...curr?.osFilter && {
-                operatingSystem: Object.values(curr.osFilter || {}).flatMap((majorOsVersion) => Object.keys(majorOsVersion))
+                operatingSystem: results[0].osFilter.length > 0
+                    ? results[0].osFilter
+                    : Object.values(curr.osFilter || {}).flatMap((majorOsVersion) => Object.keys(majorOsVersion))
             }
         }), { status: undefined, source: undefined, tagsFilter: undefined, filterbyName: undefined, operatingSystem: undefined });
         options.filters = generateFilter(status, source, tagsFilter, filterbyName, operatingSystem);
-
         onSetfilters(options?.filters);
         const searchParams = new URLSearchParams();
         calculateFilters(searchParams, options?.filters);


### PR DESCRIPTION
Reset Filters button is now always present. When adding an osFilter , if you then remove another filter behind it, it does not change the url to display operating system three times with arguments 0,1,2. 

To replicate first fix, 
- Navigate to inventory
- deselect all filters 
- Reset Filter button is still present, where before it was not

To replicate second fix
- Navigate to inventory
- Choose osFilter , 8.0 , 9.0 , whichever you like
- remove fresh and stale filters
- You'll see the url is valid, and filters are working properly
- Remove all filters, you'll see that reset filter button is still present, and if you select it you're back to default filters