### PR TITLE
fix(ESSNTL-4791): Hide all /groups requests under feature flag

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -330,7 +330,7 @@ describe('EntityTableToolbar', () => {
                 </Provider>);
                 wrapper.find('.ins-c-chip-filters button.pf-m-link').last().simulate('click');
                 const actions = store.getActions();
-                expect(actions.length).toBe(4);
+                expect(actions.length).toBe(3);
                 expect(actions[actions.length - 2]).toMatchObject({ type: 'CLEAR_FILTERS' });
                 expect(onRefreshData).toHaveBeenCalledWith({ filters: [], page: 1 });
             });

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchGroups } from '../../store/inventory-actions';
 import { HOST_GROUP_CHIP } from '../../Utilities/index';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 //for attaching this filter to the redux
 export const groupFilterState = { groupHostFilter: null };
@@ -31,9 +32,13 @@ export const buildHostGroupChips = (selectedGroups = []) => {
 
 const useGroupFilter = (apiParams = []) => {
     const dispatch = useDispatch();
+    const groupsEnabled = useFeatureFlag('hbi.ui.inventory-groups');
+
     useEffect(() => {
-        dispatch(fetchGroups(apiParams));
-    }, []);
+        if (groupsEnabled === true) {
+            dispatch(fetchGroups(apiParams));
+        }
+    }, [groupsEnabled]);
     //fetched values
     const fetchedValues = useSelector(({ groups })  => groups?.data?.results);
     //selected are the groups we selected

--- a/src/components/filters/useGroupFilter.test.js
+++ b/src/components/filters/useGroupFilter.test.js
@@ -6,6 +6,11 @@ import { createPromise as promiseMiddleware } from 'redux-promise-middleware';
 import { mockSystemProfile } from '../../__mocks__/hostApi';
 import useGroupFilter from './useGroupFilter';
 
+jest.mock('../../Utilities/useFeatureFlag', () => ({
+    __esModule: true,
+    default: () => true
+}));
+
 describe('useGroupFilter', () => {
     const mockStore = configureStore([promiseMiddleware()]);
     beforeEach(() => {

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -326,13 +326,16 @@ const Inventory = ({
                     onEditOpen(false);
                 }}
             />
-            <AddHostToGroupModal
-                isModalOpen={addHostGroupModalOpen}
-                setIsModalOpen={setAddHostGroupModalOpen}
-                modalState={currentSytem}
-                //should be replaced with a fetch to update the values in the table
-                reloadData={() => console.log('data reloaded')}
-            />
+            {
+                groupsEnabled === true &&
+                <AddHostToGroupModal
+                    isModalOpen={addHostGroupModalOpen}
+                    setIsModalOpen={setAddHostGroupModalOpen}
+                    modalState={currentSytem}
+                    //should be replaced with a fetch to update the values in the table
+                    reloadData={() => console.log('data reloaded')}
+                />
+            }
         </React.Fragment>
     );
 };


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-4791.

This makes sure Inventory doesn't make any network calls to the groups endpoints if the feature flag is disabled.

## How to test

1. Deploy locally with `ENVIRONMENT=prod npm run start:proxy`
2. (optional) Make sure https://insights.unleash.devshift.net/projects/default/features/hbi.ui.inventory-groups is disabled
3. Navigate to https://prod.foo.redhat.com:1337/insights/inventory, log in
4. Make sure the table is rendered, there is no filter "Group" available, the column "Group" is not rendered, and there are no requests to /api/inventory/v1/groups*-like endpoints in the network tab.