### PR TITLE
Forward correct inventory refs for all modules

### DIFF
--- a/src/modules/AppInfo.js
+++ b/src/modules/AppInfo.js
@@ -2,6 +2,8 @@ import React from 'react';
 import AsyncInventory from './AsyncInventory';
 import { AppInfo as AppInfoCmp } from '../components/InventoryDetail';
 
-const AppInfo = (props) => <AsyncInventory {...props} component={AppInfoCmp} />;
+const BaseAppInfo = (props) => <AsyncInventory {...props} component={AppInfoCmp}  />;
+
+const AppInfo = React.forwardRef((props, ref) => <BaseAppInfo {...props} innerRef={ref} />);
 
 export default AppInfo;

--- a/src/modules/AsyncInventory.js
+++ b/src/modules/AsyncInventory.js
@@ -50,4 +50,4 @@ AsyncInventory.defaultProps = {
     onLoad: () => undefined
 };
 
-export default React.forwardRef((props, ref) => <AsyncInventory {...props} innerRef={ref} />);
+export default AsyncInventory;

--- a/src/modules/DetailWrapper.js
+++ b/src/modules/DetailWrapper.js
@@ -2,6 +2,8 @@ import React from 'react';
 import AsyncInventory from './AsyncInventory';
 import DetailWrapperCmp from '../components/InventoryDetail/DetailRenderer';
 
-const DetailWrapper = (props) => <AsyncInventory {...props} component={DetailWrapperCmp} />;
+const BaseDetailWrapper = (props) => <AsyncInventory {...props} component={DetailWrapperCmp}  />;
+
+const DetailWrapper = React.forwardRef((props, ref) => <BaseDetailWrapper {...props} innerRef={ref} />);
 
 export default DetailWrapper;

--- a/src/modules/InventoryDetail.js
+++ b/src/modules/InventoryDetail.js
@@ -2,6 +2,8 @@ import React from 'react';
 import AsyncInventory from './AsyncInventory';
 import InventoryDetailCmp from '../components/InventoryDetail/FullDetail';
 
-const InventoryDetail = (props) => <AsyncInventory {...props} component={InventoryDetailCmp} />;
+const BaseInventoryDetail = (props) => <AsyncInventory {...props} component={InventoryDetailCmp}  />;
+
+const InventoryDetail = React.forwardRef((props, ref) => <BaseInventoryDetail {...props} innerRef={ref} />);
 
 export default InventoryDetail;

--- a/src/modules/InventoryDetailHead.js
+++ b/src/modules/InventoryDetailHead.js
@@ -2,6 +2,8 @@ import React from 'react';
 import AsyncInventory from './AsyncInventory';
 import InventoryDetailHeadComponent from '../components/InventoryDetail/InventoryDetail';
 
-const InventoryDetailHead = (props) => <AsyncInventory {...props} component={InventoryDetailHeadComponent} />;
+const BaseInventoryDetailHead = (props) => <AsyncInventory {...props} component={InventoryDetailHeadComponent}  />;
+
+const InventoryDetailHead = React.forwardRef((props, ref) => <BaseInventoryDetailHead {...props} innerRef={ref} />);
 
 export default InventoryDetailHead;

--- a/src/modules/InventoryTable.js
+++ b/src/modules/InventoryTable.js
@@ -2,7 +2,9 @@ import React from 'react';
 import AsyncInventory from './AsyncInventory';
 import { InventoryTable as InventoryTableCmp } from '../components/InventoryTable';
 
-const InventoryTable = (props) => <AsyncInventory {...props} component={InventoryTableCmp}  />;
+const BaseInventoryTable = (props) => <AsyncInventory {...props} component={InventoryTableCmp}  />;
+
+const InventoryTable = React.forwardRef((props, ref) => <BaseInventoryTable {...props} innerRef={ref} />);
 
 export default InventoryTable;
 

--- a/src/modules/TagWithDialog.js
+++ b/src/modules/TagWithDialog.js
@@ -2,6 +2,8 @@ import React from 'react';
 import AsyncInventory from './AsyncInventory';
 import TagWithDialogCmp from '../Utilities/TagWithDialog';
 
-const TagWithDialog = (props) => <AsyncInventory {...props} component={TagWithDialogCmp} />;
+const BaseTagWithDialog = (props) => <AsyncInventory {...props} component={TagWithDialogCmp}  />;
+
+const TagWithDialog = React.forwardRef((props, ref) => <BaseTagWithDialog {...props} innerRef={ref} />);
 
 export default TagWithDialog;


### PR DESCRIPTION
### Description

There was update which removed inventory connector. With that also slight adjustment to sending refs was released, however the refs were incorrectly set and passed down the chain. That causes apps not to trigger refreshes of filters in some cases. This PR fixes such issue by forwarding ref directly from top module's element.