### PR TITLE
Surface data collectors card to be used via fed modules

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -47,6 +47,7 @@ plugins.push(
             // System detail
             './SystemDetail': resolve(__dirname, '../src/components/SystemDetails/GeneralInfo.js'),
             // System detail cards
+            './GeneralInformation': resolve(__dirname, '../src/components/GeneralInfo/GeneralInformation/GeneralInformation.js'),
             './SystemCard': resolve(__dirname, '../src/components/GeneralInfo/SystemCard/SystemCard.js'),
             './OperatingSystemCard':
               resolve(__dirname, '../src/components/GeneralInfo/OperatingSystemCard/OperatingSystemCard.js'),
@@ -54,6 +55,7 @@ plugins.push(
             './ConfigurationCard': resolve(__dirname, '../src/components/GeneralInfo/ConfigurationCard/ConfigurationCard.js'),
             './CollectionCard': resolve(__dirname, '../src/components/GeneralInfo/CollectionCard/CollectionCard.js'),
             './BiosCard': resolve(__dirname, '../src/components/GeneralInfo/BiosCard/BiosCard.js'),
+            './DataCollectorsCard': resolve(__dirname, '../src/components/GeneralInfo/DataCollectorsCard/DataCollectorsCard.js'),
             // System detail data providers
             './selectors': resolve(__dirname, '../src/components/GeneralInfo/selectors/index.js'),
             './dataMapper': resolve(__dirname, '../src/components/GeneralInfo/dataMapper/index.js'),

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -17,6 +17,7 @@ plugins.push(
             // System detail
             './SystemDetail': resolve(__dirname, '../src/components/SystemDetails/GeneralInfo.js'),
             // System detail cards
+            './GeneralInformation': resolve(__dirname, '../src/components/GeneralInfo/GeneralInformation/GeneralInformation.js'),
             './SystemCard': resolve(__dirname, '../src/components/GeneralInfo/SystemCard/SystemCard.js'),
             './OperatingSystemCard':
               resolve(__dirname, '../src/components/GeneralInfo/OperatingSystemCard/OperatingSystemCard.js'),
@@ -24,6 +25,7 @@ plugins.push(
             './ConfigurationCard': resolve(__dirname, '../src/components/GeneralInfo/ConfigurationCard/ConfigurationCard.js'),
             './CollectionCard': resolve(__dirname, '../src/components/GeneralInfo/CollectionCard/CollectionCard.js'),
             './BiosCard': resolve(__dirname, '../src/components/GeneralInfo/BiosCard/BiosCard.js'),
+            './DataCollectorsCard': resolve(__dirname, '../src/components/GeneralInfo/DataCollectorsCard/DataCollectorsCard.js'),
             // System detail data providers
             './selectors': resolve(__dirname, '../src/components/GeneralInfo/selectors/index.js'),
             './dataMapper': resolve(__dirname, '../src/components/GeneralInfo/dataMapper/index.js'),


### PR DESCRIPTION
### Surface General information and Data collectors card

Since Edge is using general information screen partials from inventory shipped trough fed modules, we should expose `GeneralInformation` to be used as fallback to previsouly hand crafter UI partial and new `DataCollectorsCard` for this team to use it.