### PR TITLE
fix(ESSNTL-4745):Enable custom dates for lastSeen filter

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -47,12 +47,11 @@ export const lastSeenItems = [
     {
         value: { updatedEnd: subtractDate(30), mark: '30more' },
         label: 'More than 30 days ago'
+    },
+    {
+        value: { mark: 'custom' },
+        label: 'Custom'
     }
-    //Temporarily disabled
-    // {
-    //     value: { mark: 'custom' },
-    //     label: 'Custom'
-    // }
 ];
 export const registered = [
     { label: 'insights-client', value: 'puptoo', idName: 'Insights id', idValue: 'insights_id' },

--- a/src/components/filters/helpers.js
+++ b/src/components/filters/helpers.js
@@ -36,3 +36,9 @@ export const toValidator = (minDate) => (dateToValidate) => {
         return '';
     }
 };
+
+export const containsSpecialChars = (str) => {
+    // eslint-disable-next-line no-useless-escape
+    const specialChars = /[`!@#$%^&*()_+\=\[\]{};':"\\|,.<>\/?~]/;
+    return specialChars.test(str);
+};

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { LAST_SEEN_CHIP, lastSeenItems } from '../../Utilities/constants';
 import moment from 'moment';
-import { oldestDate } from './helpers.js';
+import { containsSpecialChars, oldestDate } from './helpers.js';
 export const lastSeenFilterState = { lastSeenFilter: [] };
 export const LAST_SEEN_FILTER = 'LAST_SEEN_FILTER';
 export const lastSeenFilterReducer = (_state, { type, payload }) => ({
@@ -90,28 +90,34 @@ export const useLastSeenFilter = (
     //This date comes from patternfly component. This manages the 1st date picker
     const onFromChange = (date) => {
         const newToDate = moment(endDate).endOf('day');
-        if (date > newToDate) {
-            setStartDate();
-            return 'End date must be later than Start date.';
+        const todaysDate = moment().endOf('day');
+        const selectedFromDate = moment(date).startOf('day');
+
+        if (!containsSpecialChars(date) && selectedFromDate < todaysDate) {
+            if (date > newToDate) {
+                setStartDate();
+                return 'End date must be later than Start date.';
+            }
+
+            setStartDate(date);
+            const apiStartDate = moment(date).startOf('day');
+            manageStartDate(apiStartDate, newToDate);
         }
-
-        setStartDate(date);
-        const apiStartDate = moment(date).startOf('day');
-
-        manageStartDate(apiStartDate, newToDate);
     };
 
     //This date comes from patternfly component. This manages the 2nd date picker
     const onToChange = (date) => {
-        if (startDate > moment(date)) {
-            return 'Start date must be earlier than End date.';
-        } else if (moment(date) > todaysDate) {
-            return 'End date must be later than Start date.';
-        } else {
-            setEndDate(date);
-            const apiEndDate = moment(date).endOf('day');
-            manageEndDate(moment(startDate), apiEndDate);
-        }
+
+        if (!containsSpecialChars(date)) {
+            if (startDate > moment(date)) {
+                return 'Start date must be earlier than End date.';
+            } else if (moment(date) > todaysDate) {
+                return 'End date must be later than Start date.';
+            } else {
+                setEndDate(date);
+                const apiEndDate = moment(date).endOf('day');
+                manageEndDate(moment(startDate), apiEndDate);
+            }}
     };
 
     return [


### PR DESCRIPTION
This PR enables custom Dates for last seen filter and addresses additional edgecases discussed here : https://issues.redhat.com/browse/ESSNTL-4746 

To test, select the last seen filter custom option,
type in unique characters like {{' , '2023-04-21' in the end date field and make sure it doesnt break anything.

For the second edge case, input two identical FUTURE dates in first the end date and then in the start date inputs. Then erase the end date input. Verify that nothing breaks. 