### PR TITLE
fix(inventory groups): changed the column order to allign with the app

### DIFF
--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -40,7 +40,7 @@ import _ from 'lodash';
 
 const GROUP_NAME = 'foobar';
 const ROOT = 'div[id="group-systems-table"]';
-const TABLE_HEADERS = ['Name', 'OS', 'Tags', 'Update method', 'Last seen'];
+const TABLE_HEADERS = ['Name', 'Tags', 'OS', 'Update method', 'Last seen'];
 const SORTABLE_HEADERS = ['Name', 'OS', 'Last seen'];
 const DEFAULT_ROW_COUNT = 50;
 

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -64,8 +64,8 @@ export const prepareColumns = (initialColumns, hideGroupColumn) => {
     // map columns to the speicifc order
     return [
         'display_name',
-        'system_profile',
         'tags',
+        'system_profile',
         'update_method',
         'groups',
         'updated'

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -26,8 +26,8 @@ import AddSystemsToGroupModal from './AddSystemsToGroupModal';
 
 const TABLE_HEADERS = [
     'Name',
-    'OS',
     'Tags',
+    'OS',
     'Update method',
     'Group',
     'Last seen'


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ESSNTL-4628.

Aligning order of the columns in the inventory table and systems table for Group + add systems Modal for Group
Sketch https://www.sketch.com/s/ee66c23d-3d18-4940-afdf-e8a3c983d22d/a/5n2kMwd

Group systems table
![image](https://user-images.githubusercontent.com/62722417/231111671-5d16ad4f-142d-4ff2-9dd8-3580c580b564.png)
Modal
![image](https://user-images.githubusercontent.com/62722417/231111852-df0844d6-a5d0-435c-9d9b-c10e33d60a32.png)
