### PR TITLE
fix: Reload table when changing the host group

### DIFF
--- a/src/components/InventoryTable/InventoryList.js
+++ b/src/components/InventoryTable/InventoryList.js
@@ -56,7 +56,7 @@ const InventoryList = React.forwardRef(({ hasAccess, onRefreshData, ...props }, 
 
     if (ref) {
         ref.current = {
-            onRefreshData: (params, disableRefresh = true) => onRefreshData(params, disableRefresh)
+            onRefreshData: (params, disableRefresh = true, forceRefresh) => onRefreshData(params, disableRefresh, forceRefresh)
         };
     }
 

--- a/src/routes/InventoryTable.cy.js
+++ b/src/routes/InventoryTable.cy.js
@@ -99,6 +99,7 @@ describe('inventory table', () => {
                 cy.get('button[type="submit"]').click();
                 cy.wait('@request');
             });
+            cy.wait('@getHosts'); // data must be reloaded
         });
 
         it('can add to existing group', () => {
@@ -115,6 +116,7 @@ describe('inventory table', () => {
                 cy.get('button[type="submit"]').click();
                 cy.wait('@request');
             });
+            cy.wait('@getHosts'); // data must be reloaded
         });
     });
 });

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -222,13 +222,13 @@ const Inventory = ({
                             isRbacEnabled
                             customFilters={{ filters, globalFilter }}
                             isFullView
-                            inventoryRef={inventory}
                             showTags
                             onRefresh={onRefresh}
                             hasCheckbox={writePermissions}
                             autoRefresh
                             ignoreRefresh
                             initialLoading={initialLoading}
+                            ref={inventory}
                             tableProps={
                                 (writePermissions && {
                                     actionResolver: (row) => tableActions(groupsEnabled, row), canSelectAll: false })}
@@ -299,9 +299,7 @@ const Inventory = ({
                             isModalOpen={addHostGroupModalOpen}
                             setIsModalOpen={setAddHostGroupModalOpen}
                             modalState={currentSystem}
-                            reloadData={() => {
-                                // TODO
-                            }}
+                            reloadData={() => inventory.current.onRefreshData(filters, false, true)}
                         />
                         {
                             removeHostsFromGroupModalOpen &&
@@ -309,9 +307,7 @@ const Inventory = ({
                                 isModalOpen={removeHostsFromGroupModalOpen}
                                 setIsModalOpen={setRemoveHostsFromGroupModalOpen}
                                 modalState={currentSystem}
-                                reloadData={() => {
-                                    // TODO
-                                }}
+                                reloadData={() => inventory.current.onRefreshData(filters, false, true)}
                             />
                         }
                     </>


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-3730, https://issues.redhat.com/browse/ESSNTL-3733.

This makes the inventory table reload data when the host is added to or removed from a group via action modals. This also fixed the wrong `ref` property propagation.

## How to test

1. Go to the inventory table
2. Try to add (the network call will fail - this is expected currently) to or remove hosts from groups (the "test" group has some hosts in `insights-qa` profile)
3. Check that after submit the rows are reloaded with the **same** filters.