### PR TITLE
perf: set perPage to 20 on Inventories table

### DIFF
--- a/src/components/InventoryTable/InventoryList.js
+++ b/src/components/InventoryTable/InventoryList.js
@@ -80,7 +80,7 @@ ContextInventoryList.propTypes = {
     ignoreRefresh: PropTypes.bool
 };
 ContextInventoryList.defaultProps = {
-    perPage: 50,
+    perPage: 20,
     page: 1,
     ignoreRefresh: true
 };

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -70,7 +70,7 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
     )
     , shallowEqual);
     const perPage = useSelector(({ entities: { perPage: invPerPage } }) => (
-        hasItems ? propsPerPage : (invPerPage || 50)
+        hasItems ? propsPerPage : (invPerPage || 20)
     )
     , shallowEqual);
     const total = useSelector(({ entities: { total: invTotal } }) => {

--- a/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
@@ -13,7 +13,7 @@ exports[`InventoryTable should render correctly - no data 1`] = `
     hideFilters={Object {}}
     onRefreshData={[Function]}
     page={1}
-    perPage={50}
+    perPage={20}
     showTags={false}
   />
   <ForwardRef
@@ -21,14 +21,14 @@ exports[`InventoryTable should render correctly - no data 1`] = `
     hasItems={false}
     onRefreshData={[Function]}
     page={1}
-    perPage={50}
+    perPage={20}
   >
     <ContextInventoryList
       hasItems={false}
       ignoreRefresh={true}
       onRefreshData={[Function]}
       page={1}
-      perPage={50}
+      perPage={20}
     />
   </ForwardRef>
   <TableToolbar

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -138,7 +138,7 @@ function onSetPagination(state, { payload }) {
     const page = parseInt(payload.page, 10);
     return {
         ...state,
-        perPage: isNaN(perPage) ? 50 : perPage,
+        perPage: isNaN(perPage) ? 20 : perPage,
         page: isNaN(page) ? 1 : page
     };
 }


### PR DESCRIPTION
This sets the default per page of the inventory table from 50 to 20. 

The metrics are varying across runs, but I am getting average numbers. Here you can see the effect of this optimization work. Both LCP and TTI metrics have increased to more than ~1 second

Before:
![image](https://user-images.githubusercontent.com/59481011/212761266-6cc909a5-9251-4064-9db6-f925457bf535.png)

After: 
![image](https://user-images.githubusercontent.com/59481011/212761324-0b9c8076-a6b5-47c3-acbb-7c061beee5c1.png)

