### PR TITLE
Limit the height of groups filter list

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import './EntityTableToolbar.scss';
 import React, { Fragment, useCallback, useEffect, useReducer } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';

--- a/src/components/InventoryTable/EntityTableToolbar.scss
+++ b/src/components/InventoryTable/EntityTableToolbar.scss
@@ -1,0 +1,4 @@
+.ins-c-primary-toolbar__group-filter ul {
+    max-height: 350px;
+    overflow: auto;
+}


### PR DESCRIPTION
No jira.

At /inventory, this limits the height of the available groups list to 350px.

## How to test

Go to /inventory. Open the groups filter, and make sure the height is no longer than 350px, and the scrollbar is rendered (if the list is long).

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/10909af4-0519-48d6-b005-ff455cedd1f4)
