### PR TITLE
chore: use travis:build for travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ install:
 jobs:
   include:
     - stage: Lint
-      script: npm run build && npm run lint
+      script: npm run lint
     - stage: Test
       script: npm run test && npm run test:ct
       after_success: npm run coverage
     - stage: Deploy
       if: (fork = false) AND (branch IN (master, master-stable, prod-beta, prod-stable))
-      script: npm run build && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
+      script: npm run travis:build && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
     - stage: Tag
       if: (fork = false) AND (branch = master)
       script: npx semantic-release


### PR DESCRIPTION
This changes the deployment step to use travis:build instead of regular build. This helps to avoid possible problems with serving correct assets according to environments.