### PR TITLE
feat(ESSNTL-3737, -3735): Rename and delete group

### DIFF
--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -60,5 +60,15 @@ export const groupDetailInterceptors = {
                 delay: 42000000 // milliseconds
             });
         }).as('getGroupDetail');
+    },
+    'patch successful': () => {
+        cy
+        .intercept('PATCH', '/api/inventory/v1/groups/*', { statusCode: 200 })
+        .as('patchGroup');
+    },
+    'delete successful': () => {
+        cy
+        .intercept('DELETE', '/api/inventory/v1/groups/*', { statusCode: 204 })
+        .as('deleteGroup');
     }
 };

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -1,33 +1,108 @@
-import { Breadcrumb, BreadcrumbItem, Skeleton } from '@patternfly/react-core';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    Dropdown,
+    DropdownItem,
+    DropdownToggle,
+    Flex,
+    FlexItem,
+    Skeleton
+} from '@patternfly/react-core';
 import {
     PageHeader,
     PageHeaderTitle
 } from '@redhat-cloud-services/frontend-components';
-import React from 'react';
-import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link, useHistory } from 'react-router-dom';
 import { routes } from '../../Routes';
 import PropTypes from 'prop-types';
+import DeleteGroupModal from '../InventoryGroups/Modals/DeleteGroupModal';
+import RenameGroupModal from '../InventoryGroups/Modals/RenameGroupModal';
+import { fetchGroupDetail } from '../../store/inventory-actions';
 
 const GroupDetailHeader = ({ groupId }) => {
-    const { uninitialized, loading, data } = useSelector((state) => state.groupDetail);
-
-    const nameOrId = uninitialized || loading ? (
-        <Skeleton width="250px" screenreaderText="Loading group details" />
-    ) : (
-        // in case of error, render just id from URL
-        data?.results?.[0]?.name || groupId
+    const dispatch = useDispatch();
+    const { uninitialized, loading, data } = useSelector(
+        (state) => state.groupDetail
     );
+
+    const [dropdownOpen, setDropdownOpen] = useState(false);
+    const [renameModalOpen, setRenameModalOpen] = useState(false);
+    const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+
+    const name = data?.results?.[0]?.name;
+    const title =
+      uninitialized || loading ? (
+          <Skeleton width="250px" screenreaderText="Loading group details" />
+      ) : (
+          name || groupId // in case of error, render just id from URL
+      );
+
+    const history = useHistory();
 
     return (
         <PageHeader>
+            <RenameGroupModal
+                isModalOpen={renameModalOpen}
+                setIsModalOpen={() => setRenameModalOpen(false)}
+                modalState={{
+                    id: groupId,
+                    name: name || groupId
+                }}
+                reloadData={() => dispatch(fetchGroupDetail(groupId))}
+            />
+            <DeleteGroupModal
+                isModalOpen={deleteModalOpen}
+                setIsModalOpen={() => setDeleteModalOpen(false)}
+                modalState={{
+                    id: groupId,
+                    name: name || groupId
+                }}
+                reloadData={() => history.push('/groups')}
+            />
             <Breadcrumb>
                 <BreadcrumbItem>
                     <Link to={routes.groups}>Groups</Link>
                 </BreadcrumbItem>
-                <BreadcrumbItem isActive>{nameOrId}</BreadcrumbItem>
+                <BreadcrumbItem isActive>{title}</BreadcrumbItem>
             </Breadcrumb>
-            <PageHeaderTitle title={nameOrId} />
+            <Flex id="group-header" justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+                <FlexItem>
+                    <PageHeaderTitle title={title} />
+                </FlexItem>
+                <FlexItem id="group-header-dropdown">
+                    <Dropdown
+                        onSelect={() => setDropdownOpen(!dropdownOpen)}
+                        autoFocus={false}
+                        isOpen={dropdownOpen}
+                        toggle={
+                            <DropdownToggle
+                                id="group-dropdown-toggle"
+                                onToggle={(isOpen) => setDropdownOpen(isOpen)}
+                                toggleVariant="secondary"
+                                isDisabled={uninitialized || loading}
+                            >
+                                Group actions
+                            </DropdownToggle>
+                        }
+                        dropdownItems={[
+                            <DropdownItem
+                                key="rename-group"
+                                onClick={() => setRenameModalOpen(true)}
+                            >
+                                Rename
+                            </DropdownItem>,
+                            <DropdownItem
+                                key="delete-group"
+                                onClick={() => setDeleteModalOpen(true)}
+                            >
+                                Delete
+                            </DropdownItem>
+                        ]}
+                    />
+                </FlexItem>
+            </Flex>
         </PageHeader>
     );
 };

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
@@ -1,9 +1,10 @@
 import { mount } from '@cypress/react';
+import { DROPDOWN, DROPDOWN_ITEM, MODAL } from '@redhat-cloud-services/frontend-components-utilities';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import groupDetailFixtures from '../../../cypress/fixtures/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C.json';
-import { groupDetailInterceptors as interceptors } from '../../../cypress/support/interceptors';
+import { groupDetailInterceptors as interceptors, groupsInterceptors } from '../../../cypress/support/interceptors';
 import { getStore } from '../../store';
 import InventoryGroupDetail from './InventoryGroupDetail';
 
@@ -58,5 +59,39 @@ describe('group detail page', () => {
         cy.get('[data-ouia-component-type="PF4/Breadcrumb"] li').last().find('.pf-c-skeleton');
         cy.get('h1').find('.pf-c-skeleton');
         cy.get('.pf-c-empty-state').find('.pf-c-spinner');
+    });
+
+    it('can open rename group modal', () => {
+        interceptors.successful();
+        interceptors['patch successful']();
+        groupsInterceptors['successful with some items'](); // intercept modal validation requests
+        mountPage();
+
+        cy.wait('@getGroupDetail');
+
+        cy.get(DROPDOWN).click();
+        cy.get(DROPDOWN_ITEM).contains('Rename').click();
+
+        cy.get(MODAL).find('input').type('1');
+        cy.get(MODAL).find('button[type=submit]').click();
+
+        cy.wait('@patchGroup').its('request.body')
+        .should('deep.equal', { name: `${groupDetailFixtures.results[0].name}1` });
+        cy.wait('@getGroupDetail'); // the page is refreshed after submition
+    });
+
+    it('can open delete group modal', () => {
+        interceptors.successful();
+        interceptors['delete successful']();
+        mountPage();
+        cy.wait('@getGroupDetail');
+
+        cy.get(DROPDOWN).click();
+        cy.get(DROPDOWN_ITEM).contains('Delete').click();
+
+        cy.get(`div[class="pf-c-check"]`).click();
+        cy.get(`button[type="submit"]`).click();
+        cy.wait('@deleteGroup').its('request.url')
+        .should('contain', groupDetailFixtures.results[0].id);
     });
 });

