### PR TITLE
fix(ADVISOR-2957): updates api to accept perPage+page params

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -116,8 +116,8 @@ export async function getEntities(items, {
         let data = await hosts.apiHostGetHostById(
             items,
             undefined,
-            undefined,
-            undefined,
+            perPage,
+            page,
             orderBy,
             orderDirection,
             undefined,


### PR DESCRIPTION
Updates the api to accept perPage and page params. There is currently a bug in [advisor](https://issues.redhat.com/browse/ADVISOR-2957) where perPage is never read, and always goes to the default 50 items per page. This means that when selected 100, only 50 can be seen. In this case 51 will appear, but the 51st item will take you to a broken page. It seems this api was updated elsewhere and this little segment was just forgotten.

To test :
- Run advisor via  npm run start:proxy -- --port=8004
- the run this inventory pr via LOCAL_API=advisor:8004~https npm run start:proxy
- Go to advisor /recommendations
- Select a recommendation to go to the rec details page (inventory table is here)
- Select 100 items per page 

Old result:
- 51 items appear, the last one breaks

Results expected with this PR:
- 100 items appear and all work fine