### PR TITLE
fix(ESSNTL-4714): fix display name unwanted reset on sort

### DIFF
--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -146,8 +146,9 @@ const InventoryTable = forwardRef(({ // eslint-disable-line react/display-name
             hideFilters: cachedProps.hideFilters,
             filters: activeFilters,
             hasItems: cachedProps.hasItems,
+            //RHIF-246: Compliance app depends on activeFiltersConfig to apply its filters.
             activeFiltersConfig: cachedProps.activeFiltersConfig,
-            ...cachedProps.customFilters,
+            ...customFilters,
             ...options
         };
 


### PR DESCRIPTION
This fixes a random issue on the Inventory table. When you enter a string into the display name filter and remove the filter one char at a time in the input element and then sort by any column, the display name filter gets reset. 

**To test** the issue happens randomly, but this way seems more frequent, so please play with the filter and sorting more:

1. Go to the inventory app and table
2. Search for a string
3. delete the filter one by one in the input
4. sort the table by any column
5.  observe that the filter is still active
