### PR TITLE
chore(RHIF-171): pass inventoryId to Patch module as a prop

### DIFF
--- a/src/components/SystemDetails/Patch.js
+++ b/src/components/SystemDetails/Patch.js
@@ -1,15 +1,21 @@
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
 import RegistryContext from '../../store/registeryContext';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 
-const PatchTab = () => {
+const PatchTab = ({ inventoryId }) => {
     const { getRegistry } = useContext(RegistryContext);
 
     return <AsyncComponent
         appName="patch"
         module="./SystemDetail"
+        //inventoryId is a requred prop by Patch module
+        inventoryId={inventoryId}
         getRegistry={getRegistry}
     />;
 };
 
+PatchTab.propTypes = {
+    inventoryId: PropTypes.string.isRequired
+};
 export default PatchTab;


### PR DESCRIPTION
Passes inventory id as a prop to Patch module. This prop is required after [this PR](https://github.com/RedHatInsights/patchman-ui/pull/956) to render system detail components.

To test please run both PR together and make sure no application breaks. Functionality should not change.