### PR TITLE
Add System Purpose field to system card

### DIFF
--- a/src/__mocks__/mockedData.json
+++ b/src/__mocks__/mockedData.json
@@ -48,7 +48,10 @@
                 ],
                 "infrastructure_type": "virtual",
                 "system_memory_bytes": 512073728,
-                "infrastructure_vendor": "qemu"
+                "infrastructure_vendor": "qemu",
+                "system_purpose": {
+                    "usage": "Production"
+                }
             }
         }
     ]

--- a/src/__mocks__/selectors.js
+++ b/src/__mocks__/selectors.js
@@ -5,7 +5,10 @@ export const testProperties = {
     cores_per_socket: 1,
     ramSize: '5 MB',
     disk_devices: [],
-    cpu_flags: []
+    cpu_flags: [],
+    system_purpose: {
+        usage: 'Production'
+    }
 };
 
 export const osTest = {

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -202,6 +202,18 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                 class=""
                 data-pf-content="true"
               >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
                 Number of CPUs
               </dt>
               <dd
@@ -1169,6 +1181,18 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                 data-pf-content="true"
               >
                 Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
               </dd>
               <dt
                 class=""
@@ -2220,6 +2244,18 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                 class=""
                 data-pf-content="true"
               >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
                 Number of CPUs
               </dt>
               <dd
@@ -3164,6 +3200,18 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                 class=""
                 data-pf-content="true"
               >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
                 Number of CPUs
               </dt>
               <dd
@@ -4095,6 +4143,18 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                 data-pf-content="true"
               >
                 Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
               </dd>
               <dt
                 class=""
@@ -5836,6 +5896,18 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                 class=""
                 data-pf-content="true"
               >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
                 Number of CPUs
               </dt>
               <dd
@@ -6810,6 +6882,18 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                 data-pf-content="true"
               >
                 Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
               </dd>
               <dt
                 class=""
@@ -7868,6 +7952,18 @@ exports[`GeneralInformation custom components should render custom Configuration
                 class=""
                 data-pf-content="true"
               >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
                 Number of CPUs
               </dt>
               <dd
@@ -8819,6 +8915,18 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                 class=""
                 data-pf-content="true"
               >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
                 Number of CPUs
               </dt>
               <dd
@@ -9757,6 +9865,18 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                 data-pf-content="true"
               >
                 Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
               </dd>
               <dt
                 class=""
@@ -11501,6 +11621,24 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                 class=""
                 data-pf-content="true"
               >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <div
+                  class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-u-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
                 Number of CPUs
               </dt>
               <dd
@@ -12668,6 +12806,18 @@ exports[`GeneralInformation should render correctly 1`] = `
                 data-pf-content="true"
               >
                 Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                System purpose
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Production
               </dd>
               <dt
                 class=""

--- a/src/components/GeneralInfo/SystemCard/SystemCard.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.js
@@ -79,6 +79,7 @@ class SystemCardCore extends Component {
             hasDisplayName,
             hasAnsibleHostname,
             hasSAP,
+            hasSystemPurpose,
             hasCPUs,
             hasSockets,
             hasCores,
@@ -141,6 +142,7 @@ class SystemCardCore extends Component {
                                 );
                             }
                         }] : [],
+                        ...hasSystemPurpose ? [{ title: 'System purpose', value: properties.systemPurpose }] : [],
                         ...hasCPUs ? [{ title: 'Number of CPUs', value: properties.cpuNumber }] : [],
                         ...hasSockets ? [{ title: 'Sockets', value: properties.sockets }] : [],
                         ...hasCores ? [{ title: 'Cores per socket', value: properties.coresPerSocket }] : [],
@@ -210,6 +212,7 @@ SystemCardCore.propTypes = {
             type: PropTypes.string
         })),
         sapIds: PropTypes.arrayOf(PropTypes.string),
+        systemPurpose: PropTypes.string,
         cpuFlags: PropTypes.array
     }),
     setDisplayName: PropTypes.func,
