### PR TITLE
ESSNTL-3456 - Hyperlink titles get into global filter tag and breaks everything

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -8,6 +8,18 @@ jest.mock('react', () => ({
     useLayoutEffect: jest.requireActual('react').useEffect
 }));
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useRouteMatch: () => ({
+        path: '/:inventoryId',
+        url: '/07c86de4-dadd-4681-8e6c-fe0baaaef479',
+        isExact: true,
+        params: {
+            inventoryId: '07c86de4-dadd-4681-8e6c-fe0baaaef479'
+        }
+    })
+}));
+
 configure({ adapter: new Adapter() });
 
 global.insights = {

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -9,7 +9,8 @@ const InventoryDetail = lazy(() => import('./routes/InventoryDetail'));
 
 export const routes = {
     table: '/',
-    detail: '/:inventoryId'
+    detail: '/:inventoryId',
+    detailWithModal: '/:inventoryId/:modalId'
 };
 
 export const Routes = () => {
@@ -39,6 +40,7 @@ export const Routes = () => {
                     />}
                     rootClass='inventory'
                 />
+                <Route exact path={routes.detailWithModal} component={InventoryDetail} rootClass='inventory' />
                 <Route exact path={routes.detail} component={InventoryDetail} rootClass='inventory' />
                 <Redirect path="*" to="/" />
             </Switch>

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -12,6 +12,8 @@ import {
     TextListItem
 } from '@patternfly/react-core';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+import { useRouteMatch } from 'react-router-dom';
+import { routes } from '../../../Routes';
 
 const valueToText = (value, singular, plural) => {
     if ((value || value === 0) && singular) {
@@ -52,6 +54,8 @@ Clickable.defaultProps = {
 };
 
 const LoadingCard = ({ title, isLoading, items, children }) => {
+    const urlMatch = useRouteMatch(routes.detailWithModal);
+    const modalId = urlMatch?.params?.modalId;
     return (
         <Stack hasGutter>
             <StackItem>
@@ -72,6 +76,7 @@ const LoadingCard = ({ title, isLoading, items, children }) => {
                                     </TextListItem>
                                     <TextListItem component={ TextListItemVariants.dd }>
                                         { isLoading && <Skeleton size={ item.size || SkeletonSize.sm } /> }
+                                        { modalId && item.onClick && item.target === modalId && item.onClick()}
                                         { !isLoading && (
                                             item.onClick && item.value ?
                                                 <Clickable item={ item }/> :

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -31,7 +31,7 @@ export const Clickable = ({ item: { onClick, value, target, plural, singular } }
             event.preventDefault();
             onClick(event, { value, target });
         } }
-        href={ `${window.location.href}/${target}` }
+        href={ `${window.location.href.split('#')[0]}/${target}` }
     >
         { valueToText(value, singular, plural) }
     </a>

--- a/src/components/InventoryDetail/InventoryDetail.js
+++ b/src/components/InventoryDetail/InventoryDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, Fragment } from 'react';
-import { useParams } from 'react-router-dom';
+import { useRouteMatch } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { loadEntity, deleteEntity } from '../../store/actions';
@@ -36,7 +36,7 @@ const InventoryDetail = ({
     ActionsWrapper,
     children
 }) => {
-    const { inventoryId } = useParams();
+    const { params: { inventoryId } } = useRouteMatch('/:inventoryId');
     const dispatch = useDispatch();
     const loaded = useSelector(({ entityDetails }) => entityDetails?.loaded || false);
     const entity = useSelector(({ entityDetails }) => entityDetails?.entity);

--- a/src/components/InventoryTable/EntityTable.test.js
+++ b/src/components/InventoryTable/EntityTable.test.js
@@ -9,16 +9,16 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { createPromise as promiseMiddleware } from 'redux-promise-middleware';
 import toJson from 'enzyme-to-json';
-import routeData from 'react-router';
+import { Router } from 'react-router';
 import { MemoryRouter } from 'react-router-dom';
 import TitleColumn from './TitleColumn';
 import InsightsDisconnected from '../../Utilities/InsightsDisconnected';
 import { defaultColumns } from '../../store/entities';
+import { createMemoryHistory } from 'history';
 
 describe('EntityTable', () => {
     let initialState;
     let mockStore;
-    const routerPush = jest.fn();
     beforeEach(() => {
         mockStore = configureStore([promiseMiddleware()]);
         initialState = {
@@ -36,9 +36,6 @@ describe('EntityTable', () => {
                 total: 500
             }
         };
-        jest.spyOn(routeData, 'useHistory').mockReturnValue({
-            push: routerPush
-        });
     });
 
     describe('DOM', () => {
@@ -534,14 +531,15 @@ describe('EntityTable', () => {
 
     describe('API', () => {
         it('should call default onRowClick', () => {
+            const history = createMemoryHistory();
             const store = mockStore(initialState);
-            const wrapper = mount(<MemoryRouter>
+            const wrapper = mount(<Router history={history}>
                 <Provider store={ store }>
                     <EntityTable loaded disableDefaultColumns/>
                 </Provider>
-            </MemoryRouter>);
+            </Router>);
             wrapper.find('table tbody tr a[widget="col"]').first().simulate('click');
-            expect(routerPush).toHaveBeenCalled();
+            expect(history.location.pathname).toBe('/testing-id');
         });
 
         it('should call onRowClick', () => {

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -29,19 +29,10 @@ const Inventory = () => {
     const firstApp = useSelector(({ entityDetails }) => entityDetails?.activeApps?.[0]);
     const currentApp = activeApp || (firstApp && firstApp.name);
     const clearNotifications = () => dispatch(actions.clearNotifications());
-
     useEffect(() => {
         insights.chrome?.hideGlobalFilter?.(true);
         insights.chrome.appAction('system-detail');
         clearNotifications();
-
-        // BZ: RHEL cockpit is linking to crc/insights/inventory/{}/insights
-        // which results in a page error, catch that and redirect
-        // TODO Remove me when BZ is fixed
-        const splitUrl = window.location.href.split('/insights');
-        if (splitUrl.length === 3) {
-            window.location = `${splitUrl[0]}/insights${splitUrl[1]}`;
-        }
     }, []);
 
     const additionalClasses = {


### PR DESCRIPTION
There are 4 commits in the PR:

- For clickable elements that are used to open modals, don't append params and anchors to the URL
- Removal or routing workaround that was introduced before BZ1958379 was closed
- Modals in the general info page can now be routed directly 
- Test updates