### PR TITLE
Render "No versions available" if there are no OS versions available

### DIFF
--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -69,7 +69,15 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
         },
         Object {
           "filterValues": Object {
-            "groups": Array [],
+            "groups": Array [
+              Object {
+                "items": Array [
+                  Object {
+                    "label": "No versions available",
+                  },
+                ],
+              },
+            ],
             "isDisabled": false,
             "onChange": [Function],
             "placeholder": "Filter by operating system",

--- a/src/components/filters/__snapshots__/useOperatingSystemFilter.test.js.snap
+++ b/src/components/filters/__snapshots__/useOperatingSystemFilter.test.js.snap
@@ -79,3 +79,53 @@ Array [
   },
 ]
 `;
+
+exports[`useOperatingSystemFilter with operating systems loaded should return empty state value if no versions obtained 1`] = `
+Array [
+  Object {
+    "filterValues": Object {
+      "groups": Array [
+        Object {
+          "items": Array [
+            Object {
+              "label": "No versions available",
+            },
+          ],
+        },
+      ],
+      "onChange": [Function],
+      "selected": Object {},
+    },
+    "label": "Operating System",
+    "type": "group",
+  },
+  Array [],
+  Array [],
+  [Function],
+]
+`;
+
+exports[`useOperatingSystemFilter with operating systems yet not loaded should return empty state value 1`] = `
+Array [
+  Object {
+    "filterValues": Object {
+      "groups": Array [
+        Object {
+          "items": Array [
+            Object {
+              "label": "No versions available",
+            },
+          ],
+        },
+      ],
+      "onChange": [Function],
+      "selected": Object {},
+    },
+    "label": "Operating System",
+    "type": "group",
+  },
+  Array [],
+  Array [],
+  [Function],
+]
+`;

--- a/src/components/filters/useOperatingSystemFilter.js
+++ b/src/components/filters/useOperatingSystemFilter.js
@@ -35,7 +35,10 @@ const useOperatingSystemFilter = (apiParams = []) => {
     }, []);
 
     useEffect(() => {
-        setGroups(groupOSFilterVersions(operatingSystems));
+        const newGroups = groupOSFilterVersions(operatingSystems);
+        setGroups((operatingSystems || []).length === 0
+            ? [{ items: [{ label: 'No versions available' }] }]
+            : newGroups);
         setSelected(
             toGroupSelection(
                 getSelectedOsFilterVersions(selected),

--- a/src/components/filters/useOperatingSystemFilter.test.js
+++ b/src/components/filters/useOperatingSystemFilter.test.js
@@ -14,19 +14,23 @@ describe('useOperatingSystemFilter', () => {
     });
 
     describe('with operating systems yet not loaded', () => {
+        const wrapper = ({ children }) => (
+            <Provider store={mockStore({})}>
+                {children}
+            </Provider>
+        );
+
         it('should initiate an API request', async () => {
-            const wrapper = ({ children }) => (
-                <Provider
-                    store={mockStore({})}
-                >
-                    {children}
-                </Provider>
-            );
             renderHook(useOperatingSystemFilter, { wrapper });
             await waitFor(() => {
                 expect(mockSystemProfile.history.get.length).toBe(1);
             });
             mockSystemProfile.resetHistory();
+        });
+
+        it('should return empty state value', () => {
+            const { result } = renderHook(useOperatingSystemFilter, { wrapper });
+            expect(result.current).toMatchSnapshot();
         });
     });
 
@@ -87,6 +91,22 @@ describe('useOperatingSystemFilter', () => {
             expect(valueUpdated).toEqual(['8.4']);
             expect(chipsUpdated).toMatchSnapshot();
         });
-    });
 
+        it('should return empty state value if no versions obtained', () => {
+            const wrapper = ({ children }) => (
+                <Provider
+                    store={mockStore({
+                        entities: {
+                            operatingSystems: [],
+                            operatingSystemsLoaded: true
+                        }
+                    })}
+                >
+                    {children}
+                </Provider>
+            );
+            const { result } = renderHook(useOperatingSystemFilter, { wrapper });
+            expect(result.current).toMatchSnapshot();
+        });
+    });
 });

--- a/src/modules/OsFilterHelpers.js
+++ b/src/modules/OsFilterHelpers.js
@@ -70,6 +70,8 @@ export const buildOSFilterConfig = (config = {}, operatingSystems = []) => ({
                 // eliminate versions that are set to false
                 return { ...prev, [major]: Object.fromEntries(Object.entries(minors).filter((version) => version[1] === true)) };
             }, {})),
-        groups: groupOSVersions(operatingSystems)
+        groups: operatingSystems.length === 0
+            ? [{ items: [{ label: 'No versions available' }] }]
+            : groupOSVersions(operatingSystems)
     }
 });

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -280,7 +280,6 @@ export default {
     [ACTION_TYPES.ALL_TAGS_REJECTED]: loadingRejected,
     [ACTION_TYPES.OPERATING_SYSTEMS_PENDING]: (state) => ({ ...state, operatingSystemsLoaded: false }),
     [ACTION_TYPES.OPERATING_SYSTEMS_FULFILLED]: versionsLoaded,
-    [ACTION_TYPES.OPERATING_SYSTEMS_REJECTED]: loadingRejected,
     [UPDATE_ENTITIES]: entitiesLoaded,
     [SHOW_ENTITIES]: (state, action) => entitiesLoaded(state, {
         payload: {


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-3341 and has to be merged only after https://github.com/RedHatInsights/insights-inventory-frontend/pull/1638.

This makes the systems table render OS filter with the single empty value "No versions available" if there is a network request error or the request is successful but doesn't have any values (empty array). 

## Screenshots

![Screenshot 2022-09-27 at 15-43-15 Inventory Red Hat Insights](https://user-images.githubusercontent.com/31385370/192552647-07fbef4a-3f5a-41f8-bc3c-26f8f3849242.png)


