### PR TITLE
fix(ESSNTL-5043): Stop throwing notifications on groups errors

### DIFF
--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -211,6 +211,9 @@ export const fetchAllTags = (
 export const fetchGroups = (search, pagination) => ({
   type: ACTION_TYPES.GROUPS,
   payload: getGroups(search, pagination),
+  meta: {
+    noError: true, // turns of automatic notification
+  },
 });
 
 export const fetchGroupDetail = (groupId) => ({
@@ -252,4 +255,7 @@ export const toggleDrawer = (isOpened) => ({
 export const fetchGroupsForEntities = (params) => ({
   type: ACTION_TYPES.GROUPS_FOR_ENTITIES,
   payload: groupsApi.apiGroupGetGroupList(params),
+  meta: {
+    noError: true, // turns of automatic notification
+  },
 });


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5043.

If there are no inventory:groups:read permissions, users were seeing the error notification when they accessed the Inventory table. This shouldn't happen, because 403 status is expected in that case and we have to silent the notificaitons.

## How to test

Have an account without inventory:groups:read permissions. Navigate to /inventory and make sure you don't see any error notification related to groups. 