### PR TITLE
feat(ESSNTL-3728): Enable multiple hosts addition to group

### DIFF
--- a/cypress/fixtures/hosts.json
+++ b/cypress/fixtures/hosts.json
@@ -292,6 +292,7 @@
       "reporter": "adipisicing veniam velit",
       "created": "1962-06-25T23:00:00.0Z",
       "account": null,
+      "group_name": "abc",
       "mac_addresses": null,
       "provider_id": "aute ut sit",
       "facts": [

--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -162,7 +162,16 @@ export const featureFlagsInterceptors = {
         cy.intercept('GET', '/feature_flags*', {
             statusCode: 200,
             body: {
-                toggles: []
+                toggles: [
+                    {
+                        name: 'hbi.ui.inventory-groups',
+                        enabled: true,
+                        variant: {
+                            name: 'disabled',
+                            enabled: true
+                        }
+                    }
+                ]
             }
         }).as('getFeatureFlag');
     }

--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -7,6 +7,7 @@ import groupsSecondPage from '../fixtures/groupsSecondPage.json';
 import groupDetailFixtures from '../fixtures/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C.json';
 import hostsFixtures from '../fixtures/hosts.json';
 
+export { hostsFixtures, groupDetailFixtures };
 export const groupsInterceptors = {
     'successful with some items': () =>
         cy
@@ -60,6 +61,23 @@ export const groupDetailInterceptors = {
             {
                 statusCode: 200,
                 body: groupDetailFixtures
+            }
+        )
+        .as('getGroupDetail'),
+    'successful with hosts': () =>
+        cy
+        .intercept(
+            'GET',
+            '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C',
+            {
+                statusCode: 200,
+                body: {
+                    ...groupDetailFixtures,
+                    results: [{
+                        ...groupDetailFixtures.results[0],
+                        host_ids: ['host-1', 'host-2']
+                    }]
+                }
             }
         )
         .as('getGroupDetail'),

--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -9,6 +9,7 @@ import {
     CHIP_GROUP,
     DROPDOWN_TOGGLE,
     hasChip,
+    MODAL,
     PAGINATION_VALUES,
     SORTING_ORDERS,
     TEXT_INPUT,
@@ -300,7 +301,21 @@ describe('selection and bulk selection', () => {
 });
 
 describe('actions', () => {
-    // TBA
+    beforeEach(() => {
+        cy.intercept('*', { statusCode: 200 });
+        hostsInterceptors.successful();
+
+        mountTable();
+
+        cy.wait('@getHosts');
+    });
+
+    it('can open systems add modal', () => {
+        cy.get('button').contains('Add systems').click();
+        cy.get(MODAL).find('h1').contains('Add systems');
+
+        cy.wait('@getHosts');
+    });
 });
 
 describe('edge cases', () => {

--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -39,7 +39,7 @@ import _ from 'lodash';
 
 const GROUP_NAME = 'foobar';
 const ROOT = 'div[id="group-systems-table"]';
-const TABLE_HEADERS = ['Name', 'Tags', 'OS', 'Update methods', 'Last seen'];
+const TABLE_HEADERS = ['Name', 'Tags', 'OS', 'Update method', 'Last seen'];
 const SORTABLE_HEADERS = ['Name', 'OS', 'Last seen'];
 const DEFAULT_ROW_COUNT = 50;
 

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -36,10 +36,10 @@ const prepareColumns = (initialColumns) => {
     // hides the "groups" column
     const columns = initialColumns.filter(({ key }) => key !== 'groups');
 
-    // additionally insert the "update methods" column
+    // additionally insert the "update method" column
     columns.splice(columns.length - 1 /* must be penultimate */, 0, {
         key: 'update_method',
-        title: 'Update methods',
+        title: 'Update method',
         sortKey: 'update_method',
         transforms: [fitContent],
         renderFunc: (value, hostId, systemData) =>

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -9,6 +9,29 @@ import { clearFilters, selectEntity } from '../../store/inventory-actions';
 import AddSystemsToGroupModal from '../InventoryGroups/Modals/AddSystemsToGroupModal';
 import InventoryTable from '../InventoryTable/InventoryTable';
 
+export const bulkSelectConfig = (dispatch, selectedNumber, noneSelected, pageSelected, rowsNumber) => ({
+    count: selectedNumber,
+    id: 'bulk-select-groups',
+    items: [
+        {
+            title: 'Select none (0)',
+            onClick: () => dispatch(selectEntity(-1, false)),
+            props: { isDisabled: noneSelected }
+        },
+        {
+            title: `${pageSelected ? 'Deselect' : 'Select'} page (${
+                rowsNumber
+            } items)`,
+            onClick: () => dispatch(selectEntity(0, !pageSelected))
+        }
+        // TODO: Implement "select all"
+    ],
+    onSelect: (value) => {
+        dispatch(selectEntity(0, value));
+    },
+    checked: selectedNumber > 0 // TODO: support partial selection (dash sign) in FEC BulkSelect
+});
+
 const prepareColumns = (initialColumns) => {
     // hides the "groups" column
     const columns = initialColumns.filter(({ key }) => key !== 'groups');
@@ -94,28 +117,7 @@ const GroupSystems = ({ groupName, groupId }) => {
                         variant: TableVariant.compact,
                         canSelectAll: false
                     }}
-                    bulkSelect={{
-                        count: selected.size,
-                        id: 'bulk-select-groups',
-                        items: [
-                            {
-                                title: 'Select none (0)',
-                                onClick: () => dispatch(selectEntity(-1, false)),
-                                props: { isDisabled: noneSelected }
-                            },
-                            {
-                                title: `${pageSelected ? 'Deselect' : 'Select'} page (${
-                                rows.length
-                            } items)`,
-                                onClick: () => dispatch(selectEntity(0, !pageSelected))
-                            }
-                        // TODO: Implement "select all"
-                        ],
-                        onSelect: (value) => {
-                            dispatch(selectEntity(0, value));
-                        },
-                        checked: selected.size > 0 // TODO: support partial selection (dash sign) in FEC BulkSelect
-                    }}
+                    bulkSelect={bulkSelectConfig(dispatch, selected.size, noneSelected, pageSelected, rows.length)}
                 >
                     <Button
                         variant='primary'

--- a/src/components/GroupSystems/index.js
+++ b/src/components/GroupSystems/index.js
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import NoSystemsEmptyState from '../InventoryGroupDetail/NoSystemsEmptyState';
 import GroupSystems from './GroupSystems';
 
-const GroupSystemsWrapper = ({ groupName }) => {
+const GroupSystemsWrapper = ({ groupName, groupId }) => {
     const { uninitialized, loading, data } = useSelector((state) => state.groupDetail);
     const hosts = data?.results?.[0]?.host_ids /* can be null */ || [];
 
@@ -18,11 +18,12 @@ const GroupSystemsWrapper = ({ groupName }) => {
     ) : hosts.length > 0 ? (
         <GroupSystems groupName={groupName}/>
     ) :
-        <NoSystemsEmptyState />;
+        <NoSystemsEmptyState groupId={groupId} groupName={groupName} />;
 };
 
 GroupSystemsWrapper.propTypes = {
-    groupName: PropTypes.string.isRequired
+    groupName: PropTypes.string.isRequired,
+    groupId: PropTypes.string.isRequired
 };
 
 export default GroupSystemsWrapper;

--- a/src/components/GroupSystems/index.js
+++ b/src/components/GroupSystems/index.js
@@ -16,7 +16,7 @@ const GroupSystemsWrapper = ({ groupName, groupId }) => {
             </EmptyStateBody>
         </EmptyState>
     ) : hosts.length > 0 ? (
-        <GroupSystems groupName={groupName}/>
+        <GroupSystems groupId={groupId} groupName={groupName} />
     ) :
         <NoSystemsEmptyState groupId={groupId} groupName={groupName} />;
 };

--- a/src/components/GroupSystems/index.js
+++ b/src/components/GroupSystems/index.js
@@ -2,7 +2,7 @@ import { EmptyState, EmptyStateBody, Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import NoGroupsEmptyState from '../InventoryGroups/NoGroupsEmptyState';
+import NoSystemsEmptyState from '../InventoryGroupDetail/NoSystemsEmptyState';
 import GroupSystems from './GroupSystems';
 
 const GroupSystemsWrapper = ({ groupName }) => {
@@ -18,7 +18,7 @@ const GroupSystemsWrapper = ({ groupName }) => {
     ) : hosts.length > 0 ? (
         <GroupSystems groupName={groupName}/>
     ) :
-        <NoGroupsEmptyState />;
+        <NoSystemsEmptyState />;
 };
 
 GroupSystemsWrapper.propTypes = {

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
@@ -36,7 +36,7 @@ before(() => {
 });
 
 describe('group detail page', () => {
-    it('name from server is rendered in header and breadcrumb', () => {
+    it.only('name from server is rendered in header and breadcrumb', () => {
         interceptors.successful();
         mountPage();
 

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
@@ -36,7 +36,7 @@ before(() => {
 });
 
 describe('group detail page', () => {
-    it.only('name from server is rendered in header and breadcrumb', () => {
+    it('name from server is rendered in header and breadcrumb', () => {
         interceptors.successful();
         mountPage();
 

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -53,7 +53,7 @@ const InventoryGroupDetail = ({ groupId }) => {
                         aria-label="Group systems tab"
                     >
                         <PageSection>
-                            <GroupSystems groupName={groupName}/>
+                            <GroupSystems groupName={groupName} groupId={groupId}/>
                         </PageSection>
                     </Tab>
                     <Tab

--- a/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
+++ b/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
@@ -31,7 +31,7 @@ const NoSystemsEmptyState = () => {
                     variant="link"
                     icon={<ExternalLinkAltIcon />}
                     iconPosition="right"
-                    // TODO: component={(props) => <a href='' {...props} />}
+                    component={() => <a href='/x' />}
                 >
                     Learn more about system groups
                 </Button>

--- a/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
+++ b/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     Button,
     EmptyState,
@@ -10,14 +10,24 @@ import {
 import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import { global_palette_black_600 as globalPaletteBlack600 } from '@patternfly/react-tokens/dist/js/global_palette_black_600';
+import AddSystemsToGroupModal from '../InventoryGroups/Modals/AddSystemsToGroupModal';
+import PropTypes from 'prop-types';
 
-const NoSystemsEmptyState = () => {
+const NoSystemsEmptyState = ({ groupId, groupName }) => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
     return (
         <EmptyState
             data-ouia-component-id="empty-state"
             data-ouia-component-type="PF4/EmptyState"
             data-ouia-safe={true}
         >
+            <AddSystemsToGroupModal
+                isModalOpen={isModalOpen}
+                setIsModalOpen={setIsModalOpen}
+                groupId={groupId}
+                groupName={groupName}
+            />
             <EmptyStateIcon icon={PlusCircleIcon} color={globalPaletteBlack600.value} />
             <Title headingLevel="h4" size="lg">
                 No systems added
@@ -25,13 +35,14 @@ const NoSystemsEmptyState = () => {
             <EmptyStateBody>
                 To manage systems more effectively, add systems to the group.
             </EmptyStateBody>
-            <Button variant="primary" onClick={() => {}}>Add systems</Button>
+            <Button variant="primary" onClick={() => setIsModalOpen(true)}>
+                Add systems
+            </Button>
             <EmptyStateSecondaryActions>
                 <Button
                     variant="link"
                     icon={<ExternalLinkAltIcon />}
                     iconPosition="right"
-                    component={() => <a href='/x' />}
                 >
                     Learn more about system groups
                 </Button>
@@ -39,4 +50,8 @@ const NoSystemsEmptyState = () => {
         </EmptyState>
     );};
 
+NoSystemsEmptyState.propTypes = {
+    groupId: PropTypes.string,
+    groupName: PropTypes.string
+};
 export default NoSystemsEmptyState;

--- a/src/components/InventoryGroupDetail/__tests__/InventoryGroupDetail.test.js
+++ b/src/components/InventoryGroupDetail/__tests__/InventoryGroupDetail.test.js
@@ -2,25 +2,11 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getStore } from '../../../store';
 import InventoryGroupDetail from '../InventoryGroupDetail';
+import { Provider } from 'react-redux';
 
-jest.mock('react-redux', () => {
-    return {
-        ...jest.requireActual('react-redux'),
-        useSelector: () => ({
-            uninitialized: false,
-            loading: false,
-            data: {
-                results: [
-                    {
-                        name: 'group-name-1'
-                    }
-                ]
-            }
-        }),
-        useDispatch: () => () => {}
-    };
-});
+jest.mock('../../../Utilities/useFeatureFlag');
 
 describe('group detail page component', () => {
     let getByRole;
@@ -29,7 +15,9 @@ describe('group detail page component', () => {
     beforeEach(() => {
         const rendered = render(
             <MemoryRouter>
-                <InventoryGroupDetail groupId="group-id-2" />
+                <Provider store={getStore()}>
+                    <InventoryGroupDetail groupId="group-id-2" />
+                </Provider>
             </MemoryRouter>
         );
         getByRole = rendered.getByRole;

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -1,0 +1,49 @@
+import { mount } from '@cypress/react';
+import FlagProvider from '@unleash/proxy-client-react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import {
+    featureFlagsInterceptors,
+    groupsInterceptors,
+    hostsInterceptors,
+    systemProfileInterceptors
+} from '../../../../cypress/support/interceptors';
+import { unleashDummyConfig } from '../../../../cypress/support/utils';
+import { getStore } from '../../../store';
+import AddSystemsToGroupModal from './AddSystemsToGroupModal';
+
+before(() => {
+    cy.window().then(
+        (window) =>
+            (window.insights = {
+                chrome: {
+                    isProd: false,
+                    auth: {
+                        getUser: () => {
+                            return Promise.resolve({});
+                        }
+                    }
+                }
+            })
+    );
+});
+
+describe('AddSystemsToGroupModal', () => {
+    it('renders', () => {
+        hostsInterceptors.successful();
+        featureFlagsInterceptors.successful();
+        systemProfileInterceptors['operating system, successful empty']();
+        groupsInterceptors['successful with some items']();
+
+        mount(
+            <FlagProvider config={unleashDummyConfig}>
+                <Provider store={getStore()}>
+                    <MemoryRouter>
+                        <AddSystemsToGroupModal isModalOpen={true} />
+                    </MemoryRouter>
+                </Provider>
+            </FlagProvider>
+        );
+    });
+});

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -1,17 +1,30 @@
 import { mount } from '@cypress/react';
+import {
+    checkTableHeaders,
+    MODAL,
+    ouiaId,
+    TABLE
+} from '@redhat-cloud-services/frontend-components-utilities';
 import FlagProvider from '@unleash/proxy-client-react';
+import _ from 'lodash';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import {
-    featureFlagsInterceptors,
-    groupsInterceptors,
-    hostsInterceptors,
-    systemProfileInterceptors
+    groupDetailInterceptors,
+    hostsFixtures,
+    hostsInterceptors
 } from '../../../../cypress/support/interceptors';
-import { unleashDummyConfig } from '../../../../cypress/support/utils';
+import {
+    selectRowN,
+    unleashDummyConfig
+} from '../../../../cypress/support/utils';
 import { getStore } from '../../../store';
 import AddSystemsToGroupModal from './AddSystemsToGroupModal';
+
+const TABLE_HEADERS = ['Name', 'Tags', 'Update methods', 'OS', 'Last seen'];
+
+const ALERT = '[data-ouia-component-type="PF4/Alert"]';
 
 before(() => {
     cy.window().then(
@@ -29,21 +42,109 @@ before(() => {
     );
 });
 
-describe('AddSystemsToGroupModal', () => {
-    it('renders', () => {
-        hostsInterceptors.successful();
-        featureFlagsInterceptors.successful();
-        systemProfileInterceptors['operating system, successful empty']();
-        groupsInterceptors['successful with some items']();
+const mountModal = () =>
+    mount(
+        <FlagProvider config={unleashDummyConfig}>
+            <Provider store={getStore()}>
+                <MemoryRouter>
+                    <AddSystemsToGroupModal
+                        isModalOpen={true}
+                        groupId="620f9ae75A8F6b83d78F3B55Af1c4b2C"
+                        setIsModalOpen={() => {}} // TODO: test that the func is called on close
+                    />
+                </MemoryRouter>
+            </Provider>
+        </FlagProvider>
+    );
 
-        mount(
-            <FlagProvider config={unleashDummyConfig}>
-                <Provider store={getStore()}>
-                    <MemoryRouter>
-                        <AddSystemsToGroupModal isModalOpen={true} />
-                    </MemoryRouter>
-                </Provider>
-            </FlagProvider>
+describe('test data', () => {
+    it('at least one system is already in a group', () => {
+        const alreadyInGroup = hostsFixtures.results.filter(
+            // eslint-disable-next-line camelcase
+            ({ group_name }) => !_.isEmpty(group_name)
         );
+        expect(alreadyInGroup.length).to.be.gte(1);
+    });
+
+    it('the first system in group has specific id', () => {
+        const alreadyInGroup = hostsFixtures.results.filter(
+            // eslint-disable-next-line camelcase
+            ({ group_name }) => !_.isEmpty(group_name)
+        );
+        expect(alreadyInGroup[0].id).to.eq('anim commodo');
+    });
+});
+
+describe('AddSystemsToGroupModal', () => {
+    beforeEach(() => {
+        cy.viewport(1920, 1080); // to accomadate the inventory table
+        cy.intercept('*', { statusCode: 200 });
+        hostsInterceptors.successful(); // default hosts list
+    });
+
+    it('renders correct header and buttons', () => {
+        mountModal();
+
+        cy.wait('@getHosts');
+        cy.get('h1').contains('Add systems');
+        cy.get('button').contains('Add systems');
+        cy.get('button').contains('Cancel');
+    });
+
+    it('renders the inventory table', () => {
+        mountModal();
+
+        cy.wait('@getHosts');
+        cy.get(ouiaId('PrimaryToolbar'));
+        cy.get(TABLE);
+        cy.get('#options-menu-bottom-pagination');
+        checkTableHeaders(TABLE_HEADERS);
+    });
+
+    it('can add systems that are not yet in group', () => {
+        groupDetailInterceptors['patch successful']();
+        groupDetailInterceptors['successful with hosts']();
+        mountModal();
+
+        cy.wait('@getHosts');
+        cy.get('button').contains('Add systems').should('be.disabled');
+        selectRowN(1);
+        cy.get('button').contains('Add systems').click();
+        cy.wait('@getGroupDetail'); // requests the current hosts list
+        cy.wait('@patchGroup')
+        .its('request.body')
+        .should('deep.equal', {
+            // eslint-disable-next-line camelcase
+            host_ids: ['host-1', 'host-2', 'dolor'] // sends the merged list of hosts
+        });
+    });
+
+    it('can add systems that are already in group', () => {
+        groupDetailInterceptors['patch successful']();
+        groupDetailInterceptors['successful with hosts']();
+        mountModal();
+
+        cy.wait('@getHosts');
+        const i =
+      hostsFixtures.results.findIndex(
+          // eslint-disable-next-line camelcase
+          ({ group_name }) => !_.isEmpty(group_name)
+      ) + 1;
+        selectRowN(i);
+        cy.get(ALERT); // check the alert is shown
+        cy.get('button').contains('Add systems').click();
+        cy.get(MODAL).find('h1').contains('Add all selected systems to group?');
+        cy.get('button')
+        .contains('Yes, add all systems to group')
+        .should('be.disabled');
+        cy.get('input[name="confirmation"]').check();
+        cy.get('button').contains('Yes, add all systems to group').click();
+        cy.wait('@getGroupDetail');
+        cy.wait('@patchGroup')
+        .its('request.body')
+        .should('deep.equal', {
+            // eslint-disable-next-line camelcase
+            host_ids: ['host-1', 'host-2', 'anim commodo'] // sends the merged list of hosts
+        });
     });
 });

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -23,7 +23,14 @@ import {
 import { getStore } from '../../../store';
 import AddSystemsToGroupModal from './AddSystemsToGroupModal';
 
-const TABLE_HEADERS = ['Name', 'Group', 'Tags', 'Update method', 'OS', 'Last seen'];
+const TABLE_HEADERS = [
+    'Name',
+    'OS',
+    'Tags',
+    'Update method',
+    'Group',
+    'Last seen'
+];
 
 const ALERT = '[data-ouia-component-type="PF4/Alert"]';
 

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -23,7 +23,7 @@ import {
 import { getStore } from '../../../store';
 import AddSystemsToGroupModal from './AddSystemsToGroupModal';
 
-const TABLE_HEADERS = ['Name', 'Group', 'Tags', 'Update methods', 'OS', 'Last seen'];
+const TABLE_HEADERS = ['Name', 'Group', 'Tags', 'Update method', 'OS', 'Last seen'];
 
 const ALERT = '[data-ouia-component-type="PF4/Alert"]';
 

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -11,6 +11,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import {
+    featureFlagsInterceptors,
     groupDetailInterceptors,
     hostsFixtures,
     hostsInterceptors
@@ -22,7 +23,7 @@ import {
 import { getStore } from '../../../store';
 import AddSystemsToGroupModal from './AddSystemsToGroupModal';
 
-const TABLE_HEADERS = ['Name', 'Tags', 'Update methods', 'OS', 'Last seen'];
+const TABLE_HEADERS = ['Name', 'Group', 'Tags', 'Update methods', 'OS', 'Last seen'];
 
 const ALERT = '[data-ouia-component-type="PF4/Alert"]';
 
@@ -80,6 +81,7 @@ describe('AddSystemsToGroupModal', () => {
         cy.viewport(1920, 1080); // to accomadate the inventory table
         cy.intercept('*', { statusCode: 200 });
         hostsInterceptors.successful(); // default hosts list
+        featureFlagsInterceptors.successful(); // to enable the Group column
     });
 
     it('renders correct header and buttons', () => {

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -133,8 +133,16 @@ const AddSystemsToGroupModal = ({
                                             setSystemSelectModalOpen(false);
                                             setConfirmationModalOpen(true); // switch to the confirmation modal
                                         } else {
-                                            await handleSystemAddition([...selected.keys()]);
-                                            setTimeout(() => dispatch(fetchGroupDetail(groupId)), 500); // refetch data for this group
+                                            await handleSystemAddition([
+                                                ...selected.keys()
+                                            ]);
+                                            setTimeout(
+                                                () =>
+                                                    dispatch(
+                                                        fetchGroupDetail(groupId)
+                                                    ),
+                                                500
+                                            ); // refetch data for this group
                                             setIsModalOpen(false);
                                         }
                                     }}

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -36,7 +36,15 @@ export const prepareColumns = (initialColumns) => {
         }
     });
 
-    return columns;
+    // map columns to the speicifc order
+    return [
+        'display_name',
+        'system_profile',
+        'tags',
+        'update_method',
+        'groups',
+        'updated'
+    ].map((colKey) => columns.find(({ key }) => key === colKey));
 };
 
 const AddSystemsToGroupModal = ({

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -21,10 +21,10 @@ import ConfirmSystemsAddModal from './ConfirmSystemsAddModal';
 export const prepareColumns = (initialColumns) => {
     const columns = initialColumns;
 
-    // additionally insert the "update methods" column
+    // additionally insert the "update method" column
     columns.splice(columns.length - 2 /* must be the 3rd col from the end */, 0, {
         key: 'update_method',
-        title: 'Update methods',
+        title: 'Update method',
         sortKey: 'update_method',
         transforms: [fitContent],
         renderFunc: (value, hostId, systemData) =>

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from './Modal';
-import { Button, Modal as PfModal } from '@patternfly/react-core';
+import { Alert, Button, Flex, FlexItem, Modal as PfModal } from '@patternfly/react-core';
 import InventoryTable from '../../InventoryTable/InventoryTable';
 import { fitContent, TableVariant } from '@patternfly/react-table';
 import { useDispatch, useSelector } from 'react-redux';
@@ -47,6 +47,9 @@ const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen }) => {
 
     // TODO: must show warning message if any of selected hosts is already in a group
 
+    // eslint-disable-next-line camelcase
+    const showWarning = [...selected].some(({ group_name }) => group_name !== undefined && group_name !== '');
+
     return isModalOpen ? (
         <>
             {/** confirmation modal */}
@@ -64,27 +67,41 @@ const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen }) => {
                 title="Add systems"
                 isOpen={systemsSelectModalOpen}
                 onClose={() => setIsModalOpen(false)}
-                actions={[
-                    <Button
-                        key="confirm"
-                        variant="primary"
-                        onClick={() => {
-                            setSystemSelectModalOpen(false);
-                            setConfirmationModalOpen(true);
-                        }
-                        }
-                        isDisabled={noneSelected}
-                    >
-                        Add systems
-                    </Button>,
-                    <Button
-                        key="cancel"
-                        variant="link"
-                        onClick={() => setIsModalOpen(false)}
-                    >
-                        Cancel
-                    </Button>
-                ]}
+                footer={
+                    <Flex direction={{ default: 'column' }} style={{ width: '100%' }}>
+                        <FlexItem fullWidth={{ default: 'fullWidth' }}>
+                            {showWarning &&
+                            <Alert
+                                variant="warning"
+                                isInline
+                                title="One or more of the selected systems already belong to a group. Adding these systems to a different group may impact system configuration."
+                            />}
+                        </FlexItem>
+                        <FlexItem>
+                            <Button
+                                key="confirm"
+                                variant="primary"
+                                onClick={() => {
+                                    setSystemSelectModalOpen(false);
+                                    setConfirmationModalOpen(true);
+                                }
+                                }
+                                isDisabled={noneSelected}
+                            >
+                                Add systems
+                            </Button>
+                            <Button
+                                key="cancel"
+                                variant="link"
+                                onClick={() => setIsModalOpen(false)}
+                            >
+                                Cancel
+                            </Button>
+                        </FlexItem>
+                    </Flex>
+
+                }
+                variant="large"
             >
                 <InventoryTable
                     columns={prepareColumns}
@@ -108,7 +125,7 @@ const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen }) => {
                                 } items)`,
                                 onClick: () => dispatch(selectEntity(0, !pageSelected))
                             }
-                        // TODO: Implement "select all"
+                            // TODO: Implement "select all"
                         ],
                         onSelect: (value) => {
                             dispatch(selectEntity(0, value));

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -11,14 +11,14 @@ import map from 'lodash/map';
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchGroupDetail, selectEntity } from '../../../store/inventory-actions';
+import { fetchGroupDetail } from '../../../store/inventory-actions';
+import { bulkSelectConfig } from '../../GroupSystems/GroupSystems';
 import InventoryTable from '../../InventoryTable/InventoryTable';
 import { addHostsToGroupById } from '../utils/api';
 import apiWithToast from '../utils/apiWithToast';
 import ConfirmSystemsAddModal from './ConfirmSystemsAddModal';
 
 export const prepareColumns = (initialColumns) => {
-    // hides the "groups" column
     const columns = initialColumns;
 
     // additionally insert the "update methods" column
@@ -169,26 +169,7 @@ const AddSystemsToGroupModal = ({
                             isStickyHeader: false,
                             canSelectAll: false
                         }}
-                        bulkSelect={{
-                            count: selected.size,
-                            id: 'bulk-select-groups',
-                            items: [
-                                {
-                                    title: 'Select none (0)',
-                                    onClick: () => dispatch(selectEntity(-1, false)),
-                                    props: { isDisabled: noneSelected }
-                                },
-                                {
-                                    title: `${pageSelected ? 'Deselect' : 'Select'} page (${rows.length} items)`,
-                                    onClick: () => dispatch(selectEntity(0, !pageSelected))
-                                }
-                                // TODO: Implement "select all"
-                            ],
-                            onSelect: (value) => {
-                                dispatch(selectEntity(0, value));
-                            },
-                            checked: selected.size > 0 // TODO: support partial selection (dash sign) in FEC BulkSelect
-                        }}
+                        bulkSelect={bulkSelectConfig(dispatch, selected.size, noneSelected, pageSelected, rows.length)}
                         initialLoading={true}
                     />
                 </Modal>

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -60,7 +60,9 @@ const AddSystemsToGroupModal = ({
 
     const alreadyHasGroup = [...selected].filter(
     // eslint-disable-next-line camelcase
-        ({ group_name }) => group_name !== undefined && group_name !== ''
+        (entry) => {
+            return entry[1].group_name !== undefined && entry[1].group_name !== '';
+        }
     );
     const showWarning = alreadyHasGroup.length > 0;
 
@@ -95,6 +97,7 @@ const AddSystemsToGroupModal = ({
                         await handleSystemAddition([...selected.keys()]);
                         setTimeout(() => dispatch(fetchGroupDetail(groupId)), 500); // refetch data for this group
                         setIsModalOpen(false);
+
                     }}
                     onBack={() => {
                         setConfirmationModalOpen(false);
@@ -125,9 +128,15 @@ const AddSystemsToGroupModal = ({
                                 <Button
                                     key="confirm"
                                     variant="primary"
-                                    onClick={() => {
-                                        setSystemSelectModalOpen(false);
-                                        setConfirmationModalOpen(true); // switch to the confirmation modal
+                                    onClick={async () => {
+                                        if (showWarning) {
+                                            setSystemSelectModalOpen(false);
+                                            setConfirmationModalOpen(true); // switch to the confirmation modal
+                                        } else {
+                                            await handleSystemAddition([...selected.keys()]);
+                                            setTimeout(() => dispatch(fetchGroupDetail(groupId)), 500); // refetch data for this group
+                                            setIsModalOpen(false);
+                                        }
                                     }}
                                     isDisabled={noneSelected}
                                 >

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -172,6 +172,7 @@ const AddSystemsToGroupModal = ({
                             },
                             checked: selected.size > 0 // TODO: support partial selection (dash sign) in FEC BulkSelect
                         }}
+                        initialLoading={true}
                     />
                 </Modal>
             </>

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -1,10 +1,9 @@
-/* eslint-disable max-len */
 import {
     Alert,
     Button,
     Flex,
     FlexItem,
-    Modal as PfModal
+    Modal
 } from '@patternfly/react-core';
 import { fitContent, TableVariant } from '@patternfly/react-table';
 import difference from 'lodash/difference';
@@ -12,7 +11,7 @@ import map from 'lodash/map';
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { selectEntity } from '../../../store/inventory-actions';
+import { fetchGroupDetail, selectEntity } from '../../../store/inventory-actions';
 import InventoryTable from '../../InventoryTable/InventoryTable';
 import { addHostsToGroupById } from '../utils/api';
 import apiWithToast from '../utils/apiWithToast';
@@ -40,7 +39,12 @@ export const prepareColumns = (initialColumns) => {
     return columns;
 };
 
-const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen, reloadData, groupId }) => {
+const AddSystemsToGroupModal = ({
+    isModalOpen,
+    setIsModalOpen,
+    groupId,
+    groupName
+}) => {
     const dispatch = useDispatch();
 
     const [confirmationModalOpen, setConfirmationModalOpen] = useState(false);
@@ -52,11 +56,10 @@ const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen, reloadData, group
 
     const noneSelected = selected.size === 0;
     const displayedIds = map(rows, 'id');
-    const pageSelected =
-    difference(displayedIds, [...selected.keys()]).length === 0;
+    const pageSelected = difference(displayedIds, [...selected.keys()]).length === 0;
 
     const alreadyHasGroup = [...selected].filter(
-        // eslint-disable-next-line camelcase
+    // eslint-disable-next-line camelcase
         ({ group_name }) => group_name !== undefined && group_name !== ''
     );
     const showWarning = alreadyHasGroup.length > 0;
@@ -66,104 +69,113 @@ const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen, reloadData, group
             const statusMessages = {
                 onSuccess: {
                     title: 'Success',
-                    description: `${hostIds} has been created successfully`
+                    description: `${hostIds.length > 1 ? 'Systems' : 'System'} added to ${groupName || groupId}`
                 },
-                onError: { title: 'Error', description: 'Failed to create group' }
+                onError: {
+                    title: 'Error',
+                    description: `Failed to add ${hostIds.length > 1 ? 'systems' : 'system'} to ${groupName || groupId}`
+                }
             };
-            return apiWithToast(dispatch, () => addHostsToGroupById(groupId, hostIds), statusMessages);
+            return apiWithToast(
+                dispatch,
+                () => addHostsToGroupById(groupId, hostIds),
+                statusMessages
+            );
         },
         [isModalOpen]
     );
 
-    return isModalOpen && (
-        <>
-            {/** confirmation modal */}
-            <ConfirmSystemsAddModal
-                isModalOpen={confirmationModalOpen}
-                onSubmit={async () => {
-                    await handleSystemAddition([...selected.keys()]);
-                    setTimeout(async () => await reloadData(), 500);
-                    setIsModalOpen(false);
-                }}
-                onBack={() => {
-                    setConfirmationModalOpen(false);
-                    setSystemSelectModalOpen(true);
-                }}
-                onCancel={() => setIsModalOpen(false)}
-                hostsNumber={alreadyHasGroup.length}
-            />
-            {/** hosts selection modal */}
-            <PfModal
-                title="Add systems"
-                isOpen={systemsSelectModalOpen}
-                onClose={() => setIsModalOpen(false)}
-                footer={
-                    <Flex direction={{ default: 'column' }} style={{ width: '100%' }}>
-                        <FlexItem fullWidth={{ default: 'fullWidth' }}>
+    return (
+        isModalOpen && (
+            <>
+                {/** confirmation modal */}
+                <ConfirmSystemsAddModal
+                    isModalOpen={confirmationModalOpen}
+                    onSubmit={async () => {
+                        await handleSystemAddition([...selected.keys()]);
+                        setTimeout(() => dispatch(fetchGroupDetail(groupId)), 500); // refetch data for this group
+                        setIsModalOpen(false);
+                    }}
+                    onBack={() => {
+                        setConfirmationModalOpen(false);
+                        setSystemSelectModalOpen(true); // switch back to the systems table modal
+                    }}
+                    onCancel={() => setIsModalOpen(false)}
+                    hostsNumber={alreadyHasGroup.length}
+                />
+                {/** hosts selection modal */}
+                <Modal
+                    title="Add systems"
+                    isOpen={systemsSelectModalOpen}
+                    onClose={() => setIsModalOpen(false)}
+                    footer={
+                        <Flex direction={{ default: 'column' }} style={{ width: '100%' }}>
                             {showWarning && (
-                                <Alert
-                                    variant="warning"
-                                    isInline
-                                    title="One or more of the selected systems
+                                <FlexItem fullWidth={{ default: 'fullWidth' }}>
+                                    <Alert
+                                        variant="warning"
+                                        isInline
+                                        title="One or more of the selected systems
                                     already belong to a group. Adding these systems
                                     to a different group may impact system configuration."
-                                />
+                                    />
+                                </FlexItem>
                             )}
-                        </FlexItem>
-                        <FlexItem>
-                            <Button
-                                key="confirm"
-                                variant="primary"
-                                onClick={() => {
-                                    setSystemSelectModalOpen(false);
-                                    setConfirmationModalOpen(true);
-                                }}
-                                isDisabled={noneSelected}
-                            >
-                                Add systems
-                            </Button>
-                            <Button
-                                key="cancel"
-                                variant="link"
-                                onClick={() => setIsModalOpen(false)}
-                            >
-                                Cancel
-                            </Button>
-                        </FlexItem>
-                    </Flex>
-                }
-                variant="large"
-            >
-                <InventoryTable
-                    columns={prepareColumns}
-                    variant={TableVariant.compact} // TODO: this doesn't affect the table variant
-                    tableProps={{
-                        isStickyHeader: false,
-                        canSelectAll: false
-                    }}
-                    bulkSelect={{
-                        count: selected.size,
-                        id: 'bulk-select-groups',
-                        items: [
-                            {
-                                title: 'Select none (0)',
-                                onClick: () => dispatch(selectEntity(-1, false)),
-                                props: { isDisabled: noneSelected }
+                            <FlexItem>
+                                <Button
+                                    key="confirm"
+                                    variant="primary"
+                                    onClick={() => {
+                                        setSystemSelectModalOpen(false);
+                                        setConfirmationModalOpen(true); // switch to the confirmation modal
+                                    }}
+                                    isDisabled={noneSelected}
+                                >
+                                    Add systems
+                                </Button>
+                                <Button
+                                    key="cancel"
+                                    variant="link"
+                                    onClick={() => setIsModalOpen(false)}
+                                >
+                                    Cancel
+                                </Button>
+                            </FlexItem>
+                        </Flex>
+                    }
+                    variant="large" // required to accomodate the systems table
+                >
+                    <InventoryTable
+                        columns={prepareColumns}
+                        variant={TableVariant.compact} // TODO: this doesn't affect the table variant
+                        tableProps={{
+                            isStickyHeader: false,
+                            canSelectAll: false
+                        }}
+                        bulkSelect={{
+                            count: selected.size,
+                            id: 'bulk-select-groups',
+                            items: [
+                                {
+                                    title: 'Select none (0)',
+                                    onClick: () => dispatch(selectEntity(-1, false)),
+                                    props: { isDisabled: noneSelected }
+                                },
+                                {
+                                    title: `${pageSelected ? 'Deselect' : 'Select'} page (${rows.length} items)`,
+                                    onClick: () => dispatch(selectEntity(0, !pageSelected))
+                                }
+                                // TODO: Implement "select all"
+                            ],
+                            onSelect: (value) => {
+                                dispatch(selectEntity(0, value));
                             },
-                            {
-                                title: `${pageSelected ? 'Deselect' : 'Select'} page (${rows.length} items)`,
-                                onClick: () => dispatch(selectEntity(0, !pageSelected))
-                            }
-                            // TODO: Implement "select all"
-                        ],
-                        onSelect: (value) => {
-                            dispatch(selectEntity(0, value));
-                        },
-                        checked: selected.size > 0 // TODO: support partial selection (dash sign) in FEC BulkSelect
-                    }}
-                />
-            </PfModal>
-        </>
+                            checked: selected.size > 0 // TODO: support partial selection (dash sign) in FEC BulkSelect
+                        }}
+                    />
+                </Modal>
+            </>
+        )
     );
 };
 
@@ -171,7 +183,8 @@ AddSystemsToGroupModal.propTypes = {
     isModalOpen: PropTypes.bool,
     setIsModalOpen: PropTypes.func,
     reloadData: PropTypes.func,
-    groupId: PropTypes.string
+    groupId: PropTypes.string,
+    groupName: PropTypes.string
 };
 
 export default AddSystemsToGroupModal;

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -1,28 +1,22 @@
 /* eslint-disable max-len */
 import {
-    componentTypes,
-    FormSpy,
-    useFormApi,
-    validatorTypes
-} from '@data-driven-forms/react-form-renderer';
-import {
     Alert,
     Button,
     Flex,
     FlexItem,
     Modal as PfModal
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import { fitContent, TableVariant } from '@patternfly/react-table';
-import warningColor from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
 import difference from 'lodash/difference';
 import map from 'lodash/map';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectEntity } from '../../../store/inventory-actions';
 import InventoryTable from '../../InventoryTable/InventoryTable';
-import Modal from './Modal';
+import { addHostsToGroupById } from '../utils/api';
+import apiWithToast from '../utils/apiWithToast';
+import ConfirmSystemsAddModal from './ConfirmSystemsAddModal';
 
 export const prepareColumns = (initialColumns) => {
     // hides the "groups" column
@@ -46,7 +40,7 @@ export const prepareColumns = (initialColumns) => {
     return columns;
 };
 
-const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen, reloadData }) => {
+const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen, reloadData, groupId }) => {
     const dispatch = useDispatch();
 
     const [confirmationModalOpen, setConfirmationModalOpen] = useState(false);
@@ -61,79 +55,42 @@ const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen, reloadData }) => 
     const pageSelected =
     difference(displayedIds, [...selected.keys()]).length === 0;
 
-    // TODO: must show warning message if any of selected hosts is already in a group
-
     const alreadyHasGroup = [...selected].filter(
         // eslint-disable-next-line camelcase
         ({ group_name }) => group_name !== undefined && group_name !== ''
     );
-    const showWarning = /* alreadyHasGroup.length > 0; */ true;
+    const showWarning = alreadyHasGroup.length > 0;
+
+    const handleSystemAddition = useCallback(
+        (hostIds) => {
+            const statusMessages = {
+                onSuccess: {
+                    title: 'Success',
+                    description: `${hostIds} has been created successfully`
+                },
+                onError: { title: 'Error', description: 'Failed to create group' }
+            };
+            return apiWithToast(dispatch, () => addHostsToGroupById(groupId, hostIds), statusMessages);
+        },
+        [isModalOpen]
+    );
 
     return isModalOpen && (
         <>
             {/** confirmation modal */}
-            <Modal
+            <ConfirmSystemsAddModal
                 isModalOpen={confirmationModalOpen}
-                title={'Add all selected systems to group?'}
-                titleIconVariant={() => (
-                    <ExclamationTriangleIcon color={warningColor.value} />
-                )}
-                closeModal={() => setIsModalOpen(false)}
-                schema={{
-                    fields: [
-                        {
-                            component: componentTypes.PLAIN_TEXT,
-                            name: 'warning-message',
-                            label: `${alreadyHasGroup.length} of the systems you selected already belong to a group. Moving them to a different group will impact their configuration.`
-                        },
-                        {
-                            component: componentTypes.CHECKBOX,
-                            name: 'confirmation',
-                            label: 'I acknowledge that this action cannot be undone.',
-                            validate: [{ type: validatorTypes.REQUIRED }]
-                        }
-                    ]
+                onSubmit={async () => {
+                    await handleSystemAddition([...selected.keys()]);
+                    setTimeout(async () => await reloadData(), 500);
+                    setIsModalOpen(false);
                 }}
-                customFormTemplate={({ formFields, schema }) => {
-                    const { getState } = useFormApi();
-                    const { submitting, valid } = getState();
-
-                    return (
-                        <form onSubmit={async () => {
-                            await console.log('TODO: fire the PATCH request');
-                            setTimeout(async () => await reloadData(), 500);
-                            setIsModalOpen(false);
-                        }}>
-                            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
-                                {schema.title}
-                                {formFields}
-                                <FormSpy>
-                                    {() => (
-                                        <Flex>
-                                            <Button
-                                                isDisabled={submitting || !valid}
-                                                type="submit"
-                                                color="primary"
-                                                variant="primary"
-                                            >
-                                                Yes, add all systems to group
-                                            </Button>
-                                            <Button onClick={() => {
-                                                setConfirmationModalOpen(false);
-                                                setSystemSelectModalOpen(true);
-                                            }} variant="secondary">
-                                                Back
-                                            </Button>
-                                            <Button variant="link" onClick={() => setIsModalOpen(false)}>
-                                                Cancel
-                                            </Button>
-                                        </Flex>
-                                    )}
-                                </FormSpy>
-                            </Flex>
-                        </form>
-                    );
+                onBack={() => {
+                    setConfirmationModalOpen(false);
+                    setSystemSelectModalOpen(true);
                 }}
+                onCancel={() => setIsModalOpen(false)}
+                hostsNumber={alreadyHasGroup.length}
             />
             {/** hosts selection modal */}
             <PfModal
@@ -213,7 +170,8 @@ const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen, reloadData }) => 
 AddSystemsToGroupModal.propTypes = {
     isModalOpen: PropTypes.bool,
     setIsModalOpen: PropTypes.func,
-    reloadData: PropTypes.func
+    reloadData: PropTypes.func,
+    groupId: PropTypes.string
 };
 
 export default AddSystemsToGroupModal;

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import Modal from './Modal';
+import { Button, Modal as PfModal } from '@patternfly/react-core';
+import InventoryTable from '../../InventoryTable/InventoryTable';
+import { fitContent, TableVariant } from '@patternfly/react-table';
+import { useDispatch, useSelector } from 'react-redux';
+import { difference, map } from 'lodash';
+import { selectEntity } from '../../../store/inventory-actions';
+
+export const prepareColumns = (initialColumns) => {
+    // hides the "groups" column
+    const columns = initialColumns;
+
+    // additionally insert the "update methods" column
+    columns.splice(columns.length - 2 /* must be the 3rd col from the end */, 0, {
+        key: 'update_method',
+        title: 'Update methods',
+        sortKey: 'update_method',
+        transforms: [fitContent],
+        renderFunc: (value, hostId, systemData) =>
+            systemData?.system_profile?.system_update_method || 'N/A',
+        props: {
+            // TODO: remove isStatic when the sorting is supported by API
+            isStatic: true,
+            width: 10
+        }
+    });
+
+    return columns;
+};
+
+const AddSystemsToGroupModal = ({ isModalOpen, setIsModalOpen }) => {
+    const dispatch = useDispatch();
+
+    const [confirmationModalOpen, setConfirmationModalOpen] = useState(false);
+    const [systemsSelectModalOpen, setSystemSelectModalOpen] = useState(true);
+    const selected = useSelector(
+        (state) => state?.entities?.selected || new Map()
+    );
+    const rows = useSelector(({ entities }) => entities?.rows || []);
+
+    const noneSelected = selected.size === 0;
+    const displayedIds = map(rows, 'id');
+    const pageSelected =
+    difference(displayedIds, [...selected.keys()]).length === 0;
+
+    // TODO: must show warning message if any of selected hosts is already in a group
+
+    return isModalOpen ? (
+        <>
+            {/** confirmation modal */}
+            <Modal
+                isModalOpen={confirmationModalOpen}
+                closeModal={() => setConfirmationModalOpen(false)}
+                title={'Add all selected systems to group?'}
+                schema={{
+                    fields: [
+                    ]
+                }}
+            />
+            {/** hosts selection modal */}
+            <PfModal
+                title="Add systems"
+                isOpen={systemsSelectModalOpen}
+                onClose={() => setIsModalOpen(false)}
+                actions={[
+                    <Button
+                        key="confirm"
+                        variant="primary"
+                        onClick={() => {
+                            setSystemSelectModalOpen(false);
+                            setConfirmationModalOpen(true);
+                        }
+                        }
+                        isDisabled={noneSelected}
+                    >
+                        Add systems
+                    </Button>,
+                    <Button
+                        key="cancel"
+                        variant="link"
+                        onClick={() => setIsModalOpen(false)}
+                    >
+                        Cancel
+                    </Button>
+                ]}
+            >
+                <InventoryTable
+                    columns={prepareColumns}
+                    variant={TableVariant.compact} // FIXME: this doesn't affect the table variant
+                    tableProps={{
+                        isStickyHeader: false,
+                        canSelectAll: false
+                    }}
+                    bulkSelect={{
+                        count: selected.size,
+                        id: 'bulk-select-groups',
+                        items: [
+                            {
+                                title: 'Select none (0)',
+                                onClick: () => dispatch(selectEntity(-1, false)),
+                                props: { isDisabled: noneSelected }
+                            },
+                            {
+                                title: `${pageSelected ? 'Deselect' : 'Select'} page (${
+                                    rows.length
+                                } items)`,
+                                onClick: () => dispatch(selectEntity(0, !pageSelected))
+                            }
+                        // TODO: Implement "select all"
+                        ],
+                        onSelect: (value) => {
+                            dispatch(selectEntity(0, value));
+                        },
+                        checked: selected.size > 0 // TODO: support partial selection (dash sign) in FEC BulkSelect
+                    }}
+                />
+            </PfModal>
+        </>
+    ) : <></>;
+};
+
+AddSystemsToGroupModal.propTypes = {
+    isModalOpen: PropTypes.bool,
+    setIsModalOpen: PropTypes.func,
+    reloadData: PropTypes.func
+};
+
+export default AddSystemsToGroupModal;

--- a/src/components/InventoryGroups/Modals/ConfirmSystemsAddModal.js
+++ b/src/components/InventoryGroups/Modals/ConfirmSystemsAddModal.js
@@ -22,12 +22,14 @@ const ConfirmSystemsAddModal = ({
         )}
         closeModal={onCancel}
         schema={confirmSystemsAddSchema(hostsNumber)}
+        reloadData={() => {}}
+        onSubmit={onSubmit}
         customFormTemplate={({ formFields, schema }) => {
-            const { getState } = useFormApi();
+            const { handleSubmit, getState } = useFormApi();
             const { submitting, valid } = getState();
 
             return (
-                <form onSubmit={onSubmit}>
+                <form onSubmit={handleSubmit}>
                     <Flex
                         direction={{ default: 'column' }}
                         spaceItems={{ default: 'spaceItemsLg' }}
@@ -45,7 +47,7 @@ const ConfirmSystemsAddModal = ({
                                     >
                                         Yes, add all systems to group
                                     </Button>
-                                    <Button onClick={onBack} variant="secondary">
+                                    <Button variant="secondary" onClick={onBack}>
                                         Back
                                     </Button>
                                     <Button variant="link" onClick={onCancel}>

--- a/src/components/InventoryGroups/Modals/ConfirmSystemsAddModal.js
+++ b/src/components/InventoryGroups/Modals/ConfirmSystemsAddModal.js
@@ -1,0 +1,72 @@
+import { FormSpy, useFormApi } from '@data-driven-forms/react-form-renderer';
+import { Button, Flex } from '@patternfly/react-core';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import warningColor from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Modal from './Modal';
+import { confirmSystemsAddSchema } from './ModalSchemas/schemes';
+
+const ConfirmSystemsAddModal = ({
+    isModalOpen,
+    onSubmit,
+    onBack,
+    onCancel,
+    hostsNumber
+}) => (
+    <Modal
+        isModalOpen={isModalOpen}
+        title={'Add all selected systems to group?'}
+        titleIconVariant={() => (
+            <ExclamationTriangleIcon color={warningColor.value} />
+        )}
+        closeModal={onCancel}
+        schema={confirmSystemsAddSchema(hostsNumber)}
+        customFormTemplate={({ formFields, schema }) => {
+            const { getState } = useFormApi();
+            const { submitting, valid } = getState();
+
+            return (
+                <form onSubmit={onSubmit}>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsLg' }}
+                    >
+                        {schema.title}
+                        {formFields}
+                        <FormSpy>
+                            {() => (
+                                <Flex>
+                                    <Button
+                                        isDisabled={submitting || !valid}
+                                        type="submit"
+                                        color="primary"
+                                        variant="primary"
+                                    >
+                                        Yes, add all systems to group
+                                    </Button>
+                                    <Button onClick={onBack} variant="secondary">
+                                        Back
+                                    </Button>
+                                    <Button variant="link" onClick={onCancel}>
+                                        Cancel
+                                    </Button>
+                                </Flex>
+                            )}
+                        </FormSpy>
+                    </Flex>
+                </form>
+            );
+        }}
+    />
+);
+
+ConfirmSystemsAddModal.propTypes = {
+    isModalOpen: PropTypes.bool,
+    onSubmit: PropTypes.func,
+    onBack: PropTypes.func,
+    onCancel: PropTypes.func,
+    hostsNumber: PropTypes.number
+};
+
+export default ConfirmSystemsAddModal;

--- a/src/components/InventoryGroups/Modals/CreateGroupModal.js
+++ b/src/components/InventoryGroups/Modals/CreateGroupModal.js
@@ -48,7 +48,6 @@ const CreateGroupModal = ({
 
     return (
         <Modal
-            data-testid="create-group-modal"
             isModalOpen={isModalOpen}
             closeModal={() => setIsModalOpen(false)}
             title="Create group"

--- a/src/components/InventoryGroups/Modals/Modal.js
+++ b/src/components/InventoryGroups/Modals/Modal.js
@@ -16,7 +16,8 @@ const RepoModal = ({
     variant,
     reloadData,
     size,
-    onSubmit
+    onSubmit,
+    customFormTemplate
 }) => {
     return (
         <Modal
@@ -29,7 +30,7 @@ const RepoModal = ({
         >
             <FormRenderer
                 schema={schema}
-                FormTemplate={(props) => (
+                FormTemplate={customFormTemplate ? customFormTemplate : (props) => (
                     <FormTemplate
                         {...props}
                         submitLabel={submitLabel}
@@ -66,7 +67,8 @@ RepoModal.propTypes = {
     size: PropTypes.string,
     additionalMappers: PropTypes.object,
     titleIconVariant: PropTypes.any,
-    validatorMapper: PropTypes.object
+    validatorMapper: PropTypes.object,
+    customFormTemplate: PropTypes.node
 };
 
 export default RepoModal;

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -22,3 +22,19 @@ export const createGroupSchema = (namePresenceValidator) => ({
         }
     ]
 });
+
+export const confirmSystemsAddSchema = (hostsNumber) => ({
+    fields: [
+        {
+            component: componentTypes.PLAIN_TEXT,
+            name: 'warning-message',
+            label: `${hostsNumber} of the systems you selected already belong to a group. Moving them to a different group will impact their configuration.`
+        },
+        {
+            component: componentTypes.CHECKBOX,
+            name: 'confirmation',
+            label: 'I acknowledge that this action cannot be undone.',
+            validate: [{ type: validatorTypes.REQUIRED }]
+        }
+    ]
+});

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -28,7 +28,8 @@ export const confirmSystemsAddSchema = (hostsNumber) => ({
         {
             component: componentTypes.PLAIN_TEXT,
             name: 'warning-message',
-            label: `${hostsNumber} of the systems you selected already belong to a group. Moving them to a different group will impact their configuration.`
+            label: `${hostsNumber} of the systems you selected already belong to a group.
+             Moving them to a different group will impact their configuration.`
         },
         {
             component: componentTypes.CHECKBOX,

--- a/src/components/InventoryGroups/Modals/RenameGroupModal.js
+++ b/src/components/InventoryGroups/Modals/RenameGroupModal.js
@@ -45,7 +45,7 @@ const RenameGroupModal = ({
             },
             onError: { title: 'Error', description: 'Failed to rename group' }
         };
-        apiWithToast(dispatch, () => updateGroupById(id, values), statusMessages);
+        apiWithToast(dispatch, () => updateGroupById(id, { name: values.name }), statusMessages);
     };
 
     const schema = useMemo(() => {

--- a/src/components/InventoryGroups/utils/api.js
+++ b/src/components/InventoryGroups/utils/api.js
@@ -2,6 +2,7 @@ import { instance } from '@redhat-cloud-services/frontend-components-utilities/i
 import { INVENTORY_API_BASE } from '../../../api';
 import { TABLE_DEFAULT_PAGINATION } from '../../../constants';
 import PropTypes from 'prop-types';
+import union from 'lodash/union';
 import fixtureGroups from '../../../../cypress/fixtures/groups.json';
 import fixtureGroupsDetails from '../../../../cypress/fixtures/groups/Ba8B79ab5adC8E41e255D5f8aDb8f1F3.json';
 
@@ -48,14 +49,20 @@ export const getGroupDetail = (groupId) => {
 };
 
 export const updateGroupById = (id, payload) => {
-    return instance.patch(`${INVENTORY_API_BASE}/groups/${id}`, {
-        name: payload.name
-    });
+    return instance.patch(`${INVENTORY_API_BASE}/groups/${id}`, payload);
 };
 
 export const deleteGroupsById = (ids = []) => {
     return instance.delete(`${INVENTORY_API_BASE}/groups/${ids.join(',')}`);
+};
 
+export const addHostsToGroupById = (id, hostIds) => {
+    return getGroupDetail(id).then((response) =>
+        updateGroupById(id, {
+            // eslint-disable-next-line camelcase
+            host_ids: union(response.results[0].host_ids, hostIds)
+        })
+    );
 };
 
 getGroups.propTypes = {

--- a/src/components/InventoryGroups/utils/api.js
+++ b/src/components/InventoryGroups/utils/api.js
@@ -57,6 +57,7 @@ export const deleteGroupsById = (ids = []) => {
 };
 
 export const addHostsToGroupById = (id, hostIds) => {
+    // the current hosts must be fetched before merging with the new ones
     return getGroupDetail(id).then((response) =>
         updateGroupById(id, {
             // eslint-disable-next-line camelcase

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -22,6 +22,7 @@ import OperatingSystemFormatter from '../Utilities/OperatingSystemFormatter';
 import { Tooltip } from '@patternfly/react-core';
 import { verifyCulledInsightsClient } from '../Utilities/sharedFunctions';
 import { fitContent } from '@patternfly/react-table';
+import isEmpty from 'lodash/isEmpty';
 
 export const defaultState = {
     loaded: false,
@@ -47,9 +48,11 @@ export const defaultColumns = (groupsEnabled = false) => ([
     ...(groupsEnabled ? [{
         key: 'groups',
         sortKey: 'groups',
-        title: 'Groups',
+        title: 'Group',
         props: { width: 10 },
-        renderFunc: () => <React.Fragment>N/A</React.Fragment>
+        // eslint-disable-next-line camelcase
+        renderFunc: (value, systemId, { group_name }) => isEmpty(group_name) ? 'N/A' : group_name,
+        transforms: [fitContent]
     }] : []),
     {
         key: 'tags',

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -175,7 +175,7 @@ function selectEntity(state, { payload }) {
 function versionsLoaded(state, { payload: { results } }) {
     return {
         ...state,
-        operatingSystems: results.map(entry => {
+        operatingSystems: (results || []).map(entry => {
             const { name, major, minor } = entry.value;
             const versionStringified = `${major}.${minor}`;
             return { label: `${name} ${versionStringified}`, value: versionStringified };


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-3728.
Mocked at https://www.sketch.com/s/c19f555b-7887-4423-b55d-575c8dd1dfb7/a/8yK3wl3.

This gives functionality to "Add systems" button in the empty state and also on the top of group systems table (/groups/%id view). The user is given the list of systems and chooses which to add to the current group. If one of the selected systems is already in a group, then the user is additionally prompted for confirmation.

## How to test

Be able to reproduce user flows from the mocks. Check the API requests are called and contain the required data about systems and groups.

## Screenshots

(the columns order has changed since https://github.com/RedHatInsights/insights-inventory-frontend/pull/1798/commits/d147b0641931510a3c52d29c196a9255a1db5ee7)

![image](https://user-images.githubusercontent.com/31385370/228503816-06622e86-2764-4958-b7a5-2c07bb8747da.png)

![image](https://user-images.githubusercontent.com/31385370/228504860-5ff31b72-c964-44b7-98fb-671e3f32ed8f.png)

![image](https://user-images.githubusercontent.com/31385370/228504918-f41cf8bc-52e3-4fb1-8c5d-0e52c383ee35.png)


