### PR TITLE
fix: get rid of circular deps to avoid early access registery context

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { getStore, RegistryContext, updateReducers } from './store';
+import { getStore, updateReducers } from './store';
+import RegistryContext from './store/registeryContext';
 import App from './App';
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import logger from 'redux-logger';

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -1,8 +1,6 @@
-import { createContext, useContext } from 'react';
+import { createContext } from 'react';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { INVENTORY_WRITE_PERMISSIONS } from '../constants';
-import { RegistryContext } from '../store';
-import { loadEntities } from '../store/actions';
 
 export const TEXT_FILTER = 'hostname_or_id';
 export const TEXTUAL_CHIP = 'textual';
@@ -96,29 +94,6 @@ export function reduceFilters(filters = []) {
     });
 }
 
-export const loadSystems = (options, showTags, getEntities) => {
-    const limitedItems = options?.items?.length > options.per_page ? options?.items?.slice(
-        (options?.page - 1) * options.per_page, options?.page * options.per_page
-    ) : options?.items;
-
-    const config = {
-        ...options.hasItems && {
-            sortBy: options?.sortBy?.key,
-            orderDirection: options?.sortBy?.direction?.toUpperCase()
-        },
-        ...options,
-        filters: options?.filters || options?.activeFilters,
-        orderBy: options?.orderBy || options?.sortBy?.key,
-        orderDirection: options?.orderDirection?.toUpperCase() || options?.sortBy?.direction?.toUpperCase(),
-        ...limitedItems?.length > 0 && {
-            itemsPage: options?.page,
-            page: 1
-        }
-    };
-
-    return loadEntities(limitedItems, config, { showTags }, getEntities);
-};
-
 export const reloadWrapper = (event, callback) => {
     event.payload.then(data => {
         callback();
@@ -165,12 +140,6 @@ export const useWritePermissions = () => {
     const { hasAccess } = usePermissionsWithContext(INVENTORY_WRITE_PERMISSIONS);
 
     return hasAccess;
-};
-
-export const useGetRegistry = () => {
-    const { getRegistry } = useContext(RegistryContext);
-
-    return getRegistry;
 };
 
 export const allStaleFilters = ['fresh', 'stale', 'stale_warning', 'unknown'];

--- a/src/Utilities/sharedFunctions.js
+++ b/src/Utilities/sharedFunctions.js
@@ -1,3 +1,5 @@
+import { loadEntities } from '../store/inventory-actions';
+
 export const subtractWeeks = (numOfWeeks, date = new Date()) => {
     date.setDate(date.getDate() - numOfWeeks * 7);
 
@@ -33,4 +35,27 @@ export const verifyCulledInsightsClient = (perReporterStaleness) => {
     } else {
         return true;
     }
+};
+
+export const loadSystems = (options, showTags, getEntities) => {
+    const limitedItems = options?.items?.length > options.per_page ? options?.items?.slice(
+        (options?.page - 1) * options.per_page, options?.page * options.per_page
+    ) : options?.items;
+
+    const config = {
+        ...options.hasItems && {
+            sortBy: options?.sortBy?.key,
+            orderDirection: options?.sortBy?.direction?.toUpperCase()
+        },
+        ...options,
+        filters: options?.filters || options?.activeFilters,
+        orderBy: options?.orderBy || options?.sortBy?.key,
+        orderDirection: options?.orderDirection?.toUpperCase() || options?.sortBy?.direction?.toUpperCase(),
+        ...limitedItems?.length > 0 && {
+            itemsPage: options?.page,
+            page: 1
+        }
+    };
+
+    return loadEntities(limitedItems, config, { showTags }, getEntities);
 };

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -8,7 +8,7 @@ import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorStat
 import InventoryList from './InventoryList';
 import Pagination from './Pagination';
 import AccessDenied from '../../Utilities/AccessDenied';
-import { loadSystems } from '../../Utilities/constants';
+import { loadSystems } from '../../Utilities/sharedFunctions';
 import isEqual from 'lodash/isEqual';
 import { entitiesLoading } from '../../store/actions';
 

--- a/src/components/InventoryTable/InventoryTable.test.js
+++ b/src/components/InventoryTable/InventoryTable.test.js
@@ -10,22 +10,8 @@ import { createPromise as promiseMiddleware } from 'redux-promise-middleware';
 import { BrowserRouter as Router } from 'react-router-dom';
 import toJson from 'enzyme-to-json';
 import { ConditionalFilter } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
-import * as actions from '../../Utilities/constants';
+import * as loadSystems from '../../Utilities/sharedFunctions';
 import { mockSystemProfile } from '../../__mocks__/hostApi';
-
-jest.mock('../../store/actions', () => {
-    const actions = jest.requireActual('../../store/actions');
-    const { ACTION_TYPES } = jest.requireActual('../../store/action-types');
-    return {
-        __esModule: true,
-        ...actions,
-        loadEntities: () => ({
-            type: ACTION_TYPES.LOAD_ENTITIES,
-            payload: () => Promise.resolve({}),
-            meta: { showTags: undefined }
-        })
-    };
-});
 
 describe('InventoryTable', () => {
     let initialState;
@@ -50,7 +36,8 @@ describe('InventoryTable', () => {
                 }
             }
         };
-        spy = jest.spyOn(actions, 'loadSystems').mockImplementation(() => ({ type: 'reload' }));
+
+        spy = jest.spyOn(loadSystems, 'loadSystems').mockImplementation(() => ({ type: 'reload' }));
         mockSystemProfile.onGet().reply(200, { results: [] });
     });
 

--- a/src/components/InventoryTable/InventoryTableInitialLoading.test.js
+++ b/src/components/InventoryTable/InventoryTableInitialLoading.test.js
@@ -5,7 +5,7 @@ import InventoryTable from './InventoryTable';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
-import * as actions from '../../Utilities/constants';
+import * as loadSystems from '../../Utilities/sharedFunctions';
 import SkeletonTable from '@redhat-cloud-services/frontend-components/SkeletonTable';
 import { Pagination } from '@patternfly/react-core';
 
@@ -39,7 +39,7 @@ describe('InventoryTable - initial loading', () => {
                 }
             }
         };
-        spy = jest.spyOn(actions, 'loadSystems').mockImplementation(() => ({ type: 'reload' }));
+        spy = jest.spyOn(loadSystems, 'loadSystems').mockImplementation(() => ({ type: 'reload' }));
         mockSystemProfile.onGet().reply(200, { results: [] });
     });
 

