### PR TITLE
RHINENG-383: Fix typo in the tooltip when insights client is not reporting

### DIFF
--- a/src/Utilities/InsightsDisconnected.js
+++ b/src/Utilities/InsightsDisconnected.js
@@ -15,7 +15,7 @@ const InsightsDisconnected = () => (
                 </GridItem>
                 <GridItem>
                     From the main navigation, open
-                    &quot;Registration Assitant&quot; to learn
+                    &quot;Registration Assistant&quot; to learn
                     how to set up Insights.
                 </GridItem>
             </Grid>


### PR DESCRIPTION
This PR is just fixing a small typo.

`s/Registration Assitant/Registration Assistant/`