### PR TITLE
refactor(RHIF-125): Apply useChrome everywhere

### DIFF
--- a/src/components/GeneralInfo/EditButton/EditButton.js
+++ b/src/components/GeneralInfo/EditButton/EditButton.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 import { PencilAltIcon } from '@patternfly/react-icons';
 
@@ -46,7 +47,9 @@ EditButtonUnknownPermissions.propTypes = {
 };
 
 const EditButtonWrapper = ({ writePermissions, ...props }) => {
-    if (insights.chrome.isProd || writePermissions || permissionsCache) {
+    const { isProd } = useChrome();
+
+    if (isProd?.() || writePermissions || permissionsCache) {
         return <InnerButton {...props} />;
     }
 

--- a/src/components/GeneralInfo/EditButton/EditButtonWithNoAccessProd.test.js
+++ b/src/components/GeneralInfo/EditButton/EditButtonWithNoAccessProd.test.js
@@ -9,6 +9,13 @@ jest.mock('@redhat-cloud-services/frontend-components-utilities/RBACHook', () =>
     usePermissionsWithContext: () => ({ hasAccess: false })
 }));
 
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+    __esModule: true,
+    default: () => ({
+        isProd: () => true
+    })
+}));
+
 describe('EditButton with no access', () => {
     let onClick;
     let link;
@@ -18,32 +25,10 @@ describe('EditButton with no access', () => {
         link = 'some-link';
     });
 
-    it('do not render with no permission', () => {
+    it('render on production', () => {
         const wrapper = mount(<EditButton
             onClick={onClick}
             link={link}
-        />);
-
-        expect(wrapper.find(PencilAltIcon)).toHaveLength(0);
-        expect(wrapper.find('a')).toHaveLength(0);
-    });
-
-    it('do not render with no permission - write permissions set to false', () => {
-        const wrapper = mount(<EditButton
-            onClick={onClick}
-            link={link}
-            writePermissions={false}
-        />);
-
-        expect(wrapper.find(PencilAltIcon)).toHaveLength(0);
-        expect(wrapper.find('a')).toHaveLength(0);
-    });
-
-    it('render when write permissions are set to true', () => {
-        const wrapper = mount(<EditButton
-            onClick={onClick}
-            link={link}
-            writePermissions={true}
         />);
 
         expect(wrapper.find(PencilAltIcon)).toHaveLength(1);

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -92,7 +92,7 @@ const Inventory = () => {
     }
 
     useEffect(() => {
-        insights?.chrome?.appObjectId?.(entity?.id);
+        chrome?.appObjectId?.(entity?.id);
     }, [entity?.id]);
 
     const onTabSelect = useCallback((_, activeApp, appName) => {


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHIF-125.

This replaces the remaining occurrences of direct call to insights.chrome with useChrome hook.