### PR TITLE
ESSNTL(4056): Adds checks against edge cases for last seen filter

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -42,6 +42,7 @@ global.insights = {
         getUserPermissions: () => Promise.resolve(['inventory:*:*'])
     }
 };
+jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01').getTime());
 
 global.shallow = shallow;
 global.render = render;

--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -42,7 +42,6 @@ global.insights = {
         getUserPermissions: () => Promise.resolve(['inventory:*:*'])
     }
 };
-jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01').getTime());
 
 global.shallow = shallow;
 global.render = render;

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -10,12 +10,47 @@ export const REGISTERED_CHIP = 'registered_with';
 export const OS_CHIP = 'operating_system';
 export const RHCD_FILTER_KEY = 'rhc_client_id';
 export const UPDATE_METHOD_KEY = 'system_update_method';
+export const LAST_SEEN_CHIP = 'last_seen';
+
+export function subtractDate(days) {
+    const date = new Date();
+    date.setDate(date.getDate() - days);
+    return date.toISOString();
+}
 
 export const staleness = [
     { label: 'Fresh', value: 'fresh' },
     { label: 'Stale', value: 'stale' },
     { label: 'Stale warning', value: 'stale_warning' },
     { label: 'Unknown', value: 'unknown' }
+];
+
+export const currentDate = new Date().toISOString();
+export const lastSeenItems = [
+    {
+        value: { updatedStart: subtractDate(1), updatedEnd: currentDate, mark: 'last24' },
+        label: 'Within last 24 hours'    },
+    {
+        value: {  updatedEnd: subtractDate(1), mark: '24more' },
+        label: 'More than 1 day ago'
+
+    },
+    {
+        value: { updatedEnd: subtractDate(7), mark: '7more' },
+        label: 'More than 7 days ago'
+    },
+    {
+        value: { updatedEnd: subtractDate(15), mark: '15more' },
+        label: 'More than 15 days ago'
+    },
+    {
+        value: { updatedEnd: subtractDate(30), mark: '30more' },
+        label: 'More than 30 days ago'
+    },
+    {
+        value: { mark: 'custom' },
+        label: 'Custom'
+    }
 ];
 export const registered = [
     { label: 'insights-client', value: 'puptoo', idName: 'Insights id', idValue: 'insights_id' },
@@ -81,7 +116,8 @@ export function reduceFilters(filters = []) {
             };
         }
 
