### PR TITLE
feat: Enable bulk hosts addition/removal to/from groups

### DIFF
--- a/cypress/fixtures/groups.json
+++ b/cypress/fixtures/groups.json
@@ -39,11 +39,11 @@
       "created_at": "1966-12-21T00:00:00.0Z"
     },
     {
-      "host_ids": null,
+      "host_ids": ["anim commodo", "dolor"],
       "updated_at": "2012-07-06T22:00:00.0Z",
-      "id": "B9bcBF737A9BA20482f9bc9f5ACcbe04",
+      "id": "54b302e4-07d2-45c5-b2f8-92a286847f9d",
       "created_at": "1944-12-04T23:00:00.0Z",
-      "name": "dolor labore dolore commodo"
+      "name": "ancd"
     },
     {
       "updated_at": "1997-03-05T23:00:00.0Z",

--- a/cypress/fixtures/hosts.json
+++ b/cypress/fixtures/hosts.json
@@ -117,157 +117,9 @@
       "groups": [
         {
           "id": "54b302e4-07d2-45c5-b2f8-92a286847f9d",
-          "name": "ancd",
-          "account": "12345",
-          "org_id": "54321",
-          "created_on": null,
-          "modified_on": null
+          "name": "ancd"
         }
       ]
-    },
-    {
-      "org_id": "consectetur elit",
-      "stale_timestamp": "2013-06-07T22:00:00.0Z",
-      "facts": [
-        {
-          "namespace": "adipisicing"
-        },
-        {
-          "namespace": "occaecat sunt"
-        },
-        {
-          "namespace": "Ut labore est velit enim"
-        },
-        {
-          "namespace": "cupidatat aliqua tempor amet"
-        },
-        {
-          "namespace": "consequat enim Ut"
-        },
-        {
-          "namespace": "incididunt"
-        },
-        {
-          "namespace": "nulla do"
-        },
-        {
-          "namespace": "proident tempor enim ut quis"
-        },
-        {
-          "namespace": "laborum"
-        },
-        {
-          "namespace": "aliqua deserunt"
-        },
-        {
-          "namespace": "velit"
-        },
-        {
-          "namespace": "et incididunt laboris non anim"
-        },
-        {
-          "namespace": "do"
-        },
-        {
-          "namespace": "est et ea "
-        },
-        {
-          "namespace": "in"
-        },
-        {
-          "namespace": "minim"
-        },
-        {
-          "namespace": "fugiat Excepteur"
-        },
-        {
-          "namespace": "dolore mollit qui"
-        },
-        {
-          "namespace": "ad"
-        },
-        {
-          "namespace": "ut sint"
-        }
-      ],
-      "ip_addresses": [
-        "ullamco",
-        "culpa officia eiusmod voluptate quis",
-        "commodo non Excepteur dolore",
-        "consequat",
-        "cillum labor",
-        "nostrud amet deserunt dolor",
-        "reprehenderit",
-        "ea in nisi",
-        "in",
-        "fugiat adipisicing",
-        "sit est in qui",
-        "ea i",
-        "exercitation adipisic",
-        "sunt exercitation",
-        "fugiat sunt est dolore sint",
-        "eiusmod nulla aute",
-        "do deserunt",
-        "commodo nostrud cupidatat Excepteur id",
-        "non irure cillum minim",
-        "tempor nulla culpa non sunt"
-      ],
-      "display_name": null,
-      "updated": "1966-08-09T23:00:00.0Z",
-      "per_reporter_staleness": {
-        "eiusmodc2": {
-          "last_check_in": "1943-10-27T00:00:00.0Z",
-          "check_in_succeeded": true,
-          "stale_timestamp": "2012-12-31T23:00:00.0Z"
-        },
-        "do_39f": {
-          "last_check_in": "1950-02-01T23:00:00.0Z",
-          "stale_timestamp": "1970-04-16T23:00:00.0Z",
-          "check_in_succeeded": false
-        },
-        "labore7": {
-          "check_in_succeeded": true,
-          "last_check_in": "1981-06-13T22:00:00.0Z",
-          "stale_timestamp": "1945-09-29T22:00:00.0Z"
-        }
-      },
-      "provider_type": null,
-      "stale_warning_timestamp": "2007-11-12T00:00:00.0Z",
-      "insights_id": null,
-      "reporter": null,
-      "satellite_id": "consequat occaecat Ut",
-      "subscription_manager_id": "magna ullamco in Ut",
-      "account": "dolore voluptate",
-      "mac_addresses": [
-        "cupidatat nisi officia magna do",
-        "commodo ad",
-        "sint est id",
-        "irure eiusmod",
-        "ea magna aute occaecat dolor",
-        "aute voluptate",
-        "esse",
-        "nisi et",
-        "et aute qui nostrud in",
-        "dolore ut",
-        "ut veniam",
-        "mollit in eu aliqua",
-        "mollit in ut Lorem",
-        "amet",
-        "Duis qui sit adipisicing sunt",
-        "dolor",
-        "do sed",
-        "adipisicing in cupidatat",
-        "anim in consectetur sit",
-        "enim minim ex labore"
-      ],
-      "ansible_host": null,
-      "id": "aute",
-      "created": "1990-07-14T22:00:00.0Z",
-      "fqdn": null,
-      "provider_id": null,
-      "bios_uuid": "anim nulla ex eiusmod voluptate",
-      "culled_timestamp": null,
-      "groups": []
     },
     {
       "org_id": "deserunt sit irure",
@@ -294,7 +146,7 @@
         "in reprehenderit ut aute",
         ""
       ],
