### PR TITLE
Fix inventory detail by using useParams instead of useRouteMatch

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -10,13 +10,8 @@ jest.mock('react', () => ({
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
-    useRouteMatch: () => ({
-        path: '/:inventoryId',
-        url: '/07c86de4-dadd-4681-8e6c-fe0baaaef479',
-        isExact: true,
-        params: {
-            inventoryId: '07c86de4-dadd-4681-8e6c-fe0baaaef479'
-        }
+    useParams: () => ({
+        inventoryId: '07c86de4-dadd-4681-8e6c-fe0baaaef479'
     })
 }));
 

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -12,8 +12,7 @@ import {
     TextListItem
 } from '@patternfly/react-core';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
-import { useRouteMatch } from 'react-router-dom';
-import { routes } from '../../../Routes';
+import { useParams } from 'react-router-dom';
 
 const valueToText = (value, singular, plural) => {
     if ((value || value === 0) && singular) {
@@ -54,8 +53,7 @@ Clickable.defaultProps = {
 };
 
 const LoadingCard = ({ title, isLoading, items, children }) => {
-    const urlMatch = useRouteMatch(routes.detailWithModal);
-    const modalId = urlMatch?.params?.modalId;
+    const { modalId } = useParams();
     return (
         <Stack hasGutter>
             <StackItem>

--- a/src/components/InventoryDetail/InventoryDetail.js
+++ b/src/components/InventoryDetail/InventoryDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, Fragment } from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { loadEntity, deleteEntity } from '../../store/actions';
@@ -36,7 +36,7 @@ const InventoryDetail = ({
     ActionsWrapper,
     children
 }) => {
-    const { params: { inventoryId } } = useRouteMatch('/:inventoryId');
+    const { inventoryId } = useParams();
     const dispatch = useDispatch();
     const loaded = useSelector(({ entityDetails }) => entityDetails?.loaded || false);
     const entity = useSelector(({ entityDetails }) => entityDetails?.entity);


### PR DESCRIPTION
### Description

There's an error when navigating to inventory detail from different application. The reason is that inv detail is looking at active system by parsing the URL. Each app defines the place where react-router-dom should look for inventoryId, however current implementation blindly checks for first string in URL. It results in broken UI where inventory is requesting URLs like `/api/invenotory/v1/hosts/inventory`.