### PR TITLE
chore: extend dependabot checking interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "12:00"
     timezone: EST
   open-pull-requests-limit: 10


### PR DESCRIPTION
Let's extend `dependabot` checking interval to a weekly manner. This will most probably not miss any updates. It might just aggregate some updates.