### PR TITLE
Add host to group

### DIFF
--- a/src/components/InventoryGroups/Modals/AddHostToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddHostToGroupModal.cy.js
@@ -1,0 +1,43 @@
+import { groupsInterceptors } from '../../../../cypress/support/interceptors';
+import AddHostToGroupModal from './AddHostToGroupModal';
+
+const mountModal = (props =
+{
+    isModalOpen: true,
+    setIsModalOpen: () => {},
+    modalState: {
+        name: 'host1',
+        id: 'host1-id'
+    },
+    reloadData: () => {}
+}) => {
+    cy.mountWithContext(AddHostToGroupModal, {}, props);
+};
+
+before(() => {
+    cy.window().then(
+        (window) =>
+            (window.insights = {
+                chrome: {
+                    auth: {
+                        getUser: () => {
+                            return Promise.resolve({});
+                        }
+                    }
+                }
+            })
+    );
+});
+
+describe('AddHostToGroupModal', () => {
+    it('makes separate requests when searching groups', () => {
+        groupsInterceptors['successful with some items']();
+        mountModal();
+
+        cy.wait('@getGroups'); // must make initial call
+        cy.get('input').type('abc');
+        cy.wait('@getGroups').its('request.url').should('contain', '?name=abc');
+        cy.get('input').type('d');
+        cy.wait('@getGroups').its('request.url').should('contain', '?name=abcd');
+    });
+});

--- a/src/components/InventoryGroups/Modals/AddHostToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddHostToGroupModal.js
@@ -77,9 +77,7 @@ AddHostToGroupModal.propTypes = {
     }),
     isModalOpen: PropTypes.bool,
     setIsModalOpen: PropTypes.func,
-    reloadData: PropTypes.func,
-    setIsCreateGroupModalOpen: PropTypes.func,
-    deviceIds: PropTypes.array
+    reloadData: PropTypes.func
 };
 
 export default AddHostToGroupModal;

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -56,7 +56,7 @@ const createDescription = (systemName) => {
 //this is a custom schema that is passed via additional mappers to the Modal component
 //it allows to create custom item types in the modal
 
-const loadOptions = async (searchValue = '') => {
+const loadOptions = awesomeDebouncePromise(async (searchValue = '') => {
     // add a slight delay for scenarios when a new group has been just created
     const data = await awesomeDebouncePromise(() => getGroups({ name: searchValue }, {}), 500)();
     // TODO: make the getGroups requests paginated
@@ -71,7 +71,7 @@ const loadOptions = async (searchValue = '') => {
             ];
         }
     }, []);
-};
+}, 500, { onlyResolvesLast: false });
 
 export const addHostSchema = (systemName) => ({
     fields: [

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -56,6 +56,23 @@ const createDescription = (systemName) => {
 //this is a custom schema that is passed via additional mappers to the Modal component
 //it allows to create custom item types in the modal
 
+const loadOptions = awesomeDebouncePromise(async (searchValue = '') => {
+    // add a slight delay for scenarios when a new group has been just created
+    const data = await awesomeDebouncePromise(() => getGroups({ name: searchValue }, {}), 500)();
+    // TODO: make the getGroups requests paginated
+    return (data?.results || []).reduce((acc, { name, id }) => {
+        if (name.toLowerCase().includes(searchValue.trim().toLowerCase())) {
+            return [
+                ...acc,
+                {
+                    label: name,
+                    value: { name, id }
+                }
+            ];
+        }
+    }, []);
+}, 500);
+
 export const addHostSchema = (systemName) => ({
     fields: [
         {
@@ -72,21 +89,7 @@ export const addHostSchema = (systemName) => ({
             isRequired: true,
             isClearable: true,
             placeholder: 'Type or click to select a group',
-            loadOptions: async (searchValue = '') => {
-                // add a slight delay for scenarios when a new group has been just created
-                const data = await awesomeDebouncePromise(getGroups, 500)();
-                return (data?.results || []).reduce((acc, { name, id }) => {
-                    if (name.toLowerCase().includes(searchValue.trim().toLowerCase())) {
-                        return [
-                            ...acc,
-                            {
-                                label: name,
-                                value: { name, id }
-                            }
-                        ];
-                    }
-                }, []);
-            },
+            loadOptions,
             validate: [{ type: validatorTypes.REQUIRED }]
         },
         {

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -56,7 +56,7 @@ const createDescription = (systemName) => {
 //this is a custom schema that is passed via additional mappers to the Modal component
 //it allows to create custom item types in the modal
 
-const loadOptions = awesomeDebouncePromise(async (searchValue = '') => {
+const loadOptions = async (searchValue = '') => {
     // add a slight delay for scenarios when a new group has been just created
     const data = await awesomeDebouncePromise(() => getGroups({ name: searchValue }, {}), 500)();
     // TODO: make the getGroups requests paginated
@@ -71,7 +71,7 @@ const loadOptions = awesomeDebouncePromise(async (searchValue = '') => {
             ];
         }
     }, []);
-}, 500);
+};
 
 export const addHostSchema = (systemName) => ({
     fields: [

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -36,7 +36,7 @@ const useGroupFilter = (apiParams = []) => {
 
     useEffect(() => {
         if (groupsEnabled === true) {
-            dispatch(fetchGroups(apiParams));
+            dispatch(fetchGroups(apiParams)); // TODO: make the request paginated (to show all the groups)
         }
     }, [groupsEnabled]);
     //fetched values


### PR DESCRIPTION
This is the same PR as https://github.com/RedHatInsights/insights-inventory-frontend/pull/1867 but with a FIX that prevents infinite loads. 

How to test
Try to find a host in the inventory table that is not in a group. Click "Add to group" and try to type some input in the groups search. The network requests to GET /groups must contain a name parameter with the input you have typed.
Make sure that if you type the group name in the search field - the search won't go "infinite spinner mode" and will either fail to find(if you are typing the name of the not existing group) or find a group you want.