### PR TITLE
fix(ESSNTL-4149): fix applying default filters from URL, with some cl…

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,8 +1,8 @@
 import { Route, Redirect, Switch } from 'react-router-dom';
-import React, { lazy, Suspense } from 'react';
-import { tagsMapper } from './constants';
-import { RHCD_FILTER_KEY, UPDATE_METHOD_KEY } from './Utilities/constants';
+import React, { lazy, Suspense, useMemo } from 'react';
+import { getSearchParams } from './constants';
 import RenderWrapper from './Utilities/Wrapper';
+
 const InventoryTable = lazy(() => import('./routes/InventoryTable'));
 const InventoryDetail = lazy(() => import('./routes/InventoryDetail'));
 
@@ -13,26 +13,19 @@ export const routes = {
 };
 
 export const Routes = () => {
-    const searchParams = new URLSearchParams(location.search);
-
+    const searchParams = useMemo(() => getSearchParams(), []);
     return (
         <Suspense fallback="">
             <Switch>
                 <Route
                     exact
                     path={routes.table}
-                    render={() => <RenderWrapper
-                        cmp={InventoryTable}
-                        status={searchParams.getAll('status')}
-                        source={searchParams.getAll('source')}
-                        filterbyName={searchParams.getAll('hostname_or_id')}
-                        tagsFilter={searchParams.getAll('tags')?.[0]?.split?.(',').reduce?.(tagsMapper, [])}
-                        operatingSystem={searchParams.getAll('operating_system')}
-                        rhcdFilter={searchParams.getAll(RHCD_FILTER_KEY)}
-                        updateMethodFilter={searchParams.getAll(UPDATE_METHOD_KEY)}
-                        page={searchParams.getAll('page')}
-                        perPage={searchParams.getAll('per_page')}/>
-                    }
+                    render={() =>
+                        <RenderWrapper
+                            cmp={InventoryTable}
+                            isRbacEnabled
+                            {...searchParams}
+                        />}
                     rootClass='inventory'
                 />
                 <Route exact path={routes.detailWithModal} component={InventoryDetail} rootClass='inventory' />

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { RHCD_FILTER_KEY, UPDATE_METHOD_KEY } from './Utilities/constants';
 
 export const tagsMapper = (acc, curr) => {
     let [namespace, keyValue] = curr.split('/');
@@ -112,3 +113,17 @@ export const INVENTORY_WRITE_PERMISSIONS = [
     'inventory:hosts:write',
     'inventory:*:write'
 ];
+
+export const getSearchParams = () => {
+    const searchParams = new URLSearchParams(location.search);
+    const status = searchParams.getAll('status');
+    const source = searchParams.getAll('source');
+    const filterbyName = searchParams.getAll('hostname_or_id');
+    const tagsFilter = searchParams.getAll('tags')?.[0]?.split?.(',').reduce?.(tagsMapper, []);
+    const operatingSystem = searchParams.getAll('operating_system');
+    const rhcdFilter = searchParams.getAll(RHCD_FILTER_KEY);
+    const updateMethodFilter = searchParams.getAll(UPDATE_METHOD_KEY);
+    const page = searchParams.getAll('page');
+    const perPage = searchParams.getAll('per_page');
+    return { status, source, tagsFilter, filterbyName, operatingSystem, rhcdFilter, updateMethodFilter, page, perPage };
+};


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ESSNTL-4149

This PR passes filters as a custom filter to be able to apply default filters from URL. It also includes some cleanup. I have removed a bunch of code that was used to add URL filters. This is possible using customsFilter after this [commit](https://github.com/RedHatInsights/insights-inventory-frontend/commit/d9c18d4cd72c2b1dbdc9751c0278134599744484)

To test:
Please run the app and play with filters, give filters and try refreshing the page. Observe that filters are applied from URL