### PR TITLE
fix(ESSNTL-5092): Fix sorting by Total systems (/groups)

### DIFF
--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -180,9 +180,9 @@ describe('url search parameters', () => {
   });
 
   it('applies sorting', () => {
-    mountTable('/?order_by=host_ids&order_how=desc');
+    mountTable('/?order_by=host_count&order_how=desc');
 
-    checkSorting('Total systems', 'descending', 'host_ids');
+    checkSorting('Total systems', 'descending', 'host_count');
   });
 });
 
@@ -194,13 +194,15 @@ describe('sorting', () => {
     cy.wait('@getGroups'); // first initial request
   });
 
-  _.zip(['name', 'host_ids'], SORTABLE_HEADERS).forEach(([category, label]) => {
-    SORTING_ORDERS.forEach((order) => {
-      it(`${order} by ${label}`, () => {
-        checkSorting(label, order, category);
+  _.zip(['name', 'host_count'], SORTABLE_HEADERS).forEach(
+    ([category, label]) => {
+      SORTING_ORDERS.forEach((order) => {
+        it(`${order} by ${label}`, () => {
+          checkSorting(label, order, category);
+        });
       });
-    });
-  });
+    }
+  );
 });
 
 describe('filtering', () => {

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -70,7 +70,7 @@ const GROUPS_TABLE_COLUMNS = [
 const GROUPS_TABLE_COLUMNS_TO_URL = {
   0: '', // reserved for selection boxes
   1: 'name',
-  2: 'host_ids',
+  2: 'host_count',
   3: 'updated_at',
 };
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5092.

## How to test

Make sure you are able to sort by the Total systems column at /groups.