### PR TITLE
fix(RHIENG-747): Fix the group delete modal behavior

### DIFF
--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -55,14 +55,14 @@ export const groupsInterceptors = {
 };
 
 export const groupDetailInterceptors = {
-    successful: () =>
+    successful: (fixtures = groupDetailFixtures) =>
         cy
         .intercept(
             'GET',
             '/api/inventory/v1/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C',
             {
                 statusCode: 200,
-                body: groupDetailFixtures
+                body: fixtures
             }
         )
         .as('getGroupDetail'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4284,11 +4284,6 @@
         "axios": "^0.21.1"
       }
     },
-    "node_modules/@redhat-cloud-services/types": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
-      "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
-    },
     "node_modules/@scalprum/core": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.5.1.tgz",
@@ -29575,11 +29570,6 @@
       "requires": {
         "axios": "^0.21.1"
       }
-    },
-    "@redhat-cloud-services/types": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
-      "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
     },
     "@scalprum/core": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "verify": "npm-run-all build lint test",
     "nightly": "npm run travis:verify",
     "start:federated": "fec static --config config/dev.webpack.config.js",
-    "test:ct": "BABEL_ENV=componentTest cypress run --component --browser chromium",
+    "test:ct": "BABEL_ENV=componentTest cypress run --component --browser chrome",
     "test:openct": "BABEL_ENV=componentTest cypress open --component",
     "test:openct:mock": "MOCK=true npm run test:openct",
     "coverage": "bash coverage.sh",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "verify": "npm-run-all build lint test",
     "nightly": "npm run travis:verify",
     "start:federated": "fec static --config config/dev.webpack.config.js",
-    "test:ct": "BABEL_ENV=componentTest cypress run --component --browser chrome",
+    "test:ct": "BABEL_ENV=componentTest cypress run --component --browser chromium",
     "test:openct": "BABEL_ENV=componentTest cypress open --component",
     "test:openct:mock": "MOCK=true npm run test:openct",
     "coverage": "bash coverage.sh",

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -85,6 +85,7 @@ const GroupDetailHeader = ({ groupId }) => {
                                 onToggle={(isOpen) => setDropdownOpen(isOpen)}
                                 toggleVariant="secondary"
                                 isDisabled={uninitialized || loading}
+                                ouiaId='group-actions-dropdown-toggle'
                             >
                                 Group actions
                             </DropdownToggle>

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
@@ -1,23 +1,20 @@
-import { mount } from '@cypress/react';
-import { DROPDOWN, DROPDOWN_ITEM, MODAL } from '@redhat-cloud-services/frontend-components-utilities';
-import React from 'react';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
+import {
+    DROPDOWN_ITEM,
+    MODAL
+} from '@redhat-cloud-services/frontend-components-utilities';
 import groupDetailFixtures from '../../../cypress/fixtures/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C.json';
-import { groupDetailInterceptors, groupsInterceptors } from '../../../cypress/support/interceptors';
-import { getStore } from '../../store';
+import {
+    groupDetailInterceptors,
+    groupsInterceptors
+} from '../../../cypress/support/interceptors';
 import InventoryGroupDetail from './InventoryGroupDetail';
 
 const TEST_GROUP_ID = '620f9ae75A8F6b83d78F3B55Af1c4b2C';
 
 const mountPage = () =>
-    mount(
-        <Provider store={getStore()}>
-            <MemoryRouter>
-                <InventoryGroupDetail groupId={TEST_GROUP_ID} />
-            </MemoryRouter>
-        </Provider>
-    );
+    cy.mountWithContext(InventoryGroupDetail, undefined, {
+        groupId: TEST_GROUP_ID
+    });
 
 before(() => {
     cy.mockWindowChrome();
@@ -35,31 +32,22 @@ describe('group detail page', () => {
         .should('have.text', groupDetailFixtures.results[0].name);
     });
 
-    /*  TODO: fix this test (affected the execution of the next tests and made them flaky)
-        it('skeletons rendered while fetching data', () => {
-        // TODO: after each hook fails for some reason for this particular test
-        Cypress.on('uncaught:exception', () => {
-            return false;
-        });
-
-        interceptors['long responding']();
+    it('skeletons rendered while fetching data', () => {
+        groupDetailInterceptors['long responding']();
         mountPage();
 
         cy.get('[data-ouia-component-type="PF4/Breadcrumb"] li').last().find('.pf-c-skeleton');
         cy.get('h1').find('.pf-c-skeleton');
         cy.get('.pf-c-empty-state').find('.pf-c-spinner');
     });
-    */
 
-    it('can open rename group modal', () => {
+    it('can rename group', () => {
         groupsInterceptors['successful with some items'](); // intercept modal validation requests
         groupDetailInterceptors.successful();
         groupDetailInterceptors['patch successful']();
         mountPage();
 
-        cy.wait('@getGroupDetail');
-
-        cy.get(DROPDOWN).click();
+        cy.ouiaId('group-actions-dropdown-toggle').should('be.enabled').click();
         cy.get(DROPDOWN_ITEM).contains('Rename').click();
 
         cy.get(MODAL).find('input').type('1');
@@ -70,13 +58,12 @@ describe('group detail page', () => {
         cy.wait('@getGroupDetail'); // the page is refreshed after submition
     });
 
-    it('can open delete group modal', () => {
+    it('can delete an empty group', () => {
         groupDetailInterceptors.successful();
         groupDetailInterceptors['delete successful']();
         mountPage();
-        cy.wait('@getGroupDetail');
 
-        cy.get(DROPDOWN).click();
+        cy.ouiaId('group-actions-dropdown-toggle').should('be.enabled').click();
         cy.get(DROPDOWN_ITEM).contains('Delete').click();
 
         cy.get(`div[class="pf-c-check"]`).click();


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-747.

Users should stay on the same page and the data they see must be not reloaded after closing group deletion modal.

## How to test

1. Find an Inventory group with at least one host and go to its details page.
2. Try to delete the group. You should see the modal saying you are unable to do that.
3. Click on the Close button and make sure the page is not reloaded/navigated to another view.
