### PR TITLE
chore: Mock GET groups related requests

### DIFF
--- a/cypress/fixtures/groups/Ba8B79ab5adC8E41e255D5f8aDb8f1F3.json
+++ b/cypress/fixtures/groups/Ba8B79ab5adC8E41e255D5f8aDb8f1F3.json
@@ -1,0 +1,37 @@
+{
+  "count": 1,
+  "page": 1,
+  "per_page": 50,
+  "results": [
+    {
+      "name": "ea velit incididunt",
+      "updated_at": "1998-04-17T22:00:00.0Z",
+      "id": "620f9ae75A8F6b83d78F3B55Af1c4b2C",
+      "account": "irure ea exercitation adipisicing velit",
+      "org_id": "non",
+      "created_at": "1994-07-28T22:00:00.0Z",
+      "host_ids": [
+        "00fcC027-F4e3-aB4D-3eB9-392B09E4E9eC",
+        "82c882beA274db74bA79Dad9695CDdcD",
+        "374ECeB4-4aA6-637a-A5d8-eBD40A51EED8",
+        "12f6cdf2-fBcA-EF8A-3cC1-739627825F5B",
+        "37F4D8D9-A1Bd-cEE7-1Bcc-A03A20589B1B",
+        "ab29a822dA3259bf4a80A586Bd2e16E0",
+        "0ed9cfebEb3bfdB9A6F51757008dFB2F",
+        "4ddCF8Ee4a5DF968CBCaaaed16F5c55f",
+        "3cfF3e49-35Af-fD3E-62eb-c4eBDa0Ac3fF",
+        "8ce37289-4B8f-cECF-a3db-94f9F9ACB45a",
+        "Fd60B4f79D74507bDE8be6913caFDa8e",
+        "BbEAB14B-9A1f-eDFB-9c3B-eF0C6b6CB4dF",
+        "14FA22F08BBFf6f9738cBED71aFf66eE",
+        "fcF870cc-8C3C-8ba9-FcdA-dff79Ba0e2dE",
+        "38B60BDf17c9E6C9Cdd11840aCb4e804",
+        "C306bEc5EAF6BfD025fa6f48b3BeAF43",
+        "83CE42Eadccd8b2e5E5Aca1eaBAB55aa",
+        "4da9f2C5d6C1Ce6EE2f3D7BBC974E7c3",
+        "CaaE8C2e-C67c-41b3-5EB8-5Fd233eC9FdC"
+      ]
+    }
+  ],
+  "total": 1
+}

--- a/src/components/InventoryGroups/utils/api.js
+++ b/src/components/InventoryGroups/utils/api.js
@@ -2,14 +2,22 @@ import { instance } from '@redhat-cloud-services/frontend-components-utilities/i
 import { INVENTORY_API_BASE } from '../../../api';
 import { TABLE_DEFAULT_PAGINATION } from '../../../constants';
 import PropTypes from 'prop-types';
+import fixtureGroups from '../../../../cypress/fixtures/groups.json';
+import fixtureGroupsDetails from '../../../../cypress/fixtures/groups/Ba8B79ab5adC8E41e255D5f8aDb8f1F3.json';
 
-export const getGroups = (search = {}, pagination = { page: 1, perPage: TABLE_DEFAULT_PAGINATION }) => {
-    const parameters = new URLSearchParams({
-        ...search,
-        ...pagination
-    }).toString();
+// eslint-disable-next-line camelcase
+export const getGroups = (search = {}, pagination = { page: 1, per_page: TABLE_DEFAULT_PAGINATION }) => {
+    if (window.Cypress) {
+        const parameters = new URLSearchParams({
+            ...search,
+            ...pagination
+        }).toString();
 
-    return instance.get(`${INVENTORY_API_BASE}/groups?${parameters}` /* , { headers: { Prefer: 'code=404' } } */);
+        return instance.get(`${INVENTORY_API_BASE}/groups?${parameters}`);
+    }
+
+    // FIXME: remove mock data when API is implemented
+    return Promise.resolve(fixtureGroups);
 };
 
 export const createGroup = (payload) => {
@@ -21,12 +29,22 @@ export const createGroup = (payload) => {
 };
 
 export const validateGroupName = (name) => {
-    return instance.get(`${INVENTORY_API_BASE}/groups`)
-    .then((resp) => resp?.results.some((group) => group.name === name));
+    if (window.Cypress) {
+        return instance.get(`${INVENTORY_API_BASE}/groups`)
+        .then((resp) => resp?.results.some((group) => group.name === name));
+    }
+
+    // FIXME: remove mock data when API is implemented
+    return Promise.resolve(fixtureGroups).then((resp) => resp?.results.some((group) => group.name === name));
 };
 
 export const getGroupDetail = (groupId) => {
-    return instance.get(`${INVENTORY_API_BASE}/groups/${groupId}`);
+    if (window.Cypress) {
+        return instance.get(`${INVENTORY_API_BASE}/groups/${groupId}`);
+    }
+
+    // FIXME: remove mock data when API is implemented
+    return Promise.resolve(fixtureGroupsDetails);
 };
 
 export const updateGroupById = (id, payload) => {

--- a/src/store/actions.test.js
+++ b/src/store/actions.test.js
@@ -2,7 +2,7 @@
 import { editAnsibleHost, editDisplayName, fetchGroups, systemProfile } from './actions';
 import { hosts } from '../api';
 import mockedData from '../__mocks__/mockedData.json';
-import mockedGroups from '../__mocks__/mockedGroups.json';
+import fixturesGroups from '../../cypress/fixtures/groups.json';
 import MockAdapter from 'axios-mock-adapter';
 
 const mocked = new MockAdapter(hosts.axios);
@@ -65,10 +65,10 @@ describe('editAnsibleHost', () => {
 describe('fetchGroups', () => {
     it('should call correct endpoint', async () => {
         mocked.onGet(new RegExp('/api/inventory/v1/groups*')).reply(() => {
-            return [200, mockedGroups];
+            return [200, fixturesGroups];
         });
         const { type, payload } = await fetchGroups();
         expect(type).toBe('GROUPS');
-        expect(await payload).toEqual(mockedGroups);
+        expect(await payload).toEqual(fixturesGroups);
     });
 });


### PR DESCRIPTION
This serves as a temporary solution for the missing GET endpoints implementation on the API level. This will allow QEs to open the views and find required components selectors.