### PR TITLE
fix(RHCLOUD-24793): Show ROS tab is azure or aws cloud provider

### DIFF
--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -78,7 +78,7 @@ const Inventory = () => {
     const cloudProvider = useSelector(({ systemProfileStore }) => systemProfileStore?.systemProfile?.cloud_provider);
     const availableApps = useMemo(() => appList.map((app) => app.name === 'ros' ? {
         ...app,
-        isVisible: ['aws', 'azure'].includes(cloudProvider)
+        isVisible: cloudProvider === 'aws'
     } : app), [cloudProvider]);
     const clearNotifications = () => dispatch(actions.clearNotifications());
 

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useStore, useDispatch } from 'react-redux';
 import { useLocation, useParams, Link, useHistory } from 'react-router-dom';
@@ -75,6 +75,11 @@ const Inventory = () => {
     const writePermissions = useWritePermissions();
     const entityLoaded = useSelector(({ entityDetails }) => entityDetails?.loaded);
     const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
+    const cloudProvider = useSelector(({ systemProfileStore }) => systemProfileStore?.systemProfile?.cloud_provider);
+    const availableApps = useMemo(() => appList.map((app) => app.name === 'ros' ? {
+        ...app,
+        isVisible: ['aws', 'azure'].includes(cloudProvider)
+    } : app), [cloudProvider]);
     const clearNotifications = () => dispatch(actions.clearNotifications());
 
     useEffect(() => {
@@ -122,7 +127,7 @@ const Inventory = () => {
                 <BreadcrumbWrapper entity={entity} entityLoaded={entityLoaded} inventoryId={inventoryId}/>
             }
             activeApp={activeApp}
-            appList={appList}
+            appList={availableApps}
             onTabSelect={onTabSelect}
         />
     );

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -58,17 +58,6 @@ function entitySelected(state, { payload }) {
     };
 }
 
-function resourceOptTabVisibility(state, { payload }) {
-    return {
-        ...state,
-        activeApps: state.activeApps?.map((entity) => entity.name === 'ros' ? ({
-            ...entity,
-            isVisible: payload
-        }) : entity
-        )
-    };
-}
-
 function entityDeleted(state, { meta }) {
     const selected = state.selected || (new Map());
     meta.systems.forEach(id => selected.delete(id));
@@ -135,8 +124,7 @@ export const tableReducer = applyReducerHash(
 
 export const entitesDetailReducer = () => applyReducerHash(
     {
-        [INVENTORY_ACTION_TYPES.LOAD_ENTITY_FULFILLED]: entityLoaded,
-        [INVENTORY_ACTION_TYPES.LOAD_SYSTEM_PROFILE_FULFILLED]: resourceOptTabVisibility
+        [INVENTORY_ACTION_TYPES.LOAD_ENTITY_FULFILLED]: entityLoaded
     },
     defaultState
 );


### PR DESCRIPTION
### Description

ROS team brought to our attention that their tab is always hidden on inventory detail. This happend because of recent inventory refactoring and we forgot to move certain part of the code. This PR re-enables it and also removes unused part of redux code which was used in the past to calculate the visibility.

### Regression

https://github.com/RedHatInsights/insights-inventory-frontend/pull/1435