### PR TITLE
fix: Use the same endpoint to add hosts to group

### DIFF
--- a/src/components/InventoryGroups/Modals/AddHostToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddHostToGroupModal.js
@@ -1,7 +1,7 @@
 import React, {  useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from './Modal';
-import { addHostToGroup } from '../utils/api';
+import { addHostsToGroupById } from '../utils/api';
 import apiWithToast from '../utils/apiWithToast';
 import { useDispatch  } from 'react-redux';
 import { CreateGroupButton } from '../SmallComponents/CreateGroupButton';
@@ -30,7 +30,7 @@ const AddHostToGroupModal = ({
 
         apiWithToast(
             dispatch,
-            () => addHostToGroup(group.id, id),
+            () => addHostsToGroupById(group.id, [id]),
             statusMessages
         );
     };

--- a/src/components/InventoryGroups/utils/api.js
+++ b/src/components/InventoryGroups/utils/api.js
@@ -40,10 +40,6 @@ export const addHostsToGroupById = (id, hostIds) => {
     return instance.post(`${INVENTORY_API_BASE}/groups/${id}/hosts`, hostIds);
 };
 
-export const addHostToGroup = (groupId, newHostId) => {
-    return instance.post(`${INVENTORY_API_BASE}/groups/${groupId}/hosts/${newHostId}`);
-};
-
 export const removeHostsFromGroup = (groupId, hostIds) => {
     return instance.delete(`${INVENTORY_API_BASE}/groups/${groupId}/hosts/${hostIds.join(',')}`);
 };

--- a/src/routes/InventoryTable.cy.js
+++ b/src/routes/InventoryTable.cy.js
@@ -104,7 +104,7 @@ describe('inventory table', () => {
 
         it('can add to existing group', () => {
             cy.intercept('POST',
-            `/api/inventory/v1/groups/${groupsFixtures.results[0].id}/hosts/${hostsFixtures.results[1].id}`
+            `/api/inventory/v1/groups/${groupsFixtures.results[0].id}/hosts`
             ).as('request');
             cy.get(ROW).eq(2).find(DROPDOWN).click();
             cy.get(DROPDOWN_ITEM).contains('Add to group').click();
@@ -114,7 +114,7 @@ describe('inventory table', () => {
                 cy.get('.pf-c-select__toggle').click(); // TODO: implement ouia selector for this component
                 cy.get('.pf-c-select__menu-item').eq(0).click();
                 cy.get('button[type="submit"]').click();
-                cy.wait('@request');
+                cy.wait('@request').its('request.body').should('deep.equal', [hostsFixtures.results[1].id]);
             });
             cy.wait('@getHosts'); // data must be reloaded
         });


### PR DESCRIPTION
(no jira)

This makes the AddHostToGroupModal use the same endpoints as in the groups systems table. The previous has implementation problems and is still not available to use. The working once receives the list of hosts to add in the body instead of listing them in URL.

## How to test

1. Navigate to /inventory
2. Select any host which is not in a group
3. Add the host to any group and make sure the operation is successful