-      "id": "anim commodo",
+      "id": "anim",
       "display_name": null,
       "insights_id": null,
       "provider_type": null,
@@ -381,7 +233,12 @@
       },
       "culled_timestamp": null,
       "fqdn": null,
-      "groups": []
+      "groups": [
+        {
+          "id": "54b302e4-07d2-45c5-b2f8-92a286847f9d",
+          "name": "ancd"
+        }
+      ]
     },
     {
       "org_id": "fugiat in quis ea",
@@ -524,8 +381,13 @@
         "nu"
       ],
       "fqdn": null,
-      "id": "ea qui dolor voluptate",
-      "groups": []
+      "id": "ea",
+      "groups": [
+        {
+          "id": "54b303e4-07d2-45c5-b2f8-92a286847f9d",
+          "name": "foobar"
+        }
+      ]
     },
     {
       "org_id": "ut do pariatur consequat",

--- a/cypress/fixtures/hosts.json
+++ b/cypress/fixtures/hosts.json
@@ -622,7 +622,7 @@
           "namespace": "Ut"
         }
       ],
-      "id": "quis enim et",
+      "id": "quis",
       "culled_timestamp": null,
       "fqdn": "cupidatat nisi ut",
       "stale_warning_timestamp": null,

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
@@ -5,10 +5,11 @@ const mountModal = (props =
 {
     isModalOpen: true,
     setIsModalOpen: () => {},
-    modalState: {
-        name: 'host1',
+    modalState: [{
+        // eslint-disable-next-line camelcase
+        display_name: 'host1',
         id: 'host1-id'
-    },
+    }],
     reloadData: () => {}
 }) => {
     cy.mountWithContext(AddSelectedHostsToGroupModal, {}, props);

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
@@ -1,5 +1,5 @@
 import { groupsInterceptors } from '../../../../cypress/support/interceptors';
-import AddHostToGroupModal from './AddHostToGroupModal';
+import AddSelectedHostsToGroupModal from './AddSelectedHostsToGroupModal';
 
 const mountModal = (props =
 {
@@ -11,14 +11,14 @@ const mountModal = (props =
     },
     reloadData: () => {}
 }) => {
-    cy.mountWithContext(AddHostToGroupModal, {}, props);
+    cy.mountWithContext(AddSelectedHostsToGroupModal, {}, props);
 };
 
 before(() => {
     cy.mockWindowChrome();
 });
 
-describe('AddHostToGroupModal', () => {
+describe('AddSelectedHostsToGroupModal', () => {
     it('makes separate requests when searching groups', () => {
         groupsInterceptors['successful with some items']();
         mountModal();

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
@@ -1,21 +1,20 @@
-import React, {  useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from './Modal';
-import { addHostToGroup } from '../utils/api';
+import { addHostsToGroup } from '../utils/api';
 import apiWithToast from '../utils/apiWithToast';
-import { useDispatch  } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { CreateGroupButton } from '../SmallComponents/CreateGroupButton';
 import { addHostSchema } from './ModalSchemas/schemes';
 import CreateGroupModal from './CreateGroupModal';
 
-const AddHostToGroupModal = ({
+const AddSelectedHostsToGroupModal = ({
     isModalOpen,
     setIsModalOpen,
-    modalState,
+    modalState: hosts,
     reloadData
 }) => {
     const dispatch = useDispatch();
-    const { display_name: displayName, id } = modalState;
 
     const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
     const handleAddDevices = (values) => {
@@ -25,12 +24,21 @@ const AddHostToGroupModal = ({
                 title: 'Success',
                 description: `System(s) have been added to ${group.name} successfully`
             },
-            onError: { title: 'Error', description: `Failed to add ${displayName} to ${group.name}` }
+            onError: {
+                title: 'Error',
+                description: `Failed to add ${
+          hosts.length > 1 ? `${hosts.length} systems` : hosts[0].display_name
+        } to ${group.name}`
+            }
         };
 
         apiWithToast(
             dispatch,
-            () => addHostToGroup(group.id, id),
+            () =>
+                addHostsToGroup(
+                    group.id,
+                    hosts.map(({ id }) => id)
+                ),
             statusMessages
         );
     };
@@ -42,7 +50,7 @@ const AddHostToGroupModal = ({
                 closeModal={() => setIsModalOpen(false)}
                 title="Add to group"
                 submitLabel="Add"
-                schema={addHostSchema(displayName)}
+                schema={addHostSchema(hosts)}
                 additionalMappers={{
                     'create-group-btn': {
                         component: CreateGroupButton,
@@ -69,15 +77,17 @@ const AddHostToGroupModal = ({
     );
 };
 
-AddHostToGroupModal.propTypes = {
-    modalState: PropTypes.shape({
-        id: PropTypes.string,
-        // eslint-disable-next-line camelcase
-        display_name: PropTypes.string
-    }),
+AddSelectedHostsToGroupModal.propTypes = {
+    modalState: PropTypes.arrayOf(
+        PropTypes.shape({
+            // eslint-disable-next-line camelcase
+            display_name: PropTypes.string,
+            id: PropTypes.string
+        })
+    ).isRequired,
     isModalOpen: PropTypes.bool,
     setIsModalOpen: PropTypes.func,
     reloadData: PropTypes.func
 };
 
-export default AddHostToGroupModal;
+export default AddSelectedHostsToGroupModal;

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -79,7 +79,7 @@ describe('test data', () => {
             // eslint-disable-next-line camelcase
             ({ group_name }) => !_.isEmpty(group_name)
         );
-        expect(alreadyInGroup[0].id).to.eq('anim commodo');
+        expect(alreadyInGroup[0].id).to.eq('anim');
     });
 });
 
@@ -153,7 +153,7 @@ describe('AddSystemsToGroupModal', () => {
         .its('request.body')
         .should('deep.equal', {
             // eslint-disable-next-line camelcase
-            host_ids: ['host-1', 'host-2', 'anim commodo'] // sends the merged list of hosts
+            host_ids: ['host-1', 'host-2', 'anim'] // sends the merged list of hosts
         });
     });
 

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -44,11 +44,14 @@ export const confirmSystemsAddSchema = (hostsNumber) => ({
     ]
 });
 
-const createDescription = (systemName) => {
+const createDescription = (hosts) => {
     return (
         <Text>
-      Select a group to add <strong>{systemName}</strong> to, or create a new
-      one.
+      Select a group to add{' '}
+            <strong>
+                {hosts.length > 1 ? `${hosts.length} systems` : hosts[0].display_name}
+            </strong>{' '}
+      to, or create a new one.
         </Text>
     );
 };
@@ -56,29 +59,36 @@ const createDescription = (systemName) => {
 //this is a custom schema that is passed via additional mappers to the Modal component
 //it allows to create custom item types in the modal
 
-const loadOptions = awesomeDebouncePromise(async (searchValue = '') => {
-    // add a slight delay for scenarios when a new group has been just created
-    const data = await awesomeDebouncePromise(() => getGroups({ name: searchValue }, {}), 500)();
-    // TODO: make the getGroups requests paginated
-    return (data?.results || []).reduce((acc, { name, id }) => {
-        if (name.toLowerCase().includes(searchValue.trim().toLowerCase())) {
-            return [
-                ...acc,
-                {
-                    label: name,
-                    value: { name, id }
-                }
-            ];
-        }
-    }, []);
-}, 500, { onlyResolvesLast: false });
+const loadOptions = awesomeDebouncePromise(
+    async (searchValue = '') => {
+        // add a slight delay for scenarios when a new group has been just created
+        const data = await awesomeDebouncePromise(
+            () => getGroups({ name: searchValue }, {}),
+            500
+        )();
+        // TODO: make the getGroups requests paginated
+        return (data?.results || []).reduce((acc, { name, id }) => {
+            if (name.toLowerCase().includes(searchValue.trim().toLowerCase())) {
+                return [
+                    ...acc,
+                    {
+                        label: name,
+                        value: { name, id }
+                    }
+                ];
+            }
+        }, []);
+    },
+    500,
+    { onlyResolvesLast: false }
+);
 
-export const addHostSchema = (systemName) => ({
+export const addHostSchema = (hosts) => ({
     fields: [
         {
             component: componentTypes.PLAIN_TEXT,
             name: 'description',
-            label: createDescription(systemName)
+            label: createDescription(hosts)
         },
         {
             component: 'select',

--- a/src/components/InventoryGroups/Modals/RemoveSelectedHostsFromGroupModal.js
+++ b/src/components/InventoryGroups/Modals/RemoveSelectedHostsFromGroupModal.js
@@ -28,7 +28,7 @@ const schema = (groupName, hosts) => ({
     ]
 });
 
-const RemoveHostsFromGroupModal = ({
+const RemoveSelectedHostsFromGroupModal = ({
     isModalOpen,
     setIsModalOpen,
     modalState: hosts,
@@ -77,7 +77,7 @@ const RemoveHostsFromGroupModal = ({
     );
 };
 
-RemoveHostsFromGroupModal.propTypes = {
+RemoveSelectedHostsFromGroupModal.propTypes = {
     modalState: PropTypes.arrayOf(
         PropTypes.shape({
             // eslint-disable-next-line camelcase
@@ -96,4 +96,4 @@ RemoveHostsFromGroupModal.propTypes = {
     reloadData: PropTypes.func
 };
 
-export default RemoveHostsFromGroupModal;
+export default RemoveSelectedHostsFromGroupModal;

--- a/src/components/InventoryGroups/utils/api.js
+++ b/src/components/InventoryGroups/utils/api.js
@@ -49,8 +49,8 @@ export const addHostsToGroupById = (id, hostIds) => {
     );
 };
 
-export const addHostToGroup = (groupId, newHostId) => {
-    return instance.post(`${INVENTORY_API_BASE}/groups/${groupId}/hosts/${newHostId}`);
+export const addHostsToGroup = (groupId, hostIds) => {
+    return instance.post(`${INVENTORY_API_BASE}/groups/${groupId}/hosts/${hostIds.join(',')}`);
 };
 
 export const removeHostsFromGroup = (groupId, hostIds) => {

--- a/src/routes/InventoryTable.cy.js
+++ b/src/routes/InventoryTable.cy.js
@@ -159,12 +159,12 @@ describe('inventory table', () => {
         it('can remove more hosts from the same group', () => {
             cy.intercept(
                 'DELETE',
-                `/api/inventory/v1/groups/${
-                hostsFixtures.results[0].groups[0].id
-                }/hosts/${hostsFixtures.results
-                .slice(0, 2)
-                .map(({ id }) => id)
-                .join(',')}`
+        `/api/inventory/v1/groups/${
+          hostsFixtures.results[0].groups[0].id
+        }/hosts/${hostsFixtures.results
+        .slice(0, 2)
+        .map(({ id }) => id)
+        .join(',')}`
             ).as('request');
 
             cy.get(ROW).find('[type="checkbox"]').eq(0).click();
@@ -177,6 +177,36 @@ describe('inventory table', () => {
 
             cy.get(MODAL).within(() => {
                 cy.get('h1').should('have.text', 'Remove from group');
+                cy.get('button[type="submit"]').click();
+                cy.wait('@request');
+            });
+            cy.wait('@getHosts'); // data must be reloaded
+        });
+
+        it('can add more hosts to existing group', () => {
+            cy.intercept(
+                'POST',
+                `/api/inventory/v1/groups/${
+                groupsFixtures.results.find(({ name }) => name === TEST_GROUP)?.id
+                }/hosts/${hostsFixtures.results
+                .slice(3, 5)
+                .map(({ id }) => id)
+                .join(',')}`
+            ).as('request');
+
+            cy.get(ROW).find('[type="checkbox"]').eq(3).click();
+            cy.get(ROW).find('[type="checkbox"]').eq(4).click();
+
+            // TODO: implement ouia selector for this component
+            cy.get('.ins-c-primary-toolbar__actions [aria-label="Actions"]').click();
+
+            cy.get(DROPDOWN_ITEM).contains('Add to group').click();
+
+            cy.get(MODAL).within(() => {
+                cy.get('h1').should('have.text', 'Add to group');
+                cy.wait('@getGroups');
+                cy.get('.pf-c-select__toggle').click(); // TODO: implement ouia selector for this component
+                cy.get('.pf-c-select__menu-item').contains(TEST_GROUP).click();
                 cy.get('button[type="submit"]').click();
                 cy.wait('@request');
             });

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -172,11 +172,10 @@ const Inventory = ({
         if (calculateSelected() > 0) {
             const selectedHosts = Array.from(selected.values());
 
-            return (
-                selectedHosts.every(({ groups }) => groups.length !== 0) &&
-                    selectedHosts.every(
-                        ({ groups }) => groups[0].name === selectedHosts[0].groups[0].name
-                    )
+            return selectedHosts.every(
+                ({ groups }) =>
+                    groups.length !== 0 &&
+                groups[0].name === selectedHosts[0].groups[0].name
             );
         }
 

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -168,6 +168,21 @@ const Inventory = ({
 
     const calculateSelected = () => selected ? selected.size : 0;
 
+    const isRemoveFromGroupsEnabled = () => {
+        if (calculateSelected() > 0) {
+            const selectedHosts = Array.from(selected.values());
+
+            return (
+                selectedHosts.every(({ groups }) => groups.length !== 0) &&
+                    selectedHosts.every(
+                        ({ groups }) => groups[0].name === selectedHosts[0].groups[0].name
+                    )
+            );
+        }
+
+        return false;
+    };
+
     //This wrapping of table actions allows to pass feature flag status and receive a prepared array of actions
     const tableActions = (groupsUiStatus, row) => {
         const standardActions = [
@@ -244,7 +259,18 @@ const Inventory = ({
                                                 handleModalToggle(true);
                                             }
                                         }
-                                    }]
+                                    },
+                                    {
+                                        label: 'Remove from group',
+                                        props: {
+                                            isDisabled: !isRemoveFromGroupsEnabled()
+                                        },
+                                        onClick: () => {
+                                            setCurrentSystem(Array.from(selected.values()));
+                                            setRemoveHostsFromGroupModalOpen(true);
+                                        }
+                                    }
+                                    ]
                                 },
                                 bulkSelect: bulkSelectConfig
                             })}


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-3731, https://issues.redhat.com/browse/ESSNTL-4197.

This makes it possible to select more hosts and remove or add the to groups.

## How to test

1. Navigate to the inventory table
2. Select more hosts which are not in any group
3. Try to add them to existing group via the Add to group action. In the end you should see the failing network request with 405 status code - it is expected for now.
4. Try to remove hosts from the same group via the Remove from group action. The endpoint is implemented and the operation must be successful. Check the hosts are truly removed from the group.

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/31c5b9fe-1142-4337-96e6-5a70de68cc8c)

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/44f994da-06ee-461a-ad9c-4548754669a5)

