### PR TITLE
fix(ESSNTL-5043): RBAC and InventoryTable actions

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -40,11 +40,7 @@ export const Routes = () => {
           exact
           path={routes.table}
           render={() => (
-            <RenderWrapper
-              cmp={InventoryTable}
-              isRbacEnabled
-              {...searchParams}
-            />
+            <RenderWrapper cmp={InventoryTable} {...searchParams} />
           )}
           rootClass="inventory"
         />

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
-import { INVENTORY_WRITE_PERMISSIONS } from '../constants';
+import { GENERAL_HOSTS_WRITE_PERMISSIONS } from '../constants';
 
 export const TEXT_FILTER = 'hostname_or_id';
 export const TEXTUAL_CHIP = 'textual';
@@ -251,8 +251,10 @@ export const generateFilter = (
     },
   ].filter(Boolean);
 
-export const useWritePermissions = () => {
-  const { hasAccess } = usePermissionsWithContext(INVENTORY_WRITE_PERMISSIONS);
+export const useHostsWritePermissions = () => {
+  const { hasAccess } = usePermissionsWithContext([
+    GENERAL_HOSTS_WRITE_PERMISSIONS,
+  ]);
 
   return hasAccess;
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -132,12 +132,6 @@ export const extraShape = PropTypes.shape({
   onClick: PropTypes.func,
 });
 
-export const INVENTORY_WRITE_PERMISSIONS = [
-  'inventory:*:*',
-  'inventory:hosts:write',
-  'inventory:*:write',
-];
-
 export const getSearchParams = () => {
   const searchParams = new URLSearchParams(location.search);
   const status = searchParams.getAll('status');
@@ -171,9 +165,6 @@ export const getSearchParams = () => {
 
 export const TABLE_DEFAULT_PAGINATION = 50; // from UX table audit
 
-export const NO_MODIFY_GROUPS_TOOLTIP_MESSAGE =
-  'You do not have the necessary permissions to modify groups. Contact your organization administrator.';
-
 export const REQUIRED_PERMISSIONS_TO_READ_GROUP = (groupId) => [
   {
     permission: 'inventory:groups:read',
@@ -204,8 +195,14 @@ export const REQUIRED_PERMISSIONS_TO_MODIFY_GROUP = (groupId) => [
   },
 ];
 
+export const NO_MODIFY_GROUPS_TOOLTIP_MESSAGE =
+  'You do not have the necessary permissions to modify groups. Contact your organization administrator.';
 export const NO_MODIFY_GROUP_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify this group. Contact your organization administrator.';
+export const NO_MODIFY_HOSTS_TOOLTIP_MESSAGE =
+  'You do not have the necessary permissions to modify hosts. Contact your organization administrator.';
+export const NO_MODIFY_HOST_TOOLTIP_MESSAGE =
+  'You do not have the necessary permissions to modify this host. Contact your organization administrator.';
 
 export const GENERAL_GROUPS_WRITE_PERMISSION = 'inventory:groups:write';
 export const GENERAL_GROUPS_READ_PERMISSION = 'inventory:groups:read';
@@ -214,3 +211,4 @@ export const GROUPS_ADMINISTRATOR_PERMISSIONS = [
   GENERAL_GROUPS_WRITE_PERMISSION,
 ];
 export const GENERAL_HOSTS_READ_PERMISSIONS = 'inventory:hosts:read';
+export const GENERAL_HOSTS_WRITE_PERMISSIONS = 'inventory:hosts:write';

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -12,7 +12,7 @@ import {
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 import { routes } from '../Routes';
 import InventoryDetail from '../components/InventoryDetail/InventoryDetail';
-import { useWritePermissions } from '../Utilities/constants';
+import { useHostsWritePermissions } from '../Utilities/constants';
 import {
   AdvisorTab,
   ComplianceTab,
@@ -89,7 +89,7 @@ const Inventory = () => {
   const store = useStore();
   const history = useHistory();
   const dispatch = useDispatch();
-  const writePermissions = useWritePermissions();
+  const writePermissions = useHostsWritePermissions();
   const entityLoaded = useSelector(
     ({ entityDetails }) => entityDetails?.loaded
   );

--- a/src/routes/InventoryTable.cy.js
+++ b/src/routes/InventoryTable.cy.js
@@ -245,10 +245,6 @@ describe('inventory table', () => {
         );
       });
 
-      it('should render no checkboxes', () => {
-        cy.get(ROW).find('[type="checkbox"]').should('not.exist');
-      });
-
       it('bulk actions are disabled', () => {
         cy.get('button')
           .contains('Delete')

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -333,7 +333,7 @@ const Inventory = ({
           isFullView
           showTags
           onRefresh={onRefresh}
-          hasCheckbox={hostsWritePermissions || canModifyGroups}
+          hasCheckbox
           autoRefresh
           ignoreRefresh
           initialLoading={initialLoading}
@@ -393,9 +393,7 @@ const Inventory = ({
                 : []),
             ],
           }}
-          {...((canModifyGroups || hostsWritePermissions) && {
-            bulkSelect: bulkSelectConfig,
-          })}
+          bulkSelect={bulkSelectConfig}
           onRowClick={(_e, id, app) =>
             history.push(`/${id}${app ? `/${app}` : ''}`)
           }

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -333,7 +333,7 @@ const Inventory = ({
           isFullView
           showTags
           onRefresh={onRefresh}
-          hasCheckbox
+          hasCheckbox={hostsWritePermissions || canModifyGroups}
           autoRefresh
           ignoreRefresh
           initialLoading={initialLoading}
@@ -393,7 +393,9 @@ const Inventory = ({
                 : []),
             ],
           }}
-          bulkSelect={bulkSelectConfig}
+          {...((canModifyGroups || hostsWritePermissions) && {
+            bulkSelect: bulkSelectConfig,
+          })}
           onRowClick={(_e, id, app) =>
             history.push(`/${id}${app ? `/${app}` : ''}`)
           }

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -274,6 +274,10 @@ const Inventory = ({
           setCurrentSystem(rowData);
           onEditOpen(() => true);
         },
+        ...(!hostsWritePermissions && {
+          isAriaDisabled: true,
+          tooltip: NO_MODIFY_HOSTS_TOOLTIP_MESSAGE,
+        }),
       },
       {
         title: 'Delete',
@@ -281,6 +285,10 @@ const Inventory = ({
           setCurrentSystem(rowData);
           handleModalToggle(() => true);
         },
+        ...(!hostsWritePermissions && {
+          isAriaDisabled: true,
+          tooltip: NO_MODIFY_HOSTS_TOOLTIP_MESSAGE,
+        }),
       },
     ];
 

--- a/src/routes/InventoryTable.test.js
+++ b/src/routes/InventoryTable.test.js
@@ -12,12 +12,15 @@ import DeleteModal from '../Utilities/DeleteModal';
 import { hosts } from '../api';
 import createXhrMock from '../Utilities/__mocks__/xhrMock';
 
-import { useGetRegistry, useWritePermissions } from '../Utilities/constants';
+import {
+  useGetRegistry,
+  useHostsWritePermissions,
+} from '../Utilities/constants';
 import { mockSystemProfile } from '../__mocks__/hostApi';
 
 jest.mock('../Utilities/constants', () => ({
   ...jest.requireActual('../Utilities/constants'),
-  useWritePermissions: jest.fn(() => true),
+  useHostsWritePermissions: jest.fn(() => true),
   useGetRegistry: jest.fn(() => ({
     getRegistry: () => ({}),
   })),
@@ -130,7 +133,7 @@ describe('InventoryTable', () => {
 
   beforeEach(() => {
     mockStore = configureStore();
-    useWritePermissions.mockImplementation(() => true);
+    useHostsWritePermissions.mockImplementation(() => true);
     useGetRegistry.mockImplementation(() => () => ({ register: () => ({}) }));
     mockSystemProfile.onGet().reply(200, { results: [] });
   });
@@ -161,7 +164,7 @@ describe('InventoryTable', () => {
 
   it('renders correctly when no write permissions', async () => {
     let wrapper;
-    useWritePermissions.mockImplementation(() => false);
+    useHostsWritePermissions.mockImplementation(() => false);
     const store = mockStore(initialStore);
 
     await act(async () => {

--- a/src/routes/InventoryTable.test.js
+++ b/src/routes/InventoryTable.test.js
@@ -154,7 +154,7 @@ describe('InventoryTable', () => {
       wrapper
         .find('.ins-c-primary-toolbar__first-action')
         .find('button')
-        .props().disabled
+        .props()['aria-disabled']
     ).toEqual(true);
     expect(wrapper.find('tbody').find('tr')).toHaveLength(1);
     expect(
@@ -174,11 +174,17 @@ describe('InventoryTable', () => {
 
     expect(
       wrapper.find('.ins-c-primary-toolbar__first-action').find('button')
-    ).toHaveLength(0);
+    ).toHaveLength(1);
+    expect(
+      wrapper
+        .find('.ins-c-primary-toolbar__first-action')
+        .find('button')
+        .props()['aria-disabled']
+    ).toEqual(true);
     expect(wrapper.find('tbody').find('tr')).toHaveLength(1);
     expect(
       wrapper.find('tbody').find('tr').find('.pf-c-dropdown')
-    ).toHaveLength(0);
+    ).toHaveLength(1);
   });
 
   it('can select and delete items', async () => {


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-5043.

This changes the behavior of InventoryTable actions: now all the actions (delete host, add to group, etc.), both bulk and per-row, are **always** shown to users. However if a user doesn't have enough write permissions (inventory:groups:write or inventory:hosts:write), the actions are disabled with a information tooltip rendered on hover.

- This also disables RBAC check for the /inventory route: asking for ['inventory:hosts:read'] is strict because if users have this permission but limited with a resource definition, then they will still have no access to the page which is not correct.

## How to test

1. Have an account for which you can manipulate permissions,
2. Go to /inventory,
3. Remove your `inventory:hosts:write` permissions and make sure you cannot delete/rename hosts,
4. Remove your `inventory:groups:write` permissions and make sure you cannot add or remove hosts from groups,
5. Check that tooltips are rendered on hover,

## Screenshots 

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/f2b321a1-2330-466f-b6ab-f87944d3b950)
