### PR TITLE
chore(RHIF-169): hide system update method filter untill API is ready

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -43,6 +43,7 @@ import {
     updateMethodFilterState
 } from '../filters';
 import useOperatingSystemFilter from '../filters/useOperatingSystemFilter';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 /**
  * Table toolbar used at top of inventory table.
@@ -100,6 +101,8 @@ const EntityTableToolbar = ({
     const [osFilterConfig, osFilterChips, osFilterValue, setOsFilterValue] = useOperatingSystemFilter();
     const [updateMethodConfig, updateMethodChips, updateMethodValue, setUpdateMethodValue] = useUpdateMethodFilter(reducer);
 
+    const isUpdateMethodEnabled = useFeatureFlag('hbi.ui.system-update-method');
+
     const {
         tagsFilter,
         tagsChip,
@@ -127,7 +130,10 @@ const EntityTableToolbar = ({
         operatingSystem: !(hideFilters.all && hideFilters.operatingSystem !== false) && !hideFilters.operatingSystem,
         tags: !(hideFilters.all && hideFilters.tags !== false) && !hideFilters.tags,
         rhcdFilter: !(hideFilters.all && hideFilters.rhcdFilter !== false) && !hideFilters.rhcdFilter,
-        updateMethodFilter: !(hideFilters.all && hideFilters.updateMethodFilter !== false) && !hideFilters.updateMethodFilter
+        //hides the filter untill API is ready. JIRA: RHIF-169
+        updateMethodFilter: isUpdateMethodEnabled &&
+            !(hideFilters.all && hideFilters.updateMethodFilter !== false)
+                && !hideFilters.updateMethodFilter
     };
 
     /**

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -10,8 +10,10 @@ import toJson from 'enzyme-to-json';
 import { mockTags, mockSystemProfile } from '../../__mocks__/hostApi';
 import TitleColumn from './TitleColumn';
 import debounce from 'lodash/debounce';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 jest.mock('lodash/debounce');
+jest.mock('../../Utilities/useFeatureFlag');
 
 describe('EntityTableToolbar', () => {
     let initialState;
@@ -92,6 +94,8 @@ describe('EntityTableToolbar', () => {
     });
 
     describe('DOM', () => {
+        useFeatureFlag.mockReturnValue(true);
+
         it('should render correctly - no data', () => {
             const store = mockStore({
                 entities: {
@@ -384,6 +388,18 @@ describe('EntityTableToolbar', () => {
             </Provider>);
             expect(toJson(wrapper.find('Reset Filter')));
             expect(toJson(wrapper.find('Test Reset Filter'))).toBeFalsy();
+        });
+    });
+
+    describe('System update method filter', () => {
+        it('Should hide the filter when flag is disabled', () => {
+            useFeatureFlag.mockReturnValue(false);
+            const store = mockStore(initialState);
+            const wrapper = mount(<Provider store={store}>
+                <EntityTableToolbar hasItems onRefreshData={onRefreshData} loaded
+                    activeFiltersConfig={{ deleteTitle: 'Test Reset Filters' }} />
+            </Provider>);
+            expect(toJson(wrapper.find('System Update Method'))).toBeFalsy();
         });
     });
 });

--- a/src/components/InventoryTable/InventoryTable.test.js
+++ b/src/components/InventoryTable/InventoryTable.test.js
@@ -12,6 +12,9 @@ import toJson from 'enzyme-to-json';
 import { ConditionalFilter } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import * as loadSystems from '../../Utilities/sharedFunctions';
 import { mockSystemProfile } from '../../__mocks__/hostApi';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
+
+jest.mock('../../Utilities/useFeatureFlag');
 
 describe('InventoryTable', () => {
     let initialState;
@@ -208,6 +211,7 @@ describe('InventoryTable', () => {
         });
 
         it('should disable only one filter', () => {
+            useFeatureFlag.mockReturnValue(true);
             const store = mockStore(initialState);
             const wrapper = mount(<Provider store={ store }>
                 <Router>

--- a/src/components/InventoryTable/InventoryTableInitialLoading.test.js
+++ b/src/components/InventoryTable/InventoryTableInitialLoading.test.js
@@ -16,6 +16,7 @@ import debounce from 'lodash/debounce';
 import { mockSystemProfile } from '../../__mocks__/hostApi';
 
 jest.mock('lodash/debounce');
+jest.mock('../../Utilities/useFeatureFlag');
 
 describe('InventoryTable - initial loading', () => {
     let initialState;

--- a/src/routes/InventoryTable.test.js
+++ b/src/routes/InventoryTable.test.js
@@ -36,6 +36,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
         on: jest.fn()
     })
 }));
+jest.mock('../Utilities/useFeatureFlag');
 
 describe('InventoryTable', () => {
     let mockStore;


### PR DESCRIPTION
Hides the System update method filter with a feature flag.

1. Run the PR locally on the stage environment.
2. Go to https://insights-stage.unleash.devshift.net/projects/default/features/hbi.ui.system-update-method.
3. Set the flag to true in default and then observe that the filter is shown.
4. Set the flag to false in default and then observe that the filter is hidden.