### PR TITLE
Stale fitler

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -16,7 +16,8 @@ export const UPDATE_METHOD_KEY = 'system_update_method';
 export const staleness = [
     { label: 'Fresh', value: 'fresh' },
     { label: 'Stale', value: 'stale' },
-    { label: 'Stale warning', value: 'stale_warning' }
+    { label: 'Stale warning', value: 'stale_warning' },
+    { label: 'Unknown', value: 'unknown' }
 ];
 export const registered = [
     { label: 'insights-client', value: 'puptoo', idName: 'Insights id', idValue: 'insights_id' },
@@ -26,9 +27,7 @@ export const registered = [
     { label: 'insights-client not connected', value: '!puptoo' }
 ];
 export const InventoryContext = createContext({});
-export const defaultFilters = {
-    staleFilter: ['fresh', 'stale']
-};
+
 export const rhcdOptions = [
     { label: 'Active', value: 'not_nil' },
     { label: 'Inactive', value: 'nil' }
@@ -93,8 +92,7 @@ export function reduceFilters(filters = []) {
         };
     }, {
         textFilter: '',
-        tagFilters: {},
-        ...defaultFilters
+        tagFilters: {}
     });
 }
 

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -7,7 +7,6 @@ import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-componen
 import { tagsFilterState, tagsFilterReducer, mapGroups } from '@redhat-cloud-services/frontend-components/FilterHooks';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import { fetchAllTags, clearFilters, toggleTagModal, setFilter } from '../../store/actions';
