### PR TITLE
feat(ESSNTL-4935): Should disable actions at /groups

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -66,19 +66,22 @@ Cypress.Commands.add('mountWithContext', (Component, options = {}, props) => {
 });
 
 // one of the fec dependencies talks to window.insights.chrome
-Cypress.Commands.add('mockWindowChrome', () => {
-  cy.window().then(
-    // one of the fec dependencies talks to window.insights.chrome
-    (window) =>
-      (window.insights = {
-        chrome: {
-          getUserPermissions: () => ['inventory:*:*'], // enable all read/write features
-          auth: {
-            getUser: () => {
-              return Promise.resolve({});
+Cypress.Commands.add(
+  'mockWindowChrome',
+  ({ userPermissions } = { userPermissions: ['inventory:*:*'] }) => {
+    cy.window().then(
+      // one of the fec dependencies talks to window.insights.chrome
+      (window) =>
+        (window.insights = {
+          chrome: {
+            getUserPermissions: () => userPermissions, // enable all read/write features
+            auth: {
+              getUser: () => {
+                return Promise.resolve({});
+              },
             },
           },
-        },
-      })
-  );
-});
+        })
+    );
+  }
+);

--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -91,7 +91,7 @@ describe('renders correctly', () => {
     waitForTable();
   });
 
-  it.only('the root container is rendered', () => {
+  it('the root container is rendered', () => {
     cy.get(ROOT);
   });
 

--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -286,8 +286,13 @@ describe('actions', () => {
   const TEST_ID = 0;
 
   it('bulk rename and delete actions are disabled when no items selected', () => {
-    cy.get(`${TOOLBAR} ${DROPDOWN}`).eq(1).click(); // open bulk action toolbar
-    cy.get(DROPDOWN_ITEM).should('have.class', 'pf-m-disabled');
+    cy.ouiaId('Actions').should('exist').click();
+    cy.get(DROPDOWN_ITEM)
+      .contains('Rename group')
+      .should('have.attr', 'aria-disabled', 'true');
+    cy.get(DROPDOWN_ITEM)
+      .contains('Delete group')
+      .should('have.attr', 'aria-disabled', 'true');
   });
 
   it('can rename a group, 1', () => {

--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -430,3 +430,30 @@ describe('edge cases', () => {
     });
   });
 });
+
+describe('integration with rbac', () => {
+  before(() => {
+    cy.mockWindowChrome(['inventory:groups:read']);
+  });
+
+  beforeEach(() => {
+    interceptors['successful with some items'](); // comment out if the mock server is running
+    mountTable();
+
+    cy.get('table[aria-label="Groups table"]').should(
+      'have.attr',
+      'data-ouia-safe',
+      'true'
+    );
+  });
+
+  it('disables selection', () => {
+    cy.ouiaId('groups-selector').should('not.exist');
+    cy.get(`${ROW} .pf-c-table__check`).should('not.exist');
+  });
+
+  it('disables actions', () => {
+    cy.ouiaId('Actions').should('not.exist');
+    cy.get(ROW).find(`${DROPDOWN} button`).should('not.exist');
+  });
+});

--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -431,7 +431,7 @@ describe('edge cases', () => {
   });
 });
 
-describe.only('integration with rbac', () => {
+describe('integration with rbac', () => {
   before(() => {
     cy.mockWindowChrome(['inventory:groups:read']);
   });
@@ -447,7 +447,7 @@ describe.only('integration with rbac', () => {
     );
   });
 
-  it.only('disables general actions', () => {
+  it('disables general actions', () => {
     cy.ouiaId('Actions').should('exist').click();
 
     cy.get(TOOLBAR)
@@ -462,7 +462,7 @@ describe.only('integration with rbac', () => {
       .should('have.attr', 'aria-disabled', 'true');
   });
 
-  it.only('disables per-row actions', () => {
+  it('disables per-row actions', () => {
     cy.get(ROW).eq(1).find(`${DROPDOWN} button`).click();
 
     cy.get(DROPDOWN_ITEM)

--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -431,7 +431,7 @@ describe('edge cases', () => {
   });
 });
 
-describe('integration with rbac', () => {
+describe.only('integration with rbac', () => {
   before(() => {
     cy.mockWindowChrome(['inventory:groups:read']);
   });
@@ -447,13 +447,29 @@ describe('integration with rbac', () => {
     );
   });
 
-  it('disables selection', () => {
-    cy.ouiaId('groups-selector').should('not.exist');
-    cy.get(`${ROW} .pf-c-table__check`).should('not.exist');
+  it.only('disables general actions', () => {
+    cy.ouiaId('Actions').should('exist').click();
+
+    cy.get(TOOLBAR)
+      .find('button')
+      .contains('Create group')
+      .should('have.attr', 'aria-disabled', 'true');
+    cy.get(DROPDOWN_ITEM)
+      .contains('Rename group')
+      .should('have.attr', 'aria-disabled', 'true');
+    cy.get(DROPDOWN_ITEM)
+      .contains('Delete group')
+      .should('have.attr', 'aria-disabled', 'true');
   });
 
-  it('disables actions', () => {
-    cy.ouiaId('Actions').should('not.exist');
-    cy.get(ROW).find(`${DROPDOWN} button`).should('not.exist');
+  it.only('disables per-row actions', () => {
+    cy.get(ROW).eq(1).find(`${DROPDOWN} button`).click();
+
+    cy.get(DROPDOWN_ITEM)
+      .contains('Rename group')
+      .should('have.attr', 'aria-disabled', 'true');
+    cy.get(DROPDOWN_ITEM)
+      .contains('Delete group')
+      .should('have.attr', 'aria-disabled', 'true');
   });
 });

--- a/src/components/InventoryGroups/InventoryGroups.cy.js
+++ b/src/components/InventoryGroups/InventoryGroups.cy.js
@@ -25,7 +25,6 @@ describe('groups table page', () => {
     mountPage();
     cy.wait('@getGroups');
 
-    cy.get('h1').contains('Groups');
     cy.get('#groups-table');
   });
 
@@ -34,7 +33,6 @@ describe('groups table page', () => {
     mountPage();
     cy.wait('@getGroups');
 
-    cy.get('h1').contains('Groups');
     cy.get('#groups-table').should('not.exist');
     cy.get('.pf-c-empty-state').find('h4').contains('Create a system group');
   });
@@ -44,7 +42,6 @@ describe('groups table page', () => {
     mountPage();
     cy.wait('@getGroups');
 
-    cy.get('h1').contains('Groups');
     cy.get('#groups-table').should('not.exist');
     cy.get('.pf-c-empty-state').find('h4').contains('Something went wrong');
   });

--- a/src/components/InventoryGroups/InventoryGroups.js
+++ b/src/components/InventoryGroups/InventoryGroups.js
@@ -1,9 +1,4 @@
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
-import {
-  PageHeader,
-  PageHeaderTitle,
-} from '@redhat-cloud-services/frontend-components/PageHeader';
-
 import React, { useEffect, useRef, useState } from 'react';
 
 import { Bullseye, Spinner } from '@patternfly/react-core';
@@ -42,24 +37,22 @@ const InventoryGroups = () => {
   }, []);
 
   return (
-    <React.Fragment>
-      <PageHeader>
-        <PageHeaderTitle title="Groups" />
-      </PageHeader>
-      <section className="pf-l-page__main-section pf-c-page__main-section">
-        {hasError ? (
-          <ErrorState />
-        ) : isLoading ? (
-          <Bullseye>
-            <Spinner />
-          </Bullseye>
-        ) : hasGroups ? (
-          <GroupsTable />
-        ) : (
-          <NoGroupsEmptyState reloadData={handleLoading} />
-        )}
-      </section>
-    </React.Fragment>
+    <section
+      className="pf-l-page__main-section pf-c-page__main-section"
+      data-ouia-component-id="groups-table-wrapper"
+    >
+      {hasError ? (
+        <ErrorState />
+      ) : isLoading ? (
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      ) : hasGroups ? (
+        <GroupsTable />
+      ) : (
+        <NoGroupsEmptyState reloadData={handleLoading} />
+      )}
+    </section>
   );
 };
 

--- a/src/routes/InventoryGroups.js
+++ b/src/routes/InventoryGroups.js
@@ -1,15 +1,47 @@
 import React, { useEffect } from 'react';
 import InventoryGroups from '../components/InventoryGroups';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import AccessDenied from '../Utilities/AccessDenied';
+import { EmptyStateVariant } from '@patternfly/react-core';
+import {
+  PageHeader,
+  PageHeaderTitle,
+} from '@redhat-cloud-services/frontend-components/PageHeader';
+
+const REQUIRED_PERMISSIONS = ['inventory:groups:read'];
 
 const Groups = () => {
   const chrome = useChrome();
+  const { hasAccess } = usePermissionsWithContext(REQUIRED_PERMISSIONS);
 
   useEffect(() => {
     chrome?.updateDocumentTitle?.('Inventory Groups | Red Hat Insights');
   }, [chrome]);
 
-  return <InventoryGroups />;
+  return (
+    <React.Fragment>
+      <PageHeader>
+        <PageHeaderTitle title="Groups" />
+      </PageHeader>
+      {hasAccess ? (
+        <InventoryGroups />
+      ) : (
+        <AccessDenied
+          title="Inventory group access permissions needed"
+          showReturnButton={false}
+          description={
+            <div>
+              You do not have the necessary inventory group permissions to see
+              inventory groups. Contact your organization administrator for
+              access.
+            </div>
+          }
+          variant={EmptyStateVariant.large} // overrides the default "full" value
+        />
+      )}
+    </React.Fragment>
+  );
 };
 
 export default Groups;

--- a/src/routes/InventoryGroups.test.js
+++ b/src/routes/InventoryGroups.test.js
@@ -1,0 +1,43 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import InventoryGroups from './InventoryGroups';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/RBACHook',
+  () => ({
+    usePermissionsWithContext: jest.fn(),
+  })
+);
+
+describe('inventory groups route', () => {
+  it('renders empty state when access forbidden', () => {
+    usePermissionsWithContext.mockImplementation(() => ({
+      hasAccess: false,
+    }));
+
+    const { container, getByText } = render(<InventoryGroups />);
+
+    expect(container.querySelector('h1')).toHaveTextContent('Groups');
+    expect(
+      getByText('Inventory group access permissions needed')
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-ouia-component-id="groups-table-wrapper"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders table wrapper when access allowed', () => {
+    usePermissionsWithContext.mockImplementation(() => ({
+      hasAccess: true,
+    }));
+
+    const { container } = render(<InventoryGroups />);
+
+    expect(container.querySelector('h1')).toHaveTextContent('Groups');
+    expect(
+      container.querySelector('[data-ouia-component-id="groups-table-wrapper"]')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-4935.

The /groups view must disable actions if users don't have `inventory:groups:write` permission.

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/b7afcfcd-adc5-4fbb-ac70-6959b07457fc)
