### PR TITLE
fix(RederWrapper): ESSNTL-4954 - Remove check for all permissions

### DIFF
--- a/src/Utilities/Wrapper.js
+++ b/src/Utilities/Wrapper.js
@@ -4,7 +4,6 @@ import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-compo
 
 const RenderWrapper = ({ cmp: Component, isRbacEnabled, inventoryRef, store, ...props }) => {
     const { hasAccess } = usePermissionsWithContext([
-        'inventory:*:*',
         'inventory:*:read',
         'inventory:hosts:read'
     ]);
@@ -12,12 +11,12 @@ const RenderWrapper = ({ cmp: Component, isRbacEnabled, inventoryRef, store, ...
     return (
         <Component
             {...props}
-            { ...inventoryRef && {
+            {...inventoryRef && {
                 ref: inventoryRef
             }}
             isRbacEnabled={isRbacEnabled}
             hasAccess={isRbacEnabled ? hasAccess : true}
-            store={ store }
+            store={store}
         />
     );
 };


### PR DESCRIPTION
The permissions are too strict, this high up.
Read permissions should be enough to view an inventory component.

**How to test:**

1) Create an user with only the "Compliance viewer" role
2) Visit the Compliance -> Systems page
3) With this the page should be accessible