-import { defaultFilters } from '../../Utilities/constants';
 import debounce from 'lodash/debounce';
 import {
     TagsModal,
@@ -287,14 +286,14 @@ const EntityTableToolbar = ({
      */
     const resetFilters = () => {
         enabledFilters.name && setTextFilter('');
-        enabledFilters.stale && setStaleFilter(defaultFilters.staleFilter);
+        enabledFilters.stale && setStaleFilter([]);
         enabledFilters.registeredWith && setRegisteredWithFilter([]);
         enabledFilters.tags && setSelectedTags({});
         enabledFilters.operatingSystem && setOsFilterValue([]);
         enabledFilters.rhcdFilter && setRhcdFilterValue([]);
         enabledFilters.updateMethodFilter && setUpdateMethodValue([]);
-        dispatch(setFilter([defaultFilters]));
-        updateData({ page: 1, filters: [defaultFilters] });
+        dispatch(setFilter([]));
+        updateData({ page: 1, filters: [] });
     };
 
     /**
@@ -323,7 +322,7 @@ const EntityTableToolbar = ({
 
                 activeFiltersConfig &&
                 activeFiltersConfig.onDelete &&
-                activeFiltersConfig.onDelete(e, [deleted, ...restDeleted], isAll, defaultFilters);
+                activeFiltersConfig.onDelete(e, [deleted, ...restDeleted], isAll);
             }
         };
     };

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -10,12 +10,12 @@ import toJson from 'enzyme-to-json';
 import { mockTags, mockSystemProfile } from '../../__mocks__/hostApi';
 import TitleColumn from './TitleColumn';
 import debounce from 'lodash/debounce';
-import { defaultFilters } from '../../Utilities';
 
 jest.mock('lodash/debounce');
 
 describe('EntityTableToolbar', () => {
     let initialState;
+    let stateWithActiveFilter;
     let mockStore;
     let onRefreshData;
 
@@ -80,6 +80,13 @@ describe('EntityTableToolbar', () => {
                     }
                 ],
                 operatingSystemsLoaded: true
+            }
+        };
+        stateWithActiveFilter = {
+            entities: {
+                ...initialState.entities,
+                loaded: true,
+                activeFilters: [{ value: 'hostname_or_id', filter: 'test' }]
             }
         };
     });
@@ -229,7 +236,7 @@ describe('EntityTableToolbar', () => {
             it('should dispatch action on delete filter', async () => {
                 debounce.mockImplementation(fn => fn);
 
-                const store = mockStore(initialState);
+                const store = mockStore(stateWithActiveFilter);
                 const wrapper = mount(<Provider store={store}>
                     <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} loaded />
                 </Provider>);
@@ -240,15 +247,7 @@ describe('EntityTableToolbar', () => {
                 });
                 wrapper.update();
                 expect(onRefreshData).toHaveBeenCalledWith(
-                    { filters: [{}, { filter: '', value: 'hostname_or_id' }, { staleFilter: ['stale'] }], page: 1, perPage: 50 }
-                );
-                onRefreshData.mockClear();
-                await act(async () => {
-                    wrapper.find('.pf-c-chip-group__list li div button').last().simulate('click');
-                });
-                wrapper.update();
-                expect(onRefreshData).toHaveBeenCalledWith(
-                    { filters: [{}, { filter: '', value: 'hostname_or_id' }, { staleFilter: [] }], page: 1, perPage: 50 }
+                    { filters: [{ filter: '', value: 'hostname_or_id' }], page: 1, perPage: 50 }
                 );
             });
 
@@ -304,7 +303,7 @@ describe('EntityTableToolbar', () => {
             });
 
             it('should dispatch action on delete all filters', () => {
-                const store = mockStore(initialState);
+                const store = mockStore(stateWithActiveFilter);
                 const wrapper = mount(<Provider store={store}>
                     <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} loaded />
                 </Provider>);
@@ -312,12 +311,12 @@ describe('EntityTableToolbar', () => {
                 const actions = store.getActions();
                 expect(actions.length).toBe(3);
                 expect(actions[actions.length - 2]).toMatchObject({ type: 'CLEAR_FILTERS' });
-                expect(onRefreshData).toHaveBeenCalledWith({ filters: [defaultFilters], page: 1 });
+                expect(onRefreshData).toHaveBeenCalledWith({ filters: [], page: 1 });
             });
 
             it('should call function on delete filter', () => {
                 const onDelete = jest.fn();
-                const store = mockStore(initialState);
+                const store = mockStore(stateWithActiveFilter);
                 const wrapper = mount(<Provider store={store}>
                     <EntityTableToolbar page={1} total={500} perPage={50} activeFiltersConfig={{
                         onDelete

--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -5,22 +5,7 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
   actionsConfig={null}
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Status",
-          "chips": Array [
-            Object {
-              "name": "Fresh",
-              "value": "fresh",
-            },
-            Object {
-              "name": "Stale",
-              "value": "stale",
-            },
-          ],
-          "type": "staleness",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -55,13 +40,14 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
+              Object {
+                "label": "Unknown",
+                "value": "unknown",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
-            "value": Array [
-              "fresh",
-              "stale",
-            ],
+            "value": undefined,
           },
           "label": "Status",
           "type": "checkbox",
@@ -181,22 +167,7 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Status",
-          "chips": Array [
-            Object {
-              "name": "Fresh",
-              "value": "fresh",
-            },
-            Object {
-              "name": "Stale",
-              "value": "stale",
-            },
-          ],
-          "type": "staleness",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -231,13 +202,14 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
+              Object {
+                "label": "Unknown",
+                "value": "unknown",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
-            "value": Array [
-              "fresh",
-              "stale",
-            ],
+            "value": undefined,
           },
           "label": "Status",
           "type": "checkbox",
@@ -404,20 +376,6 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
     Object {
       "filters": Array [
         Object {
-          "category": "Status",
-          "chips": Array [
-            Object {
-              "name": "Fresh",
-              "value": "fresh",
-            },
-            Object {
-              "name": "Stale",
-              "value": "stale",
-            },
-          ],
-          "type": "staleness",
-        },
-        Object {
           "category": "Some",
           "chips": Array [
             Object {
@@ -463,13 +421,14 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
+              Object {
+                "label": "Unknown",
+                "value": "unknown",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
-            "value": Array [
-              "fresh",
-              "stale",
-            ],
+            "value": undefined,
           },
           "label": "Status",
           "type": "checkbox",
@@ -664,22 +623,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Status",
-          "chips": Array [
-            Object {
-              "name": "Fresh",
-              "value": "fresh",
-            },
-            Object {
-              "name": "Stale",
-              "value": "stale",
-            },
-          ],
-          "type": "staleness",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -714,13 +658,14 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
+              Object {
+                "label": "Unknown",
+                "value": "unknown",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
-            "value": Array [
-              "fresh",
-              "stale",
-            ],
+            "value": undefined,
           },
           "label": "Status",
           "type": "checkbox",
@@ -938,6 +883,10 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
+              Object {
+                "label": "Unknown",
+                "value": "unknown",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
@@ -1108,22 +1057,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Status",
-          "chips": Array [
-            Object {
-              "name": "Fresh",
-              "value": "fresh",
-            },
-            Object {
-              "name": "Stale",
-              "value": "stale",
-            },
-          ],
-          "type": "staleness",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -1158,13 +1092,14 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
+              Object {
+                "label": "Unknown",
+                "value": "unknown",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
-            "value": Array [
-              "fresh",
-              "stale",
-            ],
+            "value": undefined,
           },
           "label": "Status",
           "type": "checkbox",
@@ -1380,13 +1315,14 @@ exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
+              Object {
+                "label": "Unknown",
+                "value": "unknown",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
-            "value": Array [
-              "fresh",
-              "stale",
-            ],
+            "value": undefined,
           },
           "label": "Status",
           "type": "checkbox",
@@ -1559,22 +1495,7 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Status",
-          "chips": Array [
-            Object {
-              "name": "Fresh",
-              "value": "fresh",
-            },
-            Object {
-              "name": "Stale",
-              "value": "stale",
-            },
-          ],
-          "type": "staleness",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -1609,13 +1530,14 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
+              Object {
+                "label": "Unknown",
+                "value": "unknown",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
-            "value": Array [
-              "fresh",
-              "stale",
-            ],
+            "value": undefined,
           },
           "label": "Status",
           "type": "checkbox",
@@ -1818,22 +1740,7 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Status",
-          "chips": Array [
-            Object {
-              "name": "Fresh",
-              "value": "fresh",
-            },
-            Object {
-              "name": "Stale",
-              "value": "stale",
-            },
-          ],
-          "type": "staleness",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -1868,13 +1775,14 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
+              Object {
+                "label": "Unknown",
+                "value": "unknown",
+              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
-            "value": Array [
-              "fresh",
-              "stale",
-            ],
+            "value": undefined,
           },
           "label": "Status",
           "type": "checkbox",

--- a/src/components/filters/useStalenessFilter.test.js
+++ b/src/components/filters/useStalenessFilter.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { Fragment, useEffect } from 'react';
 import { useStalenessFilter } from './useStalenessFilter';
+import { staleness } from '../../Utilities';
 import { mount } from 'enzyme';
 
 const HookRender = ({ hookAccessor, hookNotify }) => {
@@ -26,11 +27,7 @@ describe('useStalenessFilter', () => {
                 type: 'checkbox'
             });
             expect(filter.filterValues.value.length).toBe(0);
-            expect(filter.filterValues.items).toMatchObject([
-                { label: 'Fresh', value: 'fresh' },
-                { label: 'Stale', value: 'stale' },
-                { label: 'Stale warning', value: 'stale_warning' }
-            ]);
+            expect(filter.filterValues.items).toMatchObject(staleness);
         };
 
         mount(<HookRender hookAccessor={hookAccessor} />);

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -13,7 +13,7 @@ import { addNotification as addNotificationAction } from '@redhat-cloud-services
 import DeleteModal from '../Utilities/DeleteModal';
 import { TextInputModal } from '../components/SystemDetails/GeneralInfo';
 import flatMap from 'lodash/flatMap';
-import { defaultFilters, generateFilter, useGetRegistry } from '../Utilities/constants';
+import { generateFilter, useGetRegistry } from '../Utilities/constants';
 import { inventoryConnector } from '../Utilities/inventoryConnector';
 import { useWritePermissions, RHCD_FILTER_KEY, UPDATE_METHOD_KEY } from '../Utilities/constants';
 
@@ -106,11 +106,8 @@ const Inventory = ({
     const onSelectRows = (id, isSelected) => dispatch(actions.selectEntity(id, isSelected));
 
     const onRefresh = (options, callback) => {
-        if (!options?.filters) {
-            options.filters = Object.entries(defaultFilters).map(([key, val]) => ({ [key]: val }));
-        }
 
-        let results = options?.filters.filter(({ osFilter }) => osFilter);
+        let results = options?.filters?.filter(({ osFilter }) => osFilter);
         const { status, source, tagsFilter, filterbyName, operatingSystem, rhcdFilter, updateMethodFilter }
         = (options?.filters || []).reduce(
             (acc, curr) => ({
@@ -213,7 +210,6 @@ const Inventory = ({
                                 hasCheckbox={writePermissions}
                                 autoRefresh
                                 initialLoading={initialLoading}
-                                activeFiltersConfig={{ showDeleteButton: true }}
                                 {...(writePermissions && {
                                     actions: [
                                         {

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -20,7 +20,6 @@ import TitleColumn from '../components/InventoryTable/TitleColumn';
 import InsightsDisconnected from '../Utilities/InsightsDisconnected';
 import OperatingSystemFormatter from '../Utilities/OperatingSystemFormatter';
 import { Tooltip } from '@patternfly/react-core';
-import { defaultFilters } from '../Utilities/constants';
 import { verifyCulledInsightsClient } from '../Utilities/sharedFunctions';
 
 export const defaultState = {
@@ -107,7 +106,7 @@ function entitiesPending(state, { meta }) {
 function clearFilters(state) {
     return {
         ...state,
-        activeFilters: [defaultFilters]
+        activeFilters: []
     };
 }
 

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -21,7 +21,6 @@ import {
     filtersReducer,
     getOperatingSystems
 } from '../api';
-import { defaultFilters } from '../Utilities/constants';
 
 export const loadEntities = (items = [], { filters, ...config }, { showTags } = {}, getEntities = defaultGetEntities) => {
     const itemIds = items.reduce((acc, curr) => (
@@ -35,12 +34,11 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
     (config.hideFilters?.all && config.hideFilters?.[name] !== false);
 
     const updatedFilters = filters ? filters.reduce(filtersReducer, {
-        ...defaultFilters,
         ...filters.length === 0 && { registeredWithFilter: [] },
         ...(isFilterDisabled('stale') && { staleFilter: undefined }),
         ...(isFilterDisabled('registeredWith') && { registeredWithFilter: undefined }),
         ...(isFilterDisabled('operating_system') && { osFilter: undefined })
-    }) : { ...defaultFilters,
+    }) : {
         ...(isFilterDisabled('stale') && { staleFilter: undefined }),
         ...(isFilterDisabled('registeredWith') && { registeredWithFilter: undefined }),
         ...(isFilterDisabled('operating_system') && { osFilter: undefined })


### PR DESCRIPTION
Resolves: [ESSNTL-3914](https://issues.redhat.com/browse/ESSNTL-3914)

This removes default filtering completely while adding the 'Unknown' option into the status filter to be able to filter by all 4 options.

To test:

1. Visit the inventory app
2. observe that there is not any active filter by default
3. open the status filter, and observe that there is a new option 'Unknown'
4. play with the filtering: should persist refresh, should be added into URL, should filter as expected 