### PR TITLE
fix(ESSNTL-4730): Disable sorting for the Group column

### DIFF
--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -50,7 +50,7 @@ export const defaultColumns = (groupsEnabled = false) => ([
         key: 'groups',
         sortKey: 'groups',
         title: 'Group',
-        props: { width: 10 },
+        props: { width: 10, isStatic: true },
         // eslint-disable-next-line camelcase
         renderFunc: (value, systemId, { group_name }) => isEmpty(group_name) ? 'N/A' : group_name,
         transforms: [fitContent]

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -52,7 +52,7 @@ export const defaultColumns = (groupsEnabled = false) => ([
         title: 'Group',
         props: { width: 10, isStatic: true },
         // eslint-disable-next-line camelcase
-        renderFunc: (value, systemId, { group_name }) => isEmpty(group_name) ? 'N/A' : group_name,
+        renderFunc: (groups) => isEmpty(groups) ? 'N/A' : groups[0].name, // currently, one group at maximum is supported
         transforms: [fitContent]
     }] : []),
     {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-4730.

## How to test

1. Run `npm run start:proxy:beta`
2. Authenticate with insights-qa, navigate to https://stage.foo.redhat.com:1337/preview/insights/inventory
3. Check that you are unable to sort by the Group column.