--- a/src/components/SystemDetails/GeneralInfo.js
+++ b/src/components/SystemDetails/GeneralInfo.js
@@ -1,31 +1,10 @@
-import React, { useEffect, useState, Fragment } from 'react';
-import { Provider } from 'react-redux';
-import PropTypes from 'prop-types';
+import React from 'react';
+
 import GeneralInformation from '../GeneralInfo/GeneralInformation';
 export { default as TextInputModal } from '../GeneralInfo/TextInputModal';
-import Fallback from '../SpinnerFallback';
-import systemProfileStore from '../../store/systemProfileStore';
 
-const GeneralInfoTab = ({ getRegistry, ...props }) => {
-    const [Wrapper, setWrapper] = useState();
-    useEffect(() => {
-        if (getRegistry) {
-            getRegistry()?.register?.({ systemProfileStore });
-        }
-
-        setWrapper(() => getRegistry ? Provider : Fragment);
-    }, []);
-    return Wrapper ? <Wrapper
-        {...getRegistry && {
-            store: getRegistry().getStore()
-        }}
-    >
-        <GeneralInformation {...props} />
-    </Wrapper> : <Fallback />;
-};
-
-GeneralInfoTab.propTypes = {
-    getRegistry: PropTypes.func
+const GeneralInfoTab = () => {
+    return <GeneralInformation  />;
 };
 
 export default GeneralInfoTab;

--- a/src/components/SystemDetails/Patch.js
+++ b/src/components/SystemDetails/Patch.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { RegistryContext } from '../../store';
+import RegistryContext from '../../store/registeryContext';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 
 const PatchTab = () => {

--- a/src/components/SystemDetails/Ros.js
+++ b/src/components/SystemDetails/Ros.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { useRouteMatch } from 'react-router-dom';
-import { RegistryContext } from '../../store';
+import RegistryContext from '../../store/registeryContext';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 
 const RosTab = () => {
@@ -10,8 +10,8 @@ const RosTab = () => {
     return <AsyncComponent
         appName="ros"
         module="./SystemDetail"
-        getRegistry={ getRegistry }
-        inventoryId={ params.inventoryId }
+        getRegistry={getRegistry}
+        inventoryId={params.inventoryId}
     />;
 };
 

--- a/src/components/SystemDetails/Vulnerability.js
+++ b/src/components/SystemDetails/Vulnerability.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { useRouteMatch } from 'react-router-dom';
-import { RegistryContext } from '../../store';
+import RegistryContext from '../../store/registeryContext';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 
 const VulnerabilityTab = () => {
@@ -12,7 +12,7 @@ const VulnerabilityTab = () => {
         module="./SystemDetail"
         getRegistry={getRegistry}
         customItnlProvider
-        entity={ { id: params.inventoryId } }
+        entity={{ id: params.inventoryId }}
     />;
 };
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,4 @@
 
-import { createContext } from 'react';
 import MiddlewareListener from '@redhat-cloud-services/frontend-components-utilities/MiddlewareListener';
 import notificationsMiddleware from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
 import promise  from 'redux-promise-middleware';
@@ -7,10 +6,6 @@ import reducers, { entitesDetailReducer, mergeWithDetail, mergeWithEntities, tab
 export { default as reducers, tableReducer, entitesDetailReducer } from './reducers';
 import { applyMiddleware, combineReducers, compose, legacy_createStore as createStore } from 'redux';
 import { INVENTORY_ACTION_TYPES } from './action-types';
-
-export const RegistryContext = createContext({
-    getRegistry: () => {}
-});
 
 let middlewareListener;
 

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -36,6 +36,7 @@ function entityLoaded(state) {
     return {
         ...state,
         loaded: true,
+        //TODO: improve rendering active app in Inventory detail
         activeApps: [
             { title: 'General information', name: 'general_information', component: GeneralInformationTab },
             { title: 'Advisor', name: 'advisor', component: AdvisorTab },

--- a/src/store/registeryContext.js
+++ b/src/store/registeryContext.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const RegistryContext = createContext({
+    getRegistry: () => { }
+});
+
+export default RegistryContext;


### PR DESCRIPTION
This PR resolves the issue **Cannot access '__WEBPACK_DEFAULT_EXPORT__' before initialization** on stage-beta after a hard refresh on inventory pages on consumer apps. The culprit was circular deps between store/index.js and all of the activeApp components in the reducer context.

I will get rid of activeApps in the reducer as a next step improvement.

To test:
1. Please run the app with other consumer apps (Patch, vuln...)
2. Verify that all apps work together 
3. Hard refresh does not break any app
4. Inventory detail page on Inventory app works for all tabs.

Circular dep before:
![image](https://user-images.githubusercontent.com/59481011/214835272-18bd2504-85da-4870-9155-03c75003fcae.png)

Circular dep after:
![image](https://user-images.githubusercontent.com/59481011/214835377-f7bf333a-dbfd-417d-900c-df9a3c8772b2.png)

   