### PR TITLE
chore(ESSNTL-4194): Implement Inventory groups reducer

### DIFF
--- a/src/__mocks__/mockedGroups.json
+++ b/src/__mocks__/mockedGroups.json
@@ -1,0 +1,18 @@
+{
+  "total": 1,
+  "count": 1,
+  "page": 1,
+  "per_page": 50,
+  "results": [
+    {
+      "name": "aute",
+      "id": "FC7CDc2A-EbCd-36F5-f2cc-72f7f2fB960F",
+      "host_ids": [
+        "2Ab5EF47-a25f-eC8D-459D-e48Ca051b1F2",
+        "EdE9F657-B7FD-E56c-2E66-6a93ee8aabcC"
+      ],
+      "created_at": "2009-01-31T23:00:00.0Z",
+      "updated_at": "1981-07-06T22:00:00.0Z"
+    }
+  ]
+}

--- a/src/components/InventoryGroups/utils/api.js
+++ b/src/components/InventoryGroups/utils/api.js
@@ -1,0 +1,7 @@
+import { instance } from '@redhat-cloud-services/frontend-components-utilities/interceptors/interceptors';
+import { INVENTORY_API_BASE } from '../../../api';
+
+export const getGroups = () => {
+    // TODO: support parameters
+    return instance.get(`${INVENTORY_API_BASE}/groups`);
+};

--- a/src/store/action-types.js
+++ b/src/store/action-types.js
@@ -34,7 +34,8 @@ export const asyncInventory = [
     'SET_ANSIBLE_HOST',
     'LOAD_TAGS',
     'ALL_TAGS',
-    'OPERATING_SYSTEMS'
+    'OPERATING_SYSTEMS',
+    'GROUPS'
 ];
 
 export const systemIssues = [

--- a/src/store/actions.test.js
+++ b/src/store/actions.test.js
@@ -1,7 +1,8 @@
 /* eslint-disable camelcase */
-import { editAnsibleHost, editDisplayName, systemProfile } from './actions';
+import { editAnsibleHost, editDisplayName, fetchGroups, systemProfile } from './actions';
 import { hosts } from '../api';
 import mockedData from '../__mocks__/mockedData.json';
+import mockedGroups from '../__mocks__/mockedGroups.json';
 import MockAdapter from 'axios-mock-adapter';
 
 const mocked = new MockAdapter(hosts.axios);
@@ -58,5 +59,16 @@ describe('editAnsibleHost', () => {
                 }
             }
         });
+    });
+});
+
+describe('fetchGroups', () => {
+    it('should call correct endpoint', async () => {
+        mocked.onGet('/api/inventory/v1/groups').reply(() => {
+            return [200, mockedGroups];
+        });
+        const { type, payload } = await fetchGroups();
+        expect(type).toBe('GROUPS');
+        expect(await payload).toEqual(mockedGroups);
     });
 });

--- a/src/store/groups.js
+++ b/src/store/groups.js
@@ -1,0 +1,42 @@
+
+import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
+import { ACTION_TYPES } from './action-types';
+
+export const initialState = {
+    loading: false,
+    rejected: false,
+    fulfilled: false,
+    error: null,
+    data: null
+};
+
+export default applyReducerHash(
+    {
+        [ACTION_TYPES.GROUPS_PENDING]: (state) => {
+            return {
+                ...state,
+                loading: true
+            };
+        },
+        [ACTION_TYPES.GROUPS_FULFILLED]: (state, { payload }) => {
+            return {
+                ...state,
+                loading: false,
+                rejected: false,
+                fulfilled: true,
+                data: payload
+            };
+        },
+        [ACTION_TYPES.GROUPS_REJECTED]: (state, { payload: { code, status } }) => {
+            return {
+                ...state,
+                loading: false,
+                rejected: true,
+                fulfilled: false,
+                code,
+                status
+            };
+        }
+    },
+    initialState
+);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -15,9 +15,11 @@ const appReducers = {
     ...mergeWithDetail(entitesDetailReducer(INVENTORY_ACTION_TYPES))
 };
 
+const composeEnhancers = IS_DEV ? (window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose) : compose;
+
 export const getStore = (...middleware) => {
     middlewareListener = new MiddlewareListener();
-    return createStore(combineReducers(appReducers), {}, compose(applyMiddleware(...[
+    return createStore(combineReducers(appReducers), {}, composeEnhancers(applyMiddleware(...[
         middlewareListener.getMiddleware(),
         promise,
         notificationsMiddleware({

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -21,6 +21,7 @@ import {
     filtersReducer,
     getOperatingSystems
 } from '../api';
+import { getGroups } from '../components/InventoryGroups/utils/api';
 
 export const loadEntities = (items = [], { filters, ...config }, { showTags } = {}, getEntities = defaultGetEntities) => {
     const itemIds = items.reduce((acc, curr) => (
@@ -176,6 +177,11 @@ export const fetchAllTags = (search, pagination, getTags = defaultGetAllTags) =>
     type: ACTION_TYPES.ALL_TAGS,
     payload: getTags(search, pagination),
     meta: { lastDateRequestTags: Date.now() }
+});
+
+export const fetchGroups = (search, pagination) => ({
+    type: ACTION_TYPES.GROUPS,
+    payload: getGroups(search, pagination)
 });
 
 export const fetchOperatingSystems = (params = []) => ({

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -11,6 +11,7 @@ import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-uti
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import entitiesReducer, { defaultState as entitiesDefault } from './entities';
 import entityDetailsReducer, { entityDefaultState as entityDefault, updateEntity } from './entityDetails';
+import groups from './groups';
 
 export { entitiesReducer, entityDetailsReducer };
 
@@ -112,7 +113,8 @@ function onSetPagination(state, { payload }) {
 
 let reducers = {
     notifications: notificationsReducer,
-    systemProfileStore
+    systemProfileStore,
+    groups
 };
 
 export const tableReducer = applyReducerHash(

--- a/src/store/reducers.test.js
+++ b/src/store/reducers.test.js
@@ -1,5 +1,5 @@
 import { INVENTORY_ACTION_TYPES } from './action-types';
-import { tableReducer, entitesDetailReducer } from './index';
+import { tableReducer, entitesDetailReducer } from './reducers';
 
 describe('tableReducer', () => {
     test('should show default state', () => {


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-4194.

This adds reducer and related actions to enable fetching groups from /api/inventory/v1/groups.

## How to test

Try to call `dispatch(fetchGroups())` in any of the components and check whether Redux devtools fires `GROUPS_PENDING` and `GROUPS_FULFILLED` or `GROUPS_REJECTED` redux actions.