### PR TITLE
Check for hosts:read before showing group hosts

### DIFF
--- a/src/components/InventoryGroupDetail/EmptyStateNoAccess.js
+++ b/src/components/InventoryGroupDetail/EmptyStateNoAccess.js
@@ -2,7 +2,7 @@ import React from 'react';
 import AccessDenied from '../../Utilities/AccessDenied';
 import { EmptyStateVariant } from '@patternfly/react-core';
 
-const EmptyStateNoAccess = () => (
+const EmptyStateNoAccessToSystems = () => (
   <AccessDenied
     title="Access needed for systems in this group"
     showReturnButton={false}
@@ -17,4 +17,36 @@ const EmptyStateNoAccess = () => (
   />
 );
 
-export default EmptyStateNoAccess;
+const EmptyStateNoAccessToGroup = () => (
+  <AccessDenied
+    title="Inventory group access permissions needed"
+    showReturnButton={false}
+    description={
+      <div>
+        You do not have the necessary inventory group permissions to see this
+        inventory group. Contact your organization administrator for access.
+      </div>
+    }
+    variant={EmptyStateVariant.large} // overrides the default "full" value
+  />
+);
+
+const EmptyStateNoAccessToGroups = () => (
+  <AccessDenied
+    title="Inventory group access permissions needed"
+    showReturnButton={false}
+    description={
+      <div>
+        You do not have the necessary inventory group permissions to see
+        inventory groups. Contact your organization administrator for access.
+      </div>
+    }
+    variant={EmptyStateVariant.large} // overrides the default "full" value
+  />
+);
+
+export {
+  EmptyStateNoAccessToGroup,
+  EmptyStateNoAccessToSystems,
+  EmptyStateNoAccessToGroups,
+};

--- a/src/components/InventoryGroupDetail/__tests__/InventoryGroupDetail.test.js
+++ b/src/components/InventoryGroupDetail/__tests__/InventoryGroupDetail.test.js
@@ -5,12 +5,16 @@ import { MemoryRouter } from 'react-router-dom';
 import { getStore } from '../../../store';
 import InventoryGroupDetail from '../InventoryGroupDetail';
 import { Provider } from 'react-redux';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 
 jest.mock('../../../Utilities/useFeatureFlag');
+jest.mock('@redhat-cloud-services/frontend-components-utilities/RBACHook');
 
 describe('group detail page component', () => {
   let getByRole;
   let container;
+
+  usePermissionsWithContext.mockImplementation(() => ({ hasAccess: true }));
 
   beforeEach(() => {
     const rendered = render(

--- a/src/routes/InventoryGroups.js
+++ b/src/routes/InventoryGroups.js
@@ -2,13 +2,12 @@ import React, { useEffect } from 'react';
 import InventoryGroups from '../components/InventoryGroups';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
-import AccessDenied from '../Utilities/AccessDenied';
-import { EmptyStateVariant } from '@patternfly/react-core';
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { GENERAL_GROUPS_READ_PERMISSION } from '../constants';
+import { EmptyStateNoAccessToGroups } from '../components/InventoryGroupDetail/EmptyStateNoAccess';
 
 const REQUIRED_PERMISSIONS = [GENERAL_GROUPS_READ_PERMISSION];
 
@@ -25,22 +24,7 @@ const Groups = () => {
       <PageHeader>
         <PageHeaderTitle title="Groups" />
       </PageHeader>
-      {hasAccess ? (
-        <InventoryGroups />
-      ) : (
-        <AccessDenied
-          title="Inventory group access permissions needed"
-          showReturnButton={false}
-          description={
-            <div>
-              You do not have the necessary inventory group permissions to see
-              inventory groups. Contact your organization administrator for
-              access.
-            </div>
-          }
-          variant={EmptyStateVariant.large} // overrides the default "full" value
-        />
-      )}
+      {hasAccess ? <InventoryGroups /> : <EmptyStateNoAccessToGroups />}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-4937.

Adds additional check for inventory:hosts:read in order to decide whether to show the group systems or not. On page /groups/%id.