### PR TITLE
fix(ESSNTL-3378): make all apps consistent to handle insights-not-connected

### DIFF
--- a/src/components/InventoryDetail/AppInfo.js
+++ b/src/components/InventoryDetail/AppInfo.js
@@ -4,13 +4,14 @@ import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import { useStore, useSelector } from 'react-redux';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
 
 /**
  * Small component that just renders active detail with some specific class.
  * This component detail is accessed from redux if no component found `missing component` is displayed.
  * @param {*} props `componentsMapper` if you want to pass different components list.
  */
-const AppInfo = ({ componentMapper, appList }) => {
+const AppInfo = ({ componentMapper, appList, notConnected }) => {
     const store = useStore();
     const { search } = useLocation();
     const searchParams = new URLSearchParams(search);
@@ -32,17 +33,21 @@ const AppInfo = ({ componentMapper, appList }) => {
     return (
         <Fragment>
             {
-                loaded ? activeApp && (
-                    <div className={ `ins-active-app-${activeApp?.name}` }>
-                        { Cmp ?
-                            <Cmp
-                                store={store}
-                                inventoryId={entity?.id}
-                                appName={activeApp?.name}
-                            /> :
-                            'missing component'}
-                    </div>
-                ) : <Skeleton size={ SkeletonSize.md } />
+                loaded ?
+                    (
+                        notConnected && <NotConnected />
+                        || activeApp && (
+                            <div className={ `ins-active-app-${activeApp?.name}` }>
+                                { Cmp ?
+                                    <Cmp
+                                        store={store}
+                                        inventoryId={entity?.id}
+                                        appName={activeApp?.name}
+                                    /> :
+                                    'missing component'}
+                            </div>)
+                    )
+                    : <Skeleton size={ SkeletonSize.md } />
             }
         </Fragment>
     );
@@ -54,7 +59,8 @@ AppInfo.propTypes = {
         title: PropTypes.node,
         name: PropTypes.string,
         pageId: PropTypes.string
-    }))
+    })),
+    notConnected: PropTypes.bool
 };
 
 export default AppInfo;

--- a/src/components/InventoryDetail/AppInfo.test.js
+++ b/src/components/InventoryDetail/AppInfo.test.js
@@ -1,0 +1,71 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import AppInfo from './AppInfo';
+import { mount } from 'enzyme';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { createPromise as promiseMiddleware } from 'redux-promise-middleware';
+import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => ({
+        pathname: '/some/path'
+    })
+}));
+
+let initialState = {};
+let mockStore;
+let wrapper;
+beforeEach(() => {
+    mockStore = configureStore([promiseMiddleware()]);
+    initialState = {
+        entityDetails: {
+            loaded: true,
+            entity: {
+                insights_id: '0253a9b9-f9fb-4ba5-a62e-28cbb3cb16db',
+                stale_timestamp: '2260-01-01T00:00:00+00:00',
+                stale_warning_timestamp: '2260-01-08T00:00:00+00:00',
+                culled_timestamp: '2260-01-15T00:00:00+00:00',
+                created: '2022-09-29T10:17:38.158029+00:00',
+                updated: '2022-11-14T21:40:08.619998+00:00',
+                system_profile: {
+                    operating_system: {
+                        major: 9,
+                        minor: 0,
+                        name: 'RHEL'
+                    }
+                },
+                tags: [],
+                per_reporter_staleness: {
+                    puptoo: {
+                        check_in_succeeded: true,
+                        stale_timestamp: '2260-01-01T00:00:00+00:00',
+                        last_check_in: '2022-11-11T11:29:50.154804+00:00'
+                    }
+                }
+            },
+            isToggleOpened: true
+        }
+    };
+
+    const store = mockStore(initialState);
+    wrapper = mount(<Provider store={store}>
+        <AppInfo />
+    </Provider>);
+});
+
+describe('AppInfo', () => {
+    it('should render correctly', () => {
+        expect(wrapper.find(NotConnected)).toMatchSnapshot();
+    });
+    it('should render NotConnected component', () => {
+        const store = mockStore(initialState);
+        const tempWrapper = mount(<Provider store={store}>
+            <AppInfo notConnected={true}/>
+        </Provider>);
+
+        expect(tempWrapper.find(NotConnected)).toHaveLength(1);
+    });
+
+});

--- a/src/components/InventoryDetail/__snapshots__/AppInfo.test.js.snap
+++ b/src/components/InventoryDetail/__snapshots__/AppInfo.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppInfo should render correctly 1`] = `ReactWrapper {}`;

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -15,6 +15,8 @@ import InventoryDetailHead from '../modules/InventoryDetailHead';
 import AppInfo from '../modules/AppInfo';
 import DetailWrapper from '../modules/DetailWrapper';
 import { useWritePermissions } from '../Utilities/constants';
+import { verifyCulledInsightsClient } from '../Utilities/sharedFunctions';
+import { getFact } from '../components/InventoryDetail/helpers';
 
 const Inventory = () => {
     const { inventoryId } = useParams();
@@ -35,8 +37,12 @@ const Inventory = () => {
         clearNotifications();
     }, []);
 
+    const notConnected = verifyCulledInsightsClient(
+        getFact('per_reporter_staleness', entity)
+    );
+
     const additionalClasses = {
-        'ins-c-inventory__detail--general-info': currentApp && currentApp === 'general_information'
+        'ins-c-inventory__detail--general-info': (currentApp && !notConnected) && currentApp === 'general_information'
     };
 
     if (entity) {
@@ -95,6 +101,7 @@ const Inventory = () => {
                             fallback=""
                             store={store}
                             history={history}
+                            notConnected={notConnected}
                         />
                     </GridItem>
                 </Grid>


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/ESSNTL-3378

To test:

1. Visit the inventory page
2. filter the table with 'insights-not-connected' from the Data-collector filter
3. Click on a system to open the details page
4. Observe that all tabs are consistent and display the following design.

![image](https://user-images.githubusercontent.com/59481011/201936196-98b2b1d4-1a1c-4fb9-ab0c-911ad7d44116.png)
