### PR TITLE
fix(InventoryTable): Mount the component to allow state updates

### DIFF
--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -89,7 +89,7 @@ const Inventory = ({
     const [filters, onSetfilters] = useState([]);
     const [ediOpen, onEditOpen] = useState(false);
     const [globalFilter, setGlobalFilter] = useState();
-    const { loading, writePermissions } = useSelector(
+    const { writePermissions } = useSelector(
         ({ permissionsReducer }) =>
             ({ loading: permissionsReducer?.loading, writePermissions: permissionsReducer?.writePermissions }),
         shallowEqual
@@ -188,7 +188,7 @@ const Inventory = ({
                 <Grid gutter="md">
                     <GridItem span={12}>
                         {
-                            !loading && InvCmp && <InvCmp
+                            InvCmp && <InvCmp
                                 history={history}
                                 store={store}
                                 customFilters={globalFilter}


### PR DESCRIPTION
This fixes this issue:

![Screenshot 2022-06-15 at 12 41 37](https://user-images.githubusercontent.com/7757/173935311-5e57898f-06f4-434a-9b51-819ee6adea98.png)

However, I am not 100% sure what was/is happening. The `loading` was for RBAC permissions and the RenderWrapper is also requesting RBAC permissions. So, there must be a connection there, but I don't know how or what.