### PR TITLE
fix: Address some of the RBAC and Inventory groups issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@patternfly/react-table": "^4.111.45",
         "@redhat-cloud-services/frontend-components": "^3.11.2",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.14",
-        "@redhat-cloud-services/frontend-components-utilities": "^3.7.3",
+        "@redhat-cloud-services/frontend-components-utilities": "^3.7.4",
         "@redhat-cloud-services/host-inventory-client": "1.2.3",
         "@unleash/proxy-client-react": "^3.5.0",
         "awesome-debounce-promise": "^2.1.0",
@@ -4278,9 +4278,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.3.tgz",
-      "integrity": "sha512-6lXSfMjNzOYO1sreraIVCK2b5MCLuAfFuWgNzqTb+wf6u1Ix9zDGNcvPIkK985r45cGL8oAHPGL2retycMIiiQ==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.4.tgz",
+      "integrity": "sha512-MttPapDXcmBXyUXr1b5/FaOOK0/fuGimHLp0zz/qra6bOlL7NgbEGlWoaSu7mACcAsePZgjQcFli2JrFwwD4bg==",
       "dependencies": {
         "@redhat-cloud-services/types": "^0.0.24",
         "@sentry/browser": "^5.30.0",
@@ -32288,9 +32288,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.3.tgz",
-      "integrity": "sha512-6lXSfMjNzOYO1sreraIVCK2b5MCLuAfFuWgNzqTb+wf6u1Ix9zDGNcvPIkK985r45cGL8oAHPGL2retycMIiiQ==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.4.tgz",
+      "integrity": "sha512-MttPapDXcmBXyUXr1b5/FaOOK0/fuGimHLp0zz/qra6bOlL7NgbEGlWoaSu7mACcAsePZgjQcFli2JrFwwD4bg==",
       "requires": {
         "@redhat-cloud-services/types": "^0.0.24",
         "@sentry/browser": "^5.30.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@patternfly/react-table": "^4.111.45",
     "@redhat-cloud-services/frontend-components": "^3.11.2",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.14",
-    "@redhat-cloud-services/frontend-components-utilities": "^3.7.3",
+    "@redhat-cloud-services/frontend-components-utilities": "^3.7.4",
     "@redhat-cloud-services/host-inventory-client": "1.2.3",
     "@unleash/proxy-client-react": "^3.5.0",
     "awesome-debounce-promise": "^2.1.0",

--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -414,7 +414,7 @@ const READ_PERMISSIONS_WITH_RD = [
     resourceDefinitions: [
       {
         attributeFilter: {
-          key: 'groupd.id',
+          key: 'group.id',
           operation: 'equal',
           value: TEST_ID,
         },
@@ -429,7 +429,7 @@ const WRITE_PERMISSIONS_WITH_RD = [
     resourceDefinitions: [
       {
         attributeFilter: {
-          key: 'groupd.id',
+          key: 'group.id',
           operation: 'equal',
           value: TEST_ID,
         },

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
@@ -137,7 +137,7 @@ describe('integration with rbac', () => {
             resourceDefinitions: [
               {
                 attributeFilter: {
-                  key: 'groupd.id',
+                  key: 'group.id',
                   operation: 'equal',
                   value: TEST_GROUP_ID,
                 },
@@ -187,7 +187,7 @@ describe('integration with rbac', () => {
             resourceDefinitions: [
               {
                 attributeFilter: {
-                  key: 'groupd.id',
+                  key: 'group.id',
                   operation: 'equal',
                   value: TEST_GROUP_ID,
                 },

--- a/src/constants.js
+++ b/src/constants.js
@@ -180,7 +180,7 @@ export const REQUIRED_PERMISSIONS_TO_READ_GROUP = (groupId) => [
     resourceDefinitions: [
       {
         attributeFilter: {
-          key: 'groupd.id',
+          key: 'group.id',
           operation: 'equal',
           value: groupId,
         },
@@ -195,7 +195,7 @@ export const REQUIRED_PERMISSIONS_TO_MODIFY_GROUP = (groupId) => [
     resourceDefinitions: [
       {
         attributeFilter: {
-          key: 'groupd.id',
+          key: 'group.id',
           operation: 'equal',
           value: groupId,
         },

--- a/src/routes/InventoryGroups.js
+++ b/src/routes/InventoryGroups.js
@@ -1,19 +1,13 @@
 import React, { useEffect } from 'react';
 import InventoryGroups from '../components/InventoryGroups';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import { GENERAL_GROUPS_READ_PERMISSION } from '../constants';
-import { EmptyStateNoAccessToGroups } from '../components/InventoryGroupDetail/EmptyStateNoAccess';
-
-const REQUIRED_PERMISSIONS = [GENERAL_GROUPS_READ_PERMISSION];
 
 const Groups = () => {
   const chrome = useChrome();
-  const { hasAccess } = usePermissionsWithContext(REQUIRED_PERMISSIONS);
 
   useEffect(() => {
     chrome?.updateDocumentTitle?.('Inventory Groups | Red Hat Insights');
@@ -24,7 +18,7 @@ const Groups = () => {
       <PageHeader>
         <PageHeaderTitle title="Groups" />
       </PageHeader>
-      {hasAccess ? <InventoryGroups /> : <EmptyStateNoAccessToGroups />}
+      <InventoryGroups />
     </React.Fragment>
   );
 };

--- a/src/routes/InventoryGroups.test.js
+++ b/src/routes/InventoryGroups.test.js
@@ -2,37 +2,9 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import InventoryGroups from './InventoryGroups';
-import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
-
-jest.mock(
-  '@redhat-cloud-services/frontend-components-utilities/RBACHook',
-  () => ({
-    usePermissionsWithContext: jest.fn(),
-  })
-);
 
 describe('inventory groups route', () => {
-  it('renders empty state when access forbidden', () => {
-    usePermissionsWithContext.mockImplementation(() => ({
-      hasAccess: false,
-    }));
-
-    const { container, getByText } = render(<InventoryGroups />);
-
-    expect(container.querySelector('h1')).toHaveTextContent('Groups');
-    expect(
-      getByText('Inventory group access permissions needed')
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector('[data-ouia-component-id="groups-table-wrapper"]')
-    ).not.toBeInTheDocument();
-  });
-
-  it('renders table wrapper when access allowed', () => {
-    usePermissionsWithContext.mockImplementation(() => ({
-      hasAccess: true,
-    }));
-
+  it('renders header and table wrapper', () => {
     const { container } = render(<InventoryGroups />);
 
     expect(container.querySelector('h1')).toHaveTextContent('Groups');


### PR DESCRIPTION
This fixes:

- Always show the groups table. It is safe since the back end must pre-filter results based on permissions.
- Fixes typo in RD key for groups
- Updates RBAC utils package so that the group details page doesn't crash.
