### PR TITLE
fix(ESSNTL-4937): Disable Add systems in no systems state

### DIFF
--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -120,6 +120,8 @@ const GroupSystems = ({ groupName, groupId }) => {
     dispatch(selectEntity(-1, false));
   };
 
+  const enableAddSystems = canModify && canViewHosts;
+
   useEffect(() => {
     return () => {
       resetTable();
@@ -193,7 +195,7 @@ const GroupSystems = ({ groupName, groupId }) => {
           }}
           actionsConfig={{
             actions: [
-              !canModify || !canViewHosts ? (
+              !enableAddSystems ? (
                 // custom component needed since it's the first action to render (see primary toolbar implementation)
                 <Tooltip content={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}>
                   <Button isAriaDisabled>Add systems</Button>

--- a/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
+++ b/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
@@ -14,11 +14,18 @@ import { global_palette_black_600 as globalPaletteBlack600 } from '@patternfly/r
 import AddSystemsToGroupModal from '../InventoryGroups/Modals/AddSystemsToGroupModal';
 import PropTypes from 'prop-types';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { REQUIRED_PERMISSIONS_TO_MODIFY_GROUP } from '../../constants';
 
 const NoSystemsEmptyState = ({ groupId, groupName }) => {
   const { hasAccess: canViewHosts } = usePermissionsWithContext([
     'inventory:hosts:read',
   ]);
+
+  const { hasAccess: canModify } = usePermissionsWithContext(
+    REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(groupId)
+  );
+
+  const enableAddSystems = canModify && canViewHosts;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -44,7 +51,7 @@ const NoSystemsEmptyState = ({ groupId, groupName }) => {
       <EmptyStateBody>
         To manage systems more effectively, add systems to the group.
       </EmptyStateBody>
-      {canViewHosts ? (
+      {enableAddSystems ? (
         <Button variant="primary" onClick={() => setIsModalOpen(true)}>
           Add systems
         </Button>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-4937.

Disable the Add systems button if there are 0 systems in a group, but users still have not enough write permissions.