### PR TITLE
fix(InventroyTable): Add activeFiltersConfig to prop cache to trigger refresh

### DIFF
--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -63,6 +63,7 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
     initialLoading,
     ignoreRefresh,
     showTagModal,
+    activeFiltersConfig,
     tableProps,
     isRbacEnabled,
     hasCheckbox,
@@ -124,7 +125,8 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
         showTags,
         getEntities,
         customFilters,
-        hasItems
+        hasItems,
+        activeFiltersConfig
     });
 
     /**
@@ -144,6 +146,7 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
             hideFilters: cachedProps.hideFilters,
             filters: activeFilters,
             hasItems: cachedProps.hasItems,
+            activeFiltersConfig: cachedProps.activeFiltersConfig,
             ...cachedProps.customFilters,
             ...options
         };


### PR DESCRIPTION
Compliance adds filters via the `activeFiltersConfig` prop and not the `customFilters` prop and does not use the redux store to keep active filters and does therefore not trigger a refresh properly and only the first filter change in compliance would trigger a refresh, or if a filter is used coming from the inventory, like tags.

How to test:

 * Run inventory locally, possibly also with compliance
 * Open the Compliance -> Systems page
 * Filter by name, or any other "compliance filter"
 * Add to the filter and the table should refresh again

The last step would fail without this change. 