### PR TITLE
fix(ESSNTL-4387): pass down inventoryId to Advisor

### DIFF
--- a/src/components/SystemDetails/Advisor.js
+++ b/src/components/SystemDetails/Advisor.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { useStore } from 'react-redux';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+import PropTypes from 'prop-types';
 
-const AdvisorTab = () => {
+const AdvisorTab = ({ inventoryId }) => {
     return <AsyncComponent
         appName="advisor"
         module="./SystemDetail"
@@ -11,7 +12,11 @@ const AdvisorTab = () => {
         intlProps={{
             locale: navigator.language.slice(0, 2)
         }}
+        inventoryId={inventoryId}
     />;
 };
 
+AdvisorTab.propTypes = {
+    inventoryId: PropTypes.string.isRequired
+};
 export default AdvisorTab;


### PR DESCRIPTION
Currently AdvisorTab doesnt load. This prop needs to be passed it, (its passed down in advisor).

Related PR : https://github.com/RedHatInsights/insights-advisor-frontend/commit/7feca8f0d576848ae3e49d156a9b703c35d93caa 