### PR TITLE
fix(RHINENG-736): Vulnerability and Patch tab in Inventory don't show data for RHSM stystems

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -12,6 +12,10 @@ export const RHCD_FILTER_KEY = 'rhc_client_id';
 export const UPDATE_METHOD_KEY = 'system_update_method';
 export const LAST_SEEN_CHIP = 'last_seen';
 export const HOST_GROUP_CHIP = 'group_name'; // use the same naming as for the back end parameter
+//REPORTERS
+export const REPORTER_PUPTOO = 'puptoo';
+export const REPORTER_RHSM_CONDUIT = 'rhsm-conduit';
+export const REPORTER_RHSM_PROFILE_BRIDGE = 'rhsm-system-profile-bridge';
 
 export function subtractDate(days) {
   const date = new Date();

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -16,6 +16,10 @@ export const HOST_GROUP_CHIP = 'group_name'; // use the same naming as for the b
 export const REPORTER_PUPTOO = 'puptoo';
 export const REPORTER_RHSM_CONDUIT = 'rhsm-conduit';
 export const REPORTER_RHSM_PROFILE_BRIDGE = 'rhsm-system-profile-bridge';
+//APP NAMES
+export const APP_NAME_VULNERABILITY = 'vulnerabilities';
+export const APP_NAME_ADVISOR = 'advisor';
+export const APP_NAME_PATCH = 'patch';
 
 export function subtractDate(days) {
   const date = new Date();

--- a/src/Utilities/sharedFunctions.js
+++ b/src/Utilities/sharedFunctions.js
@@ -27,12 +27,14 @@ export const verifyCollectorStaleness = (reporterStaleness) => {
   }
 };
 
-export const verifyCulledInsightsClient = (perReporterStaleness) => {
+export const verifyCulledReporter = (perReporterStaleness, reporter) => {
   //TODO: get rid of !perReporterStaleness condition when dependant apps have per_reporter_staleness info
   if (!perReporterStaleness) {
     return false;
-  } else if (perReporterStaleness.puptoo) {
-    return verifyCollectorStaleness(perReporterStaleness.puptoo) === 'Culled';
+  } else if (perReporterStaleness[reporter]) {
+    return (
+      verifyCollectorStaleness(perReporterStaleness[reporter]) === 'Culled'
+    );
   } else {
     return true;
   }

--- a/src/Utilities/sharedFunctions.test.js
+++ b/src/Utilities/sharedFunctions.test.js
@@ -1,19 +1,23 @@
 /* eslint-disable no-constant-condition */
-import { subtractWeeks, verifyCulledInsightsClient } from './sharedFunctions';
+import { REPORTER_PUPTOO } from './constants';
+import { subtractWeeks, verifyCulledReporter } from './sharedFunctions';
 
 describe('sharedFunctions', () => {
   describe('verfiyDisconnectedSystem', () => {
     it('should return false when puptoo is undefined', () => {
-      const result = verifyCulledInsightsClient({});
+      const result = verifyCulledReporter({}, REPORTER_PUPTOO);
       expect(result).toBeTruthy();
     });
 
     it('should return false when puptoo is defined and stale_timestamp is not more recent than 2 weeks ago', () => {
       const testDate = subtractWeeks(1);
       // eslint-disable-next-line camelcase
-      const result = verifyCulledInsightsClient({
-        puptoo: { stale_timestamp: testDate.toDateString() },
-      });
+      const result = verifyCulledReporter(
+        {
+          puptoo: { stale_timestamp: testDate.toDateString() },
+        },
+        REPORTER_PUPTOO
+      );
       expect(result).toBeFalsy();
     });
   });

--- a/src/components/InventoryDetail/ApplicationDetails.js
+++ b/src/components/InventoryDetail/ApplicationDetails.js
@@ -1,11 +1,18 @@
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useStore } from 'react-redux';
 import { Spinner, Tab, TabContent, Tabs } from '@patternfly/react-core';
 import { verifyCulledReporter } from '../../Utilities/sharedFunctions';
 import { getFact } from './helpers';
 import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
-import { REPORTER_PUPTOO } from '../../Utilities/constants';
+import {
+  APP_NAME_ADVISOR,
+  APP_NAME_PATCH,
+  APP_NAME_VULNERABILITY,
+  REPORTER_PUPTOO,
+  REPORTER_RHSM_CONDUIT,
+  REPORTER_RHSM_PROFILE_BRIDGE,
+} from '../../Utilities/constants';
 
 /**
  * Component that renders tabs for each application detail and handles clicking on each item.
@@ -34,6 +41,8 @@ const ApplicationDetails = ({
   const [activeTabs, setActiveTabs] = useState(items);
   const [currentApp, setCurrentApp] = useState(activeApp || items?.[0]?.name);
 
+  const perReporterStaleness = getFact('per_reporter_staleness', entity);
+
   useEffect(() => {
     const filteredResult = items.filter(
       (app) => !disabledApps?.includes(app.name)
@@ -45,10 +54,25 @@ const ApplicationDetails = ({
     }
   }, [disabledApps]);
 
-  const isDisconnected = verifyCulledReporter(
-    getFact('per_reporter_staleness', entity),
-    REPORTER_PUPTOO
+  const isDisconnected = useMemo(
+    () => verifyCulledReporter(perReporterStaleness, REPORTER_PUPTOO),
+    [currentApp]
   );
+
+  const isRHSMSystem = useMemo(() => {
+    const rhsmConduit =
+      !!perReporterStaleness?.[REPORTER_RHSM_CONDUIT] &&
+      !verifyCulledReporter(perReporterStaleness, REPORTER_RHSM_CONDUIT);
+    const rhsmBridge = !!perReporterStaleness?.[REPORTER_RHSM_PROFILE_BRIDGE];
+    return rhsmBridge && rhsmConduit;
+  }, [currentApp]);
+
+  const isEmptyState = (currentApp) =>
+    (currentApp === APP_NAME_ADVISOR && isDisconnected) ||
+    (currentApp === APP_NAME_VULNERABILITY &&
+      !isRHSMSystem &&
+      isDisconnected) ||
+    (currentApp === APP_NAME_PATCH && !isRHSMSystem && isDisconnected);
 
   return (
     <React.Fragment>
@@ -95,10 +119,7 @@ const ApplicationDetails = ({
                 {item.name === currentApp && (
                   <Suspense fallback={Spinner}>
                     <section className="pf-c-page__main-section">
-                      {isDisconnected &&
-                      ['patch', 'vulnerabilities', 'advisor'].includes(
-                        currentApp
-                      ) ? (
+                      {isEmptyState(currentApp) ? (
                         <NotConnected />
                       ) : (
                         <Cmp

--- a/src/components/InventoryDetail/ApplicationDetails.js
+++ b/src/components/InventoryDetail/ApplicationDetails.js
@@ -2,9 +2,10 @@ import React, { Suspense, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useStore } from 'react-redux';
 import { Spinner, Tab, TabContent, Tabs } from '@patternfly/react-core';
-import { verifyCulledInsightsClient } from '../../Utilities/sharedFunctions';
+import { verifyCulledReporter } from '../../Utilities/sharedFunctions';
 import { getFact } from './helpers';
 import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
+import { REPORTER_PUPTOO } from '../../Utilities/constants';
 
 /**
  * Component that renders tabs for each application detail and handles clicking on each item.
@@ -44,8 +45,9 @@ const ApplicationDetails = ({
     }
   }, [disabledApps]);
 
-  const isDisconnected = verifyCulledInsightsClient(
-    getFact('per_reporter_staleness', entity)
+  const isDisconnected = verifyCulledReporter(
+    getFact('per_reporter_staleness', entity),
+    REPORTER_PUPTOO
   );
 
   return (

--- a/src/components/InventoryDetail/DetailHeader.js
+++ b/src/components/InventoryDetail/DetailHeader.js
@@ -5,9 +5,10 @@ import TopBar from './TopBar';
 import FactsInfo from './FactsInfo';
 import './InventoryDetail.scss';
 import InsightsPrompt from './InsightsPrompt';
-import { verifyCulledInsightsClient } from '../../Utilities/sharedFunctions';
+import { verifyCulledReporter } from '../../Utilities/sharedFunctions';
 import PageHeader from '@redhat-cloud-services/frontend-components/PageHeader';
 import classnames from 'classnames';
+import { REPORTER_PUPTOO } from '../../Utilities/constants';
 
 const HeaderInfo = ({
   entity,
@@ -25,9 +26,10 @@ const HeaderInfo = ({
       UUIDWrapper={UUIDWrapper}
       LastSeenWrapper={LastSeenWrapper}
     />
-    {loaded && verifyCulledInsightsClient(entity?.per_reporter_staleness) && (
-      <InsightsPrompt />
-    )}
+    {loaded &&
+      verifyCulledReporter(entity?.per_reporter_staleness, REPORTER_PUPTOO) && (
+        <InsightsPrompt />
+      )}
     {children}
   </Fragment>
 );

--- a/src/components/InventoryDetail/FactsInfo.js
+++ b/src/components/InventoryDetail/FactsInfo.js
@@ -9,7 +9,8 @@ import { DateFormat } from '@redhat-cloud-services/frontend-components/DateForma
 import { CullingInformation } from '@redhat-cloud-services/frontend-components/CullingInfo';
 import { getFact } from './helpers';
 import InsightsDisconnected from '../../Utilities/InsightsDisconnected';
-import { verifyCulledInsightsClient } from '../../Utilities/sharedFunctions';
+import { verifyCulledReporter } from '../../Utilities/sharedFunctions';
+import { REPORTER_PUPTOO } from '../../Utilities/constants';
 /**
  * Basic information about system.
  * UUID and last seen.
@@ -56,8 +57,9 @@ const FactsInfo = ({
             <Skeleton size={SkeletonSize.md} fontSize="sm" />
           )}
           {loaded &&
-            verifyCulledInsightsClient(
-              getFact('per_reporter_staleness', entity)
+            verifyCulledReporter(
+              getFact('per_reporter_staleness', entity),
+              REPORTER_PUPTOO
             ) && <InsightsDisconnected />}
         </FlexItem>
       </Flex>

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -16,12 +16,13 @@ import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-uti
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { CullingInformation } from '@redhat-cloud-services/frontend-components/CullingInfo';
 import { TagWithDialog } from '../Utilities/index';
+import { REPORTER_PUPTOO } from '../Utilities/constants';
 import groupBy from 'lodash/groupBy';
 import TitleColumn from '../components/InventoryTable/TitleColumn';
 import InsightsDisconnected from '../Utilities/InsightsDisconnected';
 import OperatingSystemFormatter from '../Utilities/OperatingSystemFormatter';
 import { Tooltip } from '@patternfly/react-core';
-import { verifyCulledInsightsClient } from '../Utilities/sharedFunctions';
+import { verifyCulledReporter } from '../Utilities/sharedFunctions';
 import { fitContent } from '@patternfly/react-table';
 import isEmpty from 'lodash/isEmpty';
 
@@ -116,7 +117,7 @@ export const defaultColumns = (groupsEnabled = false) => [
                   </React.Fragment>
                 }
               />
-              {verifyCulledInsightsClient(perReporterStaleness) && (
+              {verifyCulledReporter(perReporterStaleness, REPORTER_PUPTOO) && (
                 <InsightsDisconnected />
               )}
             </React.Fragment>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-736.

This manipulates a couple of things:

- Makes usage of support function to check staleness more generic
- Introduces checking of RHSM systems to/not display Patch and Vulnerability modules.

As this touches multiple places, increased attention would be appreciated.