### PR TITLE
fix(ESSNTL-5064): Fix groups filter by more values

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -16,7 +16,6 @@ import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/Prima
 import {
   clearFilters,
   fetchAllTags,
-  fetchGroupsForEntities,
   setFilter,
   toggleTagModal,
 } from '../../store/actions';
@@ -243,19 +242,6 @@ const EntityTableToolbar = ({
         onRefreshData(options);
         if (showTags && !hasItems) {
           dispatch(fetchAllTags(filterTagsBy, {}, getTags));
-        }
-
-        if (groupsEnabled === true) {
-          dispatch(
-            fetchGroupsForEntities(
-              undefined,
-              50,
-              undefined,
-              'name',
-              'ASC',
-              undefined
-            )
-          );
         }
       }
     },

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -2,7 +2,7 @@
 import union from 'lodash/union';
 import { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchGroups } from '../../store/inventory-actions';
+import { fetchGroupsForEntities } from '../../store/inventory-actions';
 import { HOST_GROUP_CHIP } from '../../Utilities/index';
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
 //for attaching this filter to the redux
@@ -38,7 +38,7 @@ const useGroupFilter = (apiParams = []) => {
 
   useEffect(() => {
     if (groupsEnabled === true) {
-      dispatch(fetchGroups(apiParams)); // TODO: make the request paginated (to show all the groups)
+      dispatch(fetchGroupsForEntities(apiParams)); // TODO: make the request paginated (to show all the groups)
     }
   }, [groupsEnabled]);
   //fetched values


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5064.

This fixes the groups filter in Inventory table: before, we were calling a wrong action, instead, we have to use the one that updates values under `entities`.

## How to test

1. Go to /inventory
2. Try to apply the groups filter by more values, wait for refresh, and try again,
3. The table should show correct data and also update URL parameters accordingly.