### PR TITLE
feat(ESSNTL-4935): Check permissions in no groups state

### DIFF
--- a/src/components/InventoryGroups/InventoryGroups.cy.js
+++ b/src/components/InventoryGroups/InventoryGroups.cy.js
@@ -1,19 +1,7 @@
-import { mount } from '@cypress/react';
-import React from 'react';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
 import { groupsInterceptors as interceptors } from '../../../cypress/support/interceptors';
-import { getStore } from '../../store';
 import InventoryGroups from './InventoryGroups';
 
-const mountPage = () =>
-  mount(
-    <Provider store={getStore()}>
-      <MemoryRouter>
-        <InventoryGroups />
-      </MemoryRouter>
-    </Provider>
-  );
+const mountPage = () => cy.mountWithContext(InventoryGroups);
 
 before(() => {
   cy.mockWindowChrome();
@@ -51,5 +39,17 @@ describe('groups table page', () => {
     mountPage();
 
     cy.get('[role=progressbar]').should('have.class', 'pf-c-spinner pf-m-xl');
+  });
+
+  describe('integration with rbac', () => {
+    it('disables empty state button when not enough permissions', () => {
+      interceptors['successful empty']();
+      cy.mockWindowChrome([]);
+      mountPage();
+
+      cy.get('button')
+        .contains('Create group')
+        .should('have.attr', 'aria-disabled', 'true');
+    });
   });
 });

--- a/src/components/InventoryGroups/NoGroupsEmptyState.js
+++ b/src/components/InventoryGroups/NoGroupsEmptyState.js
@@ -6,15 +6,21 @@ import {
   EmptyStateIcon,
   EmptyStateSecondaryActions,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 
 import { global_palette_black_600 as globalPaletteBlack600 } from '@patternfly/react-tokens/dist/js/global_palette_black_600';
 import CreateGroupModal from './Modals/CreateGroupModal';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+
+const REQUIRED_PERMISSIONS = ['inventory:groups:write'];
 
 const NoGroupsEmptyState = ({ reloadData }) => {
   const [createGroupModalOpen, setCreateGroupModalOpen] = useState(false);
+  const { hasAccess: canModifyGroups } =
+    usePermissionsWithContext(REQUIRED_PERMISSIONS);
 
   return (
     <EmptyState
@@ -37,9 +43,17 @@ const NoGroupsEmptyState = ({ reloadData }) => {
       <EmptyStateBody>
         Manage device operations efficiently by creating system groups.
       </EmptyStateBody>
-      <Button variant="primary" onClick={() => setCreateGroupModalOpen(true)}>
-        Create group
-      </Button>
+      {canModifyGroups ? (
+        <Button variant="primary" onClick={() => setCreateGroupModalOpen(true)}>
+          Create group
+        </Button>
+      ) : (
+        <Tooltip content="You do not have the necessary permissions to modify groups. Contact your organization administrator.">
+          <Button variant="primary" isAriaDisabled>
+            Create group
+          </Button>
+        </Tooltip>
+      )}
       <EmptyStateSecondaryActions>
         <Button
           variant="link"


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-4935.

This is a follow-up on https://github.com/RedHatInsights/insights-inventory-frontend/pull/1914: this PR should disable Create group button when there are no groups and users do not have the write permission.

## How to test

Make sure you don't have any groups and the account is missing inventory:groups:write. Check that the Create group at /groups page is disabled.

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/fa3fd426-ac77-49d1-968b-71a1e7f5c23a)
