### PR TITLE
ESSNTL(4056): Adds checks against edge cases for last seen filter

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -178,7 +178,8 @@ export const generateFilter = (status,
         rhcdFilter: Array.isArray(rhcdFilter) ? rhcdFilter : [rhcdFilter]
     },
     !isEmpty(lastSeenFilter) && {
-        lastSeenFilter: Array.isArray(lastSeenFilter) ? lastSeenFilter : [lastSeenFilter]
+        lastSeenFilter: Array.isArray(lastSeenFilter)
+            ? lastSeenItems.filter((item)=> item.value.mark === lastSeenFilter[0])[0].value : [lastSeenFilter]
     },
     !isEmpty(updateMethodFilter) && {
         updateMethodFilter: Array.isArray(updateMethodFilter) ? updateMethodFilter : [updateMethodFilter]

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -328,7 +328,11 @@ const EntityTableToolbar = ({
         [OS_CHIP]: (deleted) => setOsFilterValue(xor(osFilterValue, deleted.chips.map(({ value }) => value))),
         [RHCD_FILTER_KEY]: (deleted) => setRhcdFilterValue(onDeleteFilter(deleted, rhcdFilterValue)),
         [LAST_SEEN_CHIP]: (deleted) =>
-        {setLastSeenFilterValue(onDeleteFilter(deleted, [lastSeenFilterValue.mark])), setStartDate(), setEndDate();},
+        {
+            setLastSeenFilterValue(onDeleteFilter(deleted, [lastSeenFilterValue.mark])),
+            setStartDate(),
+            setEndDate();
+        },
         [UPDATE_METHOD_KEY]: (deleted) => setUpdateMethodValue(onDeleteFilter(deleted, updateMethodValue)),
         [HOST_GROUP_CHIP]: (deleted) => setHostGroupValue(onDeleteFilter(deleted, hostGroupValue))
     };

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -112,7 +112,8 @@ const EntityTableToolbar = ({
     const [registeredFilter, registeredChip, registeredWithFilter, setRegisteredWithFilter] = useRegisteredWithFilter(reducer);
     const [rhcdFilterConfig, rhcdFilterChips, rhcdFilterValue, setRhcdFilterValue] = useRhcdFilter(reducer);
     const [lastSeenFilter, lastSeenChip, lastSeenFilterValue, setLastSeenFilterValue,
-        toValidator, onFromChange, onToChange, endDate, startDate, rangeValidator] = useLastSeenFilter(reducer);
+        toValidator, onFromChange, onToChange, endDate, startDate, fromValidator,
+        setStartDate, setEndDate] = useLastSeenFilter(reducer);
     const [osFilterConfig, osFilterChips, osFilterValue, setOsFilterValue] = useOperatingSystemFilter();
     const [updateMethodConfig, updateMethodChips, updateMethodValue, setUpdateMethodValue] = useUpdateMethodFilter(reducer);
     const [hostGroupConfig, hostGroupChips, hostGroupValue, setHostGroupValue] = useGroupFilter();
@@ -326,7 +327,8 @@ const EntityTableToolbar = ({
         ),
         [OS_CHIP]: (deleted) => setOsFilterValue(xor(osFilterValue, deleted.chips.map(({ value }) => value))),
         [RHCD_FILTER_KEY]: (deleted) => setRhcdFilterValue(onDeleteFilter(deleted, rhcdFilterValue)),
-        [LAST_SEEN_CHIP]: (deleted) => setLastSeenFilterValue(onDeleteFilter(deleted, [lastSeenFilterValue.mark])),
+        [LAST_SEEN_CHIP]: (deleted) =>
+        {setLastSeenFilterValue(onDeleteFilter(deleted, [lastSeenFilterValue.mark])), setStartDate(), setEndDate();},
         [UPDATE_METHOD_KEY]: (deleted) => setUpdateMethodValue(onDeleteFilter(deleted, updateMethodValue)),
         [HOST_GROUP_CHIP]: (deleted) => setHostGroupValue(onDeleteFilter(deleted, hostGroupValue))
     };
@@ -343,6 +345,8 @@ const EntityTableToolbar = ({
         enabledFilters.lastSeenFilter && setLastSeenFilterValue([]);
         enabledFilters.updateMethodFilter && setUpdateMethodValue([]);
         enabledFilters.hostGroupFilter && setHostGroupValue([]);
+        setStartDate();
+        setEndDate();
         dispatch(setFilter([]));
         updateData({ page: 1, filters: [] });
     };
@@ -394,7 +398,6 @@ const EntityTableToolbar = ({
         ] : [],
         ...filterConfig?.items || []
     ];
-
     return <Fragment>
         <PrimaryToolbar
             {...props}
@@ -439,8 +442,8 @@ const EntityTableToolbar = ({
                     <DatePicker
                         onChange={onFromChange}
                         aria-label="Start date"
-                        validators={[rangeValidator]}
-
+                        validators={[fromValidator]}
+                        placeholder='Start'
                     />
                 </SplitItem>
                 <SplitItem style={{ padding: '6px 12px 0 12px' }}>
@@ -453,6 +456,7 @@ const EntityTableToolbar = ({
                         rangeStart={startDate}
                         validators={[toValidator]}
                         aria-label="End date"
+                        placeholder='End'
                     />
                 </SplitItem>
             </Split>}

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -46,6 +46,26 @@ export const useLastSeenFilter = (
     const [endDate, setEndDate] = useState();
     const todaysDate = new Date();
 
+    const manageStartDate = (apiStartDate, apiEndDate)=> {
+        if (isNaN(apiEndDate) &&  isNaN(apiStartDate)) {
+            setValue({ ...lastSeenValue, updatedStart: null, updatedEnd: null });
+        } else if (apiStartDate > apiEndDate || isNaN(apiStartDate) || apiStartDate > todaysDate) {
+            setValue({ ...lastSeenValue, updatedStart: null, updatedEnd: apiEndDate.toISOString() });
+        } else {
+            setValue({ ...lastSeenValue, updatedStart: apiStartDate.toISOString() });
+        }
+    };
+
+    const manageEndDate = (apiStartDate, apiEndDate)=> {
+        if (isNaN(apiEndDate) &&  isNaN(apiStartDate)) {
+            setValue({ ...lastSeenValue, updatedStart: null, updatedEnd: null });
+        } else if (apiStartDate > apiEndDate || isNaN(apiEndDate)) {
+            setValue({ ...lastSeenValue, updatedStart: apiStartDate.toISOString(), updatedEnd: null });
+        } else {
+            setValue({ ...lastSeenValue, updatedEnd: apiEndDate.toISOString() });
+        }
+    };
+
     const toValidator = (date) => {
         const newDate = new Date(date);
         const minDate = new Date(startDate);
@@ -84,7 +104,7 @@ export const useLastSeenFilter = (
         setStartDate(date);
         const apiStartDate = new Date(date);
         apiStartDate.setUTCHours(0);
-        setValue({ ...lastSeenValue, updatedStart: apiStartDate.toISOString() });
+        manageStartDate(apiStartDate, newToDate);
     };
 
     const onToChange = (date) => {
@@ -96,7 +116,7 @@ export const useLastSeenFilter = (
             setEndDate(date);
             const apiEndDate = new Date(date);
             apiEndDate.setUTCHours(23, 59);
-            setValue({ ...lastSeenValue, updatedEnd: apiEndDate.toISOString() });
+            manageEndDate(new Date(startDate), apiEndDate);
         }
     };
 

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -44,29 +44,60 @@ export const useLastSeenFilter = (
 
     const [startDate, setStartDate] = useState();
     const [endDate, setEndDate] = useState();
+    const todaysDate = new Date();
 
     const toValidator = (date) => {
-        date >= startDate ? '' : 'To date must be less than from date.';
-    };
+        const newDate = new Date(date);
+        const minDate = new Date(startDate);
 
-    const rangeValidator = (date) => {
-        const minDate = new Date(1950, 1, 1);
-        if (date < minDate) {
-            return 'Date is before the allowable range.';
+        if (minDate >= newDate) {
+            return 'Start date must be earlier than End date.';
+        } else if (newDate > todaysDate) {
+            return `Date must be ${todaysDate.toISOString().split('T')[0]} or earlier`;
         } else {
             return '';
         }
     };
 
-    const onFromChange = (_str, date) => {
+    const fromValidator = (date) => {
+        const minDate = new Date(1950, 1, 1);
+        const maxDate = new Date(endDate);
+
+        if (date < minDate) {
+            return 'Date is before the allowable range.';
+        } else if (date > maxDate) {
+            return `End date must be later than Start date.`;
+        } else if (date > todaysDate) {
+            return ' Start date must be earlier than End date.';
+        } else {
+            return '';
+        }
+    };
+
+    const onFromChange = (date) => {
+        const newToDate = new Date(endDate);
+        if (date > newToDate) {
+            setStartDate();
+            return 'End date must be later than Start date.';
+        }
+
         setStartDate(date);
-        setValue({ ...lastSeenValue, updatedStart: new Date(date).toISOString() });
-        date.setDate(date.getDate() + 1);
+        const apiStartDate = new Date(date);
+        apiStartDate.setUTCHours(0);
+        setValue({ ...lastSeenValue, updatedStart: apiStartDate.toISOString() });
     };
 
     const onToChange = (date) => {
-        setEndDate(date);
-        setValue({ ...lastSeenValue, updatedEnd: new Date(date).toISOString() });
+        if (startDate > new Date(date)) {
+            return 'Start date must be earlier than End date.';
+        } else if (new Date(date) > todaysDate) {
+            return 'End date must be later than Start date.';
+        } else {
+            setEndDate(date);
+            const apiEndDate = new Date(date);
+            apiEndDate.setUTCHours(23, 59);
+            setValue({ ...lastSeenValue, updatedEnd: apiEndDate.toISOString() });
+        }
     };
 
     return [
@@ -79,6 +110,8 @@ export const useLastSeenFilter = (
         onToChange,
         endDate,
         startDate,
-        rangeValidator
+        fromValidator,
+        setStartDate,
+        setEndDate
     ];
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -125,8 +125,8 @@ export const getSearchParams = () => {
     const groupHostsFilter = searchParams.getAll(HOST_GROUP_CHIP);
     const page = searchParams.getAll('page');
     const perPage = searchParams.getAll('per_page');
-    // const lastSeenFilter = searchParams.getAll('last_seen');
-    return { status, source, tagsFilter, filterbyName, operatingSystem, rhcdFilter, updateMethodFilter,
+    const lastSeenFilter = searchParams.getAll('last_seen');
+    return { status, source, tagsFilter, filterbyName, operatingSystem, rhcdFilter, updateMethodFilter, lastSeenFilter,
         page, perPage, groupHostsFilter };
 };
 

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -48,9 +48,9 @@ const filterMapper = {
         flatMap(tagFilters, mapTags)
     ),
     rhcdFilter: ({ rhcdFilter }, searchParams) => rhcdFilter?.forEach(item => searchParams.append(RHCD_FILTER_KEY, item)),
-    //TODO: Add a way to add to url in a way that allows shareable links
-    // lastSeenFilter: ({ lastSeenFilter }, searchParams) =>
-    //     Object.values(lastSeenFilter)?.forEach(item => searchParams.append('last_seen', item)),
+    lastSeenFilter: ({ lastSeenFilter }, searchParams) =>
+        Object.keys(lastSeenFilter)?.forEach(item => item === 'mark' &&
+        searchParams.append('last_seen', lastSeenFilter[item])),
     updateMethodFilter: ({ updateMethodFilter }, searchParams) =>
         updateMethodFilter?.forEach(item => searchParams.append(UPDATE_METHOD_KEY, item)),
     groupHostFilter: ({ groupHostFilter }, searchParams) => groupHostFilter


### PR DESCRIPTION
To test new updates check for the following:

When selecting last seen filter, if you refresh, filter persist

- Make sure you can copy/past the link with the filter present (this is true for all except custom, custom should populate the range picker)
- Make sure Start Date cant be larger than End Date
- Make sure End date cant be smaller than start Date
- End date and start date both cannot go past Todays date
-Should be able to delete both values manually
Filter should not break ever. I believe this PR should catch all edge cases