### PR TITLE
Revert "fix(ESSNTL-3336): fix os column sorting"

### DIFF
--- a/src/components/InventoryTable/EntityTable.js
+++ b/src/components/InventoryTable/EntityTable.js
@@ -132,6 +132,7 @@ const EntityTable = ({
                     onSort={ (event, index, direction) => {
                         onSortChange(
                             event,
+                            cells?.[index - Boolean(hasCheckbox) - Boolean(expandable)]?.sortKey ||
                             cells?.[index - Boolean(hasCheckbox) - Boolean(expandable)]?.key,
                             direction,
                             index

--- a/src/components/InventoryTable/EntityTable.js
+++ b/src/components/InventoryTable/EntityTable.js
@@ -139,7 +139,12 @@ const EntityTable = ({
                         );
                     } }
                     sortBy={ {
-                        index: cells?.findIndex(item => sortBy?.key === item.key) + Boolean(hasCheckbox) + Boolean(expandable),
+                        //Inventory API has different sortBy key than system_profile
+                        index:
+                            cells?.findIndex(
+                                item => (sortBy?.key === item.key)
+                                || (sortBy?.key === 'operating_system' && item.key === 'system_profile')
+                            ) + Boolean(hasCheckbox) + Boolean(expandable),
                         direction: sortBy?.direction
                     } }
                     { ...{

--- a/src/components/InventoryTable/EntityTable.test.js
+++ b/src/components/InventoryTable/EntityTable.test.js
@@ -183,6 +183,44 @@ describe('EntityTable', () => {
                 </MemoryRouter>);
                 expect(toJson(wrapper.find('Table'), { mode: 'shallow' })).toMatchSnapshot();
             });
+
+            it('should mark OS column as sorted in Asc order', () => {
+                const store = mockStore(initialState);
+                const wrapper = mount(<MemoryRouter>
+                    <Provider store={store}>
+                        <EntityTable
+                            loaded
+                            expandable
+                            disableDefaultColumns
+                            sortBy={{
+                                key: 'system_profile',
+                                direction: 'asc'
+                            }}
+                        />
+                    </Provider>
+                </MemoryRouter>);
+
+                expect(wrapper.find('Table').props().sortBy).toEqual({ index: 1, direction: 'asc' });
+            });
+
+            it('should mark OS column as sorted in Desc order', () => {
+                const store = mockStore(initialState);
+                const wrapper = mount(<MemoryRouter>
+                    <Provider store={store}>
+                        <EntityTable
+                            loaded
+                            expandable
+                            disableDefaultColumns
+                            sortBy={{
+                                key: 'system_profile',
+                                direction: 'desc'
+                            }}
+                        />
+                    </Provider>
+                </MemoryRouter>);
+
+                expect(wrapper.find('Table').props().sortBy).toEqual({ index: 1, direction: 'desc' });
+            });
         });
 
         it('should render correctly - compact', () => {

--- a/src/components/InventoryTable/EntityTable.test.js
+++ b/src/components/InventoryTable/EntityTable.test.js
@@ -28,7 +28,7 @@ describe('EntityTable', () => {
                 rows: [{
                     id: 'testing-id',
                     one: 'data',
-                    system_profile: { operating_system: { major: 9, name: 'RHEL' } }
+                    system_profile: {}
                 }],
                 columns: [{ key: 'one', sortKey: 'one', title: 'One', renderFunc: TitleColumn }],
                 page: 1,

--- a/src/components/InventoryTable/__snapshots__/EntityTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTable.test.js.snap
@@ -219,16 +219,7 @@ exports[`EntityTable DOM should render correctly - grid breakpoints 1`] = `
         ],
         "id": "testing-id",
         "one": "data",
-        "operating_system": Object {
-          "major": 9,
-          "name": "RHEL",
-        },
-        "system_profile": Object {
-          "operating_system": Object {
-            "major": 9,
-            "name": "RHEL",
-          },
-        },
+        "system_profile": Object {},
       },
     ]
   }
@@ -311,16 +302,7 @@ exports[`EntityTable DOM should render correctly - is expandable 1`] = `
         ],
         "id": "testing-id",
         "one": "data",
-        "operating_system": Object {
-          "major": 9,
-          "name": "RHEL",
-        },
-        "system_profile": Object {
-          "operating_system": Object {
-            "major": 9,
-            "name": "RHEL",
-          },
-        },
+        "system_profile": Object {},
       },
     ]
   }
@@ -488,16 +470,7 @@ exports[`EntityTable DOM should render correctly - with actions 1`] = `
         ],
         "id": "testing-id",
         "one": "data",
-        "operating_system": Object {
-          "major": 9,
-          "name": "RHEL",
-        },
-        "system_profile": Object {
-          "operating_system": Object {
-            "major": 9,
-            "name": "RHEL",
-          },
-        },
+        "system_profile": Object {},
       },
     ]
   }
@@ -630,16 +603,7 @@ exports[`EntityTable DOM should render correctly - without checkbox 1`] = `
         ],
         "id": "testing-id",
         "one": "data",
-        "operating_system": Object {
-          "major": 9,
-          "name": "RHEL",
-        },
-        "system_profile": Object {
-          "operating_system": Object {
-            "major": 9,
-            "name": "RHEL",
-          },
-        },
+        "system_profile": Object {},
       },
     ]
   }
