### PR TITLE
feat(ESSNTL-5041): Add hosts only if has hosts read permissions

### DIFF
--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -111,6 +111,10 @@ const GroupSystems = ({ groupName, groupId }) => {
     REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(groupId)
   );
 
+  const { hasAccess: canViewHosts } = usePermissionsWithContext([
+    'inventory:hosts:read',
+  ]);
+
   const resetTable = () => {
     dispatch(clearFilters());
     dispatch(selectEntity(-1, false));
@@ -189,7 +193,7 @@ const GroupSystems = ({ groupName, groupId }) => {
           }}
           actionsConfig={{
             actions: [
-              !canModify ? (
+              !canModify || !canViewHosts ? (
                 // custom component needed since it's the first action to render (see primary toolbar implementation)
                 <Tooltip content={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}>
                   <Button isAriaDisabled>Add systems</Button>

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
@@ -163,5 +163,12 @@ describe('integration with rbac', () => {
         .find('.pf-c-card__title') // TODO: tie to OUIA
         .should('have.text', 'User access configuration');
     });
+
+    it('cannot add systems', () => {
+      cy.get('.pf-c-empty-state').find('.pf-c-spinner').should('not.exist'); // wait
+      cy.get('button')
+        .contains('Add systems')
+        .and('have.class', 'pf-m-aria-disabled');
+    });
   });
 });

--- a/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
+++ b/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
@@ -6,14 +6,20 @@ import {
   EmptyStateIcon,
   EmptyStateSecondaryActions,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import { global_palette_black_600 as globalPaletteBlack600 } from '@patternfly/react-tokens/dist/js/global_palette_black_600';
 import AddSystemsToGroupModal from '../InventoryGroups/Modals/AddSystemsToGroupModal';
 import PropTypes from 'prop-types';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 
 const NoSystemsEmptyState = ({ groupId, groupName }) => {
+  const { hasAccess: canViewHosts } = usePermissionsWithContext([
+    'inventory:hosts:read',
+  ]);
+
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
@@ -38,9 +44,15 @@ const NoSystemsEmptyState = ({ groupId, groupName }) => {
       <EmptyStateBody>
         To manage systems more effectively, add systems to the group.
       </EmptyStateBody>
-      <Button variant="primary" onClick={() => setIsModalOpen(true)}>
-        Add systems
-      </Button>
+      {canViewHosts ? (
+        <Button variant="primary" onClick={() => setIsModalOpen(true)}>
+          Add systems
+        </Button>
+      ) : (
+        <Tooltip content="You do not have the necessary permissions to modify this group. Contact your organization administrator.">
+          <Button isAriaDisabled>Add systems</Button>
+        </Tooltip>
+      )}
       <EmptyStateSecondaryActions>
         <Button
           variant="link"


### PR DESCRIPTION
Should be merged after https://github.com/RedHatInsights/insights-inventory-frontend/pull/1920.

Implements https://issues.redhat.com/browse/ESSNTL-5041.

This makes additional check for `inventory:hosts:read`: if the permissions exists, then the Add systems button is enabled.

## How to test

Have an account with both read and write groups permissions, but hosts read missing. Check that the Add systems button is disabled on the /groups/%id page.