--- a/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
+++ b/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import GroupDetailHeader from '../GroupDetailHeader';
+import { DROPDOWN } from '@redhat-cloud-services/frontend-components-utilities';
 
 jest.mock('react-redux', () => {
     return {
@@ -17,12 +18,14 @@ jest.mock('react-redux', () => {
                     }
                 ]
             }
-        })
+        }),
+        useDispatch: () => {}
     };
 });
 
 describe('group detail header', () => {
     let getByRole;
+    let container;
 
     beforeEach(() => {
         const rendered = render(
@@ -31,6 +34,7 @@ describe('group detail header', () => {
             </MemoryRouter>
         );
         getByRole = rendered.getByRole;
+        container = rendered.container;
     });
 
     it('renders title and breadcrumbs', () => {
@@ -40,5 +44,10 @@ describe('group detail header', () => {
     it('has breadcrumbs', () => {
         expect(getByRole('navigation')).toHaveClass('pf-c-breadcrumb');
         expect(getByRole('navigation')).toHaveTextContent('group-name-1');
+    });
+
+    it('renders the actions dropdown', () => {
+        expect(container.querySelector('#group-header-dropdown')).toHaveTextContent('Group actions');
+        expect(container.querySelector(DROPDOWN)).toBeVisible();
     });
 });


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-3737.
Implements https://issues.redhat.com/browse/ESSNTL-3735.

Mocked at https://www.sketch.com/s/c19f555b-7887-4423-b55d-575c8dd1dfb7/a/4a1MVRq#Inspect.

This makes it possible to rename or delete a group from the group details page.

## How to test

1. Deploy the inventory locally, use the mock server.
2. Navigate to the /inventory/groups/%id with id equal to any random string.
3. Play with the actions toolbar on the left, try to rename, delete the group and check for the correct network requests (use https://console.stage.redhat.com/beta/docs/api/inventory/v1 as a reference).

## Screenshots

![image](https://user-images.githubusercontent.com/31385370/222479144-d05f7408-8455-4211-a244-3f3304f245e8.png)

![image](https://user-images.githubusercontent.com/31385370/222479255-e5e05828-63e4-439d-a400-a4b701fc9928.png)

![image](https://user-images.githubusercontent.com/31385370/222479341-053be169-fe01-445a-ae29-3c272544c01b.png)