@@ -846,16 +810,7 @@ exports[`EntityTable DOM sort by should render correctly - is expandable 1`] = `
         ],
         "id": "testing-id",
         "one": "data",
-        "operating_system": Object {
-          "major": 9,
-          "name": "RHEL",
-        },
-        "system_profile": Object {
-          "operating_system": Object {
-            "major": 9,
-            "name": "RHEL",
-          },
-        },
+        "system_profile": Object {},
       },
     ]
   }
@@ -934,16 +889,7 @@ exports[`EntityTable DOM sort by should render correctly - without checkbox 1`] 
         ],
         "id": "testing-id",
         "one": "data",
-        "operating_system": Object {
-          "major": 9,
-          "name": "RHEL",
-        },
-        "system_profile": Object {
-          "operating_system": Object {
-            "major": 9,
-            "name": "RHEL",
-          },
-        },
+        "system_profile": Object {},
       },
     ]
   }
@@ -1023,16 +969,7 @@ exports[`EntityTable DOM sort by should render correctly 1`] = `
         ],
         "id": "testing-id",
         "one": "data",
-        "operating_system": Object {
-          "major": 9,
-          "name": "RHEL",
-        },
-        "system_profile": Object {
-          "operating_system": Object {
-            "major": 9,
-            "name": "RHEL",
-          },
-        },
+        "system_profile": Object {},
       },
     ]
   }

--- a/src/components/InventoryTable/__snapshots__/EntityTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTable.test.js.snap
@@ -4,7 +4,7 @@ exports[`EntityTable DOM should render correctly - compact 1`] = `
 <table
   aria-label="Host inventory"
   class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
-  data-ouia-component-id="OUIA-Generated-Table-22"
+  data-ouia-component-id="OUIA-Generated-Table-26"
   data-ouia-component-type="PF4/Table"
   data-ouia-safe="true"
   role="grid"
@@ -15,7 +15,7 @@ exports[`EntityTable DOM should render correctly - compact 1`] = `
     <tr
       aria-label=""
       class=""
-      data-ouia-component-id="OUIA-Generated-TableRow-35"
+      data-ouia-component-id="OUIA-Generated-TableRow-39"
       data-ouia-component-type="PF4/TableRow"
       data-ouia-safe="true"
     >
@@ -80,7 +80,7 @@ exports[`EntityTable DOM should render correctly - compact 1`] = `
     <tr
       aria-label=""
       class=""
-      data-ouia-component-id="OUIA-Generated-TableRow-36"
+      data-ouia-component-id="OUIA-Generated-TableRow-40"
       data-ouia-component-type="PF4/TableRow"
       data-ouia-safe="true"
     >
@@ -622,7 +622,7 @@ exports[`EntityTable DOM should render correctly 1`] = `
 <table
   aria-label="Host inventory"
   class="ins-c-entity-table pf-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
