### PR TITLE
feat(ESSNTL-4938): Disable Manage access if not allowed

### DIFF
--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -123,13 +123,13 @@ const GroupsTable = () => {
   const { fetchBatched } = useFetchBatched();
   const loadingState = uninitialized || loading;
 
-  const { hasAccess: canModify } = usePermissionsWithContext(
-    GENERAL_GROUPS_WRITE_PERMISSION
-  );
+  const { hasAccess: canModify } = usePermissionsWithContext([
+    GENERAL_GROUPS_WRITE_PERMISSION,
+  ]);
 
-  const { hasAccess: canSeeHosts } = usePermissionsWithContext(
-    GENERAL_GROUPS_READ_PERMISSION
-  );
+  const { hasAccess: canSeeHosts } = usePermissionsWithContext([
+    GENERAL_GROUPS_READ_PERMISSION,
+  ]);
 
   const fetchData = useCallback(
     debounce((filters) => {

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -26,7 +26,11 @@ import upperCase from 'lodash/upperCase';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { TABLE_DEFAULT_PAGINATION } from '../../constants';
+import {
+  GENERAL_GROUPS_READ_PERMISSION,
+  GENERAL_GROUPS_WRITE_PERMISSION,
+  TABLE_DEFAULT_PAGINATION,
+} from '../../constants';
 import { fetchGroups } from '../../store/inventory-actions';
 import useFetchBatched from '../../Utilities/hooks/useFetchBatched';
 import CreateGroupModal from '../InventoryGroups/Modals/CreateGroupModal';
@@ -99,9 +103,6 @@ const groupsTableFiltersConfig = {
   },
 };
 
-const REQUIRED_PERMISSIONS_TO_MODIFY = ['inventory:groups:write'];
-const REQUIRED_PERMISSIONS_TO_SEE_HOSTS = ['inventory:hosts:read'];
-
 const GroupsTable = () => {
   const dispatch = useDispatch();
   const { rejected, uninitialized, loading, data } = useSelector(
@@ -123,11 +124,11 @@ const GroupsTable = () => {
   const loadingState = uninitialized || loading;
 
   const { hasAccess: canModify } = usePermissionsWithContext(
-    REQUIRED_PERMISSIONS_TO_MODIFY
+    GENERAL_GROUPS_WRITE_PERMISSION
   );
 
   const { hasAccess: canSeeHosts } = usePermissionsWithContext(
-    REQUIRED_PERMISSIONS_TO_SEE_HOSTS
+    GENERAL_GROUPS_READ_PERMISSION
   );
 
   const fetchData = useCallback(

--- a/src/components/InventoryGroupDetail/GroupDetailInfo.cy.js
+++ b/src/components/InventoryGroupDetail/GroupDetailInfo.cy.js
@@ -1,10 +1,13 @@
-import { mount } from '@cypress/react';
-import React from 'react';
 import { GroupDetailInfo } from './GroupDetailInfo';
 
-const mountPage = (params) => mount(<GroupDetailInfo {...params} />);
+const mountPage = (params) =>
+  cy.mountWithContext(GroupDetailInfo, undefined, params);
 
 describe('group detail information page', () => {
+  before(() => {
+    cy.mockWindowChrome();
+  });
+
   beforeEach(() => {
     mountPage({ chrome: { isBeta: () => false } });
   });
@@ -16,10 +19,7 @@ describe('group detail information page', () => {
   });
 
   it('button is present', () => {
-    cy.get('a[class="pf-c-button pf-m-secondary"]').should(
-      'have.text',
-      'Manage access'
-    );
+    cy.get('a').contains('Manage access').should('exist');
   });
 
   it('card text is present', () => {
@@ -39,5 +39,14 @@ describe('group detail information page', () => {
       mountPage({ chrome: { isBeta: () => true } });
       cy.get('a').should('have.attr', 'href', '/preview/iam/user-access');
     });
+  });
+
+  it('button disabled if not enough permissions', () => {
+    cy.mockWindowChrome([]);
+    mountPage({ chrome: { isBeta: () => true } });
+
+    cy.get('button')
+      .contains('Manage access')
+      .should('have.attr', 'aria-disabled', 'true');
   });
 });

--- a/src/components/InventoryGroupDetail/GroupDetailInfo.js
+++ b/src/components/InventoryGroupDetail/GroupDetailInfo.js
@@ -19,7 +19,8 @@ import {
 const GroupDetailInfo = ({ chrome }) => {
   const path = `${chrome.isBeta() ? '/preview' : ''}/iam/user-access`;
   const { hasAccess: isGroupsAdministrator } = usePermissionsWithContext(
-    GROUPS_ADMINISTRATOR_PERMISSIONS
+    GROUPS_ADMINISTRATOR_PERMISSIONS,
+    true // should fulfilll all requested permissions
   );
 
   return (

--- a/src/components/InventoryGroupDetail/GroupDetailInfo.js
+++ b/src/components/InventoryGroupDetail/GroupDetailInfo.js
@@ -5,21 +5,38 @@ import {
   CardBody,
   CardHeader,
   CardTitle,
+  Tooltip,
 } from '@patternfly/react-core';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ChromeLoader from '../../Utilities/ChromeLoader';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import {
+  GROUPS_ADMINISTRATOR_PERMISSIONS,
+  NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+} from '../../constants';
 
 const GroupDetailInfo = ({ chrome }) => {
   const path = `${chrome.isBeta() ? '/preview' : ''}/iam/user-access`;
+  const { hasAccess: isGroupsAdministrator } = usePermissionsWithContext(
+    GROUPS_ADMINISTRATOR_PERMISSIONS
+  );
 
   return (
     <Card>
       <CardHeader>
         <CardActions>
-          <Button component="a" href={path} variant="secondary">
-            Manage access
-          </Button>
+          {isGroupsAdministrator ? (
+            <Button component="a" href={path} variant="secondary">
+              Manage access
+            </Button>
+          ) : (
+            <Tooltip content={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}>
+              <Button isAriaDisabled variant="secondary">
+                Manage access
+              </Button>
+            </Tooltip>
+          )}
         </CardActions>
         <CardTitle className="pf-c-title pf-m-lg card-title">
           User access configuration

--- a/src/components/InventoryGroups/NoGroupsEmptyState.js
+++ b/src/components/InventoryGroups/NoGroupsEmptyState.js
@@ -14,8 +14,9 @@ import PropTypes from 'prop-types';
 import { global_palette_black_600 as globalPaletteBlack600 } from '@patternfly/react-tokens/dist/js/global_palette_black_600';
 import CreateGroupModal from './Modals/CreateGroupModal';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { GENERAL_GROUPS_WRITE_PERMISSION } from '../../constants';
 
-const REQUIRED_PERMISSIONS = ['inventory:groups:write'];
+const REQUIRED_PERMISSIONS = [GENERAL_GROUPS_WRITE_PERMISSION];
 
 const NoGroupsEmptyState = ({ reloadData }) => {
   const [createGroupModalOpen, setCreateGroupModalOpen] = useState(false);

--- a/src/constants.js
+++ b/src/constants.js
@@ -203,3 +203,10 @@ export const REQUIRED_PERMISSIONS_TO_MODIFY_GROUP = (groupId) => [
 
 export const NO_MODIFY_GROUP_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify this group. Contact your organization administrator.';
+
+export const GENERAL_GROUPS_WRITE_PERMISSION = 'inventory:groups:write';
+export const GENERAL_GROUPS_READ_PERMISSION = 'inventory:groups:read';
+export const GROUPS_ADMINISTRATOR_PERMISSIONS = [
+  GENERAL_GROUPS_READ_PERMISSION,
+  GENERAL_GROUPS_WRITE_PERMISSION,
+];

--- a/src/routes/InventoryGroups.js
+++ b/src/routes/InventoryGroups.js
@@ -8,8 +8,9 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
+import { GENERAL_GROUPS_READ_PERMISSION } from '../constants';
 
-const REQUIRED_PERMISSIONS = ['inventory:groups:read'];
+const REQUIRED_PERMISSIONS = [GENERAL_GROUPS_READ_PERMISSION];
 
 const Groups = () => {
   const chrome = useChrome();


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-4938.

This makes sure we check for the inventory groups administrator permissions: if exist for user, then enable the "Manage access" button on /groups/%id.

## Screenshots 

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/26ae7df1-8cec-4886-bfc0-53583bc4d915)

## How to test

Log in to user without inventory:groups:read or inventory:groups:write permissions. Go to any group and select the tab "Group info". The button Manage access must be disabled.