### PR TITLE
fix(ESSNTL-3727): Hide Group filter

### DIFF
--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -7,6 +7,7 @@ import {
     checkTableHeaders,
     CHIP,
     CHIP_GROUP,
+    DROPDOWN_ITEM,
     DROPDOWN_TOGGLE,
     hasChip,
     MODAL,
@@ -252,6 +253,10 @@ describe('filtering', () => {
         cy.wait('@getHosts'); // TODO: reset filters shouldn't trigger this second extra call
     });
 
+    it('should not contain group filter', () => {
+        cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
+        cy.get(DROPDOWN_ITEM).should('not.contain', 'Group');
+    });
     // TODO: add more filter cases
 });
 

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -107,6 +107,7 @@ const GroupSystems = ({ groupName, groupId }) => {
             {
                 !isModalOpen &&
                 <InventoryTable
+                    hideFilters={{ hostGroupFilter: true }}
                     columns={prepareColumns}
                     getEntities={async (items, config, showTags, defaultGetEntities) =>
                         await defaultGetEntities(


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-3727.

Hides the Group filter on the group systems view (/groups/%id).