### PR TITLE
test: Bring intercept responses to one format

### DIFF
--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -6,16 +6,29 @@ import groupDetailFixtures from '../fixtures/groups/620f9ae75A8F6b83d78F3B55Af1c
 
 export const groupsInterceptors = {
     'successful with some items': () =>
-        cy.intercept('GET', '/api/inventory/v1/groups*', fixtures).as('getGroups'),
+        cy
+        .intercept('GET', '/api/inventory/v1/groups*', {
+            statusCode: 200,
+            body: fixtures
+        })
+        .as('getGroups'),
     'successful with some items second page': () =>
-        cy.intercept('GET', '/api/inventory/v1/groups?*page=2&perPage=50*', groupsSecondPage).as('getGroupsSecond'),
+        cy
+        .intercept('GET', '/api/inventory/v1/groups?*page=2&perPage=50*', {
+            statusCode: 200,
+            body: groupsSecondPage
+        })
+        .as('getGroupsSecond'),
     'successful empty': () =>
         cy
         .intercept('GET', '/api/inventory/v1/groups*', {
-            count: 0,
-            page: 1,
-            per_page: DEFAULT_ROW_COUNT,
-            total: 0
+            statusCode: 200,
+            body: {
+                count: 0,
+                page: 1,
+                per_page: DEFAULT_ROW_COUNT,
+                total: 0
+            }
         })
         .as('getGroups'),
     'failed with server error': () => {
@@ -27,11 +40,10 @@ export const groupsInterceptors = {
         );
     },
     'long responding': () => {
-        cy.intercept('GET', '/api/inventory/v1/groups*', (req) => {
-            req.reply({
-                body: fixtures,
-                delay: 42000000 // milliseconds
-            });
+        cy.intercept('GET', '/api/inventory/v1/groups*', {
+            statusCode: 200,
+            body: fixtures,
+            delay: 42000000 // milliseconds
         }).as('getGroups');
     }
 };
@@ -39,27 +51,43 @@ export const groupsInterceptors = {
 export const groupDetailInterceptors = {
     successful: () =>
         cy
-        .intercept('GET', '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C', groupDetailFixtures)
+        .intercept(
+            'GET',
+            '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C',
+            {
+                statusCode: 200,
+                body: groupDetailFixtures
+            }
+        )
         .as('getGroupDetail'),
     empty: () =>
         cy
-        .intercept('GET', '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C', { statusCode: 404 })
+        .intercept(
+            'GET',
+            '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C',
+            { statusCode: 404 }
+        )
         .as('getGroupDetail'),
     'failed with server error': () => {
         Cypress.on('uncaught:exception', () => {
             return false;
         });
-        cy.intercept('GET', '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C', { statusCode: 500 }).as(
-            'getGroupDetail'
-        );
+        cy.intercept(
+            'GET',
+            '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C',
+            { statusCode: 500 }
+        ).as('getGroupDetail');
     },
     'long responding': () => {
-        cy.intercept('GET', '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C', (req) => {
-            req.reply({
+        cy.intercept(
+            'GET',
+            '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C',
+            {
+                statusCode: 200,
                 body: groupDetailFixtures,
                 delay: 42000000 // milliseconds
-            });
-        }).as('getGroupDetail');
+            }
+        ).as('getGroupDetail');
     }
 };
 


### PR DESCRIPTION
This rewrites some interceptors to always have the third argument compliant with the interceptors' response object interface (e.g., always include statusCode, body): https://docs.cypress.io/api/commands/intercept#Response-object-properties. This should help avoid "flakiness" for some tests and make the test code utils consistent.

## How to test

The component tests must pass.