-  data-ouia-component-id="OUIA-Generated-Table-26"
+  data-ouia-component-id="OUIA-Generated-Table-30"
   data-ouia-component-type="PF4/Table"
   data-ouia-safe="true"
   role="grid"
@@ -633,7 +633,7 @@ exports[`EntityTable DOM should render correctly 1`] = `
     <tr
       aria-label=""
       class=""
-      data-ouia-component-id="OUIA-Generated-TableRow-39"
+      data-ouia-component-id="OUIA-Generated-TableRow-43"
       data-ouia-component-type="PF4/TableRow"
       data-ouia-safe="true"
     >
@@ -698,7 +698,7 @@ exports[`EntityTable DOM should render correctly 1`] = `
     <tr
       aria-label=""
       class=""
-      data-ouia-component-id="OUIA-Generated-TableRow-40"
+      data-ouia-component-id="OUIA-Generated-TableRow-44"
       data-ouia-component-type="PF4/TableRow"
       data-ouia-safe="true"
     >

--- a/src/components/InventoryTable/helpers.js
+++ b/src/components/InventoryTable/helpers.js
@@ -31,36 +31,22 @@ export const createRows = (rows = [], columns = [], { actions, expandable, noSys
         }];
     }
 
-    return flatten(rows.map((oneItem, key) => {
-        //makes the row column key and sort key consistent, otherwise sorting does not work
-        const rowItem = {
-            ...oneItem,
-            // eslint-disable-next-line camelcase
-            operating_system: oneItem.system_profile?.operating_system
-        };
-
-        return (
-            [
-                {
-                    ...rowItem,
-                    ...rowItem.children && expandable && { isOpen: !!rowItem.isOpen },
-                    cells: buildCells(rowItem, columns, extra),
-                    actionProps: {
-                        'data-ouia-component-id': `${rowItem.id}-actions-kebab`
-                    }
-                },
-                rowItem.children && expandable && {
-                    cells: [
-                        {
-                            title: typeof rowItem.children === 'function' ? rowItem.children() : rowItem.children
-                        }
-                    ],
-                    parent: key * 2,
-                    fullWidth: true
-                }
-            ]
-        );
-    })).filter(Boolean);
+    return flatten(rows.map((oneItem, key) => ([{
+        ...oneItem,
+        ...oneItem.children && expandable && { isOpen: !!oneItem.isOpen },
+        cells: buildCells(oneItem, columns, extra),
+        actionProps: {
+            'data-ouia-component-id': `${oneItem.id}-actions-kebab`
+        }
+    }, oneItem.children && expandable && {
+        cells: [
+            {
+                title: typeof oneItem.children === 'function' ? oneItem.children() : oneItem.children
+            }
+        ],
+        parent: key * 2,
+        fullWidth: true
+    }]))).filter(Boolean);
 };
 
 export const onDeleteFilter = (deleted, currFilter = []) => {

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -38,6 +38,7 @@ export const defaultState = {
 export const defaultColumns = [
     {
         key: 'display_name',
+        sortKey: 'display_name',
         title: 'Name',
         renderFunc: TitleColumn
     },
@@ -49,15 +50,19 @@ export const defaultColumns = [
         renderFunc: (value, systemId) => <TagWithDialog count={value.length} systemId={systemId} />
     },
     {
-        key: 'operating_system',
+        key: 'system_profile',
+        sortKey: 'operating_system',
         dataLabel: 'OS',
         title: <Tooltip content={<span>Operating system</span>}><span>OS</span></Tooltip>,
-        renderFunc: (operatingSystem) => <OperatingSystemFormatter operatingSystem={operatingSystem} />,
+        // eslint-disable-next-line react/display-name
+        renderFunc: (systemProfile) => <OperatingSystemFormatter operatingSystem={systemProfile?.operating_system} />,
         props: { width: 10 }
     },
     {
         key: 'updated',
+        sortKey: 'updated',
         title: 'Last seen',
+        // eslint-disable-next-line react/display-name
         renderFunc: (
             value,
             _id,


### PR DESCRIPTION
This reverts commit ff9be46e3a7f31289eeb1d31e99fb52c93ffc292. Also fixes the bug by handing this specific sort key by getting its index explicitly in the codebase. Please verify that it works by running locally.
