### PR TITLE
fix(ESSNTL-5052): Opt in resource definition check everywhere

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,7 +46,7 @@ Cypress.Commands.add('mountWithContext', (Component, options = {}, props) => {
     >
       <Provider store={getStore()}>
         <MemoryRouter {...routerProps}>
-          <RBACProvider appName="inventory">
+          <RBACProvider appName="inventory" checkResourceDefinitions>
             {path ? (
               <Switch>
                 <Route

--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ const App = () => {
   return (
     <div className="inventory">
       <NotificationsPortal />
-      <RBACProvider appName="inventory">
+      <RBACProvider appName="inventory" checkResourceDefinitions>
         <Routes />
       </RBACProvider>
     </div>

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
@@ -46,6 +46,32 @@ describe('AddSelectedHostsToGroupModal', () => {
     });
   });
 
+  describe('with limited groups write permissions', () => {
+    it('should still disable the create group button', () => {
+      cy.mockWindowChrome({
+        userPermissions: [
+          {
+            resourceDefinitions: [
+              {
+                attributeFilter: {
+                  key: 'group.id',
+                  value: ['74d41845-9939-428d-933e-1bcffe141219'],
+                  operation: 'in',
+                },
+              },
+            ],
+            permission: 'inventory:groups:write',
+          },
+        ],
+      });
+
+      mountModal();
+      cy.get('button')
+        .contains('Create a new group')
+        .should('have.attr', 'aria-disabled', 'true');
+    });
+  });
+
   describe('with groups write permission', () => {
     before(() => {
       cy.mockWindowChrome({

--- a/src/modules/AsyncInventory.js
+++ b/src/modules/AsyncInventory.js
@@ -28,7 +28,7 @@ const AsyncInventory = ({
   }, []);
 
   return (
-    <RBACProvider appName="inventory">
+    <RBACProvider appName="inventory" checkResourceDefinitions>
       <Provider store={store}>
         <Router history={history}>
           <RenderWrapper


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5052.

We forgot to add `checkResourceDefinitions` flag to RBACProvider, and, thus, all RBAC checks were not taking RD into account. This, for example, impacted the linked Jira bug.

## How to test

Make sure you have `inventory:hosts:*` and `inventory:hosts:read` permissions. Also, you must not have `inventory:hosts:write` permissions. Go to /inventory and find any system which is not in a group. Open the addition to group modal and make sure "Create a new group" is disabled.