### PR TITLE
fix(ESSNTL-4937): Don't check RBAC for Total systems column

### DIFF
--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -482,11 +482,5 @@ describe('integration with rbac', () => {
         .contains('Delete group')
         .should('have.attr', 'aria-disabled', 'true');
     });
-
-    it.only('all host numbers are unknown', () => {
-      cy.get(`tbody ${ROW}`)
-        .find('[data-label="Total systems"]')
-        .each(($el) => cy.wrap($el).should(`have.text`, 'N/A'));
-    });
   });
 });

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -28,7 +28,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import {
   GENERAL_GROUPS_WRITE_PERMISSION,
-  GENERAL_HOSTS_READ_PERMISSIONS,
   NO_MODIFY_GROUPS_TOOLTIP_MESSAGE,
   TABLE_DEFAULT_PAGINATION,
 } from '../../constants';
@@ -128,10 +127,6 @@ const GroupsTable = () => {
     GENERAL_GROUPS_WRITE_PERMISSION,
   ]);
 
-  const { hasAccess: canSeeHosts } = usePermissionsWithContext([
-    GENERAL_HOSTS_READ_PERMISSIONS,
-  ]);
-
   const fetchData = useCallback(
     debounce((filters) => {
       const { perPage, page, sortIndex, sortDirection, ...search } = filters;
@@ -165,9 +160,7 @@ const GroupsTable = () => {
           <Link to={`groups/${group.id}`}>{group.name || group.id}</Link>
         </span>,
         <span key={index}>
-          {!canSeeHosts || isNil(group.host_count)
-            ? 'N/A'
-            : group.host_count.toString()}
+          {isNil(group.host_count) ? 'N/A' : group.host_count.toString()}
         </span>,
         <span key={index}>
           {isNil(group.updated) ? 'N/A' : <DateFormat date={group.updated} />}

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -13,7 +13,10 @@ import { fetchGroupDetail } from '../../store/inventory-actions';
 import GroupSystems from '../GroupSystems';
 import GroupDetailHeader from './GroupDetailHeader';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
-import { REQUIRED_PERMISSIONS_TO_READ_GROUP } from '../../constants';
+import {
+  REQUIRED_PERMISSIONS_TO_READ_GROUP,
+  REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS,
+} from '../../constants';
 import {
   EmptyStateNoAccessToGroup,
   EmptyStateNoAccessToSystems,
@@ -31,9 +34,9 @@ const InventoryGroupDetail = ({ groupId }) => {
     REQUIRED_PERMISSIONS_TO_READ_GROUP(groupId)
   );
 
-  const { hasAccess: canViewHosts } = usePermissionsWithContext([
-    'inventory:hosts:read',
-  ]);
+  const { hasAccess: canViewHosts } = usePermissionsWithContext(
+    REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId)
+  );
 
   useEffect(() => {
     if (canViewGroup === true) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -204,6 +204,21 @@ export const REQUIRED_PERMISSIONS_TO_MODIFY_GROUP = (groupId) => [
   },
 ];
 
+export const REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS = (groupId) => [
+  {
+    permission: 'inventory:hosts:read',
+    resourceDefinitions: [
+      {
+        attributeFilter: {
+          key: 'group.id',
+          operation: 'equal',
+          value: groupId,
+        },
+      },
+    ],
+  },
+];
+
 export const NO_MODIFY_GROUP_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify this group. Contact your organization administrator.';
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-4937.

This corrects the behavior of Total systems columns at /groups: we no longer want to calculate RBAC for each row (each group) and this is why the groups table now just renders the column value which comes from API.

## How to test

With at least inventory:groups:read permission with RD enabled for your account, make sure the Total systems always renders the value which comes from the response from backend ("hosts_count" key).
