### PR TITLE
feat: Improve 403 handling at /groups

### DIFF
--- a/src/Utilities/AccessDenied.js
+++ b/src/Utilities/AccessDenied.js
@@ -3,18 +3,19 @@ import PropTypes from 'prop-types';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import { Tooltip } from '@patternfly/react-core';
 
-const AccessDenied = ({ title, description, ...props }) => (
+const AccessDenied = ({ title, description, requiredPermission, ...props }) => (
   <NotAuthorized
     {...props}
     className="ins-c-inventory__no--access"
     title={title}
-    description={<Tooltip content="inventory:*:read">{description}</Tooltip>}
+    description={<Tooltip content={requiredPermission}>{description}</Tooltip>}
   />
 );
 
 AccessDenied.propTypes = {
   title: PropTypes.string,
   description: PropTypes.node,
+  requiredPermission: PropTypes.string,
 };
 
 AccessDenied.defaultProps = {
@@ -25,6 +26,7 @@ AccessDenied.defaultProps = {
       Organization Administrator.
     </div>
   ),
+  requiredPermission: 'inventory:*:read',
 };
 
 export default AccessDenied;

--- a/src/components/InventoryGroupDetail/EmptyStateNoAccess.js
+++ b/src/components/InventoryGroupDetail/EmptyStateNoAccess.js
@@ -14,6 +14,7 @@ const EmptyStateNoAccessToSystems = () => (
       </div>
     }
     variant={EmptyStateVariant.large} // overrides the default "full" value
+    requiredPermission="inventory:hosts:read"
   />
 );
 
@@ -28,6 +29,7 @@ const EmptyStateNoAccessToGroup = () => (
       </div>
     }
     variant={EmptyStateVariant.large} // overrides the default "full" value
+    requiredPermission="inventory:groups:read"
   />
 );
 
@@ -42,6 +44,7 @@ const EmptyStateNoAccessToGroups = () => (
       </div>
     }
     variant={EmptyStateVariant.large} // overrides the default "full" value
+    requiredPermission="inventory:groups:read"
   />
 );
 

--- a/src/components/InventoryGroups/InventoryGroups.js
+++ b/src/components/InventoryGroups/InventoryGroups.js
@@ -5,11 +5,13 @@ import { Bullseye, Spinner } from '@patternfly/react-core';
 import GroupsTable from '../GroupsTable/GroupsTable';
 import { getGroups } from '../InventoryGroups/utils/api';
 import NoGroupsEmptyState from './NoGroupsEmptyState';
+import { EmptyStateNoAccessToGroups } from '../InventoryGroupDetail/EmptyStateNoAccess';
 
 const InventoryGroups = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasGroups, setHasGroups] = useState(false);
   const [hasError, setHasError] = useState(false);
+  const [error, setError] = useState(null);
 
   const ignore = useRef(false); // https://react.dev/learn/synchronizing-with-effects#fetching-data
 
@@ -22,7 +24,10 @@ const InventoryGroups = () => {
         !ignore.current && setHasGroups(true);
       }
     } catch (error) {
-      !ignore.current && setHasError(true);
+      if (!ignore.current) {
+        setHasError(true);
+        setError(error);
+      }
     }
 
     !ignore.current && setIsLoading(false);
@@ -42,7 +47,11 @@ const InventoryGroups = () => {
       data-ouia-component-id="groups-table-wrapper"
     >
       {hasError ? (
-        <ErrorState />
+        error.status === 403 ? (
+          <EmptyStateNoAccessToGroups />
+        ) : (
+          <ErrorState />
+        )
       ) : isLoading ? (
         <Bullseye>
           <Spinner />

--- a/src/components/InventoryGroups/InventoryGroups.js
+++ b/src/components/InventoryGroups/InventoryGroups.js
@@ -47,7 +47,7 @@ const InventoryGroups = () => {
       data-ouia-component-id="groups-table-wrapper"
     >
       {hasError ? (
-        error.status === 403 ? (
+        error?.status === 403 || error?.response?.status === 403 ? (
           <EmptyStateNoAccessToGroups />
         ) : (
           <ErrorState />

--- a/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
@@ -89,6 +89,7 @@ exports[`InventoryTable should render correctly - with no access 1`] = `
             To view your systems, you must be granted inventory access from your Organization Administrator.
           </div>
         }
+        requiredPermission="inventory:*:read"
         showReturnButton={false}
         title="You do not have access to Inventory"
       />
@@ -112,6 +113,7 @@ exports[`InventoryTable should render correctly - with no access and full view 1
         To view the content of this page, you must be granted a minimum of inventory permissions from your Organization Administrator.
       </div>
     }
+    requiredPermission="inventory:*:read"
     title="This application requires Inventory permissions"
   />
 </ForwardRef>


### PR DESCRIPTION
(no jira)

This makes the /groups page render the access denied message instead of "Something went wrong" when user doesn't have enough permission to see the groups table (lacks "inventory:groups:read").

## How to test

Remove any "inventory:groups:read" permissions and try to open /groups. You have to see the "Inventory group access permissions needed" message.

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/306ff2be-6a29-49c4-8ce8-d500855954c4)