@@ -220,6 +223,7 @@ SystemCardCore.propTypes = {
     hasDisplayName: PropTypes.bool,
     hasAnsibleHostname: PropTypes.bool,
     hasSAP: PropTypes.bool,
+    hasSystemPurpose: PropTypes.bool,
     hasCPUs: PropTypes.bool,
     hasSockets: PropTypes.bool,
     hasCores: PropTypes.bool,
@@ -235,6 +239,7 @@ SystemCardCore.defaultProps = {
     hasDisplayName: true,
     hasAnsibleHostname: true,
     hasSAP: true,
+    hasSystemPurpose: true,
     hasCPUs: true,
     hasSockets: true,
     hasCores: true,

--- a/src/components/GeneralInfo/SystemCard/SystemCard.test.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.test.js
@@ -231,6 +231,7 @@ describe('SystemCard', () => {
         'hasDisplayName',
         'hasAnsibleHostname',
         'hasSAP',
+        'hasSystemPurpose',
         'hasCPUs',
         'hasSockets',
         'hasCores',

--- a/src/components/GeneralInfo/SystemCard/__snapshots__/SystemCard.test.js.snap
+++ b/src/components/GeneralInfo/SystemCard/__snapshots__/SystemCard.test.js.snap
@@ -139,6 +139,18 @@ exports[`SystemCard should not render hasAnsibleHostname 1`] = `
           class=""
           data-pf-content="true"
         >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
           Number of CPUs
         </dt>
         <dd
@@ -202,6 +214,518 @@ exports[`SystemCard should not render hasAnsibleHostname 1`] = `
 `;
 
 exports[`SystemCard should not render hasCPUFlags 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-ouia-component-id="OUIA-Generated-Text-22"
+        data-ouia-component-type="PF4/Text"
+        data-ouia-safe="true"
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-61"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-62"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-63"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasCPUs 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-ouia-component-id="OUIA-Generated-Text-19"
+        data-ouia-component-type="PF4/Text"
+        data-ouia-safe="true"
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-52"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-53"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-54"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasCores 1`] = `
 <div
   class="pf-l-stack pf-m-gutter"
 >
@@ -395,489 +919,13 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
           class=""
           data-pf-content="true"
         >
-          Number of CPUs
+          System purpose
         </dt>
         <dd
           class=""
           data-pf-content="true"
         >
-          1
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          Sockets
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          1
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          Cores per socket
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          1
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RAM
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          5 MB
-        </dd>
-      </dl>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`SystemCard should not render hasCPUs 1`] = `
-<div
-  class="pf-l-stack pf-m-gutter"
->
-  <div
-    class="pf-l-stack__item"
-  >
-    <div
-      class="pf-c-content"
-    >
-      <h1
-        class=""
-        data-ouia-component-id="OUIA-Generated-Text-18"
-        data-ouia-component-type="PF4/Text"
-        data-ouia-safe="true"
-        data-pf-content="true"
-      >
-        System properties
-      </h1>
-    </div>
-  </div>
-  <div
-    class="pf-l-stack__item pf-m-fill"
-  >
-    <div
-      class="pf-c-content"
-    >
-      <dl
-        class=""
-        data-pf-content="true"
-      >
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          <span>
-            Host name
-          </span>
-          <button
-            aria-disabled="false"
-            aria-label="Action for Host name"
-            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-49"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe="true"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-              />
-            </svg>
-          </button>
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          <span>
-            Display name
-          </span>
-          <button
-            aria-disabled="false"
-            aria-label="Action for Display name"
-            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-50"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe="true"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-              />
-            </svg>
-          </button>
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          test-display-name
-          <a
-            class="ins-c-inventory__detail--action"
-            href="http://localhost:5000//display_name"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
-              />
-            </svg>
-          </a>
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          <span>
-            Ansible hostname
-          </span>
-          <button
-            aria-disabled="false"
-            aria-label="Action for Ansible hostname"
-            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-51"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe="true"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-              />
-            </svg>
-          </button>
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          test-ansible-host
-          <a
-            class="ins-c-inventory__detail--action"
-            href="http://localhost:5000//ansible_name"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
-              />
-            </svg>
-          </a>
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          SAP
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          Sockets
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          1
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          Cores per socket
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          1
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          CPU flags
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          0 flags
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          RAM
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          5 MB
-        </dd>
-      </dl>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`SystemCard should not render hasCores 1`] = `
-<div
-  class="pf-l-stack pf-m-gutter"
->
-  <div
-    class="pf-l-stack__item"
-  >
-    <div
-      class="pf-c-content"
-    >
-      <h1
-        class=""
-        data-ouia-component-id="OUIA-Generated-Text-20"
-        data-ouia-component-type="PF4/Text"
-        data-ouia-safe="true"
-        data-pf-content="true"
-      >
-        System properties
-      </h1>
-    </div>
-  </div>
-  <div
-    class="pf-l-stack__item pf-m-fill"
-  >
-    <div
-      class="pf-c-content"
-    >
-      <dl
-        class=""
-        data-pf-content="true"
-      >
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          <span>
-            Host name
-          </span>
-          <button
-            aria-disabled="false"
-            aria-label="Action for Host name"
-            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-55"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe="true"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-              />
-            </svg>
-          </button>
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          <span>
-            Display name
-          </span>
-          <button
-            aria-disabled="false"
-            aria-label="Action for Display name"
-            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-56"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe="true"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-              />
-            </svg>
-          </button>
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          test-display-name
-          <a
-            class="ins-c-inventory__detail--action"
-            href="http://localhost:5000//display_name"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
-              />
-            </svg>
-          </a>
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          <span>
-            Ansible hostname
-          </span>
-          <button
-            aria-disabled="false"
-            aria-label="Action for Ansible hostname"
-            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-57"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe="true"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-              />
-            </svg>
-          </button>
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          test-ansible-host
-          <a
-            class="ins-c-inventory__detail--action"
-            href="http://localhost:5000//ansible_name"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align:-0.125em"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
-              />
-            </svg>
-          </a>
-        </dd>
-        <dt
-          class=""
-          data-pf-content="true"
-        >
-          SAP
-        </dt>
-        <dd
-          class=""
-          data-pf-content="true"
-        >
-          Not available
+          Production
         </dd>
         <dt
           class=""
@@ -1067,6 +1115,18 @@ exports[`SystemCard should not render hasDisplayName 1`] = `
           data-pf-content="true"
         >
           Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
         </dd>
         <dt
           class=""
@@ -1291,6 +1351,18 @@ exports[`SystemCard should not render hasHostName 1`] = `
           class=""
           data-pf-content="true"
         >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
           Number of CPUs
         </dt>
         <dd
@@ -1365,7 +1437,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
     >
       <h1
         class=""
-        data-ouia-component-id="OUIA-Generated-Text-22"
+        data-ouia-component-id="OUIA-Generated-Text-23"
         data-ouia-component-type="PF4/Text"
         data-ouia-safe="true"
         data-pf-content="true"
@@ -1395,7 +1467,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
             aria-disabled="false"
             aria-label="Action for Host name"
             class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-61"
+            data-ouia-component-id="OUIA-Generated-Button-plain-64"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
@@ -1432,7 +1504,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
             aria-disabled="false"
             aria-label="Action for Display name"
             class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-62"
+            data-ouia-component-id="OUIA-Generated-Button-plain-65"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
@@ -1487,7 +1559,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
             aria-disabled="false"
             aria-label="Action for Ansible hostname"
             class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-63"
+            data-ouia-component-id="OUIA-Generated-Button-plain-66"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
@@ -1542,6 +1614,18 @@ exports[`SystemCard should not render hasRAM 1`] = `
           data-pf-content="true"
         >
           Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
         </dd>
         <dt
           class=""
@@ -1779,6 +1863,18 @@ exports[`SystemCard should not render hasSAP 1`] = `
           class=""
           data-pf-content="true"
         >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
           Number of CPUs
         </dt>
         <dd
@@ -1853,7 +1949,7 @@ exports[`SystemCard should not render hasSockets 1`] = `
     >
       <h1
         class=""
-        data-ouia-component-id="OUIA-Generated-Text-19"
+        data-ouia-component-id="OUIA-Generated-Text-20"
         data-ouia-component-type="PF4/Text"
         data-ouia-safe="true"
         data-pf-content="true"
@@ -1883,7 +1979,7 @@ exports[`SystemCard should not render hasSockets 1`] = `
             aria-disabled="false"
             aria-label="Action for Host name"
             class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-52"
+            data-ouia-component-id="OUIA-Generated-Button-plain-55"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
@@ -1920,7 +2016,7 @@ exports[`SystemCard should not render hasSockets 1`] = `
             aria-disabled="false"
             aria-label="Action for Display name"
             class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-53"
+            data-ouia-component-id="OUIA-Generated-Button-plain-56"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
@@ -1975,7 +2071,263 @@ exports[`SystemCard should not render hasSockets 1`] = `
             aria-disabled="false"
             aria-label="Action for Ansible hostname"
             class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-54"
+            data-ouia-component-id="OUIA-Generated-Button-plain-57"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasSystemPurpose 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-ouia-component-id="OUIA-Generated-Text-18"
+        data-ouia-component-type="PF4/Text"
+        data-ouia-safe="true"
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-49"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-50"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-51"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
@@ -2036,6 +2388,18 @@ exports[`SystemCard should not render hasSockets 1`] = `
           data-pf-content="true"
         >
           Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
         </dt>
         <dd
           class=""
@@ -2250,6 +2614,24 @@ exports[`SystemCard should render correctly - no data 1`] = `
           data-pf-content="true"
         >
           SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <div
+            class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+          >
+            <span
+              class="pf-u-screen-reader"
+            />
+          </div>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          System purpose
         </dt>
         <dd
           class=""
@@ -2557,6 +2939,18 @@ exports[`SystemCard should render correctly with SAP IDS 1`] = `
           class=""
           data-pf-content="true"
         >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
           Number of CPUs
         </dt>
         <dd
@@ -2808,6 +3202,18 @@ exports[`SystemCard should render correctly with data 1`] = `
           data-pf-content="true"
         >
           Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
         </dd>
         <dt
           class=""
@@ -3069,6 +3475,18 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
           class=""
           data-pf-content="true"
         >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
           Number of CPUs
         </dt>
         <dd
@@ -3143,7 +3561,7 @@ exports[`SystemCard should render extra 1`] = `
     >
       <h1
         class=""
-        data-ouia-component-id="OUIA-Generated-Text-23"
+        data-ouia-component-id="OUIA-Generated-Text-24"
         data-ouia-component-type="PF4/Text"
         data-ouia-safe="true"
         data-pf-content="true"
@@ -3173,7 +3591,7 @@ exports[`SystemCard should render extra 1`] = `
             aria-disabled="false"
             aria-label="Action for Host name"
             class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-64"
+            data-ouia-component-id="OUIA-Generated-Button-plain-67"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
@@ -3210,7 +3628,7 @@ exports[`SystemCard should render extra 1`] = `
             aria-disabled="false"
             aria-label="Action for Display name"
             class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-65"
+            data-ouia-component-id="OUIA-Generated-Button-plain-68"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
@@ -3265,7 +3683,7 @@ exports[`SystemCard should render extra 1`] = `
             aria-disabled="false"
             aria-label="Action for Ansible hostname"
             class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-            data-ouia-component-id="OUIA-Generated-Button-plain-66"
+            data-ouia-component-id="OUIA-Generated-Button-plain-69"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
@@ -3320,6 +3738,18 @@ exports[`SystemCard should render extra 1`] = `
           data-pf-content="true"
         >
           Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          System purpose
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Production
         </dd>
         <dt
           class=""

--- a/src/components/GeneralInfo/selectors/selectors.js
+++ b/src/components/GeneralInfo/selectors/selectors.js
@@ -16,6 +16,7 @@ export const propertiesSelector = ({
     ramSize,
     disk_devices,
     sap_sids,
+    system_purpose,
     cpu_flags
 } = {}, { facts } = { }) => ({
     cpuNumber: number_of_cpus || facts?.rhsm?.CPU_CORES,
@@ -35,6 +36,7 @@ export const propertiesSelector = ({
     })
     ),
     sapIds: sap_sids,
+    systemPurpose: system_purpose?.usage,
     cpuFlags: cpu_flags
 });
 

--- a/src/components/GeneralInfo/selectors/selectors.test.js
+++ b/src/components/GeneralInfo/selectors/selectors.test.js
@@ -23,7 +23,8 @@ it('propertiesSelector should return correct data', () => {
         coresPerSocket: 1,
         ramSize: '5 MB',
         storage: [],
-        cpuFlags: []
+        cpuFlags: [],
+        systemPurpose: 'Production'
     });
 });
 
@@ -33,7 +34,8 @@ it('propertiesSelector - no data', () => {
         sockets: undefined,
         coresPerSocket: undefined,
         ramSize: undefined,
-        storage: undefined
+        storage: undefined,
+        systemPurpose: undefined
     });
 });
 

--- a/src/store/__snapshots__/systemProfileStore.test.js.snap
+++ b/src/store/__snapshots__/systemProfileStore.test.js.snap
@@ -50,6 +50,9 @@ Object {
   ],
   "satellite_managed": false,
   "system_memory_bytes": 512073728,
+  "system_purpose": Object {
+    "usage": "Production",
+  },
   "yum_repos": Array [
     Object {
       "enabled": false,


### PR DESCRIPTION
This PR addresses [ESSNTL-601](https://issues.redhat.com/browse/ESSNTL-601).
It adds a "System purpose" field in-between "SAP" and "Number of CPUs", and its value is equal to `system_profile.system_purpose.usage`.