### PR TITLE
Update JS client to newest version 1.0.110

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@redhat-cloud-services/frontend-components": "^3.9.9",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.9",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.24",
-        "@redhat-cloud-services/host-inventory-client": "1.0.96",
+        "@redhat-cloud-services/host-inventory-client": "1.0.110",
         "classnames": "^2.3.1",
         "graphql": "^15.6.0",
         "html-webpack-plugin": "^5.5.0",
@@ -3014,9 +3014,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/host-inventory-client": {
-      "version": "1.0.96",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.96.tgz",
-      "integrity": "sha512-OJxEGDesHXc7vKdb86SBZ5pNnaWDerNjE0hAiGktUvKXBqZY3Ag/k6IaYKZPE0TYMFRgjJPsyLTVBTpu1JQAow==",
+      "version": "1.0.110",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.110.tgz",
+      "integrity": "sha512-v9oCvciIc3RPkJOSGo0D/ZD1GxyCsFSQ+bthCH4rrJ5gK4NOVv60laf/jVNcyA3/mPYMuF2EqI/SylgEv/KNDw==",
       "dependencies": {
         "axios": "^0.21.1"
       }
@@ -19689,9 +19689,9 @@
       }
     },
     "@redhat-cloud-services/host-inventory-client": {
-      "version": "1.0.96",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.96.tgz",
-      "integrity": "sha512-OJxEGDesHXc7vKdb86SBZ5pNnaWDerNjE0hAiGktUvKXBqZY3Ag/k6IaYKZPE0TYMFRgjJPsyLTVBTpu1JQAow==",
+      "version": "1.0.110",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.110.tgz",
+      "integrity": "sha512-v9oCvciIc3RPkJOSGo0D/ZD1GxyCsFSQ+bthCH4rrJ5gK4NOVv60laf/jVNcyA3/mPYMuF2EqI/SylgEv/KNDw==",
       "requires": {
         "axios": "^0.21.1"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@redhat-cloud-services/frontend-components": "^3.9.9",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.9",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.24",
-    "@redhat-cloud-services/host-inventory-client": "1.0.96",
+    "@redhat-cloud-services/host-inventory-client": "1.0.110",
     "classnames": "^2.3.1",
     "graphql": "^15.6.0",
     "html-webpack-plugin": "^5.5.0",

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -107,6 +107,8 @@ export async function getEntities(items, {
             undefined,
             undefined,
             undefined,
+            undefined,
+            undefined,
             { cancelToken: controller && controller.token }
         );
 
@@ -155,6 +157,8 @@ export async function getEntities(items, {
             undefined,
             undefined,
             filters.hostnameOrId,
+            undefined,
+            undefined,
             undefined,
             undefined,
             perPage,
@@ -226,6 +230,12 @@ export function getAllTags(search, { filters, pagination, ...options } = { pagin
         (pagination && pagination.page) || 1,
         staleFilter,
         search || hostnameOrId,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
         registeredWithFilter,
         undefined,
         {


### PR DESCRIPTION
### Description

Since there were a few new features added to the JS client we should update to the latest one. This PR uses the newest version 1.0.110 and updates all changed requests based on the docs generated from the openapi spec.