### PR TITLE
fix: Show image details just show when edge hosted image

### DIFF
--- a/src/components/SystemDetails/GeneralInfo.js
+++ b/src/components/SystemDetails/GeneralInfo.js
@@ -1,21 +1,26 @@
 import React from 'react';
-
+import { useSelector } from 'react-redux';
 import GeneralInformation from '../GeneralInfo/GeneralInformation';
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
 export { default as TextInputModal } from '../GeneralInfo/TextInputModal';
 
 const GeneralInfoTab = (props) => {
+  const systemProfile = useSelector(
+    ({ systemProfileStore }) => systemProfileStore?.systemProfile
+  );
+  const isEdgeHost = systemProfile?.host_type === 'edge';
   const enableEdgeImageDetails = useFeatureFlag(
     'edgeParity.inventory-system-detail'
   );
   const enableEdgeInventoryListDetails = useFeatureFlag(
     'edgeParity.inventory-list'
   );
+
   return (
     <GeneralInformation
       {...props}
       showImageDetails={
-        enableEdgeImageDetails && enableEdgeInventoryListDetails
+        enableEdgeImageDetails && enableEdgeInventoryListDetails && isEdgeHost
       }
     />
   );


### PR DESCRIPTION
After Edge image details federated module was merged some time ago, this new section was be showed to all images (DNS/OSTree). This PR will add an origin validation to just show when host is Edge. 

Ticket: [THEEDGE-3466](https://issues.redhat.com/browse/THEEDGE-3466) 


