### PR TITLE
Fix clicking on gen info detail links

### DIFF
--- a/src/components/GeneralInfo/BiosCard/BiosCard.test.js
+++ b/src/components/GeneralInfo/BiosCard/BiosCard.test.js
@@ -6,6 +6,16 @@ import BiosCard from './BiosCard';
 import configureStore from 'redux-mock-store';
 import { biosTest } from '../../../__mocks__/selectors';
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => ({
+        pathname: 'localhost:3000/example/path'
+    }),
+    useHistory: () => ({
+        push: () => undefined
+    })
+}));
+
 describe('BiosCard', () => {
     let initialState;
     let mockStore;

--- a/src/components/GeneralInfo/CollectionCard/CollectionCard.test.js
+++ b/src/components/GeneralInfo/CollectionCard/CollectionCard.test.js
@@ -7,6 +7,16 @@ import configureStore from 'redux-mock-store';
 import { collectInfoTest } from '../../../__mocks__/selectors';
 import { Tooltip } from '@patternfly/react-core';
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => ({
+        pathname: 'localhost:3000/example/path'
+    }),
+    useHistory: () => ({
+        push: () => undefined
+    })
+}));
+
 describe('CollectionCard', () => {
     let initialState;
     let mockStore;

--- a/src/components/GeneralInfo/ConfigurationCard/ConfigurationCard.test.js
+++ b/src/components/GeneralInfo/ConfigurationCard/ConfigurationCard.test.js
@@ -6,6 +6,16 @@ import ConfigurationCard from './ConfigurationCard';
 import configureStore from 'redux-mock-store';
 import { configTest } from '../../../__mocks__/selectors';
 
+const location = {};
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => location,
+    useHistory: () => ({
+        push: () => undefined
+    })
+}));
+
 describe('ConfigurationCard', () => {
     let initialState;
     let mockStore;
@@ -20,6 +30,7 @@ describe('ConfigurationCard', () => {
                 }
             }
         };
+        location.pathname = 'localhost:3000/example/path';
     });
 
     it('should render correctly - no data', () => {
@@ -68,6 +79,7 @@ describe('ConfigurationCard', () => {
         it('should call handleClick on packages', () => {
             const store = mockStore(initialState);
             const onClick = jest.fn();
+            location.pathname = 'localhost:3000/example/installed_packages';
             const wrapper = mount(<ConfigurationCard handleClick={ onClick } store={ store } />);
             wrapper.find('dd a').first().simulate('click');
             expect(onClick).toHaveBeenCalled();
@@ -76,22 +88,25 @@ describe('ConfigurationCard', () => {
         it('should call handleClick on services', () => {
             const store = mockStore(initialState);
             const onClick = jest.fn();
+            location.pathname = 'localhost:3000/example/services';
             const wrapper = mount(<ConfigurationCard handleClick={ onClick } store={ store } />);
             wrapper.find('dd a').at(1).simulate('click');
             expect(onClick).toHaveBeenCalled();
         });
 
-        it('should call handleClick on services', () => {
+        it('should call handleClick on processes', () => {
             const store = mockStore(initialState);
             const onClick = jest.fn();
+            location.pathname = 'localhost:3000/example/running_processes';
             const wrapper = mount(<ConfigurationCard handleClick={ onClick } store={ store } />);
             wrapper.find('dd a').at(2).simulate('click');
             expect(onClick).toHaveBeenCalled();
         });
 
-        it('should call handleClick on services', () => {
+        it('should call handleClick on repositories', () => {
             const store = mockStore(initialState);
             const onClick = jest.fn();
+            location.pathname = 'localhost:3000/example/repositories';
             const wrapper = mount(<ConfigurationCard handleClick={ onClick } store={ store } />);
             wrapper.find('dd a').at(3).simulate('click');
             expect(onClick).toHaveBeenCalled();

--- a/src/components/GeneralInfo/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
+++ b/src/components/GeneralInfo/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
@@ -166,15 +166,10 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
                           data-pf-content={true}
                         >
                           <Clickable
-                            item={
-                              Object {
-                                "onClick": [Function],
-                                "singular": "package",
-                                "target": "installed_packages",
-                                "title": "Installed packages",
-                                "value": 1,
-                              }
-                            }
+                            onClick={[Function]}
+                            singular="package"
+                            target="installed_packages"
+                            value={1}
                           >
                             <a
                               href="http://localhost:5000//installed_packages"
@@ -203,15 +198,10 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
                           data-pf-content={true}
                         >
                           <Clickable
-                            item={
-                              Object {
-                                "onClick": [Function],
-                                "singular": "service",
-                                "target": "services",
-                                "title": "Services",
-                                "value": 1,
-                              }
-                            }
+                            onClick={[Function]}
+                            singular="service"
+                            target="services"
+                            value={1}
                           >
                             <a
                               href="http://localhost:5000//services"
@@ -240,16 +230,11 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
                           data-pf-content={true}
                         >
                           <Clickable
-                            item={
-                              Object {
-                                "onClick": [Function],
-                                "plural": "processes",
-                                "singular": "process",
-                                "target": "running_processes",
-                                "title": "Running processes",
-                                "value": 1,
-                              }
-                            }
+                            onClick={[Function]}
+                            plural="processes"
+                            singular="process"
+                            target="running_processes"
+                            value={1}
                           >
                             <a
                               href="http://localhost:5000//running_processes"
@@ -278,14 +263,9 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
                           data-pf-content={true}
                         >
                           <Clickable
-                            item={
-                              Object {
-                                "onClick": [Function],
-                                "target": "repositories",
-                                "title": "Repositories",
-                                "value": "1 enabled",
-                              }
-                            }
+                            onClick={[Function]}
+                            target="repositories"
+                            value="1 enabled"
                           >
                             <a
                               href="http://localhost:5000//repositories"

--- a/src/components/GeneralInfo/DataCollectorsCard/DataCollectorsCard.test.js
+++ b/src/components/GeneralInfo/DataCollectorsCard/DataCollectorsCard.test.js
@@ -5,6 +5,16 @@ import toJson from 'enzyme-to-json';
 import DataCollectorsCard from './DataCollectorsCard';
 import configureStore from 'redux-mock-store';
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => ({
+        pathname: 'localhost:3000/example/path'
+    }),
+    useHistory: () => ({
+        push: () => undefined
+    })
+}));
+
 describe('DataCollectorsCard', () => {
     let initialState;
     let mockStore;

--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
@@ -19,6 +19,7 @@ import { ConfigurationCard } from '../ConfigurationCard';
 import { SystemStatusCard } from '../SystemStatusCard';
 import { DataCollectorsCard } from '../DataCollectorsCard/DataCollectorsCard';
 import { Provider } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import './general-information.scss';
 
 class GeneralInformation extends Component {
@@ -44,6 +45,10 @@ class GeneralInformation extends Component {
 
     handleModalToggle = (modalTitle = '', { cells, rows, expandable, filters } = {}, modalVariant = 'small') => {
         rows && this.onSort(undefined, expandable ? 1 : 0, SortByDirection.asc, rows);
+        if (this.state.isModalOpen) {
+            this.props.history.push(this.props.location.pathname.split('/').slice(0, -1).join('/'));
+        }
+
         this.setState(({ isModalOpen }) => ({
             isModalOpen: !isModalOpen,
             modalTitle,
@@ -141,7 +146,9 @@ GeneralInformation.propTypes = {
     SystemStatusCardWrapper: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
     DataCollectorsCardWrapper: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
     CollectionCardWrapper: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
-    children: PropTypes.node
+    children: PropTypes.node,
+    history: PropTypes.any,
+    location: PropTypes.any
 };
 GeneralInformation.defaultProps = {
     entity: {},
@@ -166,4 +173,4 @@ const mapDispatchToProps = (dispatch) => ({
     loadSystemDetail: (itemId) => dispatch(systemProfile(itemId))
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(GeneralInformation);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(GeneralInformation));

--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.test.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.test.js
@@ -8,6 +8,7 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { osTest, biosTest, collectInfoTest, configTest, infraTest, testProperties } from '../../../__mocks__/selectors';
 import promiseMiddleware from 'redux-promise-middleware';
+import { MemoryRouter } from 'react-router-dom';
 
 import { hosts } from '../../../api/api';
 import MockAdapter from 'axios-mock-adapter';
@@ -20,11 +21,22 @@ jest.mock('@redhat-cloud-services/frontend-components-utilities/RBACHook', () =>
     usePermissionsWithContext: () => ({ hasAccess: true })
 }));
 
+const location = {};
+const history = {};
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => location,
+    useHistory: () => history
+}));
+
 describe('GeneralInformation', () => {
     let initialState;
     let mockStore;
 
     beforeEach(() => {
+        location.pathname = 'localhost:3000/example/path';
+        history.push = () => undefined;
         mockStore = configureStore([promiseMiddleware]);
         initialState = {
             entityDetails: {
@@ -66,17 +78,21 @@ describe('GeneralInformation', () => {
 
     it('should render correctly - no data', () => {
         const store = mockStore({ systemProfileStore: {}, entityDetails: {} });
-        const wrapper = render(<Provider store={ store }>
-            <GeneralInformation />
-        </Provider>);
+        const wrapper = render(<MemoryRouter>
+            <Provider store={ store }>
+                <GeneralInformation />
+            </Provider>
+        </MemoryRouter>);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render correctly', () => {
         const store = mockStore(initialState);
-        const wrapper = render(<Provider store={ store }>
-            <GeneralInformation />
-        </Provider>);
+        const wrapper = render(<MemoryRouter>
+            <Provider store={ store }>
+                <GeneralInformation />
+            </Provider>
+        </MemoryRouter>);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
@@ -91,17 +107,21 @@ describe('GeneralInformation', () => {
         ].map((item) => {
             it(`should not render ${item}`, () => {
                 const store = mockStore(initialState);
-                const wrapper = render(<Provider store={ store }>
-                    <GeneralInformation {...{ [item]: false }} />
-                </Provider>);
+                const wrapper = render(<MemoryRouter>
+                    <Provider store={ store }>
+                        <GeneralInformation {...{ [item]: false }} />
+                    </Provider>
+                </MemoryRouter>);
                 expect(toJson(wrapper)).toMatchSnapshot();
             });
 
             it(`should render custom ${item}`, () => {
                 const store = mockStore(initialState);
-                const wrapper = render(<Provider store={ store }>
-                    <GeneralInformation {...{ [item]: () => <div>test</div> }} />
-                </Provider>);
+                const wrapper = render(<MemoryRouter>
+                    <Provider store={ store }>
+                        <GeneralInformation {...{ [item]: () => <div>test</div> }} />
+                    </Provider>
+                </MemoryRouter>);
                 expect(toJson(wrapper)).toMatchSnapshot();
             });
         });
@@ -118,18 +138,26 @@ describe('GeneralInformation', () => {
                         per_reporter_staleness: {}
                     }
                 } });
-            mount(<Provider store={ store }>
-                <GeneralInformation />
-            </Provider>);
+            mount(<MemoryRouter>
+                <Provider store={ store }>
+                    <GeneralInformation />
+                </Provider>
+            </MemoryRouter>);
             expect(store.getActions()[0].type).toBe('LOAD_SYSTEM_PROFILE_PENDING');
         });
 
         it('should open modal', () => {
             const store = mockStore(initialState);
-            const wrapper = mount(<Provider store={ store }>
-                <GeneralInformation />
-            </Provider>);
+            history.push = jest.fn();
+            location.pathname = 'localhost:3000/example/interfaces';
+
+            const wrapper = mount(<MemoryRouter>
+                <Provider store={ store }>
+                    <GeneralInformation />
+                </Provider>
+            </MemoryRouter>);
             wrapper.find('a[href$="interfaces"]').first().simulate('click');
+            expect(history.push).toBeCalledWith(`${location.pathname}/interfaces`);
             wrapper.update();
             expect(wrapper.find('GeneralInformation').instance().state.isModalOpen).toBe(true);
             expect(wrapper.find('GeneralInformation').instance().state.modalTitle).toBe('Interfaces/NICs');
@@ -137,9 +165,12 @@ describe('GeneralInformation', () => {
 
         it('should update on sort', () => {
             const store = mockStore(initialState);
-            const wrapper = mount(<Provider store={ store }>
-                <GeneralInformation />
-            </Provider>);
+            location.pathname = 'localhost:3000/example/interfaces';
+            const wrapper = mount(<MemoryRouter>
+                <Provider store={ store }>
+                    <GeneralInformation />
+                </Provider>
+            </MemoryRouter>);
             wrapper.find('a[href$="interfaces"]').first().simulate('click');
             wrapper.update();
             const [firstRow, secondRow] = wrapper.find('GeneralInformation').instance().state.rows;
@@ -151,9 +182,12 @@ describe('GeneralInformation', () => {
 
         it('should open modal', () => {
             const store = mockStore(initialState);
-            const wrapper = mount(<Provider store={ store }>
-                <GeneralInformation />
-            </Provider>);
+            location.pathname = 'localhost:3000/example/interfaces';
+            const wrapper = mount(<MemoryRouter>
+                <Provider store={ store }>
+                    <GeneralInformation />
+                </Provider>
+            </MemoryRouter>);
             wrapper.find('a[href$="interfaces"]').first().simulate('click');
             wrapper.update();
             wrapper.find('.ins-c-inventory__detail--dialog button.pf-m-plain').first().simulate('click');
@@ -163,9 +197,11 @@ describe('GeneralInformation', () => {
 
         it('should calculate first index when expandable', () => {
             const store = mockStore(initialState);
-            const wrapper = mount(<Provider store={ store }>
-                <GeneralInformation />
-            </Provider>);
+            const wrapper = mount(<MemoryRouter>
+                <Provider store={ store }>
+                    <GeneralInformation />
+                </Provider>
+            </MemoryRouter>);
             wrapper.find('GeneralInformation').instance().handleModalToggle('title', {
                 cells: [{ title: 'one' }, { title: 'two' }],
                 rows: [

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -459,7 +459,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -1443,7 +1443,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -2501,7 +2501,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -4305,7 +4305,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -5095,7 +5095,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -6153,7 +6153,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -7144,7 +7144,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -8209,7 +8209,7 @@ exports[`GeneralInformation custom components should render custom Configuration
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -10034,7 +10034,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -10831,7 +10831,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>
@@ -13068,7 +13068,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                 data-pf-content="true"
               >
                 <a
-                  href="http://localhost:5000//undefined"
+                  href="http://localhost:5000//ipv6"
                 >
                   2 addresses
                 </a>

--- a/src/components/GeneralInfo/InfrastructureCard/InfrastructureCard.js
+++ b/src/components/GeneralInfo/InfrastructureCard/InfrastructureCard.js
@@ -40,6 +40,7 @@ const InfrastructureCardCore = ({
             value: infrastructure.ipv6?.length,
             plural: 'addresses',
             singular: 'address',
+            target: 'ipv6',
             onClick: () => {
                 handleClick(
                     'IPv6',

--- a/src/components/GeneralInfo/InfrastructureCard/InfrastructureCard.test.js
+++ b/src/components/GeneralInfo/InfrastructureCard/InfrastructureCard.test.js
@@ -6,11 +6,22 @@ import InfrastructureCard from './InfrastructureCard';
 import configureStore from 'redux-mock-store';
 import { infraTest, rhsmFacts } from '../../../__mocks__/selectors';
 
+const location = {};
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => location,
+    useHistory: () => ({
+        push: () => undefined
+    })
+}));
+
 describe('InfrastructureCard', () => {
     let initialState;
     let mockStore;
 
     beforeEach(() => {
+        location.pathname = 'localhost:3000/example/path';
         mockStore = configureStore();
         initialState = {
             systemProfileStore: {
@@ -77,25 +88,28 @@ describe('InfrastructureCard', () => {
             expect(onClick).not.toHaveBeenCalled();
         });
 
-        it('should call handleClick on packages', () => {
+        it('should call handleClick on ipv4', () => {
             const store = mockStore(initialState);
             const onClick = jest.fn();
+            location.pathname = 'localhost:3000/example/ipv4';
             const wrapper = mount(<InfrastructureCard handleClick={ onClick } store={ store } />);
             wrapper.find('dd a').first().simulate('click');
             expect(onClick).toHaveBeenCalled();
         });
 
-        it('should call handleClick on services', () => {
+        it('should call handleClick on ipv6', () => {
             const store = mockStore(initialState);
             const onClick = jest.fn();
+            location.pathname = 'localhost:3000/example/ipv6';
             const wrapper = mount(<InfrastructureCard handleClick={ onClick } store={ store } />);
             wrapper.find('dd a').at(1).simulate('click');
             expect(onClick).toHaveBeenCalled();
         });
 
-        it('should call handleClick on services', () => {
+        it('should call handleClick on interfaces', () => {
             const store = mockStore(initialState);
             const onClick = jest.fn();
+            location.pathname = 'localhost:3000/example/interfaces';
             const wrapper = mount(<InfrastructureCard handleClick={ onClick } store={ store } />);
             wrapper.find('dd a').at(2).simulate('click');
             expect(onClick).toHaveBeenCalled();

--- a/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
+++ b/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
@@ -66,7 +66,7 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
           data-pf-content="true"
         >
           <a
-            href="http://localhost:5000//undefined"
+            href="http://localhost:5000//ipv6"
           >
             1 address
           </a>
@@ -268,7 +268,7 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
           data-pf-content="true"
         >
           <a
-            href="http://localhost:5000//undefined"
+            href="http://localhost:5000//ipv6"
           >
             1 address
           </a>
@@ -349,7 +349,7 @@ exports[`InfrastructureCard should not render hasType 1`] = `
           data-pf-content="true"
         >
           <a
-            href="http://localhost:5000//undefined"
+            href="http://localhost:5000//ipv6"
           >
             1 address
           </a>
@@ -446,7 +446,7 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
           data-pf-content="true"
         >
           <a
-            href="http://localhost:5000//undefined"
+            href="http://localhost:5000//ipv6"
           >
             1 address
           </a>
@@ -682,7 +682,7 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
           data-pf-content="true"
         >
           <a
-            href="http://localhost:5000//undefined"
+            href="http://localhost:5000//ipv6"
           >
             1 address
           </a>
@@ -888,7 +888,7 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
           data-pf-content="true"
         >
           <a
-            href="http://localhost:5000//undefined"
+            href="http://localhost:5000//ipv6"
           >
             1 address
           </a>
@@ -997,7 +997,7 @@ exports[`InfrastructureCard should render extra 1`] = `
           data-pf-content="true"
         >
           <a
-            href="http://localhost:5000//undefined"
+            href="http://localhost:5000//ipv6"
           >
             1 address
           </a>

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.test.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.test.js
@@ -3,6 +3,18 @@ import { shallow, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import LoadingCard, { Clickable } from './LoadingCard';
 
+const history = {
+    push: () => undefined
+};
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => ({
+        pathname: 'localhost:3000/example/path'
+    }),
+    useHistory: () => history
+}));
+
 describe('LoadingCard', () => {
     [true, false].map(isLoading => {
         it(`Loading card render - isLoading: ${isLoading}`, () => {
@@ -219,11 +231,8 @@ describe('LoadingCard', () => {
 
     it('Clickable should render', () => {
         const onClick = jest.fn();
-        const wrapper = shallow(<Clickable item={ {
-            onClick,
-            value: 15,
-            target: 'some-target'
-        } } />);
+        history.push = onClick;
+        const wrapper = shallow(<Clickable value="15" target="some-target" />);
         wrapper.find('a').first().simulate('click', {
             preventDefault: () => {
             }
@@ -232,13 +241,19 @@ describe('LoadingCard', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
+    it('clickable should click', () => {
+        const onClick = jest.fn();
+        const wrapper = mount(<Clickable onClick={onClick} value="15" target="path"/>);
+        wrapper.find('a').first().simulate('click', {
+            preventDefault: () => {
+            }
+        });
+        expect(onClick).toHaveBeenCalled();
+    });
+
     it('Clickable should render - 0 value', () => {
         const onClick = jest.fn();
-        const wrapper = shallow(<Clickable item={ {
-            onClick,
-            value: 0,
-            target: 'some-target'
-        } } />);
+        const wrapper = shallow(<Clickable onClick={onClick} value={0} target="some-target" />);
         expect(onClick).not.toHaveBeenCalled();
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/src/components/GeneralInfo/LoadingCard/__snapshots__/LoadingCard.test.js.snap
+++ b/src/components/GeneralInfo/LoadingCard/__snapshots__/LoadingCard.test.js.snap
@@ -94,14 +94,8 @@ exports[`LoadingCard Loading card render 1`] = `
           component="dd"
         >
           <Clickable
-            item={
-              Object {
-                "onClick": [MockFunction],
-                "size": "md",
-                "title": "test-title",
-                "value": "some value",
-              }
-            }
+            onClick={[MockFunction]}
+            value="some value"
           />
         </TextListItem>
         <TextListItem

--- a/src/components/GeneralInfo/OperatingSystemCard/OperatingSystemCard.test.js
+++ b/src/components/GeneralInfo/OperatingSystemCard/OperatingSystemCard.test.js
@@ -6,11 +6,22 @@ import OperatingSystemCard from './OperatingSystemCard';
 import configureStore from 'redux-mock-store';
 import { osTest, rhsmFacts } from '../../../__mocks__/selectors';
 
+const location = {};
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => location,
+    useHistory: () => ({
+        push: () => undefined
+    })
+}));
+
 describe('OperatingSystemCard', () => {
     let initialState;
     let mockStore;
 
     beforeEach(() => {
+        location.pathname = 'localhost:3000/example/path';
         mockStore = configureStore();
         initialState = {
             systemProfileStore: {
@@ -94,6 +105,7 @@ describe('OperatingSystemCard', () => {
 
             const store = mockStore(initialState);
             const onClick = jest.fn();
+            location.pathname = 'localhost:3000/example/kernel_modules';
             const wrapper = mount(<OperatingSystemCard handleClick={ onClick } store={ store } />);
             wrapper.find('dd a').first().simulate('click');
             expect(onClick).toHaveBeenCalled();

--- a/src/components/GeneralInfo/SystemCard/SystemCard.test.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.test.js
@@ -13,6 +13,16 @@ import mockedData from '../../../__mocks__/mockedData.json';
 
 const mock = new MockAdapter(hosts.axios, { onNoMatch: 'throwException' });
 
+const location = {};
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => location,
+    useHistory: () => ({
+        push: () => undefined
+    })
+}));
+
 jest.mock('@redhat-cloud-services/frontend-components-utilities/RBACHook', () => ({
     esModule: true,
     usePermissionsWithContext: () => ({ hasAccess: true })
@@ -27,6 +37,8 @@ describe('SystemCard', () => {
         mock.onGet('/api/inventory/v1/hosts/test-id/system_profile').reply(200, mockedData);
         mock.onGet('/api/inventory/v1/hosts/test-id').reply(200, mockedData);
         mock.onGet('/api/inventory/v1/hosts/test-id/system_profile?fields%5Bsystem_profile%5D%5B%5D=operating_system').reply(200, mockedData); // eslint-disable-line
+
+        location.pathname = 'localhost:3000/example/path';
 
         initialState = {
             entityDetails: {
@@ -181,6 +193,7 @@ describe('SystemCard', () => {
                 }
             });
             const handleClick = jest.fn();
+            location.pathname = 'localhost:3000/example/sap_sids';
 
             const wrapper = mount(<SystemCard store={ store } handleClick={handleClick}/>);
             wrapper.find('dd a').last().simulate('click');
@@ -209,6 +222,7 @@ describe('SystemCard', () => {
                 }
             });
             const handleClick = jest.fn();
+            location.pathname = 'localhost:3000/example/flag';
 
             const wrapper = mount(<SystemCard store={ store } handleClick={handleClick}/>);
             wrapper.find('dd a').last().simulate('click');

--- a/src/components/GeneralInfo/SystemStatusCard/SystemStatusCard.test.js
+++ b/src/components/GeneralInfo/SystemStatusCard/SystemStatusCard.test.js
@@ -5,6 +5,16 @@ import toJson from 'enzyme-to-json';
 import SystemStatusCard from './SystemStatusCard';
 import configureStore from 'redux-mock-store';
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => ({
+        pathname: 'localhost:3000/example/path'
+    }),
+    useHistory: () => ({
+        push: () => undefined
+    })
+}));
+
 describe('SystemStatusCard', () => {
     let initialState;
     let mockStore;

--- a/src/components/InventoryDetail/InventoryDetail.js
+++ b/src/components/InventoryDetail/InventoryDetail.js
@@ -34,23 +34,22 @@ const InventoryDetail = ({
     TagsWrapper,
     DeleteWrapper,
     ActionsWrapper,
+    inventoryId,
     children
 }) => {
-    const { inventoryId } = useParams();
     const dispatch = useDispatch();
     const loaded = useSelector(({ entityDetails }) => entityDetails?.loaded || false);
     const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
     useEffect(() => {
-        const currId = inventoryId || location.pathname.replace(/\/$/, '').split('/').pop();
-        if (!entity || !(entity?.id === currId) || !loaded) {
-            dispatch(loadEntity(currId, { hasItems: true }, { showTags }));
+        if (!entity || !(entity?.id === inventoryId) || !loaded) {
+            dispatch(loadEntity(inventoryId, { hasItems: true }, { showTags }));
         }
     }, []);
     return <div className="ins-entity-detail">
         {loaded && !entity ? (
             <SystemNotFound
                 onBackToListClick={onBackToListClick}
-                inventoryId={location.pathname.split('/')[location.pathname.split('/').length - 1]}
+                inventoryId={inventoryId}
             />
         ) : <Fragment>
             <TopBar
@@ -112,7 +111,8 @@ InventoryDetail.propTypes = {
     TitleWrapper: PropTypes.elementType,
     TagsWrapper: PropTypes.elementType,
     DeleteWrapper: PropTypes.elementType,
-    ActionsWrapper: PropTypes.elementType
+    ActionsWrapper: PropTypes.elementType,
+    inventoryId: PropTypes.string
 };
 InventoryDetail.defaultProps = {
     actions: [],
@@ -125,5 +125,23 @@ InventoryDetail.defaultProps = {
     DeleteWrapper: Fragment,
     ActionsWrapper: Fragment
 };
+
+const InventoryDetailWrapper = ({ inventoryId, ...props }) => {
+    const { inventoryId: entityId } = useParams();
+    if (!inventoryId) {
+        console.warn('~~~~~~~~~~');
+        console.warn('~~~~~~~~~~');
+        console.warn('Missing inventoryId! Please provide one, we will remove the fallback from URL soon.');
+        console.warn('~~~~~~~~~~');
+        console.warn('~~~~~~~~~~');
+    }
+
+    return <InventoryDetail
+        inventoryId={inventoryId || entityId || location.pathname.replace(/\/$/, '').split('/').pop()}
+        {...props}
+    />;
+};
+
+InventoryDetailWrapper.propTypes = InventoryDetail.propTypes;
 
 export default InventoryDetail;

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useStore, useDispatch } from 'react-redux';
-import { useRouteMatch } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import './inventory.scss';
 import { Link, useHistory } from 'react-router-dom';
 import { entitesDetailReducer, RegistryContext } from '../store';
@@ -17,10 +17,10 @@ import DetailWrapper from '../modules/DetailWrapper';
 import { useWritePermissions } from '../Utilities/constants';
 
 const Inventory = () => {
+    const { inventoryId } = useParams();
     const store = useStore();
     const history = useHistory();
     const dispatch = useDispatch();
-    const { params: { inventoryId } } = useRouteMatch('/:inventoryId');
     const { getRegistry } = useContext(RegistryContext);
     const writePermissions = useWritePermissions();
     const entityLoaded = useSelector(({ entityDetails }) => entityDetails?.loaded);
@@ -83,6 +83,7 @@ const Inventory = () => {
                         hideInvLink
                         showDelete={writePermissions}
                         hideInvDrawer
+                        inventoryId={inventoryId}
                     />
                 }
             </PageHeader>


### PR DESCRIPTION
### Description

When opening new tab from General information links the UI breaks because inventory ID is incorrectly calculated. This PR fixes it by consuming `inventoryId` from parent component (which should know about what is active by checking the router param). We should go around all apps and adapt to this new behavior, once that is done we can remove the wrapper component.