### PR TITLE
Fed mod router

### DIFF
--- a/src/components/InventoryTable/EntityTable.js
+++ b/src/components/InventoryTable/EntityTable.js
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { selectEntity, setSort } from '../../store/actions';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
+// import { useNavigate, useHistory } from 'react-router-dom';
 import {
     Table as PfTable,
     TableBody,
@@ -42,8 +42,9 @@ const EntityTable = ({
     columnsCounter
 }) => {
     const dispatch = useDispatch();
-    const history = useHistory();
-    const location = useLocation();
+
+    // TODO: after depenent applications migrate to router v6, use following proper navigation
+    // const navigate = useNavigate && useNavigate();
     const columns = useColumns(columnsProp, disableDefaultColumns, showTags, columnsCounter);
     const rows = useSelector(({ entities: { rows } }) => rows);
 
@@ -65,7 +66,9 @@ const EntityTable = ({
     , [loaded, columns, hasItems, rows, isExpandable]);
 
     const defaultRowClick = (_event, key) => {
-        history.push(`${location.pathname}${location.pathname.slice(-1) === '/' ? '' : '/'}${key}`);
+        // TODO: after depenent applications migrate to router v6, use following proper navigation
+        // navigate(`/${key}`);
+        window.history.pushState({}, null, `/${window.location.pathname}/${key}`);
     };
 
     delete tableProps.RowWrapper;

--- a/src/modules/AsyncInventory.js
+++ b/src/modules/AsyncInventory.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
-import { Router } from 'react-router-dom';
 import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACProvider';
 
 import * as storeMod from '../store/redux';
@@ -23,14 +22,12 @@ const AsyncInventory = ({ component, onLoad, store, history, innerRef, ...props 
     return (
         <RBACProvider appName="inventory">
             <Provider store={store}>
-                <Router history={history}>
-                    <RenderWrapper
-                        { ...props }
-                        isRbacEnabled
-                        inventoryRef={ innerRef }
-                        store={ store }
-                        cmp={ component } />
-                </Router>
+                <RenderWrapper
+                    { ...props }
+                    isRbacEnabled
+                    inventoryRef={ innerRef }
+                    store={ store }
+                    cmp={ component } />
             </Provider>
         </RBACProvider>
     );


### PR DESCRIPTION
This PR is intended for only demonstration and discussion. It is meant to be rebased on top of [this proper PR](https://github.com/RedHatInsights/insights-inventory-frontend/pull/1831). 

This is a draft solution for the react-router upgrade chicken and egg problem. With this in place, inventory does not use react-router-dom in federated modules enabling consumer apps to upgrade their package independently. 