### PR TITLE
fix(ESSNTL-3730): Refresh groups when new created

### DIFF
--- a/src/components/InventoryGroups/Modals/AddHostToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddHostToGroupModal.js
@@ -1,11 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, {  useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from './Modal';
 import { addHostToGroup } from '../utils/api';
 import apiWithToast from '../utils/apiWithToast';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch  } from 'react-redux';
 import { CreateGroupButton } from '../SmallComponents/CreateGroupButton';
-import { fetchGroups } from '../../../store/inventory-actions';
 import { addHostSchema } from './ModalSchemas/schemes';
 import CreateGroupModal from './CreateGroupModal';
 
@@ -15,14 +14,7 @@ const AddHostToGroupModal = ({
     modalState,
     reloadData
 }) => {
-
     const dispatch = useDispatch();
-    //we have to fetch groups to make them available in state
-    useEffect(() => {
-        dispatch(fetchGroups());
-    }, []);
-
-    const groups = useSelector(({ groups }) => groups?.data?.results);
 
     const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
     const handleAddDevices = (values) => {
@@ -49,7 +41,7 @@ const AddHostToGroupModal = ({
                 closeModal={() => setIsModalOpen(false)}
                 title="Add to group"
                 submitLabel="Add"
-                schema={addHostSchema(modalState.name, groups)}
+                schema={addHostSchema(modalState.name)}
                 additionalMappers={{
                     'create-group-btn': {
                         component: CreateGroupButton,
@@ -67,7 +59,6 @@ const AddHostToGroupModal = ({
                 <CreateGroupModal
                     isModalOpen={isCreateGroupModalOpen}
                     setIsModalOpen={setIsCreateGroupModalOpen}
-                    reloadData={() => console.log('data reloaded')}
                     //modal before prop tells create group modal that it should
                     //reopen add host modal when user closes create group modal
                     modalBefore={true}

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -3,6 +3,7 @@ import validatorTypes from '@data-driven-forms/react-form-renderer/validator-typ
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import { nameValidator } from '../../helpers/validate';
 import { Text } from '@patternfly/react-core';
+import { getGroups } from '../../utils/api';
 
 export const createGroupSchema = (namePresenceValidator) => ({
     fields: [
@@ -45,7 +46,8 @@ export const confirmSystemsAddSchema = (hostsNumber) => ({
 const createDescription = (systemName) => {
     return (
         <Text>
-        Select a group to add <strong>{systemName}</strong> to, or create a new one.
+      Select a group to add <strong>{systemName}</strong> to, or create a new
+      one.
         </Text>
     );
 };
@@ -53,7 +55,7 @@ const createDescription = (systemName) => {
 //this is a custom schema that is passed via additional mappers to the Modal component
 //it allows to create custom item types in the modal
 
-export const addHostSchema = (systemName, groups) => ({
+export const addHostSchema = (systemName) => ({
     fields: [
         {
             component: componentTypes.PLAIN_TEXT,
@@ -69,12 +71,26 @@ export const addHostSchema = (systemName, groups) => ({
             isRequired: true,
             isClearable: true,
             placeholder: 'Type or click to select a group',
-            options: (groups || []).map(({ id, name }) => ({
-                label: name,
-                value: { name, id }
-            })),
+            loadOptions: (searchValue = '') =>
+                getGroups().then(({ results = [] }) => {
+                    return results.reduce((acc, { name, id }) => {
+                        if (name.toLowerCase().includes(searchValue.trim().toLowerCase())) {
+                            return [
+                                ...acc,
+                                {
+                                    label: name,
+                                    value: { name, id }
+                                }
+                            ];
+                        }
+                    }, []);
+                }),
             validate: [{ type: validatorTypes.REQUIRED }]
         },
-        { component: 'create-group-btn', name: 'create-group-btn', isRequired: true }
+        {
+            component: 'create-group-btn',
+            name: 'create-group-btn',
+            isRequired: true
+        }
     ]
 });


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/ESSNTL-3730?focusedId=22178599&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22178599.

Make it possible for the modal ("add host to group") to refresh the list of available groups after users have created the new one.

## How to test

1. Run `npm run start:proxy:beta`
2. Navigate to https://stage.foo.redhat.com:1337/preview/insights/inventory
3. Find any available host and try to open "Add to group" modal
4. Try to create a new group, submit, then check that you are 1) redirected back to the main modal, 2) the list of available groups contains the group you have just created.
5. Try to select the new group and submit the modal.
6. You must get an error (405 error code) - this is expected, but the request should contain the id of the new group and also the id of the selected host.

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/5076754c-418d-477b-99a9-e39d7534bfca)
