### PR TITLE
feat(ESSNTL-4365): Enable actions in the groups table

### DIFF
--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -62,3 +62,16 @@ export const groupDetailInterceptors = {
         }).as('getGroupDetail');
     }
 };
+
+export const deleteGroupsInterceptors = {
+    'successful deletion': () => {
+        cy.intercept('DELETE', '/api/inventory/v1/groups/*', {
+            statusCode: 204
+        }).as('deleteGroups');
+    },
+    'failed deletion (invalid request)': () => {
+        cy.intercept('DELETE', '/api/inventory/v1/groups/*', {
+            statusCode: 400
+        }).as('deleteGroups');
+    }
+};

--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -15,7 +15,10 @@ import {
     TEXT_INPUT,
     TOOLBAR,
     TOOLBAR_FILTER,
-    DROPDOWN_TOGGLE
+    DROPDOWN_TOGGLE,
+    DROPDOWN,
+    DROPDOWN_ITEM,
+    MODAL
 } from '@redhat-cloud-services/frontend-components-utilities';
 import _ from 'lodash';
 import React from 'react';
@@ -125,14 +128,12 @@ describe('pagination', () => {
     });
 
     it('can change page limit', () => {
-        cy.wait('@getGroups').then(() => {
-            // first initial call
-            cy.wrap(PAGINATION_VALUES).each((el) => {
-                changePagination(el).then(() => {
-                    cy.wait('@getGroups')
-                    .its('request.url')
-                    .should('include', `perPage=${el}`);
-                });
+        cy.wait('@getGroups'); // first initial call
+        PAGINATION_VALUES.forEach((el) => {
+            changePagination(el).then(() => {
+                cy.wait('@getGroups')
+                .its('request.url')
+                .should('include', `perPage=${el}`);
             });
         });
     });
@@ -252,6 +253,63 @@ describe('selection and bulk selection', () => {
         cy.get(DROPDOWN_TOGGLE).eq(0).click(); // open selection dropdown
         cy.get('.pf-c-dropdown__menu > li').eq(1).click();
         checkSelectedNumber(0);
+    });
+});
+
+describe('actions', () => {
+    beforeEach(() => {
+        interceptors['successful with some items']();
+        mountTable();
+
+        cy.wait('@getGroups'); // first initial request
+    });
+
+    const TEST_ID = 0;
+
+    it('bulk rename and delete actions are disabled when no items selected', () => {
+        cy.get(`${TOOLBAR} ${DROPDOWN}`).eq(1).click(); // open bulk action toolbar
+        cy.get(DROPDOWN_ITEM).should('have.class', 'pf-m-disabled');
+    });
+
+    it('can rename a group, 1', () => {
+        cy.get(ROW).eq(TEST_ID + 1).find(`${DROPDOWN} button`).click();
+        cy.get(DROPDOWN_ITEM).contains('Rename group').click();
+        cy.get(MODAL).find('h1').should('contain.text', 'Rename group');
+        cy.get(MODAL).find('input').should('have.value', fixtures.results[TEST_ID].name);
+
+        cy.wait('@getGroups'); // validate request
+    });
+
+    it('can rename a group, 2', () => {
+        selectRowN(TEST_ID + 1);
+        cy.get(`${TOOLBAR} ${DROPDOWN}`).eq(1).click(); // open bulk action toolbar
+        cy.get(DROPDOWN_ITEM).contains('Rename group').click();
+        cy.get(MODAL).find('h1').should('contain.text', 'Rename group');
+        cy.get(MODAL).find('input').should('have.value', fixtures.results[TEST_ID].name);
+
+        cy.wait('@getGroups'); // validate request
+    });
+
+    it('can delete a group, 1', () => {
+        cy.get(ROW).eq(TEST_ID + 1).find(`${DROPDOWN} button`).click();
+        cy.get(DROPDOWN_ITEM).contains('Delete group').click();
+        cy.get(MODAL).find('h1').should('contain.text', 'Delete group');
+        cy.get(MODAL).find('p').should('contain.text', fixtures.results[TEST_ID].name);
+    });
+
+    it('can delete a group, 2', () => {
+        selectRowN(TEST_ID + 1);
+        cy.get(`${TOOLBAR} ${DROPDOWN}`).eq(1).click(); // open bulk action toolbar
+        cy.get(DROPDOWN_ITEM).contains('Delete group').click();
+        cy.get(MODAL).find('h1').should('contain.text', 'Delete group');
+        cy.get(MODAL).find('p').should('contain.text', fixtures.results[TEST_ID].name);
+    });
+
+    it('can create a group', () => {
+        cy.get(TOOLBAR).find('button').contains('Create group').click();
+        cy.get(MODAL).find('h1').should('contain.text', 'Create group');
+
+        cy.wait('@getGroups'); // validate request
     });
 });
 

--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -293,7 +293,7 @@ describe('actions', () => {
     it('can delete a group, 1', () => {
         cy.get(ROW).eq(TEST_ID + 1).find(`${DROPDOWN} button`).click();
         cy.get(DROPDOWN_ITEM).contains('Delete group').click();
-        cy.get(MODAL).find('h1').should('contain.text', 'Delete group');
+        cy.get(MODAL).find('h1').should('contain.text', 'Delete group?');
         cy.get(MODAL).find('p').should('contain.text', fixtures.results[TEST_ID].name);
     });
 
@@ -301,8 +301,18 @@ describe('actions', () => {
         selectRowN(TEST_ID + 1);
         cy.get(`${TOOLBAR} ${DROPDOWN}`).eq(1).click(); // open bulk action toolbar
         cy.get(DROPDOWN_ITEM).contains('Delete group').click();
-        cy.get(MODAL).find('h1').should('contain.text', 'Delete group');
+        cy.get(MODAL).find('h1').should('contain.text', 'Delete group?');
         cy.get(MODAL).find('p').should('contain.text', fixtures.results[TEST_ID].name);
+    });
+
+    it('can delete more groups', () => {
+        const TEST_ROWS = [2, 3];
+        TEST_ROWS.forEach((row) => selectRowN(row));
+
+        cy.get(`${TOOLBAR} ${DROPDOWN}`).eq(1).click(); // open bulk action toolbar
+        cy.get(DROPDOWN_ITEM).contains('Delete groups').click();
+        cy.get(MODAL).find('h1').should('contain.text', 'Delete groups?');
+        cy.get(MODAL).find('p').should('contain.text', `${TEST_ROWS.length} groups and all their data`);
     });
 
     it('can create a group', () => {

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -29,6 +29,9 @@ import { Link } from 'react-router-dom';
 import { TABLE_DEFAULT_PAGINATION } from '../../constants';
 import { fetchGroups } from '../../store/inventory-actions';
 import useFetchBatched from '../../Utilities/hooks/useFetchBatched';
+import CreateGroupModal from '../InventoryGroups/Modals/CreateGroupModal';
+import DeleteGroupModal from '../InventoryGroups/Modals/DeleteGroupModal';
+import RenameGroupModal from '../InventoryGroups/Modals/RenameGroupModal';
 import { getGroups } from '../InventoryGroups/utils/api';
 import { generateLoadingRows } from '../InventoryTable/helpers';
 import NoEntitiesFound from '../InventoryTable/NoEntitiesFound';
@@ -70,6 +73,10 @@ const GroupsTable = () => {
     const [filters, setFilters] = useState(GROUPS_TABLE_INITIAL_STATE);
     const [rows, setRows] = useState([]);
     const [selectedIds, setSelectedIds] = useState([]);
+    const [selectedGroup, setSelectedGroup] = useState({});
+    const [createModalOpen, setCreateModalOpen] = useState(false);
+    const [renameModalOpen, setRenameModalOpen] = useState(false);
+    const [deleteModalOpen, setDeleteModalOpen] = useState(false);
     const groups = useMemo(() => data?.results || [], [data]);
     const { fetchBatched } = useFetchBatched();
 
@@ -105,9 +112,15 @@ const GroupsTable = () => {
                 <span key={index}>{<DateFormat date={group.updated_at} />}</span>
             ],
             groupId: group.id,
+            groupName: group.name,
             selected: selectedIds.includes(group.id)
         }));
         setRows(newRows);
+
+        setSelectedGroup({
+            id: selectedIds[0],
+            name: groups.find(({ id }) => id === selectedIds[0])?.name
+        });
     }, [groups, selectedIds]);
 
     // TODO: convert initial URL params to filters
@@ -233,6 +246,23 @@ const GroupsTable = () => {
 
     return (
         <div id="groups-table">
+            <CreateGroupModal
+                isModalOpen={createModalOpen}
+                setIsModalOpen={setCreateModalOpen}
+                reloadData={() => {fetchData(filters);}}
+            />
+            <RenameGroupModal
+                isModalOpen={renameModalOpen}
+                setIsModalOpen={setRenameModalOpen}
+                reloadData={() => fetchData(filters)}
+                modalState={selectedGroup}
+            />
+            <DeleteGroupModal
+                isModalOpen={deleteModalOpen}
+                setIsModalOpen={setDeleteModalOpen}
+                reloadData={() => fetchData(filters)}
+                modalState={selectedGroup}
+            />
             <PrimaryToolbar
                 pagination={{
                     itemCount: data?.total || 0,
@@ -287,6 +317,27 @@ const GroupsTable = () => {
                     ouiaId: 'groups-selector',
                     count: selectedIds.length
                 }}
+                actionsConfig={{
+                    actions: [
+                        {
+                            label: 'Create group',
+                            onClick: () => setCreateModalOpen(true)
+                        },
+                        {
+                            label: 'Rename group',
+                            onClick: () => setRenameModalOpen(true),
+                            props: {
+                                isDisabled: selectedIds.length !== 1
+                            }
+                        },
+                        {
+                            label: 'Delete group',
+                            onClick: () => setDeleteModalOpen(true),
+                            props: {
+                                isDisabled: selectedIds.length !== 1
+                            }
+                        }
+                    ] }}
             />
             <Table
                 aria-label="Groups table"
@@ -303,6 +354,28 @@ const GroupsTable = () => {
                 isStickyHeader
                 onSelect={onSelect}
                 canSelectAll={false}
+                actions={[
+                    {
+                        title: 'Rename group',
+                        onClick: (event, rowIndex, { groupId, groupName }) => {
+                            setSelectedGroup({
+                                id: groupId,
+                                name: groupName
+                            });
+                            setRenameModalOpen(true);
+                        }
+                    },
+                    {
+                        title: 'Delete group',
+                        onClick: (event, rowIndex, { groupId, groupName }) => {
+                            setSelectedGroup({
+                                id: groupId,
+                                name: groupName
+                            });
+                            setDeleteModalOpen(true);
+                        }
+                    }
+                ]}
             >
                 <TableHeader />
                 <TableBody />

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -261,7 +261,9 @@ const GroupsTable = () => {
                 isModalOpen={deleteModalOpen}
                 setIsModalOpen={setDeleteModalOpen}
                 reloadData={() => fetchData(filters)}
-                modalState={selectedGroup}
+                modalState={selectedIds.length > 1 ? {
+                    ids: selectedIds
+                } : selectedGroup}
             />
             <PrimaryToolbar
                 pagination={{
@@ -331,10 +333,10 @@ const GroupsTable = () => {
                             }
                         },
                         {
-                            label: 'Delete group',
+                            label: selectedIds.length > 1 ? 'Delete groups' : 'Delete group',
                             onClick: () => setDeleteModalOpen(true),
                             props: {
-                                isDisabled: selectedIds.length !== 1
+                                isDisabled: selectedIds.length === 0
                             }
                         }
                     ] }}

--- a/src/components/InventoryGroups/Modals/CreateGroupModal.js
+++ b/src/components/InventoryGroups/Modals/CreateGroupModal.js
@@ -65,7 +65,5 @@ export default CreateGroupModal;
 CreateGroupModal.propTypes = {
     isModalOpen: PropTypes.bool,
     setIsModalOpen: PropTypes.func,
-    reloadData: PropTypes.func,
-    deviceIds: PropTypes.array,
-    isOpen: PropTypes.bool
+    reloadData: PropTypes.func
 };

--- a/src/components/InventoryGroups/Modals/DeleteGroupModal.js
+++ b/src/components/InventoryGroups/Modals/DeleteGroupModal.js
@@ -71,9 +71,10 @@ const DeleteGroupModal = ({
 };
 
 DeleteGroupModal.propTypes = {
-    id: PropTypes.number,
-    name: PropTypes.string,
-    modalState: PropTypes.object,
+    modalState: PropTypes.shape({
+        id: PropTypes.string,
+        name: PropTypes.string
+    }),
     isModalOpen: PropTypes.bool,
     setIsModalOpen: PropTypes.func,
     reloadData: PropTypes.func

--- a/src/components/InventoryGroups/Modals/DeleteGroupModal.js
+++ b/src/components/InventoryGroups/Modals/DeleteGroupModal.js
@@ -3,26 +3,37 @@ import PropTypes from 'prop-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import Modal from './Modal';
-import { deleteGroupById } from '../utils/api';
+import { deleteGroupsById } from '../utils/api';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import warningColor from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
 import { Text } from '@patternfly/react-core';
 import apiWithToast from '../utils/apiWithToast';
 import { useDispatch } from 'react-redux';
 
-const description = (name) => (
-    <Text>
-        <strong>{name} </strong>and all its data will be permanently deleted.
-    Associated systems will be removed from the group but will not be deleted.
-    </Text>
-);
+const description = (name = '', groupsCount) => {
+    const isMultiple = name === '' && groupsCount;
 
-const schema = (name) => ({
+    return isMultiple ? (
+        <Text>
+            <strong>{groupsCount}</strong> groups and all their data will be
+            permanently deleted. Associated systems will be removed from the
+            groups but will not be deleted.
+        </Text>
+    ) : (
+        <Text>
+            <strong>{name}</strong> and all its data will be
+            permanently deleted. Associated systems will be removed from the
+            group but will not be deleted.
+        </Text>
+    );
+};
+
+const schema = (name, groupsCount) => ({
     fields: [
         {
             component: componentTypes.PLAIN_TEXT,
             name: 'warning-message',
-            label: description(name)
+            label: description(name, groupsCount)
         },
         {
             component: componentTypes.CHECKBOX,
@@ -41,7 +52,8 @@ const DeleteGroupModal = ({
     reloadData = defaultValueToBeRemoved,
     modalState
 }) => {
-    const { id, name } = modalState;
+    const { id, name, ids } = modalState;
+    const isMultiple = (ids || []).length > 0;
     const dispatch = useDispatch();
 
     const handleDeleteGroup = () => {
@@ -52,18 +64,20 @@ const DeleteGroupModal = ({
             },
             onError: { title: 'Error', description: 'Failed to delete group' }
         };
-        apiWithToast(dispatch, () => deleteGroupById(id), statusMessages);
+        apiWithToast(dispatch, () => deleteGroupsById(isMultiple ? ids : [id]), statusMessages);
     };
 
     return (
         <Modal
             isModalOpen={isModalOpen}
             closeModal={() => setIsModalOpen(false)}
-            title="Delete group?"
-            titleIconVariant={() => (<ExclamationTriangleIcon color={warningColor.value} />)}
+            title={isMultiple ? 'Delete groups?' : 'Delete group?'}
+            titleIconVariant={() => (
+                <ExclamationTriangleIcon color={warningColor.value} />
+            )}
             variant="danger"
             submitLabel="Delete"
-            schema={schema(name)}
+            schema={schema(name, (ids || []).length)}
             onSubmit={handleDeleteGroup}
             reloadData={reloadData}
         />
@@ -73,7 +87,8 @@ const DeleteGroupModal = ({
 DeleteGroupModal.propTypes = {
     modalState: PropTypes.shape({
         id: PropTypes.string,
-        name: PropTypes.string
+        name: PropTypes.string,
+        ids: PropTypes.array
     }),
     isModalOpen: PropTypes.bool,
     setIsModalOpen: PropTypes.func,

--- a/src/components/InventoryGroups/Modals/RenameGroupModal.js
+++ b/src/components/InventoryGroups/Modals/RenameGroupModal.js
@@ -78,8 +78,10 @@ const RenameGroupModal = ({
 };
 
 RenameGroupModal.propTypes = {
-    id: PropTypes.number,
-    modalState: PropTypes.object,
+    modalState: PropTypes.shape({
+        id: PropTypes.string,
+        name: PropTypes.string
+    }),
     isModalOpen: PropTypes.bool,
     setIsModalOpen: PropTypes.func,
     reloadData: PropTypes.func

--- a/src/components/InventoryGroups/utils/api.js
+++ b/src/components/InventoryGroups/utils/api.js
@@ -35,8 +35,8 @@ export const updateGroupById = (id, payload) => {
     });
 };
 
-export const deleteGroupById = (id) => {
-    return instance.delete(`${INVENTORY_API_BASE}/groups/${id}`);
+export const deleteGroupsById = (ids = []) => {
+    return instance.delete(`${INVENTORY_API_BASE}/groups/${ids.join(',')}`);
 
 };
 


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-4365.

- Connects modals to the appropriate action buttons in the groups table.
- Improves the delete group modal so that it can accept more group IDs and perform the deletion request with multiple IDs.

## How to test:

1.  Run `npm run mock-server` and `npm run start:mock:beta` in separate terminals.
2. Navigate to https://stage.foo.redhat.com:1337/beta/insights/inventory/groups.
3. Use toolbar or per-row actions kebab to use the features on selected groups.
4. Check the right network requests are made after performing any action. (visually there can be some bugs due to the mocked crazy API).
5. Check the components tests pass.

## Screenshots

![image](https://user-images.githubusercontent.com/31385370/222165033-707b0bfe-57ff-4de5-b4aa-7de907689597.png)

![image](https://user-images.githubusercontent.com/31385370/222164965-2cc2bd2c-4f6c-4f20-967d-e1255d155199.png)

![image](https://user-images.githubusercontent.com/31385370/222427068-5eccc9d5-d7ba-4520-8edc-52a05e810d6e.png)
