### PR TITLE
chore(InventoryTable): remove unused filters param

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -369,7 +369,6 @@ EntityTableToolbar.propTypes = {
     hasAccess: PropTypes.bool,
     filterConfig: PropTypes.object,
     total: PropTypes.number,
-    filters: PropTypes.array,
     hasItems: PropTypes.bool,
     page: PropTypes.number,
     onClearFilters: PropTypes.func,
@@ -413,7 +412,6 @@ EntityTableToolbar.defaultProps = {
     showTags: false,
     hasAccess: true,
     activeFiltersConfig: {},
-    filters: [],
     hideFilters: {}
 };
 

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -44,7 +44,6 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
     total: propsTotal,
     page: propsPage,
     perPage: propsPerPage,
-    filters,
     showTags,
     sortBy: propsSortBy,
     customFilters,
@@ -188,7 +187,6 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
                     customFilters={customFilters}
                     hasAccess={hasAccess}
                     items={ items }
-                    filters={ filters }
                     hasItems={ hasItems }
                     total={ pagination.total }
                     page={ pagination.page }
@@ -246,7 +244,6 @@ InventoryTable.propTypes = {
     total: PropTypes.number,
     page: PropTypes.number,
     perPage: PropTypes.number,
-    filters: PropTypes.any,
     showTags: PropTypes.bool,
     getTags: PropTypes.func,
     sortBy: PropTypes.object,

--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -116,7 +116,6 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
       ],
     }
   }
-  filters={Array []}
   pagination={
     <Skeleton
       size="lg"
@@ -277,7 +276,6 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
       ],
     }
   }
-  filters={Array []}
   pagination={
     Object {
       "isDisabled": false,
@@ -484,7 +482,6 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
       ],
     }
   }
-  filters={Array []}
   pagination={
     Object {
       "isDisabled": false,
@@ -657,7 +654,6 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
       ],
     }
   }
-  filters={Array []}
   pagination={
     Object {
       "isDisabled": false,
@@ -818,7 +814,6 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
       ],
     }
   }
-  filters={Array []}
   pagination={
     Object {
       "isDisabled": false,
@@ -984,7 +979,6 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
       ],
     }
   }
-  filters={Array []}
   pagination={
     Object {
       "isDisabled": false,
@@ -1007,7 +1001,6 @@ exports[`EntityTableToolbar DOM should render correctly - with items 1`] = `
     }
   }
   className="ins-c-inventory__table--toolbar ins-c-inventory__table--toolbar-has-items"
-  filters={Array []}
   pagination={
     Object {
       "isDisabled": false,
@@ -1152,7 +1145,6 @@ exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
       ],
     }
   }
-  filters={Array []}
   pagination={
     Object {
       "isDisabled": true,
@@ -1356,7 +1348,6 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
       ],
     }
   }
-  filters={Array []}
   pagination={
     Object {
       "isDisabled": false,
@@ -1530,7 +1521,6 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
       ],
     }
   }
-  filters={Array []}
   pagination={
     Object {
       "isDisabled": false,

--- a/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
@@ -8,7 +8,6 @@ exports[`InventoryTable should render correctly - no data 1`] = `
         "deleteTitle": "Reset filters",
       }
     }
-    filters={Array []}
     hasAccess={true}
     hasItems={false}
     hideFilters={Object {}}
@@ -49,7 +48,6 @@ exports[`InventoryTable should render correctly - with no access 1`] = `
         "deleteTitle": "Reset filters",
       }
     }
-    filters={Array []}
     hasAccess={false}
     hasItems={false}
     hideFilters={Object {}}
@@ -127,7 +125,6 @@ exports[`InventoryTable should render correctly 1`] = `
         "deleteTitle": "Reset filters",
       }
     }
-    filters={Array []}
     hasAccess={true}
     hasItems={false}
     hideFilters={Object {}}
@@ -238,7 +235,6 @@ exports[`InventoryTable should render correctly with items 1`] = `
         "deleteTitle": "Reset filters",
       }
     }
-    filters={Array []}
     hasAccess={true}
     hasItems={true}
     hideFilters={Object {}}
@@ -349,7 +345,6 @@ exports[`InventoryTable should render correctly with items no totla 1`] = `
         "deleteTitle": "Reset filters",
       }
     }
-    filters={Array []}
     hasAccess={true}
     hasItems={true}
     hideFilters={Object {}}


### PR DESCRIPTION
I have recently identified that InventoryTable has a "filters" parameter which is not utilized by the components nor any of the children components. I propose to remove this from the propTypes - a tiny contribution to reduce the components complexity/misleading interface.