### PR TITLE
test: Stabilize cypress component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "verify": "npm-run-all build lint test",
     "nightly": "npm run travis:verify",
     "start:federated": "fec static --config config/dev.webpack.config.js",
-    "test:ct": "BABEL_ENV=componentTest cypress run --component",
+    "test:ct": "BABEL_ENV=componentTest cypress run --component --browser chrome",
     "test:openct": "BABEL_ENV=componentTest cypress open --component",
     "test:openct:mock": "MOCK=true npm run test:openct",
     "coverage": "bash coverage.sh",

--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -79,6 +79,8 @@ describe('renders correctly', () => {
     beforeEach(() => {
         interceptors['successful with some items'](); // comment out if the mock server is running
         mountTable();
+
+        cy.wait('@getGroups'); // first initial call
     });
 
     it('the root container is rendered', () => {
@@ -98,10 +100,11 @@ describe('defaults', () => {
     beforeEach(() => {
         interceptors['successful with some items']();
         mountTable();
+
+        cy.wait('@getGroups'); // first initial call
     });
 
     it(`pagination is set to ${DEFAULT_ROW_COUNT}`, () => {
-        cy.wait('@getGroups');
         cy.get('.pf-c-options-menu__toggle-text')
         .find('b')
         .eq(0)
@@ -117,6 +120,8 @@ describe('pagination', () => {
     beforeEach(() => {
         interceptors['successful with some items']();
         mountTable();
+
+        cy.wait('@getGroups'); // first initial call
     });
 
     it('shows correct total number of groups', () => {
@@ -128,7 +133,6 @@ describe('pagination', () => {
     });
 
     it('can change page limit', () => {
-        cy.wait('@getGroups'); // first initial call
         PAGINATION_VALUES.forEach((el) => {
             changePagination(el).then(() => {
                 cy.wait('@getGroups')
@@ -139,7 +143,6 @@ describe('pagination', () => {
     });
 
     it('can change page', () => {
-        cy.wait('@getGroups');
         cy.get('button[data-action=next]').eq(0).click(); // click "next page" button
         cy.wait('@getGroups').its('request.url').should('include', `page=2`);
     });
@@ -149,6 +152,8 @@ describe('sorting', () => {
     beforeEach(() => {
         interceptors['successful with some items']();
         mountTable();
+
+        cy.wait('@getGroups'); // first initial call
     });
 
     const checkSorting = (label, order, dataField) => {
@@ -181,6 +186,8 @@ describe('filtering', () => {
     beforeEach(() => {
         interceptors['successful with some items']();
         mountTable();
+
+        cy.wait('@getGroups'); // first initial call
     });
 
     const applyNameFilter = () =>
@@ -190,6 +197,7 @@ describe('filtering', () => {
     it('renders filter chip', () => {
         applyNameFilter();
         hasChip('Name', 'lorem');
+        cy.wait('@getGroups');
     });
 
     it('sends correct request', () => {


### PR DESCRIPTION
This PR 
1. **rewrites some flaky tests** that assert network requests and their search parameters (e.g. filter, sorting, etc.). The problem is that cypress doesn't wait or flush all the requests between `it`s and thus some tests can assert on wrongly intercepted requests. It must be resolved now by `cy.wait`ing for all requests that we set up interceptors for.
   1. Example: the inventory groups table makes the initial request for all data via GET `/groups`. If in the tests we change the pagination and then `cy.wait` for the new paginated request, then it can happen that the first requests hasn't been finished yet and `cy.wait` will catch the very first request instead of the request made after changing pagination (the one we need to check).
2.  **makes cypress run component tests in chrome** browser instead of electron. Before we had a problem that CI would fail with `Could not process 'reset:browser:tabs:for:next:test'. No automation clients connected.` error. https://github.com/cypress-io/cypress/issues/22208 suggests to force running in chrome.

## How to test

CI must pass.