### PR TITLE
fix(popover): sorting a-z

### DIFF
--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
@@ -36,7 +36,7 @@ class GeneralInformation extends Component {
       const bSortBy = (
         '' + (secondRow[index].sortValue || secondRow[index])
       ).toLocaleLowerCase();
-      return aSortBy > bSortBy ? -1 : 1;
+      return aSortBy < bSortBy ? -1 : 1;
     });
     this.setState({
       rows: direction === SortByDirection.asc ? sorted : sorted.reverse(),


### PR DESCRIPTION
Item sorted ascendingly are fixed, sorted from A-Z. This might impact numbers, as those would be also ASC starting from 0.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

ESSNTL-3473
RHINENG-737