### PR TITLE
fix: Provide search value when loading groups options

### DIFF
--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -56,6 +56,23 @@ const createDescription = (systemName) => {
 //this is a custom schema that is passed via additional mappers to the Modal component
 //it allows to create custom item types in the modal
 
+const loadOptions = awesomeDebouncePromise(async (searchValue = '') => {
+    // add a slight delay for scenarios when a new group has been just created
+    const data = await awesomeDebouncePromise(() => getGroups({ name: searchValue }, {}), 500)();
+    // TODO: make the getGroups requests paginated
+    return (data?.results || []).reduce((acc, { name, id }) => {
+        if (name.toLowerCase().includes(searchValue.trim().toLowerCase())) {
+            return [
+                ...acc,
+                {
+                    label: name,
+                    value: { name, id }
+                }
+            ];
+        }
+    }, []);
+}, 500);
+
 export const addHostSchema = (systemName) => ({
     fields: [
         {
@@ -72,21 +89,7 @@ export const addHostSchema = (systemName) => ({
             isRequired: true,
             isClearable: true,
             placeholder: 'Type or click to select a group',
-            loadOptions: async (searchValue = '') => {
-                // add a slight delay for scenarios when a new group has been just created
-                const data = await awesomeDebouncePromise(getGroups, 500)();
-                return (data?.results || []).reduce((acc, { name, id }) => {
-                    if (name.toLowerCase().includes(searchValue.trim().toLowerCase())) {
-                        return [
-                            ...acc,
-                            {
-                                label: name,
-                                value: { name, id }
-                            }
-                        ];
-                    }
-                }, []);
-            },
+            loadOptions,
             validate: [{ type: validatorTypes.REQUIRED }]
         },
         {

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -36,7 +36,7 @@ const useGroupFilter = (apiParams = []) => {
 
     useEffect(() => {
         if (groupsEnabled === true) {
-            dispatch(fetchGroups(apiParams));
+            dispatch(fetchGroups(apiParams)); // TODO: make the request paginated (to show all the groups)
         }
     }, [groupsEnabled]);
     //fetched values


### PR DESCRIPTION
This is a quick patch that provides one extra `name` argument when loading groups options list in AddHostToGroupModal. 

## How to test

Try to find a host in the inventory table that is not in a group. Click "Add to group" and try to type some input in the groups search. The network requests to GET /groups must contain `name` parameter with the input you have typed.