### PR TITLE
fix(ESSNTL-4486): Update API functions names

### DIFF
--- a/src/routes/InventoryTable.test.js
+++ b/src/routes/InventoryTable.test.js
@@ -155,7 +155,7 @@ describe('InventoryTable', () => {
 
         window.XMLHttpRequest = jest.fn().mockImplementation(createXhrMock());
 
-        hosts.apiHostDeleteById = jest.fn().mockImplementation(() => Promise.resolve());
+        hosts.apiHostDeleteHostById = jest.fn().mockImplementation(() => Promise.resolve());
         const selected = new Map();
         selected.set(system1.id, system1);
 

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -6,7 +6,7 @@ export * from './inventory-actions';
 
 export const deleteEntity = (systems, displayName) => ({
     type: ACTION_TYPES.REMOVE_ENTITY,
-    payload: hosts.apiHostDeleteById(systems),
+    payload: hosts.apiHostDeleteHostById(systems),
     meta: {
         notifications: {
             fulfilled: {

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -130,7 +130,7 @@ export const systemProfile = (itemId) => ({
 
 export const editDisplayName = (id, value) => ({
     type: ACTION_TYPES.SET_DISPLAY_NAME,
-    payload: hosts.apiHostPatchHost(id, { display_name: value }), // eslint-disable-line camelcase
+    payload: hosts.apiHostPatchHostById(id, { display_name: value }), // eslint-disable-line camelcase
     meta: {
         notifications: {
             fulfilled: {
@@ -144,7 +144,7 @@ export const editDisplayName = (id, value) => ({
 
 export const editAnsibleHost = (id, value) => ({
     type: ACTION_TYPES.SET_ANSIBLE_HOST,
-    payload: hosts.apiHostPatchHost(id, { ansible_host: value }), // eslint-disable-line camelcase
+    payload: hosts.apiHostPatchHostById(id, { ansible_host: value }), // eslint-disable-line camelcase
     meta: {
         notifications: {
             fulfilled: {
@@ -193,7 +193,7 @@ export const fetchOperatingSystems = (params = []) => ({
 
 export const deleteEntity = (systems, displayName) => ({
     type: ACTION_TYPES.REMOVE_ENTITY,
-    payload: hosts.apiHostDeleteById(systems),
+    payload: hosts.apiHostDeleteHostById(systems),
     meta: {
         notifications: {
             fulfilled: {


### PR DESCRIPTION
After https://github.com/RedHatInsights/insights-inventory-frontend/pull/1847/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19 upgrade, it turned out some `javascript-clients` functions changed their naming. This updates the places where incorrect function were called.

## How to test

Deploy the PR, navigate to Inventory and try to change display name, ansible name or delete host. The operations must be completed successfully and without errors.