### PR TITLE
fix(essntl-3736): fix for group deletion

### DIFF
--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -77,6 +77,7 @@ const GroupsTable = () => {
     const [createModalOpen, setCreateModalOpen] = useState(false);
     const [renameModalOpen, setRenameModalOpen] = useState(false);
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+    const [kebabDeleteGroup, setKebabDeleteGroup] = useState(false);
     const groups = useMemo(() => data?.results || [], [data]);
     const { fetchBatched } = useFetchBatched();
 
@@ -261,9 +262,11 @@ const GroupsTable = () => {
                 isModalOpen={deleteModalOpen}
                 setIsModalOpen={setDeleteModalOpen}
                 reloadData={() => fetchData(filters)}
-                modalState={selectedIds.length > 1 ? {
-                    ids: selectedIds
-                } : selectedGroup}
+                modalState={
+                    kebabDeleteGroup ? selectedGroup :
+                        selectedIds.length > 1 ? {
+                            ids: selectedIds
+                        } : selectedGroup}
             />
             <PrimaryToolbar
                 pagination={{
@@ -334,7 +337,9 @@ const GroupsTable = () => {
                         },
                         {
                             label: selectedIds.length > 1 ? 'Delete groups' : 'Delete group',
-                            onClick: () => setDeleteModalOpen(true),
+                            onClick: () => {
+                                setKebabDeleteGroup(false);
+                                setDeleteModalOpen(true);},
                             props: {
                                 isDisabled: selectedIds.length === 0
                             }
@@ -370,6 +375,7 @@ const GroupsTable = () => {
                     {
                         title: 'Delete group',
                         onClick: (event, rowIndex, { groupId, groupName }) => {
+                            setKebabDeleteGroup(true);
                             setSelectedGroup({
                                 id: groupId,
                                 name: groupName


### PR DESCRIPTION
How to test the fix: 
1. Open groups table https://stage.foo.redhat.com:1337/preview/insights/inventory/groups
2. Select several groups
3. Click on the kebab button and try to delete the group. 
4. The modal should have the name of the group from the same row that you clicked to open delete modal.
5. Try to delete these selected groups - only group from the clicked row should be deleted.
6. Try to do the same (repeat step 1 and 2) then click on the actions in the Toolbar of the table and try to delete several groups at once.