### PR TITLE
refactor(ESSNTL-3724): Connect /groups to feature flags

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,7 +1,10 @@
 import { Route, Redirect, Switch } from 'react-router-dom';
 import React, { lazy, Suspense, useMemo } from 'react';
+import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
+import { InvalidObject } from '@redhat-cloud-services/frontend-components';
 import { getSearchParams } from './constants';
 import RenderWrapper from './Utilities/Wrapper';
+import useFeatureFlag from './Utilities/useFeatureFlag';
 
 const InventoryTable = lazy(() => import('./routes/InventoryTable'));
 const InventoryDetail = lazy(() => import('./routes/InventoryDetail'));
@@ -16,6 +19,8 @@ export const routes = {
 
 export const Routes = () => {
     const searchParams = useMemo(() => getSearchParams(), []);
+    const groupsEnabled = useFeatureFlag('hbi.ui.inventory-groups');
+
     return (
         <Suspense fallback="">
             <Switch>
@@ -30,7 +35,22 @@ export const Routes = () => {
                         />}
                     rootClass='inventory'
                 />
-                <Route exact path={routes.groups} component={InventoryGroups} rootClass='inventory' />
+                <Route
+                    exact
+                    path={routes.groups}
+                    component={
+                        groupsEnabled
+                            ? InventoryGroups
+                            : () => (
+                                <EmptyState>
+                                    <EmptyStateBody>
+                                        <InvalidObject />
+                                    </EmptyStateBody>
+                                </EmptyState>
+                            )
+                    }
+                    rootClass="inventory"
+                />
                 <Route exact path={routes.detailWithModal} component={InventoryDetail} rootClass='inventory' />
                 <Route exact path={routes.detail} component={InventoryDetail} rootClass='inventory' />
                 <Redirect path="*" to="/" />


### PR DESCRIPTION
This makes Inventory hide /groups page component if the feature flag is set to false.

## How to test

1. Deploy the PR locally using stage environment.
2. Go to https://insights-stage.unleash.devshift.net/projects/default/features/hbi.ui.inventory-groups.
3. Set the flag to true in default and then check that the /groups page is rendered.
4. Set the flag to false in default and then check that the /groups page is not rendered and return 404 page.
