### PR TITLE
chore(deps): bump host-inventory-client to 1.0.116

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@redhat-cloud-services/frontend-components": "^3.9.25",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.12",
         "@redhat-cloud-services/frontend-components-utilities": "^3.3.9",
-        "@redhat-cloud-services/host-inventory-client": "1.0.110",
+        "@redhat-cloud-services/host-inventory-client": "1.0.116",
         "classnames": "^2.3.1",
         "graphql": "^15.6.0",
         "html-webpack-plugin": "^5.5.0",
@@ -3394,9 +3394,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/host-inventory-client": {
-      "version": "1.0.110",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.110.tgz",
-      "integrity": "sha512-v9oCvciIc3RPkJOSGo0D/ZD1GxyCsFSQ+bthCH4rrJ5gK4NOVv60laf/jVNcyA3/mPYMuF2EqI/SylgEv/KNDw==",
+      "version": "1.0.116",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.116.tgz",
+      "integrity": "sha512-jgYqaIUYI1zhzUOTbMa3gWZWdvCwBVvAmqgRPAq72Wwtl1SvgqCClBlbodsX5edqMkIaXkkEAfXY50a9vaccoA==",
       "dependencies": {
         "axios": "^0.21.1"
       }
@@ -21558,9 +21558,9 @@
       }
     },
     "@redhat-cloud-services/host-inventory-client": {
-      "version": "1.0.110",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.110.tgz",
-      "integrity": "sha512-v9oCvciIc3RPkJOSGo0D/ZD1GxyCsFSQ+bthCH4rrJ5gK4NOVv60laf/jVNcyA3/mPYMuF2EqI/SylgEv/KNDw==",
+      "version": "1.0.116",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.116.tgz",
+      "integrity": "sha512-jgYqaIUYI1zhzUOTbMa3gWZWdvCwBVvAmqgRPAq72Wwtl1SvgqCClBlbodsX5edqMkIaXkkEAfXY50a9vaccoA==",
       "requires": {
         "axios": "^0.21.1"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@redhat-cloud-services/frontend-components": "^3.9.25",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.12",
     "@redhat-cloud-services/frontend-components-utilities": "^3.3.9",
-    "@redhat-cloud-services/host-inventory-client": "1.0.110",
+    "@redhat-cloud-services/host-inventory-client": "1.0.116",
     "classnames": "^2.3.1",
     "graphql": "^15.6.0",
     "html-webpack-plugin": "^5.5.0",


### PR DESCRIPTION
Updates **@redhat-cloud-services/host-inventory-client** to 1.0.116 to have new system update method filtering in the API.