### PR TITLE
fix: Hide bulk add to/remove from group under FF

### DIFF
--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -269,26 +269,27 @@ const Inventory = ({
                                             }
                                         }
                                     },
-                                    {
-                                        label: 'Add to group',
-                                        props: {
-                                            isDisabled: !isBulkAddHostsToGroupsEnabled()
+                                    ...groupsEnabled ? [
+                                        {
+                                            label: 'Add to group',
+                                            props: {
+                                                isDisabled: !isBulkAddHostsToGroupsEnabled()
+                                            },
+                                            onClick: () => {
+                                                setCurrentSystem(Array.from(selected.values()));
+                                                setAddHostGroupModalOpen(true);
+                                            }
                                         },
-                                        onClick: () => {
-                                            setCurrentSystem(Array.from(selected.values()));
-                                            setAddHostGroupModalOpen(true);
-                                        }
-                                    },
-                                    {
-                                        label: 'Remove from group',
-                                        props: {
-                                            isDisabled: !isBulkRemoveFromGroupsEnabled()
-                                        },
-                                        onClick: () => {
-                                            setCurrentSystem(Array.from(selected.values()));
-                                            setRemoveHostsFromGroupModalOpen(true);
-                                        }
-                                    }
+                                        {
+                                            label: 'Remove from group',
+                                            props: {
+                                                isDisabled: !isBulkRemoveFromGroupsEnabled()
+                                            },
+                                            onClick: () => {
+                                                setCurrentSystem(Array.from(selected.values()));
+                                                setRemoveHostsFromGroupModalOpen(true);
+                                            }
+                                        }] : []
                                     ]
                                 },
                                 bulkSelect: bulkSelectConfig


### PR DESCRIPTION
On the systems page (/inventory), the bulk addition to or removal from a group must be hidden if the feature flag is set to false.