### PR TITLE
chore(customDate): remove custome date

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -47,11 +47,12 @@ export const lastSeenItems = [
     {
         value: { updatedEnd: subtractDate(30), mark: '30more' },
         label: 'More than 30 days ago'
-    },
-    {
-        value: { mark: 'custom' },
-        label: 'Custom'
     }
+    //Temporarily disabled
+    // {
+    //     value: { mark: 'custom' },
+    //     label: 'Custom'
+    // }
 ];
 export const registered = [
     { label: 'insights-client', value: 'puptoo', idName: 'Insights id', idValue: 'insights_id' },


### PR DESCRIPTION
In an effort the remove this lastseen custom blocker of inventory release, temporarily removing the custom value from the drop down and remove ability to select custom dates.