### PR TITLE
fix(systemProfileStore): Repositories are enabled by default

### DIFF
--- a/src/store/systemProfileStore.js
+++ b/src/store/systemProfileStore.js
@@ -27,7 +27,7 @@ export function systemProfilePending(state) {
 export function calculateRepos(repos) {
     return repos && repos.reduce((acc, curr) => ({
         ...acc,
-        ...curr.enabled ? {
+        ...!('enabled' in curr) || curr.enabled ? {
             enabled: [...acc.enabled, curr]
         } : {
             disabled: [...acc.disabled, curr]

--- a/src/store/systemProfileStore.test.js
+++ b/src/store/systemProfileStore.test.js
@@ -29,8 +29,8 @@ it('should calculate repos', () => {
     }, {
         enabled: false
     }]);
-    expect(repos.disabled.length).toBe(2);
-    expect(repos.enabled.length).toBe(1);
+    expect(repos.disabled.length).toBe(1);
+    expect(repos.enabled.length).toBe(2);
 });
 
 it('should calculate NIC', () => {


### PR DESCRIPTION
The `enabled` field in repository configurations defaults to 1, so consider repositories where this option is missing as enabled.