### PR TITLE
Fix hardcoding changes from 2787

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -341,4 +341,24 @@ describe('EntityTableToolbar', () => {
             );
         });
     });
+
+    describe('Passes activeFilterConfig correctly', () => {
+        it('Uses the activeFilterConfig  when passed it, uses the text passed in instead of the default', () => {
+            const store = mockStore(initialState);
+            const wrapper = mount(<Provider store={store}>
+                <EntityTableToolbar hasItems onRefreshData={onRefreshData} loaded
+                    activeFiltersConfig={{ deleteTitle: 'Test Reset Filters' }}/>
+            </Provider>);
+            expect(toJson(wrapper.find('Test Reset Filter')));
+            expect(toJson(wrapper.find('Reset Filter'))).toBeFalsy();
+        });
+        it('Uses the default activeFilterConfig when nothing is passed in, finds default text', () => {
+            const store = mockStore(initialState);
+            const wrapper = mount(<Provider store={store}>
+                <EntityTableToolbar hasItems onRefreshData={onRefreshData} loaded/>
+            </Provider>);
+            expect(toJson(wrapper.find('Reset Filter')));
+            expect(toJson(wrapper.find('Test Reset Filter'))).toBeFalsy();
+        });
+    });
 });

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -201,7 +201,7 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
                     paginationProps={paginationProps}
                     loaded={loaded}
                     showTagModal={showTagModal}
-                    activeFiltersConfig={{ deleteTitle: 'Reset filters', ...props.activeFiltersConfig, showDeleteButton: true }}
+                    activeFiltersConfig={{ deleteTitle: 'Reset filters', ...props.activeFiltersConfig }}
                 >
                     { children }
                 </EntityTableToolbar>

--- a/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
@@ -6,7 +6,6 @@ exports[`InventoryTable should render correctly - no data 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
-        "showDeleteButton": true,
       }
     }
     filters={Array []}
@@ -48,7 +47,6 @@ exports[`InventoryTable should render correctly - with no access 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
-        "showDeleteButton": true,
       }
     }
     filters={Array []}
@@ -127,7 +125,6 @@ exports[`InventoryTable should render correctly 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
-        "showDeleteButton": true,
       }
     }
     filters={Array []}
@@ -239,7 +236,6 @@ exports[`InventoryTable should render correctly with items 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
-        "showDeleteButton": true,
       }
     }
     filters={Array []}
@@ -351,7 +347,6 @@ exports[`InventoryTable should render correctly with items no totla 1`] = `
     activeFiltersConfig={
       Object {
         "deleteTitle": "Reset filters",
-        "showDeleteButton": true,
       }
     }
     filters={Array []}

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -201,6 +201,7 @@ const Inventory = ({
                                 hasCheckbox={writePermissions}
                                 autoRefresh
                                 initialLoading={initialLoading}
+                                activeFiltersConfig={{ showDeleteButton: true }}
                                 {...(writePermissions && {
                                     actions: [
                                         {


### PR DESCRIPTION
In PR 2782, I updated the wrong InventoryTable (there are 3). This PR reverts the hard coding of ShowDeleteButton in an inventory table that gets imported, and hard codes it in the one just for this repo. The reset Filter Button is to always be present as per UI/UX. In inventory the Reset Filter button should always be present with this PR.

 To see if it affects another Repo, you can run something like advisor or vulnerability via` npm run start:proxy:beta -- --port=8004` and run inventory with something like `LOCAL_API=vulnerability:8004~https npm run start:proxy`.
