### PR TITLE
fix: Fix the create group modal not opening

### DIFF
--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
@@ -41,6 +41,7 @@ const AddSelectedHostsToGroupModal = ({
 
     return (
         <>
+            {!isCreateGroupModalOpen &&
             <Modal
                 isModalOpen={isModalOpen}
                 closeModal={() => setIsModalOpen(false)}
@@ -50,15 +51,13 @@ const AddSelectedHostsToGroupModal = ({
                 additionalMappers={{
                     'create-group-btn': {
                         component: CreateGroupButton,
-                        closeModal: () => {
-                            setIsCreateGroupModalOpen(true);
-                            setIsModalOpen(false);
-                        }
+                        closeModal: () => setIsCreateGroupModalOpen(true)
                     }
                 }}
                 onSubmit={handleAddDevices}
                 reloadData={reloadData}
             />
+            }
             {isCreateGroupModalOpen && (
                 <CreateGroupModal
                     isModalOpen={isCreateGroupModalOpen}

--- a/src/routes/InventoryTable.cy.js
+++ b/src/routes/InventoryTable.cy.js
@@ -215,5 +215,13 @@ describe('inventory table', () => {
             });
             cy.wait('@getHosts'); // data must be reloaded
         });
+
+        it('can add to a new group', () => {
+            cy.get(ROW).find('[type="checkbox"]').eq(3).click();
+            cy.get('.ins-c-primary-toolbar__actions [aria-label="Actions"]').click();
+            cy.get(DROPDOWN_ITEM).contains('Add to group').click();
+            cy.get(MODAL).find('button').contains('Create a new group').click();
+            cy.get(MODAL).find('h1').should('have.text', 'Create group');
+        });
     });
 });


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-3730.

## How to test

1. Navigate to /inventory.
2. Find a host not assigned to any group and click "Add to group"
3. Click on "Create a new group" and make sure the modal opens, you are able to create a new group, you are redirected back to the first modal and you can finally add the host to the newly created group.