### PR TITLE
feat(ESSNTL-3578): show update method field in details page

### DIFF
--- a/src/components/GeneralInfo/OperatingSystemCard/OperatingSystemCard.js
+++ b/src/components/GeneralInfo/OperatingSystemCard/OperatingSystemCard.js
@@ -43,6 +43,7 @@ const OperatingSystemCardCore = ({
                     );
                 }
             }] : [],
+            ...systemInfo.systemUpdateMethod ? [{ title: 'Update method', value: systemInfo.systemUpdateMethod }] : [],
             ...extra.map(({ onClick, ...item }) => ({
                 ...item,
                 ...onClick && { onClick: (e) => onClick(e, handleClick) }

--- a/src/components/GeneralInfo/selectors/selectors.js
+++ b/src/components/GeneralInfo/selectors/selectors.js
@@ -45,13 +45,15 @@ export const operatingSystem = ({
     operating_system,
     os_kernel_version,
     last_boot_time,
-    kernel_modules
+    kernel_modules,
+    system_update_method
 } = {}, { facts } = {}) => ({
     release: operating_system,
     kernelRelease: os_kernel_version,
     architecture: arch || facts?.rhsm?.ARCHITECTURE,
     bootTime: last_boot_time,
-    kernelModules: kernel_modules
+    kernelModules: kernel_modules,
+    systemUpdateMethod: system_update_method
 });
 
 export const biosSelector = ({


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/ESSNTL-3578

To test:

1. Open the inventory app
2. Select any system that is not disconnected from insights
3. Observe that a new 'Update method' field has appeared in **Operating system** card


TODO: will cover with cypress test after https://github.com/RedHatInsights/insights-inventory-frontend/pull/1865 gets merged.