### PR TITLE
fix(InventoryTable): ESSNTL-3505 - Only use columns already in the store

### DIFF
--- a/src/components/InventoryTable/hooks/useColumns.js
+++ b/src/components/InventoryTable/hooks/useColumns.js
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/helpers/helpers';
+import { defaultColumns } from '../../../store/entities';
+
+const isColumnEnabled = (key, disableColumns, showTags) =>
+    (key === 'tags' && showTags) ||
+    (key !== 'tags' && (Array.isArray(disableColumns) && !(disableColumns).includes(key)));
+
+const useColumns = (columnsProp, disableDefaultColumns, showTags, columnsCounter) => {
+    const columnsRedux = useSelector(
+        ({ entities: { columns } }) => columns,
+        (next, prev) => next.every(
+            ({ key }, index) => prev.findIndex(({ key: prevKey }) => prevKey === key) === index
+        )
+    );
+    const disabledColumns = Array.isArray(disableDefaultColumns) ? disableDefaultColumns : [];
+    const defaultColumnsFiltered = useMemo(() => (disableDefaultColumns === true) ?
+        [] : defaultColumns().filter(({ key }) =>
+            isColumnEnabled(key, disabledColumns, showTags)
+        ), [disabledColumns, disableDefaultColumns, showTags]);
+
+    return useMemo(() => {
+        if (typeof columnsProp === 'function') {
+            return columnsProp(defaultColumns());
+        } else if (columnsProp) {
+            return mergeArraysByKey([
+                defaultColumnsFiltered,
+                columnsProp
+            ], 'key');
+        } else if (!columnsProp && columnsRedux) {
+            return columnsRedux;
+        }  else {
+            return defaultColumnsFiltered;
+        }
+    }, [
+        showTags,
+        Array.isArray(disableDefaultColumns) ? disableDefaultColumns.join() : disableDefaultColumns,
+        Array.isArray(columnsProp) ?
+            columnsProp.map(({ key }) => key).join() :
+            typeof columnsProp === 'function' ? 'function' : columnsProp,
+        Array.isArray(columnsRedux) ? columnsRedux.map(({ key }) => key).join() : columnsRedux,
+        columnsCounter
+    ]);
+};
+
+export default useColumns;

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -94,10 +94,10 @@ export const defaultColumns = () => ([
 function entitiesPending(state, { meta }) {
     return {
         ...state,
-        columns: mergeArraysByKey([
+        ...state.columns && { columns: mergeArraysByKey([
             defaultColumns().filter(({ key }) => key !== 'tags' || meta?.showTags),
             state.columns
-        ], 'key'),
+        ], 'key') } || {},
         rows: [],
         loaded: false,
         lastDateRequest: meta.lastDateRequest


### PR DESCRIPTION
**Steps to reproduce:**

1.) Open the "Settings" -> "Remote Host Configuration" page.
2.) Click the top right "View log" link
3.) Go to the "Systems" tab (Make sure there are systems in the list, otherwise the error is not triggered)
4.) Close the modal.
5.) Enter `window.__scalprum__.scalprumOptions.cacheTimeout = 1;` into the console to force a lower module cache timeout.
6.) After waiting reopen the "View log" modal

On Prod/Stage this should throw errors and not load the inventory. With this PR the errors should not occur and the Inventory should load normally. 