-        const foundKey = ['staleFilter', 'registeredWithFilter', 'osFilter', 'rhcdFilter', 'updateMethodFilter', '']
+        const foundKey = ['staleFilter', 'registeredWithFilter', 'osFilter', 'rhcdFilter', 'updateMethodFilter',
+            'lastSeenFilter', '']
         .find(item => Object.keys(oneFilter).includes(item));
 
         return {
@@ -105,7 +141,8 @@ export const reloadWrapper = (event, callback) => {
 
 export const isEmpty = (check) => !check || check?.length === 0;
 
-export const generateFilter = (status, source, tagsFilter, filterbyName, operatingSystem, rhcdFilter, updateMethodFilter) => ([
+export const generateFilter = (status, source, tagsFilter, filterbyName,
+    operatingSystem, rhcdFilter, lastSeenFilter, updateMethodFilter) => ([
     !isEmpty(status) && {
         staleFilter: Array.isArray(status) ? status : [status]
     },
@@ -130,6 +167,9 @@ export const generateFilter = (status, source, tagsFilter, filterbyName, operati
     },
     !isEmpty(rhcdFilter) && {
         rhcdFilter: Array.isArray(rhcdFilter) ? rhcdFilter : [rhcdFilter]
+    },
+    !isEmpty(lastSeenFilter) && {
+        lastSeenFilter: Array.isArray(lastSeenFilter) ? lastSeenFilter : [lastSeenFilter]
     },
     !isEmpty(updateMethodFilter) && {
         updateMethodFilter: Array.isArray(updateMethodFilter) ? updateMethodFilter : [updateMethodFilter]

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -29,7 +29,7 @@ export const currentDate = new Date().toISOString();
 export const lastSeenItems = [
     {
         value: { updatedStart: subtractDate(1), updatedEnd: currentDate, mark: 'last24' },
-        label: 'Within last 24 hours'    },
+        label: 'Within the last 24 hours'    },
     {
         value: {  updatedEnd: subtractDate(1), mark: '24more' },
         label: 'More than 1 day ago'

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -98,6 +98,7 @@ export const filtersReducer = (acc, filter = {}) => ({
     ...'registeredWithFilter' in filter && { registeredWithFilter: filter.registeredWithFilter },
     ...'osFilter' in filter && { osFilter: filter.osFilter },
     ...'rhcdFilter' in filter && { rhcdFilter: filter.rhcdFilter },
+    ...'lastSeenFilter' in filter && { lastSeenFilter: filter.lastSeenFilter },
     ...'updateMethodFilter' in filter && { updateMethodFilter: filter.updateMethodFilter }
 });
 
@@ -112,6 +113,7 @@ export async function getEntities(items, {
     fields = { system_profile: ['operating_system'] },
     ...options
 }, showTags) {
+
     if (hasItems && items?.length > 0) {
         let data = await hosts.apiHostGetHostById(
             items,
@@ -191,7 +193,9 @@ export async function getEntities(items, {
                 query: {
                     ...(options.filter && Object.keys(options.filter).length && generateFilter(options.filter)),
                     ...(calculateSystemProfile(filters)),
-                    ...(fields && Object.keys(fields).length && generateFilter(fields, 'fields'))
+                    ...(fields && Object.keys(fields).length && generateFilter(fields, 'fields')),
+                    ...filters?.lastSeenFilter?.updatedStart && { updated_start: filters.lastSeenFilter.updatedStart },
+                    ...filters?.lastSeenFilter?.updatedEnd && { updated_end: filters.lastSeenFilter.updatedEnd }
                 }
             }
         )

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React, { Fragment, useEffect, useCallback, useReducer } from 'react';
+import React, { Fragment, useEffect, useCallback, useReducer, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import xor from 'lodash/xor';
@@ -19,7 +19,8 @@ import {
     TAG_CHIP,
     arrayToSelection,
     RHCD_FILTER_KEY,
-    UPDATE_METHOD_KEY
+    UPDATE_METHOD_KEY,
+    LAST_SEEN_CHIP
 } from '../../Utilities/index';
 import { onDeleteFilter, onDeleteTag } from './helpers';
 import {
@@ -28,6 +29,7 @@ import {
     useRegisteredWithFilter,
     useTagsFilter,
     useRhcdFilter,
+    uselastSeenFilter,
     useUpdateMethodFilter,
     textFilterState,
     textFilterReducer,
@@ -40,10 +42,13 @@ import {
     rhcdFilterReducer,
     rhcdFilterState,
     updateMethodFilterReducer,
-    updateMethodFilterState
+    updateMethodFilterState,
+    lastSeenFilterReducer,
+    lastSeenFilterState
 } from '../filters';
 import useOperatingSystemFilter from '../filters/useOperatingSystemFilter';
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
+import { DatePicker, Split, SplitItem } from '@patternfly/react-core';
 
 /**
  * Table toolbar used at top of inventory table.
@@ -81,6 +86,7 @@ const EntityTableToolbar = ({
         tagsFilterReducer,
         operatingSystemFilterReducer,
         rhcdFilterReducer,
+        lastSeenFilterReducer,
         updateMethodFilterReducer
     ]), {
         ...textFilterState,
@@ -88,7 +94,8 @@ const EntityTableToolbar = ({
         ...registeredWithFilterState,
         ...tagsFilterState,
         ...rhcdFilterState,
-        ...updateMethodFilterState
+        ...updateMethodFilterState,
+        ...lastSeenFilterState
     });
     const filters = useSelector(({ entities: { activeFilters } }) => activeFilters);
     const allTagsLoaded = useSelector(({ entities: { allTagsLoaded } }) => allTagsLoaded);
@@ -98,6 +105,7 @@ const EntityTableToolbar = ({
     const [stalenessFilter, stalenessChip, staleFilter, setStaleFilter] = useStalenessFilter(reducer);
     const [registeredFilter, registeredChip, registeredWithFilter, setRegisteredWithFilter] = useRegisteredWithFilter(reducer);
     const [rhcdFilterConfig, rhcdFilterChips, rhcdFilterValue, setRhcdFilterValue] = useRhcdFilter(reducer);
+    const [lastSeenFilter, lastSeenChip, lastSeenFilterValue, setLastSeenFilterValue] = uselastSeenFilter(reducer);
     const [osFilterConfig, osFilterChips, osFilterValue, setOsFilterValue] = useOperatingSystemFilter();
     const [updateMethodConfig, updateMethodChips, updateMethodValue, setUpdateMethodValue] = useUpdateMethodFilter(reducer);
 
@@ -130,6 +138,7 @@ const EntityTableToolbar = ({
         operatingSystem: !(hideFilters.all && hideFilters.operatingSystem !== false) && !hideFilters.operatingSystem,
         tags: !(hideFilters.all && hideFilters.tags !== false) && !hideFilters.tags,
         rhcdFilter: !(hideFilters.all && hideFilters.rhcdFilter !== false) && !hideFilters.rhcdFilter,
+        lastSeenFilter: !(hideFilters.all && hideFilters.lastSeen !== false) && !hideFilters.lastSeen,
         //hides the filter untill API is ready. JIRA: RHIF-169
         updateMethodFilter: isUpdateMethodEnabled &&
             !(hideFilters.all && hideFilters.updateMethodFilter !== false)
@@ -171,7 +180,7 @@ const EntityTableToolbar = ({
      */
     useEffect(() => {
         const {
-            textFilter, tagFilters, staleFilter, registeredWithFilter, osFilter, rhcdFilter, updateMethodFilter
+            textFilter, tagFilters, staleFilter, registeredWithFilter, osFilter, rhcdFilter, lastSeenFilter, updateMethodFilter
         } = reduceFilters([...filters || [], ...customFilters?.filters || []]);
 
         debouncedRefresh();
@@ -182,6 +191,7 @@ const EntityTableToolbar = ({
         enabledFilters.operatingSystem && setOsFilterValue(osFilter);
         enabledFilters.rhcdFilter && setRhcdFilterValue(rhcdFilter);
         enabledFilters.updateMethodFilter && setUpdateMethodValue(updateMethodFilter);
+        enabledFilters.lastSeenFilter && setLastSeenFilterValue(lastSeenFilter);
     }, []);
 
     /**
@@ -262,6 +272,12 @@ const EntityTableToolbar = ({
     }, [rhcdFilterValue]);
 
     useEffect(() => {
+        if (shouldReload && enabledFilters.lastSeenFilter) {
+            onSetFilter(lastSeenFilterValue, 'lastSeenFilter', debouncedRefresh);
+        }
+    }, [lastSeenFilterValue]);
+
+    useEffect(() => {
         if (shouldReload && enabledFilters.updateMethodFilter) {
             onSetFilter(updateMethodValue, 'updateMethodFilter', debouncedRefresh);
         }
@@ -285,6 +301,7 @@ const EntityTableToolbar = ({
         ),
         [OS_CHIP]: (deleted) => setOsFilterValue(xor(osFilterValue, deleted.chips.map(({ value }) => value))),
         [RHCD_FILTER_KEY]: (deleted) => setRhcdFilterValue(onDeleteFilter(deleted, rhcdFilterValue)),
+        [LAST_SEEN_CHIP]: (deleted) => setLastSeenFilterValue(onDeleteFilter(deleted, [lastSeenFilterValue.mark])),
         [UPDATE_METHOD_KEY]: (deleted) => setUpdateMethodValue(onDeleteFilter(deleted, updateMethodValue))
     };
     /**
@@ -297,6 +314,7 @@ const EntityTableToolbar = ({
         enabledFilters.tags && setSelectedTags({});
         enabledFilters.operatingSystem && setOsFilterValue([]);
         enabledFilters.rhcdFilter && setRhcdFilterValue([]);
+        enabledFilters.lastSeenFilter && setLastSeenFilterValue([]);
         enabledFilters.updateMethodFilter && setUpdateMethodValue([]);
         dispatch(setFilter([]));
         updateData({ page: 1, filters: [] });
@@ -316,6 +334,7 @@ const EntityTableToolbar = ({
                 ...!hasItems && enabledFilters.operatingSystem ? osFilterChips : [],
                 ...!hasItems && enabledFilters.rhcdFilter ? rhcdFilterChips : [],
                 ...!hasItems && enabledFilters.updateMethodFilter ? updateMethodChips : [],
+                ...!hasItems && enabledFilters.lastSeenFilter ? lastSeenChip : [],
                 ...activeFiltersConfig?.filters || []
             ],
             onDelete: (e, [deleted, ...restDeleted], isAll) => {
@@ -341,10 +360,25 @@ const EntityTableToolbar = ({
             ...enabledFilters.registeredWith ? [registeredFilter] : [],
             ...enabledFilters.rhcdFilter ? [rhcdFilterConfig] : [],
             ...enabledFilters.updateMethodFilter ? [updateMethodConfig] : [],
+            ...enabledFilters.lastSeenFilter ? [lastSeenFilter] : [],
             ...showTags && enabledFilters.tags ? [tagsFilter] : []
         ] : [],
         ...filterConfig?.items || []
     ];
+    const [startDate, setStartDate] = useState();
+    const [endDate, setEndDate] = useState();
+
+    const toValidator = date => date >= startDate ? '' : 'To date must be less than from date';
+    const onFromChange = (_str, date) => {
+        setStartDate((date));
+        setLastSeenFilterValue({ ...lastSeenFilterValue, updatedStart: new Date(date).toISOString() });
+        date.setDate(date.getDate() + 1);
+    };
+
+    const onToChange = (date) => {
+        setEndDate(date);
+        setLastSeenFilterValue({ ...lastSeenFilterValue, updatedEnd: new Date(date).toISOString() });
+    };
 
     return <Fragment>
         <PrimaryToolbar
@@ -384,7 +418,29 @@ const EntityTableToolbar = ({
                 ...paginationProps
             } : <Skeleton size={SkeletonSize.lg} />}
         >
+            {lastSeenFilterValue?.mark === 'custom' &&
+            <Split>
+                <SplitItem>
+                    <DatePicker
+                        onChange={onFromChange}
+                        aria-label="Start date"
+                    />
+                </SplitItem>
+                <SplitItem style={{ padding: '6px 12px 0 12px' }}>
+            to
+                </SplitItem>
+                <SplitItem>
+                    <DatePicker
+                        value={endDate}
+                        onChange={onToChange}
+                        rangeStart={startDate}
+                        validators={[toValidator]}
+                        aria-label="End date"
+                    />
+                </SplitItem>
+            </Split>}
             { children }
+
         </PrimaryToolbar>
         {
             (showTags || enabledFilters.tags || showTagModal) && <TagsModal
@@ -430,6 +486,7 @@ EntityTableToolbar.propTypes = {
         stale: PropTypes.bool,
         operatingSystem: PropTypes.bool,
         rhcdFilter: PropTypes.bool,
+        lastSeen: PropTypes.bool,
         updateMethodFilter: PropTypes.bool,
         all: PropTypes.bool
     }),

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -106,7 +106,7 @@ const EntityTableToolbar = ({
     const [registeredFilter, registeredChip, registeredWithFilter, setRegisteredWithFilter] = useRegisteredWithFilter(reducer);
     const [rhcdFilterConfig, rhcdFilterChips, rhcdFilterValue, setRhcdFilterValue] = useRhcdFilter(reducer);
     const [lastSeenFilter, lastSeenChip, lastSeenFilterValue, setLastSeenFilterValue,
-        toValidator, onFromChange, onToChange, endDate, startDate] = useLastSeenFilter(reducer);
+        toValidator, onFromChange, onToChange, endDate, startDate, rangeValidator] = useLastSeenFilter(reducer);
     const [osFilterConfig, osFilterChips, osFilterValue, setOsFilterValue] = useOperatingSystemFilter();
     const [updateMethodConfig, updateMethodChips, updateMethodValue, setUpdateMethodValue] = useUpdateMethodFilter(reducer);
 
@@ -411,6 +411,8 @@ const EntityTableToolbar = ({
                     <DatePicker
                         onChange={onFromChange}
                         aria-label="Start date"
+                        validators={[rangeValidator]}
+
                     />
                 </SplitItem>
                 <SplitItem style={{ padding: '6px 12px 0 12px' }}>

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React, { Fragment, useEffect, useCallback, useReducer, useState } from 'react';
+import React, { Fragment, useEffect, useCallback, useReducer } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import xor from 'lodash/xor';
@@ -29,7 +29,7 @@ import {
     useRegisteredWithFilter,
     useTagsFilter,
     useRhcdFilter,
-    uselastSeenFilter,
+    useLastSeenFilter,
     useUpdateMethodFilter,
     textFilterState,
     textFilterReducer,
@@ -105,7 +105,8 @@ const EntityTableToolbar = ({
     const [stalenessFilter, stalenessChip, staleFilter, setStaleFilter] = useStalenessFilter(reducer);
     const [registeredFilter, registeredChip, registeredWithFilter, setRegisteredWithFilter] = useRegisteredWithFilter(reducer);
     const [rhcdFilterConfig, rhcdFilterChips, rhcdFilterValue, setRhcdFilterValue] = useRhcdFilter(reducer);
-    const [lastSeenFilter, lastSeenChip, lastSeenFilterValue, setLastSeenFilterValue] = uselastSeenFilter(reducer);
+    const [lastSeenFilter, lastSeenChip, lastSeenFilterValue, setLastSeenFilterValue,
+        toValidator, onFromChange, onToChange, endDate, startDate] = useLastSeenFilter(reducer);
     const [osFilterConfig, osFilterChips, osFilterValue, setOsFilterValue] = useOperatingSystemFilter();
     const [updateMethodConfig, updateMethodChips, updateMethodValue, setUpdateMethodValue] = useUpdateMethodFilter(reducer);
 
@@ -365,20 +366,6 @@ const EntityTableToolbar = ({
         ] : [],
         ...filterConfig?.items || []
     ];
-    const [startDate, setStartDate] = useState();
-    const [endDate, setEndDate] = useState();
-
-    const toValidator = date => date >= startDate ? '' : 'To date must be less than from date';
-    const onFromChange = (_str, date) => {
-        setStartDate((date));
-        setLastSeenFilterValue({ ...lastSeenFilterValue, updatedStart: new Date(date).toISOString() });
-        date.setDate(date.getDate() + 1);
-    };
-
-    const onToChange = (date) => {
-        setEndDate(date);
-        setLastSeenFilterValue({ ...lastSeenFilterValue, updatedEnd: new Date(date).toISOString() });
-    };
 
     return <Fragment>
         <PrimaryToolbar

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -14,6 +14,12 @@ import debounce from 'lodash/debounce';
 jest.mock('lodash/debounce');
 jest.mock('../../Utilities/useFeatureFlag');
 
+jest.mock('../../Utilities/constants', () => ({
+    ...jest.requireActual('../../Utilities/constants'),
+    lastSeenItems: jest.fn().mockReturnValue([])
+
+}));
+
 describe('EntityTableToolbar', () => {
     let initialState;
     let stateWithActiveFilter;

--- a/src/components/InventoryTable/InventoryTable.test.js
+++ b/src/components/InventoryTable/InventoryTable.test.js
@@ -220,7 +220,7 @@ describe('InventoryTable', () => {
             </Provider>);
 
             expect(wrapper.find(ConditionalFilter).props().items.map(({ label }) => label)).toEqual(
-                ['Status', 'Operating System', 'Data Collector', 'RHC status', 'System Update Method', 'Last Seen', 'Tags']
+                ['Status', 'Operating System', 'Data Collector', 'RHC status', 'System Update Method', 'Last seen', 'Tags']
             );
         });
 

--- a/src/components/InventoryTable/InventoryTable.test.js
+++ b/src/components/InventoryTable/InventoryTable.test.js
@@ -220,7 +220,7 @@ describe('InventoryTable', () => {
             </Provider>);
 
             expect(wrapper.find(ConditionalFilter).props().items.map(({ label }) => label)).toEqual(
-                ['Status', 'Operating System', 'Data Collector', 'RHC status', 'System Update Method', 'Tags']
+                ['Status', 'Operating System', 'Data Collector', 'RHC status', 'System Update Method', 'Last Seen', 'Tags']
             );
         });
 

--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -5,13 +5,7 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
   actionsConfig={null}
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Last Seen",
-          "chips": Array [],
-          "type": "last_seen",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -133,6 +127,18 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
           "type": "checkbox",
           "value": "rhc-status",
         },
+        Object {
+          "filterValues": Object {
+            "isDisabled": false,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
+        },
       ],
     }
   }
@@ -148,13 +154,7 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Last Seen",
-          "chips": Array [],
-          "type": "last_seen",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -316,6 +316,18 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
           "type": "checkbox",
           "value": "rhc-status",
         },
+        Object {
+          "filterValues": Object {
+            "isDisabled": false,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
+        },
       ],
     }
   }
@@ -337,11 +349,6 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
   activeFiltersConfig={
     Object {
       "filters": Array [
-        Object {
-          "category": "Last Seen",
-          "chips": Array [],
-          "type": "last_seen",
-        },
         Object {
           "category": "Some",
           "chips": Array [
@@ -517,6 +524,18 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
+        },
+        Object {
+          "filterValues": Object {
             "className": "ins-c-tagfilter",
             "filterBy": "",
             "isDisabled": false,
@@ -565,13 +584,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Last Seen",
-          "chips": Array [],
-          "type": "last_seen",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -736,6 +749,18 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
         Object {
           "filterValues": Object {
             "isDisabled": false,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
+        },
+        Object {
+          "filterValues": Object {
+            "isDisabled": false,
             "placeholder": "Filter by filter by text",
           },
           "label": "Filter by text",
@@ -770,11 +795,6 @@ exports[`EntityTableToolbar DOM should render correctly - with customFilters 1`]
             },
           ],
           "type": "rhc_client_id",
-        },
-        Object {
-          "category": "Last Seen",
-          "chips": Array [],
-          "type": "last_seen",
         },
       ],
       "onDelete": [Function],
@@ -942,6 +962,18 @@ exports[`EntityTableToolbar DOM should render correctly - with customFilters 1`]
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
+        },
+        Object {
+          "filterValues": Object {
             "className": "ins-c-tagfilter",
             "filterBy": "",
             "isDisabled": false,
@@ -1000,11 +1032,6 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
             },
           ],
           "type": "staleness",
-        },
-        Object {
-          "category": "Last Seen",
-          "chips": Array [],
-          "type": "last_seen",
         },
       ],
       "onDelete": [Function],
@@ -1170,6 +1197,18 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
           "type": "checkbox",
           "value": "rhc-status",
         },
+        Object {
+          "filterValues": Object {
+            "isDisabled": false,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
+        },
       ],
     }
   }
@@ -1190,13 +1229,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Last Seen",
-          "chips": Array [],
-          "type": "last_seen",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -1357,6 +1390,18 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
           "label": "RHC status",
           "type": "checkbox",
           "value": "rhc-status",
+        },
+        Object {
+          "filterValues": Object {
+            "isDisabled": false,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
         },
       ],
     }
@@ -1556,6 +1601,18 @@ exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
           "type": "checkbox",
           "value": "rhc-status",
         },
+        Object {
+          "filterValues": Object {
+            "isDisabled": true,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
+        },
       ],
     }
   }
@@ -1584,13 +1641,7 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Last Seen",
-          "chips": Array [],
-          "type": "last_seen",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -1751,6 +1802,18 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
           "label": "RHC status",
           "type": "checkbox",
           "value": "rhc-status",
+        },
+        Object {
+          "filterValues": Object {
+            "isDisabled": false,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
         },
         Object {
           "filterValues": Object {
@@ -1810,13 +1873,7 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [
-        Object {
-          "category": "Last Seen",
-          "chips": Array [],
-          "type": "last_seen",
-        },
-      ],
+      "filters": Array [],
       "onDelete": [Function],
     }
   }
@@ -1977,6 +2034,18 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
           "label": "RHC status",
           "type": "checkbox",
           "value": "rhc-status",
+        },
+        Object {
+          "filterValues": Object {
+            "isDisabled": false,
+            "items": [MockFunction],
+            "onChange": [Function],
+            "placeholder": "Filter by last seen",
+            "value": undefined,
+          },
+          "label": "Last seen",
+          "type": "radio",
+          "value": "last_seen",
         },
       ],
     }

--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -5,7 +5,13 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
   actionsConfig={null}
   activeFiltersConfig={
     Object {
-      "filters": Array [],
+      "filters": Array [
+        Object {
+          "category": "Last Seen",
+          "chips": Array [],
+          "type": "last_seen",
+        },
+      ],
       "onDelete": [Function],
     }
   }
@@ -142,7 +148,13 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [],
+      "filters": Array [
+        Object {
+          "category": "Last Seen",
+          "chips": Array [],
+          "type": "last_seen",
+        },
+      ],
       "onDelete": [Function],
     }
   }
@@ -325,6 +337,11 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
   activeFiltersConfig={
     Object {
       "filters": Array [
+        Object {
+          "category": "Last Seen",
+          "chips": Array [],
+          "type": "last_seen",
+        },
         Object {
           "category": "Some",
           "chips": Array [
@@ -548,7 +565,13 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [],
+      "filters": Array [
+        Object {
+          "category": "Last Seen",
+          "chips": Array [],
+          "type": "last_seen",
+        },
+      ],
       "onDelete": [Function],
     }
   }
@@ -747,6 +770,11 @@ exports[`EntityTableToolbar DOM should render correctly - with customFilters 1`]
             },
           ],
           "type": "rhc_client_id",
+        },
+        Object {
+          "category": "Last Seen",
+          "chips": Array [],
+          "type": "last_seen",
         },
       ],
       "onDelete": [Function],
@@ -973,6 +1001,11 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
           ],
           "type": "staleness",
         },
+        Object {
+          "category": "Last Seen",
+          "chips": Array [],
+          "type": "last_seen",
+        },
       ],
       "onDelete": [Function],
     }
@@ -1157,7 +1190,13 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [],
+      "filters": Array [
+        Object {
+          "category": "Last Seen",
+          "chips": Array [],
+          "type": "last_seen",
+        },
+      ],
       "onDelete": [Function],
     }
   }
@@ -1545,7 +1584,13 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [],
+      "filters": Array [
+        Object {
+          "category": "Last Seen",
+          "chips": Array [],
+          "type": "last_seen",
+        },
+      ],
       "onDelete": [Function],
     }
   }
@@ -1765,7 +1810,13 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
 <PrimaryToolbar
   activeFiltersConfig={
     Object {
-      "filters": Array [],
+      "filters": Array [
+        Object {
+          "category": "Last Seen",
+          "chips": Array [],
+          "type": "last_seen",
+        },
+      ],
       "onDelete": [Function],
     }
   }

--- a/src/components/filters/index.js
+++ b/src/components/filters/index.js
@@ -5,6 +5,7 @@ export * from './useTagsFilter';
 export * from './useOperatingSystemFilter';
 export * from './useRhcdFilter';
 export * from './useUpdateMethodFilter';
+export * from './useLastSeenFilter';
 export const filtersReducer = (reducersList) => (state, action) => reducersList.reduce((acc, curr) => ({
     ...acc,
     ...curr?.(state, action)

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -24,7 +24,8 @@ export const uselastSeenFilter = ([state, dispatch] = [lastSeenFilterState]) => 
             items: lastSeenItems
         }
     };
-    const chip = !Array.isArray(lastSeenValue) ? [{
+
+    const chip = (!Array.isArray(lastSeenValue) && lastSeenValue !== undefined)  ? [{
         category: 'Last seen',
         type: LAST_SEEN_CHIP,
         chips: lastSeenItems.filter(({ value }) => value?.mark === lastSeenValue?.mark)

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -9,7 +9,7 @@ export const lastSeenFilterReducer = (_state, { type, payload }) => ({
     }
 });
 
-export const uselastSeenFilter = ([state, dispatch] = [lastSeenFilterState]) => {
+export const useLastSeenFilter = ([state, dispatch] = [lastSeenFilterState]) => {
     let [lastSeenStateValue, setLastSeenValue] = useState({});
     const lastSeenValue = dispatch ? state.lastSeenFilter : [lastSeenStateValue];
     const setValue = dispatch ? (newValue) => dispatch({ type: LAST_SEEN_FILTER, payload: newValue }) : setLastSeenValue;
@@ -32,5 +32,21 @@ export const uselastSeenFilter = ([state, dispatch] = [lastSeenFilterState]) => 
         .map(({ label, ...props }) => ({ name: label, ...props }))
     }] : [];
 
-    return [filter, chip, lastSeenValue, setValue];
+    const [startDate, setStartDate] = useState();
+    const [endDate, setEndDate] = useState();
+
+    const toValidator = date => date >= startDate ? '' : 'To date must be less than from date';
+
+    const onFromChange = (_str, date) => {
+        setStartDate((date));
+        setValue({ ...lastSeenValue, updatedStart: new Date(date).toISOString() });
+        date.setDate(date.getDate() + 1);
+    };
+
+    const onToChange = (date) => {
+        setEndDate(date);
+        setValue({ ...lastSeenValue, updatedEnd: new Date(date).toISOString() });
+    };
+
+    return [filter, chip, lastSeenValue, setValue, toValidator, onFromChange, onToChange, endDate, startDate];
 };

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -4,15 +4,19 @@ import { LAST_SEEN_CHIP, lastSeenItems } from '../../Utilities/constants';
 export const lastSeenFilterState = { lastSeenFilter: [] };
 export const LAST_SEEN_FILTER = 'LAST_SEEN_FILTER';
 export const lastSeenFilterReducer = (_state, { type, payload }) => ({
-    ...type === LAST_SEEN_FILTER && {
+    ...(type === LAST_SEEN_FILTER && {
         lastSeenFilter: payload
-    }
+    })
 });
 
-export const useLastSeenFilter = ([state, dispatch] = [lastSeenFilterState]) => {
+export const useLastSeenFilter = (
+    [state, dispatch] = [lastSeenFilterState]
+) => {
     let [lastSeenStateValue, setLastSeenValue] = useState({});
     const lastSeenValue = dispatch ? state.lastSeenFilter : [lastSeenStateValue];
-    const setValue = dispatch ? (newValue) => dispatch({ type: LAST_SEEN_FILTER, payload: newValue }) : setLastSeenValue;
+    const setValue = dispatch
+        ? (newValue) => dispatch({ type: LAST_SEEN_FILTER, payload: newValue })
+        : setLastSeenValue;
 
     const filter = {
         label: 'Last seen',
@@ -25,20 +29,37 @@ export const useLastSeenFilter = ([state, dispatch] = [lastSeenFilterState]) => 
         }
     };
 
-    const chip = (!Array.isArray(lastSeenValue) && lastSeenValue !== undefined)  ? [{
-        category: 'Last seen',
-        type: LAST_SEEN_CHIP,
-        chips: lastSeenItems.filter(({ value }) => value?.mark === lastSeenValue?.mark)
-        .map(({ label, ...props }) => ({ name: label, ...props }))
-    }] : [];
+    const chip =
+    !Array.isArray(lastSeenValue) && lastSeenValue !== undefined
+        ? [
+            {
+                category: 'Last seen',
+                type: LAST_SEEN_CHIP,
+                chips: lastSeenItems
+                .filter(({ value }) => value?.mark === lastSeenValue?.mark)
+                .map(({ label, ...props }) => ({ name: label, ...props }))
+            }
+        ]
+        : [];
 
     const [startDate, setStartDate] = useState();
     const [endDate, setEndDate] = useState();
 
-    const toValidator = date => date >= startDate ? '' : 'To date must be less than from date';
+    const toValidator = (date) => {
+        date >= startDate ? '' : 'To date must be less than from date.';
+    };
+
+    const rangeValidator = (date) => {
+        const minDate = new Date(1950, 1, 1);
+        if (date < minDate) {
+            return 'Date is before the allowable range.';
+        } else {
+            return '';
+        }
+    };
 
     const onFromChange = (_str, date) => {
-        setStartDate((date));
+        setStartDate(date);
         setValue({ ...lastSeenValue, updatedStart: new Date(date).toISOString() });
         date.setDate(date.getDate() + 1);
     };
@@ -48,5 +69,16 @@ export const useLastSeenFilter = ([state, dispatch] = [lastSeenFilterState]) => 
         setValue({ ...lastSeenValue, updatedEnd: new Date(date).toISOString() });
     };
 
-    return [filter, chip, lastSeenValue, setValue, toValidator, onFromChange, onToChange, endDate, startDate];
+    return [
+        filter,
+        chip,
+        lastSeenValue,
+        setValue,
+        toValidator,
+        onFromChange,
+        onToChange,
+        endDate,
+        startDate,
+        rangeValidator
+    ];
 };

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { LAST_SEEN_CHIP, lastSeenItems } from '../../Utilities/constants';
+
+export const lastSeenFilterState = { lastSeenFilter: [] };
+export const LAST_SEEN_FILTER = 'LAST_SEEN_FILTER';
+export const lastSeenFilterReducer = (_state, { type, payload }) => ({
+    ...type === LAST_SEEN_FILTER && {
+        lastSeenFilter: payload
+    }
+});
+
+export const uselastSeenFilter = ([state, dispatch] = [lastSeenFilterState]) => {
+    let [lastSeenStateValue, setLastSeenValue] = useState({});
+    const lastSeenValue = dispatch ? state.lastSeenFilter : [lastSeenStateValue];
+    const setValue = dispatch ? (newValue) => dispatch({ type: LAST_SEEN_FILTER, payload: newValue }) : setLastSeenValue;
+
+    const filter = {
+        label: 'Last seen',
+        value: 'last_seen',
+        type: 'radio',
+        filterValues: {
+            value: lastSeenValue,
+            onChange: (_e, value) => setValue(value),
+            items: lastSeenItems
+        }
+    };
+    const chip = !Array.isArray(lastSeenValue) ? [{
+        category: 'Last seen',
+        type: LAST_SEEN_CHIP,
+        chips: lastSeenItems.filter(({ value }) => value?.mark === lastSeenValue?.mark)
+        .map(({ label, ...props }) => ({ name: label, ...props }))
+    }] : [];
+
+    return [filter, chip, lastSeenValue, setValue];
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -65,7 +65,6 @@ export const generateFilters = (cells = [], filters = [], activeFilters = {}, on
     filters.map((filter, key) => {
         const activeKey = filter.index || key;
         const activeLabel = cells[activeKey] && (cells[activeKey].title || cells[activeKey]);
-
         return ({
             value: String(activeKey),
             label: activeLabel,
@@ -125,7 +124,9 @@ export const getSearchParams = () => {
     const updateMethodFilter = searchParams.getAll(UPDATE_METHOD_KEY);
     const page = searchParams.getAll('page');
     const perPage = searchParams.getAll('per_page');
-    return { status, source, tagsFilter, filterbyName, operatingSystem, rhcdFilter, updateMethodFilter, page, perPage };
+    // const lastSeenFilter = searchParams.getAll('last_seen');
+    return { status, source, tagsFilter, filterbyName, operatingSystem, rhcdFilter, updateMethodFilter,
+        page, perPage };
 };
 
 export const TABLE_DEFAULT_PAGINATION = 50; // from UX table audit

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -48,6 +48,9 @@ const filterMapper = {
         flatMap(tagFilters, mapTags)
     ),
     rhcdFilter: ({ rhcdFilter }, searchParams) => rhcdFilter?.forEach(item => searchParams.append(RHCD_FILTER_KEY, item)),
+    //TODO: Add a way to add to url in a way that allows shareable links
+    // lastSeenFilter: ({ lastSeenFilter }, searchParams) =>
+    //     Object.values(lastSeenFilter)?.forEach(item => searchParams.append('last_seen', item)),
     updateMethodFilter: ({ updateMethodFilter }, searchParams) =>
         updateMethodFilter?.forEach(item => searchParams.append(UPDATE_METHOD_KEY, item))
 };
@@ -58,7 +61,6 @@ const calculateFilters = (searchParams, filters = []) => {
             filterMapper?.[key]?.(filter, searchParams);
         });
     });
-
     return searchParams;
 };
 
@@ -78,6 +80,7 @@ const Inventory = ({
     operatingSystem,
     rhcdFilter,
     updateMethodFilter,
+    lastSeenFilter,
     page,
     perPage,
     initialLoading,
@@ -89,7 +92,7 @@ const Inventory = ({
     const [isModalOpen, handleModalToggle] = useState(false);
     const [currentSytem, activateSystem] = useState({});
     const [filters, onSetfilters] = useState(
-        generateFilter(status, source, tagsFilter, filterbyName, operatingSystem, rhcdFilter, updateMethodFilter)
+        generateFilter(status, source, tagsFilter, filterbyName, operatingSystem, rhcdFilter, updateMethodFilter, lastSeenFilter)
     );
     const [ediOpen, onEditOpen] = useState(false);
     const [globalFilter, setGlobalFilter] = useState();
@@ -289,6 +292,7 @@ Inventory.propTypes = {
     initialLoading: PropTypes.bool,
     rhcdFilter: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
     updateMethodFilter: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
+    lastSeenFilter: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
     hasAccess: PropTypes.bool
 };
 

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -40,6 +40,7 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
         ...(isFilterDisabled('operating_system') && { osFilter: undefined })
     }) : {
         ...(isFilterDisabled('stale') && { staleFilter: undefined }),
+        ...(isFilterDisabled('last_seen') && { lastSeenFilter: undefined }),
         ...(isFilterDisabled('registeredWith') && { registeredWithFilter: undefined }),
         ...(isFilterDisabled('operating_system') && { osFilter: undefined })
     };


### PR DESCRIPTION
To test new updates check for the following:

- When selecting last seen filter, if you refresh, filter persist
- Make sure you can copy/past the link with the filter present (this is true for all except custom, custom should populate the range picker)
- Make sure Start Date cant be larger than End Date
- Make sure End date cant be smaller than start Date
- End date and start date both cannot go past Todays date

The only current way to select the same date in both fields, is to

- Select a date on the EndDate 
- Invalidate that date (write something like 2023-10-00)
- Then input the date originally typed in on the End that (the end date just say 'invalid date' as you do this) on the Start Date

The filter will load both args into the request, but it should Not break. 
Other than this edge case there shouldnt be a way to select the same day on both (if there is some other hacky way, it should not break)
Filter should no break ever. I believe this should catch all edge cases
