### PR TITLE
fix(TagsApi): ESSNTL-3427 add fetch tags for all stale status

### DIFF
--- a/src/Utilities/TagsModal.js
+++ b/src/Utilities/TagsModal.js
@@ -61,7 +61,7 @@ const TagsModal = ({
 
     const fetchTags = (pagination, filterBy) => {
         if (!activeSystemTag) {
-            dispatch(fetchAllTags(filterBy, { pagination }, getTags));
+            dispatch(fetchAllTags(filterBy, pagination, getTags));
         } else {
             setStatePagination(() => pagination);
         }

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -155,3 +155,5 @@ export const useGetRegistry = () => {
 
     return getRegistry;
 };
+
+export const allStaleFilters = ['fresh', 'stale', 'stale_warning', 'unknown'];

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -5,7 +5,7 @@ import flatMap from 'lodash/flatMap';
 import instance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import { generateFilter, mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { HostsApi, TagsApi, SystemProfileApi } from '@redhat-cloud-services/host-inventory-client';
-import { defaultFilters } from '../Utilities/constants';
+import { allStaleFilters } from '../Utilities/constants';
 
 export { instance };
 export const hosts = new HostsApi(undefined, INVENTORY_API_BASE, instance);
@@ -212,38 +212,25 @@ export function getTags(systemId, search, { pagination } = { pagination: {} }) {
     );
 }
 
-export function getAllTags(search, { filters, pagination, ...options } = { pagination: {} }) {
-    const {
-        tagFilters,
-        staleFilter,
-        registeredWithFilter,
-        osFilter,
-        hostnameOrId
-    } = filters ? filters.reduce(filtersReducer, defaultFilters) : defaultFilters;
+export function getAllTags(search, pagination = {}) {
     return tags.apiTagGetTags(
-        [
-            ...tagFilters ? constructTags(tagFilters) : [],
-            ...options.tags || []
-        ],
+        [],
         'tag',
         'ASC',
-        (pagination && pagination.perPage) || 10,
-        (pagination && pagination.page) || 1,
-        staleFilter,
-        search || hostnameOrId,
+        pagination.perPage || 10,
+        pagination.page || 1,
+        //TODO: ask the backend to return all tags by default.
+        allStaleFilters,
+        search,
         undefined,
         undefined,
         undefined,
         undefined,
         undefined,
         undefined,
-        registeredWithFilter,
         undefined,
-        {
-            query: {
-                ...(calculateSystemProfile(osFilter))
-            }
-        }
+        undefined,
+        undefined
     );
 }
 

--- a/src/api/tagsApi.test.js
+++ b/src/api/tagsApi.test.js
@@ -4,7 +4,8 @@ import MockAdapter from 'axios-mock-adapter';
 describe('getAllTags', () => {
     const mockedTags = new MockAdapter(tags.axios, { onNoMatch: 'throwException' });
     it('should generate get all tags call', async () => {
-        const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale';
+        // eslint-disable-next-line max-len
+        const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&staleness=stale_warning&staleness=unknown';
         mockedTags.onGet(
             `/api/inventory/v1/tags${params}`
         ).replyOnce(200, { test: 'test' });
@@ -14,100 +15,29 @@ describe('getAllTags', () => {
 
     it('should generate get all tags call with search', async () => {
         // eslint-disable-next-line max-len
-        const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&search=something';
+        const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&staleness=stale_warning&staleness=unknown&search=something';
         mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
         const data = await getAllTags('something');
         expect(data).toMatchObject({ test: 'test' });
     });
 
-    describe('tagFilters', () => {
-        it('should generate get all tags call with tagFilters', async () => {
-            // eslint-disable-next-line max-len
-            const params = '?tags=namespace%2Fsome%20key%3Dsome%20value&tags=some%20key&order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale';
-            mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
-            const data = await getAllTags(undefined, {
-                filters: [{
-                    tagFilters: [{
-                        values: [{
-                            value: 'some value',
-                            tagKey: 'some key'
-                        }],
-                        category: 'namespace'
-                    },
-                    {
-                        values: [{
-                            value: '',
-                            tagKey: 'some key'
-                        }],
-                        category: ''
-                    }]
-                }]
-            });
-            expect(data).toMatchObject({ test: 'test' });
-        });
-
-        it('should generate get all tags call with staleFilter', async () => {
-            const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=something';
-            mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
-            const data = await getAllTags(undefined, {
-                filters: [{
-                    staleFilter: ['something']
-                }]
-            });
-            expect(data).toMatchObject({ test: 'test' });
-        });
-
-        it('should generate get all tags call with osFilter', async () => {
-            mockedTags.resetHistory();
-            // eslint-disable-next-line max-len
-            const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&filter%5Bsystem_profile%5D%5Boperating_system%5D%5BRHEL%5D%5Bversion%5D%5Beq%5D%5B%5D=8.1';
-            mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
-            const data = await getAllTags(undefined, {
-                filters: [{
-                    osFilter: {
-                        '8.0': {
-                            8.1: true
-                        }
-                    }
-                }]
-            });
-            expect(data).toMatchObject({ test: 'test' });
-        });
-
-        it('should generate get all tags call with registeredWithFilter', async () => {
-            // eslint-disable-next-line max-len
-            const params = '?order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&registered_with=something';
-            mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
-            const data = await getAllTags(undefined, {
-                filters: [{
-                    registeredWithFilter: ['something']
-                }]
-            });
-            expect(data).toMatchObject({ test: 'test' });
-        });
-    });
-
     describe('pagination', () => {
         it('should generate get all tags call with perPage', async () => {
             // eslint-disable-next-line max-len
-            const params = '?order_by=tag&order_how=ASC&per_page=50&page=1&staleness=fresh&staleness=stale';
+            const params = '?order_by=tag&order_how=ASC&per_page=50&page=1&staleness=fresh&staleness=stale&staleness=stale_warning&staleness=unknown';
             mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
             const data = await getAllTags(undefined, {
-                pagination: {
-                    perPage: 50
-                }
+                perPage: 50
             });
             expect(data).toMatchObject({ test: 'test' });
         });
 
         it('should generate get all tags call with page', async () => {
             // eslint-disable-next-line max-len
-            const params = '?order_by=tag&order_how=ASC&per_page=10&page=20&staleness=fresh&staleness=stale';
+            const params = '?order_by=tag&order_how=ASC&per_page=10&page=20&staleness=fresh&staleness=stale&staleness=stale_warning&staleness=unknown';
             mockedTags.onGet(`/api/inventory/v1/tags${params}`).replyOnce(200, { test: 'test' });
             const data = await getAllTags(undefined, {
-                pagination: {
-                    page: 20
-                }
+                page: 20
             });
             expect(data).toMatchObject({ test: 'test' });
         });

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -108,7 +108,7 @@ const EntityTableToolbar = ({
     const debounceGetAllTags = useCallback(debounce((config, options) => {
         if (showTags && !hasItems && hasAccess) {
             dispatch(fetchAllTags(config, {
-                ...options
+                ...options?.pagination
             },  getTags));
         }
     }, 800), [customFilters?.tags]);

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -174,9 +174,9 @@ export const toggleTagModal = (isOpen) => ({
     payload: { isOpen }
 });
 
-export const fetchAllTags = (search, options, getTags = defaultGetAllTags) => ({
+export const fetchAllTags = (search, pagination, getTags = defaultGetAllTags) => ({
     type: ACTION_TYPES.ALL_TAGS,
-    payload: getTags(search, options),
+    payload: getTags(search, pagination),
     meta: { lastDateRequestTags: Date.now() }
 });
 


### PR DESCRIPTION
This is a follow-up PR to fetch tags for stale_warning systems also. It looks like the UI needs to pass all staleness filters to get all existing tags. 

To test:
1. navigate to the Inventory app
2. Verify that the API req to /tags is made with parameters staleness =  'fresh', 'stale', 'stale_warning', 'unknown'.
3. Verify that the tags modal opens as expected
4. Verify that the pagination works as expected