### PR TITLE
fix(ESSNTL-4746): LastSeen filter backend edge case

### DIFF
--- a/src/components/filters/helpers.js
+++ b/src/components/filters/helpers.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-export const oldestDate = new Date(1950, 1, 1);
+export const oldestDate = new Date(1970, 1, 1);
 //validators control what date ranges can be selected in the component.
 //both validators need to keep in mind todays date, and the other components inputed date.
 

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -94,10 +94,10 @@ export const useLastSeenFilter = (
         const todaysDate = moment().endOf('day');
         const selectedFromDate = moment(date).startOf('day');
 
-        if (!containsSpecialChars(date) &&
+        if ((!containsSpecialChars(date) &&
          selectedFromDate < todaysDate &&
           date.length > DEFAULT_DATE_LENGTH &&
-           selectedFromDate > oldestDate) {
+           selectedFromDate > oldestDate) || date.length === 0) {
             if (date > newToDate) {
                 setStartDate();
                 return 'End date must be later than Start date.';
@@ -112,7 +112,7 @@ export const useLastSeenFilter = (
     //This date comes from patternfly component. This manages the 2nd date picker
     const onToChange = (date) => {
 
-        if (!containsSpecialChars(date) && date.length > DEFAULT_DATE_LENGTH) {
+        if ((!containsSpecialChars(date) && date.length > DEFAULT_DATE_LENGTH) || date.length === 0) {
             if (startDate > moment(date)) {
                 return 'Start date must be earlier than End date.';
             } else if (moment(date) > todaysDate) {

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { containsSpecialChars, oldestDate } from './helpers.js';
 export const lastSeenFilterState = { lastSeenFilter: [] };
 export const LAST_SEEN_FILTER = 'LAST_SEEN_FILTER';
+export const DEFAULT_DATE_LENGTH = 9;
 export const lastSeenFilterReducer = (_state, { type, payload }) => ({
     ...(type === LAST_SEEN_FILTER && {
         lastSeenFilter: payload
@@ -93,7 +94,10 @@ export const useLastSeenFilter = (
         const todaysDate = moment().endOf('day');
         const selectedFromDate = moment(date).startOf('day');
 
-        if (!containsSpecialChars(date) && selectedFromDate < todaysDate && date.length > 9 && selectedFromDate > oldestDate) {
+        if (!containsSpecialChars(date) &&
+         selectedFromDate < todaysDate &&
+          date.length > DEFAULT_DATE_LENGTH &&
+           selectedFromDate > oldestDate) {
             if (date > newToDate) {
                 setStartDate();
                 return 'End date must be later than Start date.';
@@ -108,7 +112,7 @@ export const useLastSeenFilter = (
     //This date comes from patternfly component. This manages the 2nd date picker
     const onToChange = (date) => {
 
-        if (!containsSpecialChars(date) && date.length > 9) {
+        if (!containsSpecialChars(date) && date.length > DEFAULT_DATE_LENGTH) {
             if (startDate > moment(date)) {
                 return 'Start date must be earlier than End date.';
             } else if (moment(date) > todaysDate) {

--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -93,7 +93,7 @@ export const useLastSeenFilter = (
         const todaysDate = moment().endOf('day');
         const selectedFromDate = moment(date).startOf('day');
 
-        if (!containsSpecialChars(date) && selectedFromDate < todaysDate) {
+        if (!containsSpecialChars(date) && selectedFromDate < todaysDate && date.length > 9 && selectedFromDate > oldestDate) {
             if (date > newToDate) {
                 setStartDate();
                 return 'End date must be later than Start date.';
@@ -108,7 +108,7 @@ export const useLastSeenFilter = (
     //This date comes from patternfly component. This manages the 2nd date picker
     const onToChange = (date) => {
 
-        if (!containsSpecialChars(date)) {
+        if (!containsSpecialChars(date) && date.length > 9) {
             if (startDate > moment(date)) {
                 return 'Start date must be earlier than End date.';
             } else if (moment(date) > todaysDate) {


### PR DESCRIPTION
The backend returns a 503 in specific scenarios, this PR adds additional edge cases to lastSeen filter while the backend figures out the issue. This also allows the check on both ends. 

To test, 
Try entering random strings in the custom date inputs, 
Try entering incomplete dates, like 201 or 192,
Enter years well past our time like 1900s