### PR TITLE
Lift async use effect callback.

### DIFF
--- a/src/components/InventoryGroups/InventoryGroups.js
+++ b/src/components/InventoryGroups/InventoryGroups.js
@@ -15,8 +15,8 @@ const InventoryGroups = () => {
     const [hasGroups, setHasGroups] = useState(false);
     const [hasError, setHasError] = useState(false);
 
-    useEffect(async () => {
-    // make initial request to check if there is at least one group available
+    const handleLoading = async () => {
+        // make initial request to check if there is at least one group available
         try {
             const { total } = await getGroups();
 
@@ -28,6 +28,10 @@ const InventoryGroups = () => {
         }
 
         setIsLoading(false);
+    };
+
+    useEffect(() => {
+        handleLoading();
     }, []);
 
     return (


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-26362

The `useEffect` hook can't use async callback function. Any async side effects have to be lifted out of the hook.