### PR TITLE
fix(AppEntry): Calling init with undefined causes an error in non-dev

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -12,7 +12,7 @@ const InventoryApp = () => {
     const store = registry?.getStore();
 
     useEffect(() => {
-        setRegistry(init(IS_DEV ? logger : undefined));
+        setRegistry(IS_DEV ? init(logger) : init());
 
         return () => {
             setRegistry(undefined);


### PR DESCRIPTION
When passing `undefined` in non-dev environments, it would raise an error, as it expects a middleware function.