### PR TITLE
test: Fix failing AddSystemsToGroupModal test

### DIFF
--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -304,6 +304,7 @@ describe('actions', () => {
     beforeEach(() => {
         cy.intercept('*', { statusCode: 200 });
         hostsInterceptors.successful();
+        featureFlagsInterceptors.successful(); // make Groups col available
 
         mountTable();
 

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -44,7 +44,8 @@ export const prepareColumns = (initialColumns) => {
         'update_method',
         'groups',
         'updated'
-    ].map((colKey) => columns.find(({ key }) => key === colKey));
+    ].map((colKey) => columns.find(({ key }) => key === colKey))
+    .filter(Boolean); // eliminate possible undefined's
 };
 
 const AddSystemsToGroupModal = ({


### PR DESCRIPTION
`prepareColumns` could send array containing `undefined` values (e.g., for the Group column because it depends on the feature flag setting). This PR puts more safety in managing this column: filters out `undefined` values and also makes sure the test has the feature flag set to true.

## How to test

https://github.com/RedHatInsights/insights-inventory-frontend/blob/d3181ba5b5923847c7c02b5e5af9176fe54ed406/src/components/GroupSystems/GroupSystems.cy.js#L314 should pass.