### PR TITLE
feat(ESSNTL-4934): Hide host number if users are not allowed

### DIFF
--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -69,6 +69,10 @@ describe('test data', () => {
   it('the third row has at least one host', () => {
     expect(fixtures.results[2].host_count > 0).to.be.true;
   });
+
+  it('at least one group has known host number', () => {
+    expect(fixtures.results.some(({ host_count }) => host_count !== undefined));
+  });
 });
 
 describe('renders correctly', () => {
@@ -452,29 +456,37 @@ describe('integration with rbac', () => {
     );
   });
 
-  it('disables general actions', () => {
-    cy.ouiaId('Actions').should('exist').click();
+  describe('with only groups read', () => {
+    it('disables general actions', () => {
+      cy.ouiaId('Actions').should('exist').click();
 
-    cy.get(TOOLBAR)
-      .find('button')
-      .contains('Create group')
-      .should('have.attr', 'aria-disabled', 'true');
-    cy.get(DROPDOWN_ITEM)
-      .contains('Rename group')
-      .should('have.attr', 'aria-disabled', 'true');
-    cy.get(DROPDOWN_ITEM)
-      .contains('Delete group')
-      .should('have.attr', 'aria-disabled', 'true');
-  });
+      cy.get(TOOLBAR)
+        .find('button')
+        .contains('Create group')
+        .should('have.attr', 'aria-disabled', 'true');
+      cy.get(DROPDOWN_ITEM)
+        .contains('Rename group')
+        .should('have.attr', 'aria-disabled', 'true');
+      cy.get(DROPDOWN_ITEM)
+        .contains('Delete group')
+        .should('have.attr', 'aria-disabled', 'true');
+    });
 
-  it('disables per-row actions', () => {
-    cy.get(ROW).eq(1).find(`${DROPDOWN} button`).click();
+    it('disables per-row actions', () => {
+      cy.get(ROW).eq(1).find(`${DROPDOWN} button`).click();
 
-    cy.get(DROPDOWN_ITEM)
-      .contains('Rename group')
-      .should('have.attr', 'aria-disabled', 'true');
-    cy.get(DROPDOWN_ITEM)
-      .contains('Delete group')
-      .should('have.attr', 'aria-disabled', 'true');
+      cy.get(DROPDOWN_ITEM)
+        .contains('Rename group')
+        .should('have.attr', 'aria-disabled', 'true');
+      cy.get(DROPDOWN_ITEM)
+        .contains('Delete group')
+        .should('have.attr', 'aria-disabled', 'true');
+    });
+
+    it('all host numbers are unknown', () => {
+      cy.get(`tbody ${ROW}`)
+        .find('[data-label="Total systems"]')
+        .each(($el) => cy.wrap($el).should(`have.text`, 'N/A'));
+    });
   });
 });

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -99,7 +99,8 @@ const groupsTableFiltersConfig = {
   },
 };
 
-const REQUIRED_PERMISSIONS_MODIFY = ['inventory:groups:write'];
+const REQUIRED_PERMISSIONS_TO_MODIFY = ['inventory:groups:write'];
+const REQUIRED_PERMISSIONS_TO_SEE_HOSTS = ['inventory:hosts:read'];
 
 const GroupsTable = () => {
   const dispatch = useDispatch();
@@ -122,7 +123,11 @@ const GroupsTable = () => {
   const loadingState = uninitialized || loading;
 
   const { hasAccess: canModify } = usePermissionsWithContext(
-    REQUIRED_PERMISSIONS_MODIFY
+    REQUIRED_PERMISSIONS_TO_MODIFY
+  );
+
+  const { hasAccess: canSeeHosts } = usePermissionsWithContext(
+    REQUIRED_PERMISSIONS_TO_SEE_HOSTS
   );
 
   const fetchData = useCallback(
@@ -158,7 +163,9 @@ const GroupsTable = () => {
           <Link to={`groups/${group.id}`}>{group.name || group.id}</Link>
         </span>,
         <span key={index}>
-          {isNil(group.host_count) ? 'N/A' : group.host_count.toString()}
+          {!canSeeHosts || isNil(group.host_count)
+            ? 'N/A'
+            : group.host_count.toString()}
         </span>,
         <span key={index}>
           {isNil(group.updated) ? 'N/A' : <DateFormat date={group.updated} />}


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-4934.

This makes the groups table render 'N/A' if users do not have hosts read permissions.

## How to test

1. Log into account that doesn't have the `inventory:hosts:read` permission
2. Open the groups page (/inventory/groups), and make sure all "Total systems" values are N/A.