### PR TITLE
fix(ESSNTL-5110): Improve RBAC checks for delete and edit button on the System details view

### DIFF
--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -146,10 +146,10 @@ export const deleteGroupsInterceptors = {
 };
 
 export const hostsDetailInterceptors = {
-  successful: () => {
+  successful: (fixtures = hostDetail) => {
     cy.intercept('GET', '/api/inventory/v1/hosts/*', {
       statusCode: 200,
-      body: hostDetail,
+      body: fixtures,
     }).as('getHostDetail');
   },
 };

--- a/src/components/GeneralInfo/BiosCard/__snapshots__/BiosCard.test.js.snap
+++ b/src/components/GeneralInfo/BiosCard/__snapshots__/BiosCard.test.js.snap
@@ -3,7 +3,7 @@
 exports[`BiosCard should not render hasReleaseDate 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-6"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -42,21 +42,25 @@ exports[`BiosCard should not render hasReleaseDate 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Version title"
             >
               Version
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Version value"
             >
               test-version
             </dd>
@@ -71,7 +75,7 @@ exports[`BiosCard should not render hasReleaseDate 1`] = `
 exports[`BiosCard should not render hasVendor 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-4"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -110,21 +114,25 @@ exports[`BiosCard should not render hasVendor 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Version title"
             >
               Version
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Version value"
             >
               test-version
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Release date title"
             >
               Release date
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release date value"
             >
               01 Apr 2014
             </dd>
@@ -139,7 +147,7 @@ exports[`BiosCard should not render hasVendor 1`] = `
 exports[`BiosCard should not render hasVersion 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-5"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -178,21 +186,25 @@ exports[`BiosCard should not render hasVersion 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Release date title"
             >
               Release date
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release date value"
             >
               01 Apr 2014
             </dd>
@@ -207,7 +219,7 @@ exports[`BiosCard should not render hasVersion 1`] = `
 exports[`BiosCard should render correctly - no data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-1"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -246,11 +258,13 @@ exports[`BiosCard should render correctly - no data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -262,11 +276,13 @@ exports[`BiosCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Version title"
             >
               Version
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Version value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -278,11 +294,13 @@ exports[`BiosCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Release date title"
             >
               Release date
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release date value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -303,7 +321,7 @@ exports[`BiosCard should render correctly - no data 1`] = `
 exports[`BiosCard should render correctly with data - wrong date 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-3"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -342,31 +360,37 @@ exports[`BiosCard should render correctly with data - wrong date 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Version title"
             >
               Version
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Version value"
             >
               test-version
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Release date title"
             >
               Release date
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release date value"
             >
               Not available
             </dd>
@@ -381,7 +405,7 @@ exports[`BiosCard should render correctly with data - wrong date 1`] = `
 exports[`BiosCard should render correctly with data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-2"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -420,31 +444,37 @@ exports[`BiosCard should render correctly with data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Version title"
             >
               Version
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Version value"
             >
               test-version
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Release date title"
             >
               Release date
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release date value"
             >
               01 Apr 2014
             </dd>
@@ -459,7 +489,7 @@ exports[`BiosCard should render correctly with data 1`] = `
 exports[`BiosCard should render extra 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-7"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -498,51 +528,61 @@ exports[`BiosCard should render extra 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Version title"
             >
               Version
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Version value"
             >
               test-version
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Release date title"
             >
               Release date
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release date value"
             >
               01 Apr 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="something title"
             >
               something
             </dt>
             <dd
               class=""
+              data-ouia-component-id="something value"
             >
               test
             </dd>
             <dt
               class=""
+              data-ouia-component-id="with click title"
             >
               with click
             </dt>
             <dd
               class=""
+              data-ouia-component-id="with click value"
             >
               <a
                 href="http://localhost:5000//undefined"

--- a/src/components/GeneralInfo/CollectionCard/__snapshots__/CollectionCard.test.js.snap
+++ b/src/components/GeneralInfo/CollectionCard/__snapshots__/CollectionCard.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CollectionCard should not render hasClient 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-4"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -42,41 +42,49 @@ exports[`CollectionCard should not render hasClient 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Last check-in title"
             >
               Last check-in
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last check-in value"
             >
               01 Jun 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Insights id title"
             >
               Insights id
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights id value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Reporter title"
             >
               Reporter
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Reporter value"
             >
               Not available
             </dd>
@@ -91,7 +99,7 @@ exports[`CollectionCard should not render hasClient 1`] = `
 exports[`CollectionCard should not render hasInsightsId 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-7"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -130,11 +138,13 @@ exports[`CollectionCard should not render hasInsightsId 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Insights client title"
             >
               Insights client
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights client value"
             >
               <span>
                 test-client
@@ -142,31 +152,37 @@ exports[`CollectionCard should not render hasInsightsId 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last check-in title"
             >
               Last check-in
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last check-in value"
             >
               01 Jun 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Reporter title"
             >
               Reporter
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Reporter value"
             >
               Not available
             </dd>
@@ -181,7 +197,7 @@ exports[`CollectionCard should not render hasInsightsId 1`] = `
 exports[`CollectionCard should not render hasLastCheckIn 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-5"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -220,11 +236,13 @@ exports[`CollectionCard should not render hasLastCheckIn 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Insights client title"
             >
               Insights client
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights client value"
             >
               <span>
                 test-client
@@ -232,31 +250,37 @@ exports[`CollectionCard should not render hasLastCheckIn 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Insights id title"
             >
               Insights id
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights id value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Reporter title"
             >
               Reporter
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Reporter value"
             >
               Not available
             </dd>
@@ -271,7 +295,7 @@ exports[`CollectionCard should not render hasLastCheckIn 1`] = `
 exports[`CollectionCard should not render hasRegistered 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-6"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -310,11 +334,13 @@ exports[`CollectionCard should not render hasRegistered 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Insights client title"
             >
               Insights client
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights client value"
             >
               <span>
                 test-client
@@ -322,31 +348,37 @@ exports[`CollectionCard should not render hasRegistered 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last check-in title"
             >
               Last check-in
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last check-in value"
             >
               01 Jun 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Insights id title"
             >
               Insights id
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights id value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Reporter title"
             >
               Reporter
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Reporter value"
             >
               Not available
             </dd>
@@ -361,7 +393,7 @@ exports[`CollectionCard should not render hasRegistered 1`] = `
 exports[`CollectionCard should not render hasReporter 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-8"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -400,11 +432,13 @@ exports[`CollectionCard should not render hasReporter 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Insights client title"
             >
               Insights client
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights client value"
             >
               <span>
                 test-client
@@ -412,31 +446,37 @@ exports[`CollectionCard should not render hasReporter 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last check-in title"
             >
               Last check-in
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last check-in value"
             >
               01 Jun 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Insights id title"
             >
               Insights id
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights id value"
             >
               Not available
             </dd>
@@ -451,7 +491,7 @@ exports[`CollectionCard should not render hasReporter 1`] = `
 exports[`CollectionCard should render correctly - no data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-1"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -490,11 +530,13 @@ exports[`CollectionCard should render correctly - no data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Insights client title"
             >
               Insights client
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights client value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -506,11 +548,13 @@ exports[`CollectionCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last check-in title"
             >
               Last check-in
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last check-in value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -522,11 +566,13 @@ exports[`CollectionCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -538,11 +584,13 @@ exports[`CollectionCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Insights id title"
             >
               Insights id
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights id value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -554,11 +602,13 @@ exports[`CollectionCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Reporter title"
             >
               Reporter
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Reporter value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -579,7 +629,7 @@ exports[`CollectionCard should render correctly - no data 1`] = `
 exports[`CollectionCard should render correctly with data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-2"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -618,11 +668,13 @@ exports[`CollectionCard should render correctly with data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Insights client title"
             >
               Insights client
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights client value"
             >
               <span>
                 test-client
@@ -630,41 +682,49 @@ exports[`CollectionCard should render correctly with data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last check-in title"
             >
               Last check-in
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last check-in value"
             >
               01 Jun 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Insights id title"
             >
               Insights id
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights id value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Reporter title"
             >
               Reporter
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Reporter value"
             >
               Not available
             </dd>
@@ -679,7 +739,7 @@ exports[`CollectionCard should render correctly with data 1`] = `
 exports[`CollectionCard should render extra 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-9"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -718,11 +778,13 @@ exports[`CollectionCard should render extra 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Insights client title"
             >
               Insights client
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights client value"
             >
               <span>
                 test-client
@@ -730,61 +792,73 @@ exports[`CollectionCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last check-in title"
             >
               Last check-in
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last check-in value"
             >
               01 Jun 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Insights id title"
             >
               Insights id
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Insights id value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Reporter title"
             >
               Reporter
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Reporter value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="something title"
             >
               something
             </dt>
             <dd
               class=""
+              data-ouia-component-id="something value"
             >
               test
             </dd>
             <dt
               class=""
+              data-ouia-component-id="with click title"
             >
               with click
             </dt>
             <dd
               class=""
+              data-ouia-component-id="with click value"
             >
               <a
                 href="http://localhost:5000//undefined"

--- a/src/components/GeneralInfo/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
+++ b/src/components/GeneralInfo/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
@@ -100,10 +100,12 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
       }
       title="Configuration"
     >
-      <Card>
+      <Card
+        ouiaId="system-properties-card"
+      >
         <article
           className="pf-c-card"
-          data-ouia-component-id="OUIA-Generated-Card-4"
+          data-ouia-component-id="system-properties-card"
           data-ouia-component-type="PF4/Card"
           data-ouia-safe={true}
           id=""
@@ -161,18 +163,22 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
                             >
                               <TextListItem
                                 component="dt"
+                                data-ouia-component-id="Installed packages title"
                               >
                                 <dt
                                   className=""
+                                  data-ouia-component-id="Installed packages title"
                                 >
                                   Installed packages
                                 </dt>
                               </TextListItem>
                               <TextListItem
                                 component="dd"
+                                data-ouia-component-id="Installed packages value"
                               >
                                 <dd
                                   className=""
+                                  data-ouia-component-id="Installed packages value"
                                 >
                                   <Clickable
                                     onClick={[Function]}
@@ -191,18 +197,22 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
                               </TextListItem>
                               <TextListItem
                                 component="dt"
+                                data-ouia-component-id="Services title"
                               >
                                 <dt
                                   className=""
+                                  data-ouia-component-id="Services title"
                                 >
                                   Services
                                 </dt>
                               </TextListItem>
                               <TextListItem
                                 component="dd"
+                                data-ouia-component-id="Services value"
                               >
                                 <dd
                                   className=""
+                                  data-ouia-component-id="Services value"
                                 >
                                   <Clickable
                                     onClick={[Function]}
@@ -221,18 +231,22 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
                               </TextListItem>
                               <TextListItem
                                 component="dt"
+                                data-ouia-component-id="Running processes title"
                               >
                                 <dt
                                   className=""
+                                  data-ouia-component-id="Running processes title"
                                 >
                                   Running processes
                                 </dt>
                               </TextListItem>
                               <TextListItem
                                 component="dd"
+                                data-ouia-component-id="Running processes value"
                               >
                                 <dd
                                   className=""
+                                  data-ouia-component-id="Running processes value"
                                 >
                                   <Clickable
                                     onClick={[Function]}
@@ -252,18 +266,22 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
                               </TextListItem>
                               <TextListItem
                                 component="dt"
+                                data-ouia-component-id="Repositories title"
                               >
                                 <dt
                                   className=""
+                                  data-ouia-component-id="Repositories title"
                                 >
                                   Repositories
                                 </dt>
                               </TextListItem>
                               <TextListItem
                                 component="dd"
+                                data-ouia-component-id="Repositories value"
                               >
                                 <dd
                                   className=""
+                                  data-ouia-component-id="Repositories value"
                                 >
                                   <Clickable
                                     onClick={[Function]}
@@ -299,7 +317,7 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
 exports[`ConfigurationCard should not render hasPackages 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-9"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -338,11 +356,13 @@ exports[`ConfigurationCard should not render hasPackages 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Services title"
             >
               Services
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Services value"
             >
               <a
                 href="http://localhost:5000//services"
@@ -352,11 +372,13 @@ exports[`ConfigurationCard should not render hasPackages 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Running processes title"
             >
               Running processes
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Running processes value"
             >
               <a
                 href="http://localhost:5000//running_processes"
@@ -366,11 +388,13 @@ exports[`ConfigurationCard should not render hasPackages 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Repositories title"
             >
               Repositories
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Repositories value"
             >
               <a
                 href="http://localhost:5000//repositories"
@@ -389,7 +413,7 @@ exports[`ConfigurationCard should not render hasPackages 1`] = `
 exports[`ConfigurationCard should not render hasProcesses 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-11"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -428,11 +452,13 @@ exports[`ConfigurationCard should not render hasProcesses 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Installed packages title"
             >
               Installed packages
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Installed packages value"
             >
               <a
                 href="http://localhost:5000//installed_packages"
@@ -442,11 +468,13 @@ exports[`ConfigurationCard should not render hasProcesses 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Services title"
             >
               Services
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Services value"
             >
               <a
                 href="http://localhost:5000//services"
@@ -456,11 +484,13 @@ exports[`ConfigurationCard should not render hasProcesses 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Repositories title"
             >
               Repositories
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Repositories value"
             >
               <a
                 href="http://localhost:5000//repositories"
@@ -479,7 +509,7 @@ exports[`ConfigurationCard should not render hasProcesses 1`] = `
 exports[`ConfigurationCard should not render hasRepositories 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-12"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -518,11 +548,13 @@ exports[`ConfigurationCard should not render hasRepositories 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Installed packages title"
             >
               Installed packages
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Installed packages value"
             >
               <a
                 href="http://localhost:5000//installed_packages"
@@ -532,11 +564,13 @@ exports[`ConfigurationCard should not render hasRepositories 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Services title"
             >
               Services
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Services value"
             >
               <a
                 href="http://localhost:5000//services"
@@ -546,11 +580,13 @@ exports[`ConfigurationCard should not render hasRepositories 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Running processes title"
             >
               Running processes
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Running processes value"
             >
               <a
                 href="http://localhost:5000//running_processes"
@@ -569,7 +605,7 @@ exports[`ConfigurationCard should not render hasRepositories 1`] = `
 exports[`ConfigurationCard should not render hasServices 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-10"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -608,11 +644,13 @@ exports[`ConfigurationCard should not render hasServices 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Installed packages title"
             >
               Installed packages
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Installed packages value"
             >
               <a
                 href="http://localhost:5000//installed_packages"
@@ -622,11 +660,13 @@ exports[`ConfigurationCard should not render hasServices 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Running processes title"
             >
               Running processes
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Running processes value"
             >
               <a
                 href="http://localhost:5000//running_processes"
@@ -636,11 +676,13 @@ exports[`ConfigurationCard should not render hasServices 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Repositories title"
             >
               Repositories
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Repositories value"
             >
               <a
                 href="http://localhost:5000//repositories"
@@ -659,7 +701,7 @@ exports[`ConfigurationCard should not render hasServices 1`] = `
 exports[`ConfigurationCard should render correctly - no data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-1"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -698,11 +740,13 @@ exports[`ConfigurationCard should render correctly - no data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Installed packages title"
             >
               Installed packages
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Installed packages value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -714,11 +758,13 @@ exports[`ConfigurationCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Services title"
             >
               Services
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Services value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -730,11 +776,13 @@ exports[`ConfigurationCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Running processes title"
             >
               Running processes
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Running processes value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -746,11 +794,13 @@ exports[`ConfigurationCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Repositories title"
             >
               Repositories
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Repositories value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -771,7 +821,7 @@ exports[`ConfigurationCard should render correctly - no data 1`] = `
 exports[`ConfigurationCard should render correctly with data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-2"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -810,11 +860,13 @@ exports[`ConfigurationCard should render correctly with data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Installed packages title"
             >
               Installed packages
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Installed packages value"
             >
               <a
                 href="http://localhost:5000//installed_packages"
@@ -824,11 +876,13 @@ exports[`ConfigurationCard should render correctly with data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Services title"
             >
               Services
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Services value"
             >
               <a
                 href="http://localhost:5000//services"
@@ -838,11 +892,13 @@ exports[`ConfigurationCard should render correctly with data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Running processes title"
             >
               Running processes
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Running processes value"
             >
               <a
                 href="http://localhost:5000//running_processes"
@@ -852,11 +908,13 @@ exports[`ConfigurationCard should render correctly with data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Repositories title"
             >
               Repositories
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Repositories value"
             >
               <a
                 href="http://localhost:5000//repositories"
@@ -875,7 +933,7 @@ exports[`ConfigurationCard should render correctly with data 1`] = `
 exports[`ConfigurationCard should render enabled/disabled 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-3"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -914,11 +972,13 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Installed packages title"
             >
               Installed packages
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Installed packages value"
             >
               <a
                 href="http://localhost:5000//installed_packages"
@@ -928,11 +988,13 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Services title"
             >
               Services
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Services value"
             >
               <a
                 href="http://localhost:5000//services"
@@ -942,11 +1004,13 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Running processes title"
             >
               Running processes
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Running processes value"
             >
               <a
                 href="http://localhost:5000//running_processes"
@@ -956,11 +1020,13 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Repositories title"
             >
               Repositories
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Repositories value"
             >
               <a
                 href="http://localhost:5000//repositories"
@@ -979,7 +1045,7 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
 exports[`ConfigurationCard should render extra 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-13"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -1018,11 +1084,13 @@ exports[`ConfigurationCard should render extra 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Installed packages title"
             >
               Installed packages
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Installed packages value"
             >
               <a
                 href="http://localhost:5000//installed_packages"
@@ -1032,11 +1100,13 @@ exports[`ConfigurationCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Services title"
             >
               Services
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Services value"
             >
               <a
                 href="http://localhost:5000//services"
@@ -1046,11 +1116,13 @@ exports[`ConfigurationCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Running processes title"
             >
               Running processes
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Running processes value"
             >
               <a
                 href="http://localhost:5000//running_processes"
@@ -1060,11 +1132,13 @@ exports[`ConfigurationCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Repositories title"
             >
               Repositories
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Repositories value"
             >
               <a
                 href="http://localhost:5000//repositories"
@@ -1074,21 +1148,25 @@ exports[`ConfigurationCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="something title"
             >
               something
             </dt>
             <dd
               class=""
+              data-ouia-component-id="something value"
             >
               test
             </dd>
             <dt
               class=""
+              data-ouia-component-id="with click title"
             >
               with click
             </dt>
             <dd
               class=""
+              data-ouia-component-id="with click value"
             >
               <a
                 href="http://localhost:5000//undefined"

--- a/src/components/GeneralInfo/DataCollectorsCard/__snapshots__/DataCollectorsCard.test.js.snap
+++ b/src/components/GeneralInfo/DataCollectorsCard/__snapshots__/DataCollectorsCard.test.js.snap
@@ -3,7 +3,7 @@
 exports[`DataCollectorsCard should render correctly - no data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-1"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -321,7 +321,7 @@ exports[`DataCollectorsCard should render correctly - no data 1`] = `
 exports[`DataCollectorsCard should render correctly with data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-2"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -639,7 +639,7 @@ exports[`DataCollectorsCard should render correctly with data 1`] = `
 exports[`DataCollectorsCard should render custom collectors 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-3"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""

--- a/src/components/GeneralInfo/EditButton/EditButton.js
+++ b/src/components/GeneralInfo/EditButton/EditButton.js
@@ -5,15 +5,24 @@ import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-compo
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 import { PencilAltIcon } from '@patternfly/react-icons';
+import {
+  NO_MODIFY_HOST_TOOLTIP_MESSAGE,
+  REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP,
+} from '../../../constants';
+import { useSelector } from 'react-redux';
+import { Button, Tooltip } from '@patternfly/react-core';
 
 const InnerButton = ({ link, onClick }) => (
-  <a
-    className="ins-c-inventory__detail--action"
+  <Button
+    component="a"
     href={`${window.location.href}/${link}`}
     onClick={onClick}
+    className="ins-c-inventory__detail--action"
+    aria-label="Edit"
+    variant="plain"
   >
     <PencilAltIcon />
-  </a>
+  </Button>
 );
 
 InnerButton.propTypes = {
@@ -24,18 +33,30 @@ InnerButton.propTypes = {
 let permissionsCache = undefined;
 
 const EditButtonUnknownPermissions = (props) => {
-  const { hasAccess } = usePermissionsWithContext([
-    'inventory:*:*',
-    'inventory:hosts:write',
-    'inventory:*:write',
-  ]);
+  const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
 
-  if (hasAccess) {
-    permissionsCache = hasAccess;
+  const { hasAccess: canEditHost } = usePermissionsWithContext([
+    'inventory:hosts:write',
+    ...(entity?.groups?.[0]?.id !== undefined // if the host is in a group, then we can check group level access
+      ? [REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP(entity?.groups?.[0]?.id)]
+      : []),
+  ]);
+  if (canEditHost) {
+    permissionsCache = canEditHost;
   }
 
-  if (!hasAccess) {
-    return null;
+  if (!canEditHost) {
+    return (
+      <Tooltip
+        aria="none"
+        aria-live="polite"
+        content={NO_MODIFY_HOST_TOOLTIP_MESSAGE}
+      >
+        <Button isAriaDisabled aria-label="Edit" variant="plain">
+          <PencilAltIcon />
+        </Button>
+      </Tooltip>
+    );
   }
 
   return <InnerButton {...props} />;
@@ -57,7 +78,11 @@ const EditButtonWrapper = ({ writePermissions, ...props }) => {
     return <EditButtonUnknownPermissions {...props} />;
   }
 
-  return null;
+  return (
+    <Tooltip content={NO_MODIFY_HOST_TOOLTIP_MESSAGE}>
+      <PencilAltIcon />
+    </Tooltip>
+  );
 };
 
 EditButtonWrapper.propTypes = {

--- a/src/components/GeneralInfo/EditButton/EditButton.js
+++ b/src/components/GeneralInfo/EditButton/EditButton.js
@@ -30,8 +30,6 @@ InnerButton.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
 
-let permissionsCache = undefined;
-
 const EditButtonUnknownPermissions = (props) => {
   const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
 
@@ -41,9 +39,6 @@ const EditButtonUnknownPermissions = (props) => {
       ? [REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP(entity?.groups?.[0]?.id)]
       : []),
   ]);
-  if (canEditHost) {
-    permissionsCache = canEditHost;
-  }
 
   if (!canEditHost) {
     return (
@@ -70,7 +65,7 @@ EditButtonUnknownPermissions.propTypes = {
 const EditButtonWrapper = ({ writePermissions, ...props }) => {
   const { isProd } = useChrome();
 
-  if (isProd?.() || writePermissions || permissionsCache) {
+  if (isProd?.() || writePermissions) {
     return <InnerButton {...props} />;
   }
 

--- a/src/components/GeneralInfo/EditButton/EditButton.js
+++ b/src/components/GeneralInfo/EditButton/EditButton.js
@@ -42,11 +42,7 @@ const EditButtonUnknownPermissions = (props) => {
 
   if (!canEditHost) {
     return (
-      <Tooltip
-        aria="none"
-        aria-live="polite"
-        content={NO_MODIFY_HOST_TOOLTIP_MESSAGE}
-      >
+      <Tooltip content={NO_MODIFY_HOST_TOOLTIP_MESSAGE}>
         <Button isAriaDisabled aria-label="Edit" variant="plain">
           <PencilAltIcon />
         </Button>
@@ -75,7 +71,9 @@ const EditButtonWrapper = ({ writePermissions, ...props }) => {
 
   return (
     <Tooltip content={NO_MODIFY_HOST_TOOLTIP_MESSAGE}>
-      <PencilAltIcon />
+      <Button isAriaDisabled aria-label="Edit" variant="plain">
+        <PencilAltIcon />
+      </Button>
     </Tooltip>
   );
 };

--- a/src/components/GeneralInfo/EditButton/EditButtonWithAccess.test.js
+++ b/src/components/GeneralInfo/EditButton/EditButtonWithAccess.test.js
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 import EditButton from './EditButton';
+import { Tooltip } from '@patternfly/react-core';
 
 jest.mock(
   '@redhat-cloud-services/frontend-components-utilities/RBACHook',
@@ -12,6 +13,11 @@ jest.mock(
     usePermissionsWithContext: () => ({ hasAccess: true }),
   })
 );
+
+jest.mock('react-redux', () => ({
+  esModule: true,
+  useSelector: () => ({}),
+}));
 
 describe('EditButton with access', () => {
   let onClick;
@@ -22,9 +28,10 @@ describe('EditButton with access', () => {
     link = 'some-link';
   });
 
-  it('renders with permission', () => {
+  it('enables with permission', () => {
     const wrapper = mount(<EditButton onClick={onClick} link={link} />);
 
+    expect(wrapper.find(Tooltip)).toHaveLength(0);
     expect(wrapper.find(PencilAltIcon)).toHaveLength(1);
     expect(wrapper.find('a').props().href).toEqual(
       'http://localhost:5000//some-link'

--- a/src/components/GeneralInfo/EditButton/EditButtonWithNoAccess.test.js
+++ b/src/components/GeneralInfo/EditButton/EditButtonWithNoAccess.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 import EditButton from './EditButton';
+import { Tooltip } from '@patternfly/react-core';
 
 jest.mock(
   '@redhat-cloud-services/frontend-components-utilities/RBACHook',
@@ -11,6 +12,11 @@ jest.mock(
     usePermissionsWithContext: () => ({ hasAccess: false }),
   })
 );
+
+jest.mock('react-redux', () => ({
+  esModule: true,
+  useSelector: () => ({}),
+}));
 
 describe('EditButton with no access', () => {
   let onClick;
@@ -21,27 +27,30 @@ describe('EditButton with no access', () => {
     link = 'some-link';
   });
 
-  it('do not render with no permission', () => {
+  it('disables with no permission', () => {
     const wrapper = mount(<EditButton onClick={onClick} link={link} />);
 
-    expect(wrapper.find(PencilAltIcon)).toHaveLength(0);
+    expect(wrapper.find(Tooltip)).toHaveLength(1);
+    expect(wrapper.find(PencilAltIcon)).toHaveLength(1);
     expect(wrapper.find('a')).toHaveLength(0);
   });
 
-  it('do not render with no permission - write permissions set to false', () => {
+  it('disables with no permission - write permissions set to false', () => {
     const wrapper = mount(
       <EditButton onClick={onClick} link={link} writePermissions={false} />
     );
 
-    expect(wrapper.find(PencilAltIcon)).toHaveLength(0);
+    expect(wrapper.find(Tooltip)).toHaveLength(1);
+    expect(wrapper.find(PencilAltIcon)).toHaveLength(1);
     expect(wrapper.find('a')).toHaveLength(0);
   });
 
-  it('render when write permissions are set to true', () => {
+  it('enables when write permissions are set to true', () => {
     const wrapper = mount(
       <EditButton onClick={onClick} link={link} writePermissions={true} />
     );
 
+    expect(wrapper.find(Tooltip)).toHaveLength(0);
     expect(wrapper.find(PencilAltIcon)).toHaveLength(1);
     expect(wrapper.find('a').props().href).toEqual(
       'http://localhost:5000//some-link'

--- a/src/components/GeneralInfo/EditButton/EditButtonWithNoAccessProd.test.js
+++ b/src/components/GeneralInfo/EditButton/EditButtonWithNoAccessProd.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 import EditButton from './EditButton';
+import { Tooltip } from '@patternfly/react-core';
 
 jest.mock(
   '@redhat-cloud-services/frontend-components-utilities/RBACHook',
@@ -19,6 +20,11 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   }),
 }));
 
+jest.mock('react-redux', () => ({
+  esModule: true,
+  useSelector: () => ({}),
+}));
+
 describe('EditButton with no access', () => {
   let onClick;
   let link;
@@ -28,9 +34,10 @@ describe('EditButton with no access', () => {
     link = 'some-link';
   });
 
-  it('render on production', () => {
+  it('renders on production', () => {
     const wrapper = mount(<EditButton onClick={onClick} link={link} />);
 
+    expect(wrapper.find(Tooltip)).toHaveLength(0);
     expect(wrapper.find(PencilAltIcon)).toHaveLength(1);
     expect(wrapper.find('a').props().href).toEqual(
       'http://localhost:5000//some-link'

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -18,7 +18,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-39"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -57,6 +57,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -65,7 +66,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                           aria-disabled="false"
                           aria-label="Action for Host name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-19"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -87,11 +88,13 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -100,7 +103,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                           aria-disabled="false"
                           aria-label="Action for Display name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-20"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -122,9 +125,15 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-21"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -144,6 +153,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -152,7 +162,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-22"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -174,10 +184,16 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-23"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -197,71 +213,85 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -277,7 +307,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-40"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -316,31 +346,37 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -350,11 +386,13 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -364,11 +402,13 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -388,7 +428,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-41"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -427,41 +467,49 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -477,7 +525,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-42"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -804,7 +852,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-43"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -843,11 +891,13 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -855,41 +905,49 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -905,7 +963,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-44"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -944,11 +1002,13 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -958,11 +1018,13 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -972,11 +1034,13 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -986,11 +1050,13 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -1029,7 +1095,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-75"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -1068,6 +1134,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -1076,7 +1143,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                           aria-disabled="false"
                           aria-label="Action for Host name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-31"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-49"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -1098,11 +1165,13 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -1111,7 +1180,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                           aria-disabled="false"
                           aria-label="Action for Display name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-32"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-50"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -1133,9 +1202,15 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-51"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -1155,6 +1230,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -1163,7 +1239,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-33"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-52"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -1185,10 +1261,16 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-53"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -1208,71 +1290,85 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -1288,7 +1384,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-76"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -1327,31 +1423,37 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -1361,11 +1463,13 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -1375,11 +1479,13 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -1399,7 +1505,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-77"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -1438,41 +1544,49 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -1488,7 +1602,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-78"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -1815,7 +1929,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-79"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -1854,11 +1968,13 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -1866,41 +1982,49 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -1916,7 +2040,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-80"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -1955,31 +2079,37 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -1995,7 +2125,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-81"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -2034,11 +2164,13 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -2048,11 +2180,13 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -2062,11 +2196,13 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -2076,11 +2212,13 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -2119,7 +2257,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-63"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -2158,6 +2296,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -2166,7 +2305,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                           aria-disabled="false"
                           aria-label="Action for Host name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-25"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-39"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -2188,11 +2327,13 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -2201,7 +2342,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                           aria-disabled="false"
                           aria-label="Action for Display name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-26"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-40"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -2223,9 +2364,15 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-41"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -2245,6 +2392,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -2253,7 +2401,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-27"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-42"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -2275,10 +2423,16 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-43"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -2298,71 +2452,85 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -2378,7 +2546,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-64"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -2417,31 +2585,37 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -2451,11 +2625,13 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -2465,11 +2641,13 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -2489,7 +2667,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-65"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -2528,41 +2706,49 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -2578,7 +2764,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-66"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -2905,7 +3091,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-67"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -2944,11 +3130,13 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -2956,41 +3144,49 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -3006,7 +3202,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-68"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -3045,31 +3241,37 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -3104,7 +3306,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-51"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -3143,6 +3345,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -3151,7 +3354,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                           aria-disabled="false"
                           aria-label="Action for Host name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-29"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -3173,11 +3376,13 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -3186,7 +3391,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                           aria-disabled="false"
                           aria-label="Action for Display name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-20"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-30"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -3208,9 +3413,15 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-31"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -3230,6 +3441,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -3238,7 +3450,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-21"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-32"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -3260,10 +3472,16 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-33"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -3283,71 +3501,85 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -3363,7 +3595,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-52"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -3402,41 +3634,49 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -3452,7 +3692,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-53"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -3779,7 +4019,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-54"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -3818,11 +4058,13 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -3830,41 +4072,49 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -3880,7 +4130,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-55"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -3919,31 +4169,37 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -3959,7 +4215,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-56"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -3998,11 +4254,13 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -4012,11 +4270,13 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -4026,11 +4286,13 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -4040,11 +4302,13 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -4083,7 +4347,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-27"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -4122,6 +4386,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -4129,93 +4394,6 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                         <button
                           aria-disabled="false"
                           aria-label="Action for Host name"
-                          class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-7"
-                          data-ouia-component-type="PF4/Button"
-                          data-ouia-safe="true"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align:-0.125em"
-                            viewBox="0 0 512 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-                            />
-                          </svg>
-                        </button>
-                      </dt>
-                      <dd
-                        class=""
-                      >
-                        Not available
-                      </dd>
-                      <dt
-                        class=""
-                      >
-                        <span>
-                          Display name
-                        </span>
-                        <button
-                          aria-disabled="false"
-                          aria-label="Action for Display name"
-                          class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-8"
-                          data-ouia-component-type="PF4/Button"
-                          data-ouia-safe="true"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align:-0.125em"
-                            viewBox="0 0 512 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-                            />
-                          </svg>
-                        </button>
-                      </dt>
-                      <dd
-                        class=""
-                      >
-                        <a
-                          class="ins-c-inventory__detail--action"
-                          href="http://localhost:5000//display_name"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align:-0.125em"
-                            viewBox="0 0 512 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
-                            />
-                          </svg>
-                        </a>
-                      </dd>
-                      <dt
-                        class=""
-                      >
-                        <span>
-                          Ansible hostname
-                        </span>
-                        <button
-                          aria-disabled="false"
-                          aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
                           data-ouia-component-id="OUIA-Generated-Button-plain-9"
                           data-ouia-component-type="PF4/Button"
@@ -4239,10 +4417,112 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="Display name title"
+                      >
+                        <span>
+                          Display name
+                        </span>
+                        <button
+                          aria-disabled="false"
+                          aria-label="Action for Display name"
+                          class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align:-0.125em"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                            />
+                          </svg>
+                        </button>
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Display name value"
+                      >
+                        <a
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          href="http://localhost:5000//display_name"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align:-0.125em"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                            />
+                          </svg>
+                        </a>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="Ansible hostname title"
+                      >
+                        <span>
+                          Ansible hostname
+                        </span>
+                        <button
+                          aria-disabled="false"
+                          aria-label="Action for Ansible hostname"
+                          class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align:-0.125em"
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                            />
+                          </svg>
+                        </button>
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -4262,71 +4542,85 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -4342,7 +4636,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-28"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -4381,31 +4675,37 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -4415,11 +4715,13 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -4429,11 +4731,13 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -4453,7 +4757,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-29"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -4492,41 +4796,49 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -4542,7 +4854,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-30"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -4869,7 +5181,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-31"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -4908,31 +5220,37 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -4948,7 +5266,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-32"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -4987,11 +5305,13 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -5001,11 +5321,13 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -5015,11 +5337,13 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -5029,11 +5353,13 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -5072,7 +5398,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-15"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -5111,31 +5437,37 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -5145,11 +5477,13 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -5159,11 +5493,13 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -5183,7 +5519,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-16"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -5222,41 +5558,49 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -5272,7 +5616,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-17"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -5599,7 +5943,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-18"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -5638,11 +5982,13 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -5650,41 +5996,49 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -5700,7 +6054,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-19"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -5739,31 +6093,37 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -5779,7 +6139,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-20"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -5818,11 +6178,13 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -5832,11 +6194,13 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -5846,11 +6210,13 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -5860,11 +6226,13 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -5903,7 +6271,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-45"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -5942,6 +6310,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -5950,7 +6319,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                           aria-disabled="false"
                           aria-label="Action for Host name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-24"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -5972,11 +6341,13 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -5985,7 +6356,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                           aria-disabled="false"
                           aria-label="Action for Display name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-25"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -6007,9 +6378,15 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-26"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -6029,6 +6406,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -6037,7 +6415,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-27"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -6059,10 +6437,16 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-28"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -6082,71 +6466,85 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -6162,7 +6560,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-46"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -6201,31 +6599,37 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -6235,11 +6639,13 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -6249,11 +6655,13 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -6273,7 +6681,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-47"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -6312,41 +6720,49 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -6362,7 +6778,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-48"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -6689,7 +7105,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-49"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -6728,11 +7144,13 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -6740,41 +7158,49 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -6797,7 +7223,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-50"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -6836,11 +7262,13 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -6850,11 +7278,13 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -6864,11 +7294,13 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -6878,11 +7310,13 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -6921,7 +7355,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-82"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -6960,6 +7394,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -6968,7 +7403,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                           aria-disabled="false"
                           aria-label="Action for Host name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-34"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-54"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -6990,11 +7425,13 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -7003,7 +7440,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                           aria-disabled="false"
                           aria-label="Action for Display name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-35"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-55"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -7025,9 +7462,15 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-56"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -7047,6 +7490,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -7055,7 +7499,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-36"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-57"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -7077,10 +7521,16 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-58"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -7100,71 +7550,85 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -7180,7 +7644,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-83"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -7219,31 +7683,37 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -7253,11 +7723,13 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -7267,11 +7739,13 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -7291,7 +7765,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-84"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -7330,41 +7804,49 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -7380,7 +7862,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-85"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -7707,7 +8189,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-86"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -7746,11 +8228,13 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -7758,41 +8242,49 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -7808,7 +8300,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-87"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -7847,31 +8339,37 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -7887,7 +8385,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-88"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -7926,11 +8424,13 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -7940,11 +8440,13 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -7954,11 +8456,13 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -7968,11 +8472,13 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -8018,7 +8524,7 @@ exports[`GeneralInformation custom components should render custom Configuration
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-69"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -8057,6 +8563,7 @@ exports[`GeneralInformation custom components should render custom Configuration
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -8065,7 +8572,7 @@ exports[`GeneralInformation custom components should render custom Configuration
                           aria-disabled="false"
                           aria-label="Action for Host name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-28"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-44"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -8087,11 +8594,13 @@ exports[`GeneralInformation custom components should render custom Configuration
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -8100,7 +8609,7 @@ exports[`GeneralInformation custom components should render custom Configuration
                           aria-disabled="false"
                           aria-label="Action for Display name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-29"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-45"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -8122,9 +8631,15 @@ exports[`GeneralInformation custom components should render custom Configuration
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-46"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -8144,6 +8659,7 @@ exports[`GeneralInformation custom components should render custom Configuration
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -8152,7 +8668,7 @@ exports[`GeneralInformation custom components should render custom Configuration
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-30"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-47"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -8174,10 +8690,16 @@ exports[`GeneralInformation custom components should render custom Configuration
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-48"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -8197,71 +8719,85 @@ exports[`GeneralInformation custom components should render custom Configuration
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -8277,7 +8813,7 @@ exports[`GeneralInformation custom components should render custom Configuration
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-70"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -8316,31 +8852,37 @@ exports[`GeneralInformation custom components should render custom Configuration
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -8350,11 +8892,13 @@ exports[`GeneralInformation custom components should render custom Configuration
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -8364,11 +8908,13 @@ exports[`GeneralInformation custom components should render custom Configuration
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -8388,7 +8934,7 @@ exports[`GeneralInformation custom components should render custom Configuration
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-71"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -8427,41 +8973,49 @@ exports[`GeneralInformation custom components should render custom Configuration
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -8477,7 +9031,7 @@ exports[`GeneralInformation custom components should render custom Configuration
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-72"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -8804,7 +9358,7 @@ exports[`GeneralInformation custom components should render custom Configuration
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-73"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -8843,11 +9397,13 @@ exports[`GeneralInformation custom components should render custom Configuration
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -8855,41 +9411,49 @@ exports[`GeneralInformation custom components should render custom Configuration
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -8905,7 +9469,7 @@ exports[`GeneralInformation custom components should render custom Configuration
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-74"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -8944,31 +9508,37 @@ exports[`GeneralInformation custom components should render custom Configuration
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -9010,7 +9580,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-57"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -9049,6 +9619,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -9057,7 +9628,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                           aria-disabled="false"
                           aria-label="Action for Host name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-22"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-34"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -9079,11 +9650,13 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -9092,7 +9665,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                           aria-disabled="false"
                           aria-label="Action for Display name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-23"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-35"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -9114,9 +9687,15 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-36"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -9136,6 +9715,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -9144,7 +9724,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-24"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-37"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -9166,10 +9746,16 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-38"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -9189,71 +9775,85 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -9276,7 +9876,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-58"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -9315,41 +9915,49 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -9365,7 +9973,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-59"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -9692,7 +10300,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-60"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -9731,11 +10339,13 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -9743,41 +10353,49 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -9793,7 +10411,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-61"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -9832,31 +10450,37 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -9872,7 +10496,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-62"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -9911,11 +10535,13 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -9925,11 +10551,13 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -9939,11 +10567,13 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -9953,11 +10583,13 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -9996,7 +10628,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-33"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -10035,6 +10667,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -10043,7 +10676,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                           aria-disabled="false"
                           aria-label="Action for Host name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-14"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -10065,11 +10698,13 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -10078,7 +10713,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                           aria-disabled="false"
                           aria-label="Action for Display name"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-15"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -10100,9 +10735,15 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -10122,6 +10763,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -10130,7 +10772,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-17"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -10152,10 +10794,16 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -10175,71 +10823,85 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -10255,7 +10917,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-34"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -10294,31 +10956,37 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -10328,11 +10996,13 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -10342,11 +11012,13 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -10366,7 +11038,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-35"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -10405,41 +11077,49 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -10455,7 +11135,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-36"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -10789,7 +11469,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-37"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -10828,31 +11508,37 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -10868,7 +11554,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-38"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -10907,11 +11593,13 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -10921,11 +11609,13 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -10935,11 +11625,13 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -10949,11 +11641,13 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -10999,7 +11693,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-21"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -11038,31 +11732,37 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -11072,11 +11772,13 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -11086,11 +11788,13 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -11110,7 +11814,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-22"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -11149,41 +11853,49 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -11199,7 +11911,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-23"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -11526,7 +12238,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-24"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -11565,11 +12277,13 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -11577,41 +12291,49 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -11627,7 +12349,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-25"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -11666,31 +12388,37 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -11706,7 +12434,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-26"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -11745,11 +12473,13 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -11759,11 +12489,13 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -11773,11 +12505,13 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -11787,11 +12521,13 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"
@@ -11830,7 +12566,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-1"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -11869,6 +12605,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -11899,6 +12636,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
@@ -11910,6 +12648,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -11940,6 +12679,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
@@ -11951,6 +12691,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -11981,6 +12722,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
@@ -11992,11 +12734,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12008,11 +12752,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12024,11 +12770,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12040,11 +12788,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12056,11 +12806,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12072,11 +12824,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12088,11 +12842,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12114,7 +12870,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-2"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -12153,11 +12909,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12169,11 +12927,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12185,11 +12945,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12201,11 +12963,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12217,11 +12981,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12243,7 +13009,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-3"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -12282,11 +13048,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12298,11 +13066,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12314,11 +13084,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12330,11 +13102,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12356,7 +13130,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-4"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -12683,7 +13457,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-5"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -12722,11 +13496,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12738,11 +13514,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12754,11 +13532,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12770,11 +13550,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12786,11 +13568,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12812,7 +13596,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-6"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -12851,11 +13635,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12867,11 +13653,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12883,11 +13671,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12909,7 +13699,7 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-7"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -12948,11 +13738,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12964,11 +13756,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12980,11 +13774,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -12996,11 +13792,13 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -13041,7 +13839,7 @@ exports[`GeneralInformation should render correctly 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-8"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -13080,6 +13878,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Host name title"
                       >
                         <span>
                           Host name
@@ -13110,11 +13909,13 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Host name value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Display name title"
                       >
                         <span>
                           Display name
@@ -13145,9 +13946,15 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Display name value"
                       >
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//display_name"
                         >
                           <svg
@@ -13167,6 +13974,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Ansible hostname title"
                       >
                         <span>
                           Ansible hostname
@@ -13175,7 +13983,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                           aria-disabled="false"
                           aria-label="Action for Ansible hostname"
                           class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-7"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe="true"
                           type="button"
@@ -13197,10 +14005,16 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Ansible hostname value"
                       >
                         test-id
                         <a
-                          class="ins-c-inventory__detail--action"
+                          aria-disabled="false"
+                          aria-label="Edit"
+                          class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
                           href="http://localhost:5000//ansible_name"
                         >
                           <svg
@@ -13220,71 +14034,85 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="SAP title"
                       >
                         SAP
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="SAP value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="System purpose title"
                       >
                         System purpose
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="System purpose value"
                       >
                         Production
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Number of CPUs title"
                       >
                         Number of CPUs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Number of CPUs value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Sockets title"
                       >
                         Sockets
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Sockets value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Cores per socket title"
                       >
                         Cores per socket
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Cores per socket value"
                       >
                         1
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="CPU flags title"
                       >
                         CPU flags
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="CPU flags value"
                       >
                         0 flags
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RAM title"
                       >
                         RAM
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RAM value"
                       >
                         5 MB
                       </dd>
@@ -13300,7 +14128,7 @@ exports[`GeneralInformation should render correctly 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-9"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -13339,31 +14167,37 @@ exports[`GeneralInformation should render correctly 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Type title"
                       >
                         Type
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Type value"
                       >
                         test-type
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv4 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv4"
@@ -13373,11 +14207,13 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="IPv6 addresses title"
                       >
                         IPv6 addresses
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="IPv6 addresses value"
                       >
                         <a
                           href="http://localhost:5000//ipv6"
@@ -13387,11 +14223,13 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Interfaces/NICs title"
                       >
                         Interfaces/NICs
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Interfaces/NICs value"
                       >
                         <a
                           href="http://localhost:5000//interfaces"
@@ -13411,7 +14249,7 @@ exports[`GeneralInformation should render correctly 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-10"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -13450,41 +14288,49 @@ exports[`GeneralInformation should render correctly 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Current state title"
                       >
                         Current state
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Current state value"
                       >
                         Active
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Registered title"
                       >
                         Registered
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Registered value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last upload title"
                       >
                         Last upload
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last upload value"
                       >
                         Invalid date
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="RHC title"
                       >
                         RHC
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="RHC value"
                       >
                         Not available
                       </dd>
@@ -13500,7 +14346,7 @@ exports[`GeneralInformation should render correctly 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-11"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -13827,7 +14673,7 @@ exports[`GeneralInformation should render correctly 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-12"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -13866,11 +14712,13 @@ exports[`GeneralInformation should render correctly 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Release title"
                       >
                         Release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release value"
                       >
                         <span>
                           test-release
@@ -13878,41 +14726,49 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel release title"
                       >
                         Kernel release
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel release value"
                       >
                         test-kernel
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Architecture title"
                       >
                         Architecture
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Architecture value"
                       >
                         test-arch
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Last boot time title"
                       >
                         Last boot time
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Last boot time value"
                       >
                         Not available
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Kernel modules title"
                       >
                         Kernel modules
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Kernel modules value"
                       >
                         0 modules
                       </dd>
@@ -13928,7 +14784,7 @@ exports[`GeneralInformation should render correctly 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-13"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -13967,31 +14823,37 @@ exports[`GeneralInformation should render correctly 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Vendor title"
                       >
                         Vendor
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Vendor value"
                       >
                         test-vendor
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Version title"
                       >
                         Version
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Version value"
                       >
                         test-version
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Release date title"
                       >
                         Release date
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Release date value"
                       >
                         01 Apr 2014
                       </dd>
@@ -14007,7 +14869,7 @@ exports[`GeneralInformation should render correctly 1`] = `
         >
           <article
             class="pf-c-card"
-            data-ouia-component-id="OUIA-Generated-Card-14"
+            data-ouia-component-id="system-properties-card"
             data-ouia-component-type="PF4/Card"
             data-ouia-safe="true"
             id=""
@@ -14046,11 +14908,13 @@ exports[`GeneralInformation should render correctly 1`] = `
                     >
                       <dt
                         class=""
+                        data-ouia-component-id="Installed packages title"
                       >
                         Installed packages
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Installed packages value"
                       >
                         <a
                           href="http://localhost:5000//installed_packages"
@@ -14060,11 +14924,13 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Services title"
                       >
                         Services
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Services value"
                       >
                         <a
                           href="http://localhost:5000//services"
@@ -14074,11 +14940,13 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Running processes title"
                       >
                         Running processes
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Running processes value"
                       >
                         <a
                           href="http://localhost:5000//running_processes"
@@ -14088,11 +14956,13 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Repositories title"
                       >
                         Repositories
                       </dt>
                       <dd
                         class=""
+                        data-ouia-component-id="Repositories value"
                       >
                         <a
                           href="http://localhost:5000//repositories"

--- a/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
+++ b/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
@@ -3,7 +3,7 @@
 exports[`InfrastructureCard should not render hasIPv4 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-11"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -42,31 +42,37 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Type title"
             >
               Type
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Type value"
             >
               test-type
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv6 addresses title"
             >
               IPv6 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv6 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv6"
@@ -76,11 +82,13 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Interfaces/NICs title"
             >
               Interfaces/NICs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Interfaces/NICs value"
             >
               <a
                 href="http://localhost:5000//interfaces"
@@ -99,7 +107,7 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
 exports[`InfrastructureCard should not render hasIPv6 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-12"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -138,31 +146,37 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Type title"
             >
               Type
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Type value"
             >
               test-type
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv4 addresses title"
             >
               IPv4 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv4 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv4"
@@ -172,11 +186,13 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Interfaces/NICs title"
             >
               Interfaces/NICs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Interfaces/NICs value"
             >
               <a
                 href="http://localhost:5000//interfaces"
@@ -195,7 +211,7 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
 exports[`InfrastructureCard should not render hasInterfaces 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-13"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -234,31 +250,37 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Type title"
             >
               Type
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Type value"
             >
               test-type
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv4 addresses title"
             >
               IPv4 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv4 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv4"
@@ -268,11 +290,13 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv6 addresses title"
             >
               IPv6 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv6 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv6"
@@ -291,7 +315,7 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
 exports[`InfrastructureCard should not render hasType 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-9"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -330,21 +354,25 @@ exports[`InfrastructureCard should not render hasType 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv4 addresses title"
             >
               IPv4 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv4 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv4"
@@ -354,11 +382,13 @@ exports[`InfrastructureCard should not render hasType 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv6 addresses title"
             >
               IPv6 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv6 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv6"
@@ -368,11 +398,13 @@ exports[`InfrastructureCard should not render hasType 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Interfaces/NICs title"
             >
               Interfaces/NICs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Interfaces/NICs value"
             >
               <a
                 href="http://localhost:5000//interfaces"
@@ -391,7 +423,7 @@ exports[`InfrastructureCard should not render hasType 1`] = `
 exports[`InfrastructureCard should not render hasVendor 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-10"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -430,21 +462,25 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Type title"
             >
               Type
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Type value"
             >
               test-type
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv4 addresses title"
             >
               IPv4 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv4 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv4"
@@ -454,11 +490,13 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv6 addresses title"
             >
               IPv6 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv6 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv6"
@@ -468,11 +506,13 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Interfaces/NICs title"
             >
               Interfaces/NICs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Interfaces/NICs value"
             >
               <a
                 href="http://localhost:5000//interfaces"
@@ -491,7 +531,7 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
 exports[`InfrastructureCard should render correctly - no data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-1"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -530,11 +570,13 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Type title"
             >
               Type
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Type value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -546,11 +588,13 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -562,11 +606,13 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv4 addresses title"
             >
               IPv4 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv4 addresses value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -578,11 +624,13 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv6 addresses title"
             >
               IPv6 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv6 addresses value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -594,11 +642,13 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Interfaces/NICs title"
             >
               Interfaces/NICs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Interfaces/NICs value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -619,7 +669,7 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
 exports[`InfrastructureCard should render correctly with data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-2"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -658,31 +708,37 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Type title"
             >
               Type
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Type value"
             >
               test-type
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv4 addresses title"
             >
               IPv4 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv4 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv4"
@@ -692,11 +748,13 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv6 addresses title"
             >
               IPv6 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv6 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv6"
@@ -706,11 +764,13 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Interfaces/NICs title"
             >
               Interfaces/NICs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Interfaces/NICs value"
             >
               <a
                 href="http://localhost:5000//interfaces"
@@ -729,7 +789,7 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
 exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-3"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -768,51 +828,61 @@ exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Type title"
             >
               Type
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Type value"
             >
               virtual
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv4 addresses title"
             >
               IPv4 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv4 addresses value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv6 addresses title"
             >
               IPv6 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv6 addresses value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Interfaces/NICs title"
             >
               Interfaces/NICs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Interfaces/NICs value"
             >
               Not available
             </dd>
@@ -827,7 +897,7 @@ exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
 exports[`InfrastructureCard should render enabled/disabled 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-4"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -866,31 +936,37 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Type title"
             >
               Type
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Type value"
             >
               test-type
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv4 addresses title"
             >
               IPv4 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv4 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv4"
@@ -900,11 +976,13 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv6 addresses title"
             >
               IPv6 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv6 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv6"
@@ -914,11 +992,13 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Interfaces/NICs title"
             >
               Interfaces/NICs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Interfaces/NICs value"
             >
               <a
                 href="http://localhost:5000//interfaces"
@@ -937,7 +1017,7 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
 exports[`InfrastructureCard should render extra 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-14"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -976,31 +1056,37 @@ exports[`InfrastructureCard should render extra 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Type title"
             >
               Type
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Type value"
             >
               test-type
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Vendor title"
             >
               Vendor
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Vendor value"
             >
               test-vendor
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv4 addresses title"
             >
               IPv4 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv4 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv4"
@@ -1010,11 +1096,13 @@ exports[`InfrastructureCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="IPv6 addresses title"
             >
               IPv6 addresses
             </dt>
             <dd
               class=""
+              data-ouia-component-id="IPv6 addresses value"
             >
               <a
                 href="http://localhost:5000//ipv6"
@@ -1024,11 +1112,13 @@ exports[`InfrastructureCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Interfaces/NICs title"
             >
               Interfaces/NICs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Interfaces/NICs value"
             >
               <a
                 href="http://localhost:5000//interfaces"
@@ -1038,21 +1128,25 @@ exports[`InfrastructureCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="something title"
             >
               something
             </dt>
             <dd
               class=""
+              data-ouia-component-id="something value"
             >
               test
             </dd>
             <dt
               class=""
+              data-ouia-component-id="with click title"
             >
               with click
             </dt>
             <dd
               class=""
+              data-ouia-component-id="with click value"
             >
               <a
                 href="http://localhost:5000//undefined"

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -64,7 +64,7 @@ Clickable.propTypes = {
 };
 
 const LoadingCard = ({ title, isLoading, items, children }) => (
-  <Card>
+  <Card ouiaId="system-properties-card">
     <CardBody>
       <Stack hasGutter>
         <StackItem>
@@ -90,10 +90,24 @@ const LoadingCard = ({ title, isLoading, items, children }) => (
                     key
                   ) => (
                     <Fragment key={key}>
-                      <TextListItem component={TextListItemVariants.dt}>
+                      <TextListItem
+                        component={TextListItemVariants.dt}
+                        data-ouia-component-id={`${
+                          typeof itemTitle === 'string'
+                            ? itemTitle
+                            : itemTitle?.props?.title
+                        } title`}
+                      >
                         {itemTitle}
                       </TextListItem>
-                      <TextListItem component={TextListItemVariants.dd}>
+                      <TextListItem
+                        component={TextListItemVariants.dd}
+                        data-ouia-component-id={`${
+                          typeof itemTitle === 'string'
+                            ? itemTitle
+                            : itemTitle?.props?.title
+                        } value`}
+                      >
                         {isLoading && (
                           <Skeleton size={size || SkeletonSize.sm} />
                         )}

--- a/src/components/GeneralInfo/LoadingCard/__snapshots__/LoadingCard.test.js.snap
+++ b/src/components/GeneralInfo/LoadingCard/__snapshots__/LoadingCard.test.js.snap
@@ -28,7 +28,9 @@ exports[`LoadingCard Clickable should render 1`] = `
 `;
 
 exports[`LoadingCard Loading card render - isLoading: false 1`] = `
-<Card>
+<Card
+  ouiaId="system-properties-card"
+>
   <CardBody>
     <Stack
       hasGutter={true}
@@ -51,7 +53,9 @@ exports[`LoadingCard Loading card render - isLoading: false 1`] = `
 `;
 
 exports[`LoadingCard Loading card render - isLoading: true 1`] = `
-<Card>
+<Card
+  ouiaId="system-properties-card"
+>
   <CardBody>
     <Stack
       hasGutter={true}
@@ -74,7 +78,9 @@ exports[`LoadingCard Loading card render - isLoading: true 1`] = `
 `;
 
 exports[`LoadingCard Loading card render 1`] = `
-<Card>
+<Card
+  ouiaId="system-properties-card"
+>
   <CardBody>
     <Stack
       hasGutter={true}
@@ -97,11 +103,13 @@ exports[`LoadingCard Loading card render 1`] = `
           >
             <TextListItem
               component="dt"
+              data-ouia-component-id="test-title title"
             >
               test-title
             </TextListItem>
             <TextListItem
               component="dd"
+              data-ouia-component-id="test-title value"
             >
               <Clickable
                 onClick={[MockFunction]}
@@ -110,11 +118,13 @@ exports[`LoadingCard Loading card render 1`] = `
             </TextListItem>
             <TextListItem
               component="dt"
+              data-ouia-component-id="just title title"
             >
               just title
             </TextListItem>
             <TextListItem
               component="dd"
+              data-ouia-component-id="just title value"
             >
               Not available
             </TextListItem>
@@ -127,7 +137,9 @@ exports[`LoadingCard Loading card render 1`] = `
 `;
 
 exports[`LoadingCard should render loading bars 1`] = `
-<Card>
+<Card
+  ouiaId="system-properties-card"
+>
   <CardBody>
     <Stack
       hasGutter={true}
@@ -150,11 +162,13 @@ exports[`LoadingCard should render loading bars 1`] = `
           >
             <TextListItem
               component="dt"
+              data-ouia-component-id="test-title title"
             >
               test-title
             </TextListItem>
             <TextListItem
               component="dd"
+              data-ouia-component-id="test-title value"
             >
               <Skeleton
                 size="md"
@@ -162,11 +176,13 @@ exports[`LoadingCard should render loading bars 1`] = `
             </TextListItem>
             <TextListItem
               component="dt"
+              data-ouia-component-id="just title title"
             >
               just title
             </TextListItem>
             <TextListItem
               component="dd"
+              data-ouia-component-id="just title value"
             >
               <Skeleton
                 size="sm"

--- a/src/components/GeneralInfo/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
+++ b/src/components/GeneralInfo/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
@@ -3,7 +3,7 @@
 exports[`OperatingSystemCard should not render hasArchitecture 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-9"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -42,11 +42,13 @@ exports[`OperatingSystemCard should not render hasArchitecture 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Release title"
             >
               Release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release value"
             >
               <span>
                 test-release
@@ -54,31 +56,37 @@ exports[`OperatingSystemCard should not render hasArchitecture 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel release title"
             >
               Kernel release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel release value"
             >
               test-kernel
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last boot time title"
             >
               Last boot time
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last boot time value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel modules title"
             >
               Kernel modules
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel modules value"
             >
               0 modules
             </dd>
@@ -93,7 +101,7 @@ exports[`OperatingSystemCard should not render hasArchitecture 1`] = `
 exports[`OperatingSystemCard should not render hasKernelModules 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-11"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -132,11 +140,13 @@ exports[`OperatingSystemCard should not render hasKernelModules 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Release title"
             >
               Release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release value"
             >
               <span>
                 test-release
@@ -144,31 +154,37 @@ exports[`OperatingSystemCard should not render hasKernelModules 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel release title"
             >
               Kernel release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel release value"
             >
               test-kernel
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Architecture title"
             >
               Architecture
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Architecture value"
             >
               test-arch
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last boot time title"
             >
               Last boot time
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last boot time value"
             >
               Not available
             </dd>
@@ -183,7 +199,7 @@ exports[`OperatingSystemCard should not render hasKernelModules 1`] = `
 exports[`OperatingSystemCard should not render hasKernelRelease 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-8"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -222,11 +238,13 @@ exports[`OperatingSystemCard should not render hasKernelRelease 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Release title"
             >
               Release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release value"
             >
               <span>
                 test-release
@@ -234,31 +252,37 @@ exports[`OperatingSystemCard should not render hasKernelRelease 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Architecture title"
             >
               Architecture
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Architecture value"
             >
               test-arch
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last boot time title"
             >
               Last boot time
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last boot time value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel modules title"
             >
               Kernel modules
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel modules value"
             >
               0 modules
             </dd>
@@ -273,7 +297,7 @@ exports[`OperatingSystemCard should not render hasKernelRelease 1`] = `
 exports[`OperatingSystemCard should not render hasLastBoot 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-10"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -312,11 +336,13 @@ exports[`OperatingSystemCard should not render hasLastBoot 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Release title"
             >
               Release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release value"
             >
               <span>
                 test-release
@@ -324,31 +350,37 @@ exports[`OperatingSystemCard should not render hasLastBoot 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel release title"
             >
               Kernel release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel release value"
             >
               test-kernel
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Architecture title"
             >
               Architecture
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Architecture value"
             >
               test-arch
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel modules title"
             >
               Kernel modules
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel modules value"
             >
               0 modules
             </dd>
@@ -363,7 +395,7 @@ exports[`OperatingSystemCard should not render hasLastBoot 1`] = `
 exports[`OperatingSystemCard should not render hasRelease 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-7"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -402,41 +434,49 @@ exports[`OperatingSystemCard should not render hasRelease 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Kernel release title"
             >
               Kernel release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel release value"
             >
               test-kernel
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Architecture title"
             >
               Architecture
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Architecture value"
             >
               test-arch
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last boot time title"
             >
               Last boot time
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last boot time value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel modules title"
             >
               Kernel modules
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel modules value"
             >
               0 modules
             </dd>
@@ -451,7 +491,7 @@ exports[`OperatingSystemCard should not render hasRelease 1`] = `
 exports[`OperatingSystemCard should render correctly - no data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-1"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -490,11 +530,13 @@ exports[`OperatingSystemCard should render correctly - no data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Release title"
             >
               Release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -506,11 +548,13 @@ exports[`OperatingSystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel release title"
             >
               Kernel release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel release value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -522,11 +566,13 @@ exports[`OperatingSystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Architecture title"
             >
               Architecture
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Architecture value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -538,11 +584,13 @@ exports[`OperatingSystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last boot time title"
             >
               Last boot time
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last boot time value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -554,11 +602,13 @@ exports[`OperatingSystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel modules title"
             >
               Kernel modules
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel modules value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -579,7 +629,7 @@ exports[`OperatingSystemCard should render correctly - no data 1`] = `
 exports[`OperatingSystemCard should render correctly with data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-2"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -618,11 +668,13 @@ exports[`OperatingSystemCard should render correctly with data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Release title"
             >
               Release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release value"
             >
               <span>
                 test-release
@@ -630,41 +682,49 @@ exports[`OperatingSystemCard should render correctly with data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel release title"
             >
               Kernel release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel release value"
             >
               test-kernel
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Architecture title"
             >
               Architecture
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Architecture value"
             >
               test-arch
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last boot time title"
             >
               Last boot time
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last boot time value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel modules title"
             >
               Kernel modules
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel modules value"
             >
               0 modules
             </dd>
@@ -679,7 +739,7 @@ exports[`OperatingSystemCard should render correctly with data 1`] = `
 exports[`OperatingSystemCard should render correctly with rhsm facts 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-4"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -718,11 +778,13 @@ exports[`OperatingSystemCard should render correctly with rhsm facts 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Release title"
             >
               Release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release value"
             >
               <span>
                 Not available
@@ -730,41 +792,49 @@ exports[`OperatingSystemCard should render correctly with rhsm facts 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel release title"
             >
               Kernel release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel release value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Architecture title"
             >
               Architecture
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Architecture value"
             >
               x86_64
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last boot time title"
             >
               Last boot time
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last boot time value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel modules title"
             >
               Kernel modules
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel modules value"
             >
               Not available
             </dd>
@@ -779,7 +849,7 @@ exports[`OperatingSystemCard should render correctly with rhsm facts 1`] = `
 exports[`OperatingSystemCard should render enabled/disabled 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-3"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -818,11 +888,13 @@ exports[`OperatingSystemCard should render enabled/disabled 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Release title"
             >
               Release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release value"
             >
               <span>
                 test-release
@@ -830,41 +902,49 @@ exports[`OperatingSystemCard should render enabled/disabled 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel release title"
             >
               Kernel release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel release value"
             >
               test-kernel
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Architecture title"
             >
               Architecture
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Architecture value"
             >
               test-arch
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last boot time title"
             >
               Last boot time
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last boot time value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel modules title"
             >
               Kernel modules
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel modules value"
             >
               0 modules
             </dd>
@@ -879,7 +959,7 @@ exports[`OperatingSystemCard should render enabled/disabled 1`] = `
 exports[`OperatingSystemCard should render extra 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-12"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -918,11 +998,13 @@ exports[`OperatingSystemCard should render extra 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Release title"
             >
               Release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Release value"
             >
               <span>
                 test-release
@@ -930,61 +1012,73 @@ exports[`OperatingSystemCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel release title"
             >
               Kernel release
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel release value"
             >
               test-kernel
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Architecture title"
             >
               Architecture
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Architecture value"
             >
               test-arch
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last boot time title"
             >
               Last boot time
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last boot time value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Kernel modules title"
             >
               Kernel modules
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Kernel modules value"
             >
               0 modules
             </dd>
             <dt
               class=""
+              data-ouia-component-id="something title"
             >
               something
             </dt>
             <dd
               class=""
+              data-ouia-component-id="something value"
             >
               test
             </dd>
             <dt
               class=""
+              data-ouia-component-id="with click title"
             >
               with click
             </dt>
             <dd
               class=""
+              data-ouia-component-id="with click value"
             >
               <a
                 href="http://localhost:5000//undefined"

--- a/src/components/GeneralInfo/SystemCard/SystemCard.test.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.test.js
@@ -10,6 +10,7 @@ import promiseMiddleware from 'redux-promise-middleware';
 import { hosts } from '../../../api/api';
 import MockAdapter from 'axios-mock-adapter';
 import mockedData from '../../../__mocks__/mockedData.json';
+import { Provider } from 'react-redux';
 
 const mock = new MockAdapter(hosts.axios, { onNoMatch: 'throwException' });
 
@@ -67,13 +68,21 @@ describe('SystemCard', () => {
 
   it('should render correctly - no data', () => {
     const store = mockStore({ systemProfileStore: {}, entityDetails: {} });
-    const wrapper = render(<SystemCard store={store} />);
+    const wrapper = render(
+      <Provider store={store}>
+        <SystemCard />
+      </Provider>
+    );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render correctly with data', () => {
     const store = mockStore(initialState);
-    const wrapper = render(<SystemCard store={store} />);
+    const wrapper = render(
+      <Provider store={store}>
+        <SystemCard />
+      </Provider>
+    );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
@@ -88,7 +97,11 @@ describe('SystemCard', () => {
         },
       },
     });
-    const wrapper = render(<SystemCard store={store} />);
+    const wrapper = render(
+      <Provider store={store}>
+        <SystemCard />
+      </Provider>
+    );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
@@ -101,14 +114,22 @@ describe('SystemCard', () => {
         },
       },
     });
-    const wrapper = render(<SystemCard store={store} />);
+    const wrapper = render(
+      <Provider store={store}>
+        <SystemCard />
+      </Provider>
+    );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   describe('API', () => {
     it('should calculate correct ansible host - direct ansible host', () => {
       const store = mockStore(initialState);
-      const wrapper = mount(<SystemCard store={store} />);
+      const wrapper = mount(
+        <Provider store={store}>
+          <SystemCard />
+        </Provider>
+      );
       expect(
         wrapper.find('SystemCardCore').first().instance().getAnsibleHost()
       ).toBe('test-ansible-host');
@@ -125,7 +146,11 @@ describe('SystemCard', () => {
           },
         },
       });
-      const wrapper = mount(<SystemCard store={store} />);
+      const wrapper = mount(
+        <Provider store={store}>
+          <SystemCard />
+        </Provider>
+      );
       expect(
         wrapper.find('SystemCardCore').first().instance().getAnsibleHost()
       ).toBe('test-fqdn');
@@ -142,7 +167,11 @@ describe('SystemCard', () => {
           },
         },
       });
-      const wrapper = mount(<SystemCard store={store} />);
+      const wrapper = mount(
+        <Provider store={store}>
+          <SystemCard />
+        </Provider>
+      );
       expect(
         wrapper.find('SystemCardCore').first().instance().getAnsibleHost()
       ).toBe('test-id');
@@ -150,7 +179,11 @@ describe('SystemCard', () => {
 
     it('should show edit display name', () => {
       const store = mockStore(initialState);
-      const wrapper = mount(<SystemCard store={store} />);
+      const wrapper = mount(
+        <Provider store={store}>
+          <SystemCard />
+        </Provider>
+      );
       wrapper
         .find('a[href$="display_name"]')
         .first()
@@ -173,7 +206,11 @@ describe('SystemCard', () => {
 
     it('should show edit display name', () => {
       const store = mockStore(initialState);
-      const wrapper = mount(<SystemCard store={store} />);
+      const wrapper = mount(
+        <Provider store={store}>
+          <SystemCard />
+        </Provider>
+      );
       wrapper
         .find('a[href$="ansible_name"]')
         .first()
@@ -200,7 +237,11 @@ describe('SystemCard', () => {
         .onGet('/api/inventory/v1/hosts/test-id/system_profile')
         .reply(200, mockedData);
       const store = mockStore(initialState);
-      const wrapper = mount(<SystemCard store={store} />);
+      const wrapper = mount(
+        <Provider store={store}>
+          <SystemCard />
+        </Provider>
+      );
       wrapper
         .find('a[href$="display_name"]')
         .first()
@@ -208,7 +249,7 @@ describe('SystemCard', () => {
           preventDefault: () => undefined,
         });
       wrapper.find('button[data-action="confirm"]').first().simulate('click');
-      expect(store.getActions()[0].type).toBe('UPDATE_DISPLAY_NAME_PENDING');
+      expect(store.getActions().length).toBe(0); // the button is disabled since the input hasn't been changed
     });
 
     it('should call edit display name actions', () => {
@@ -217,7 +258,11 @@ describe('SystemCard', () => {
         .onGet('/api/inventory/v1/hosts/test-id/system_profile')
         .reply(200, mockedData);
       const store = mockStore(initialState);
-      const wrapper = mount(<SystemCard store={store} />);
+      const wrapper = mount(
+        <Provider store={store}>
+          <SystemCard />
+        </Provider>
+      );
       wrapper
         .find('a[href$="ansible_name"]')
         .first()
@@ -225,7 +270,7 @@ describe('SystemCard', () => {
           preventDefault: () => undefined,
         });
       wrapper.find('button[data-action="confirm"]').first().simulate('click');
-      expect(store.getActions()[0].type).toBe('SET_ANSIBLE_HOST_PENDING');
+      expect(store.getActions().length).toBe(0); // the button is disabled since the input hasn't been changed
     });
 
     it('should handle click on SAP identifiers', () => {
@@ -243,7 +288,9 @@ describe('SystemCard', () => {
       location.pathname = 'localhost:3000/example/sap_sids';
 
       const wrapper = mount(
-        <SystemCard store={store} handleClick={handleClick} />
+        <Provider store={store}>
+          <SystemCard handleClick={handleClick} />
+        </Provider>
       );
       wrapper.find('dd a').last().simulate('click');
       expect(handleClick).toHaveBeenCalledWith('SAP IDs (SID)', {
@@ -273,7 +320,9 @@ describe('SystemCard', () => {
       location.pathname = 'localhost:3000/example/flag';
 
       const wrapper = mount(
-        <SystemCard store={store} handleClick={handleClick} />
+        <Provider store={store}>
+          <SystemCard handleClick={handleClick} />
+        </Provider>
       );
       wrapper.find('dd a').last().simulate('click');
       expect(handleClick).toHaveBeenCalledWith('CPU flags', {
@@ -304,7 +353,9 @@ describe('SystemCard', () => {
     it(`should not render ${item}`, () => {
       const store = mockStore(initialState);
       const wrapper = render(
-        <SystemCard store={store} {...{ [item]: false }} />
+        <Provider store={store}>
+          <SystemCard {...{ [item]: false }} />
+        </Provider>
       );
       expect(toJson(wrapper)).toMatchSnapshot();
     })
@@ -313,17 +364,19 @@ describe('SystemCard', () => {
   it('should render extra', () => {
     const store = mockStore(initialState);
     const wrapper = render(
-      <SystemCard
-        store={store}
-        extra={[
-          { title: 'something', value: 'test' },
-          {
-            title: 'with click',
-            value: '1 tests',
-            onClick: (_e, handleClick) => handleClick('Something', {}, 'small'),
-          },
-        ]}
-      />
+      <Provider store={store}>
+        <SystemCard
+          extra={[
+            { title: 'something', value: 'test' },
+            {
+              title: 'with click',
+              value: '1 tests',
+              onClick: (_e, handleClick) =>
+                handleClick('Something', {}, 'small'),
+            },
+          ]}
+        />
+      </Provider>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });

--- a/src/components/GeneralInfo/SystemCard/__snapshots__/SystemCard.test.js.snap
+++ b/src/components/GeneralInfo/SystemCard/__snapshots__/SystemCard.test.js.snap
@@ -3,7 +3,7 @@
 exports[`SystemCard should not render hasAnsibleHostname 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-16"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -42,6 +42,7 @@ exports[`SystemCard should not render hasAnsibleHostname 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -50,7 +51,7 @@ exports[`SystemCard should not render hasAnsibleHostname 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-48"
+                data-ouia-component-id="OUIA-Generated-Button-plain-75"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -72,11 +73,13 @@ exports[`SystemCard should not render hasAnsibleHostname 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -85,7 +88,7 @@ exports[`SystemCard should not render hasAnsibleHostname 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-49"
+                data-ouia-component-id="OUIA-Generated-Button-plain-76"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -107,10 +110,16 @@ exports[`SystemCard should not render hasAnsibleHostname 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-77"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -130,71 +139,85 @@ exports[`SystemCard should not render hasAnsibleHostname 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -209,7 +232,7 @@ exports[`SystemCard should not render hasAnsibleHostname 1`] = `
 exports[`SystemCard should not render hasCPUFlags 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-22"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -248,6 +271,7 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -256,7 +280,7 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-65"
+                data-ouia-component-id="OUIA-Generated-Button-plain-103"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -278,11 +302,13 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -291,7 +317,7 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-66"
+                data-ouia-component-id="OUIA-Generated-Button-plain-104"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -313,10 +339,16 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-105"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -336,6 +368,7 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -344,7 +377,7 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-67"
+                data-ouia-component-id="OUIA-Generated-Button-plain-106"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -366,10 +399,16 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-107"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -389,61 +428,73 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -458,7 +509,7 @@ exports[`SystemCard should not render hasCPUFlags 1`] = `
 exports[`SystemCard should not render hasCPUs 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-19"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -497,6 +548,7 @@ exports[`SystemCard should not render hasCPUs 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -505,7 +557,7 @@ exports[`SystemCard should not render hasCPUs 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-56"
+                data-ouia-component-id="OUIA-Generated-Button-plain-88"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -527,11 +579,13 @@ exports[`SystemCard should not render hasCPUs 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -540,7 +594,7 @@ exports[`SystemCard should not render hasCPUs 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-57"
+                data-ouia-component-id="OUIA-Generated-Button-plain-89"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -562,10 +616,16 @@ exports[`SystemCard should not render hasCPUs 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-90"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -585,6 +645,7 @@ exports[`SystemCard should not render hasCPUs 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -593,7 +654,7 @@ exports[`SystemCard should not render hasCPUs 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-58"
+                data-ouia-component-id="OUIA-Generated-Button-plain-91"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -615,10 +676,16 @@ exports[`SystemCard should not render hasCPUs 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-92"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -638,61 +705,73 @@ exports[`SystemCard should not render hasCPUs 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -707,7 +786,7 @@ exports[`SystemCard should not render hasCPUs 1`] = `
 exports[`SystemCard should not render hasCores 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-21"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -746,6 +825,7 @@ exports[`SystemCard should not render hasCores 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -754,7 +834,7 @@ exports[`SystemCard should not render hasCores 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-62"
+                data-ouia-component-id="OUIA-Generated-Button-plain-98"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -776,11 +856,13 @@ exports[`SystemCard should not render hasCores 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -789,7 +871,7 @@ exports[`SystemCard should not render hasCores 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-63"
+                data-ouia-component-id="OUIA-Generated-Button-plain-99"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -811,10 +893,16 @@ exports[`SystemCard should not render hasCores 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-100"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -834,6 +922,7 @@ exports[`SystemCard should not render hasCores 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -842,7 +931,7 @@ exports[`SystemCard should not render hasCores 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-64"
+                data-ouia-component-id="OUIA-Generated-Button-plain-101"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -864,10 +953,16 @@ exports[`SystemCard should not render hasCores 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-102"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -887,61 +982,73 @@ exports[`SystemCard should not render hasCores 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -956,7 +1063,7 @@ exports[`SystemCard should not render hasCores 1`] = `
 exports[`SystemCard should not render hasDisplayName 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-15"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -995,6 +1102,7 @@ exports[`SystemCard should not render hasDisplayName 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -1003,7 +1111,7 @@ exports[`SystemCard should not render hasDisplayName 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-46"
+                data-ouia-component-id="OUIA-Generated-Button-plain-72"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1025,11 +1133,13 @@ exports[`SystemCard should not render hasDisplayName 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -1038,7 +1148,7 @@ exports[`SystemCard should not render hasDisplayName 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-47"
+                data-ouia-component-id="OUIA-Generated-Button-plain-73"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1060,10 +1170,16 @@ exports[`SystemCard should not render hasDisplayName 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-74"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -1083,71 +1199,85 @@ exports[`SystemCard should not render hasDisplayName 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -1162,7 +1292,7 @@ exports[`SystemCard should not render hasDisplayName 1`] = `
 exports[`SystemCard should not render hasHostName 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-14"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -1201,6 +1331,7 @@ exports[`SystemCard should not render hasHostName 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -1209,7 +1340,7 @@ exports[`SystemCard should not render hasHostName 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-44"
+                data-ouia-component-id="OUIA-Generated-Button-plain-68"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1231,10 +1362,16 @@ exports[`SystemCard should not render hasHostName 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-69"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -1254,6 +1391,7 @@ exports[`SystemCard should not render hasHostName 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -1262,7 +1400,7 @@ exports[`SystemCard should not render hasHostName 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-45"
+                data-ouia-component-id="OUIA-Generated-Button-plain-70"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1284,10 +1422,16 @@ exports[`SystemCard should not render hasHostName 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-71"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -1307,71 +1451,85 @@ exports[`SystemCard should not render hasHostName 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -1386,7 +1544,7 @@ exports[`SystemCard should not render hasHostName 1`] = `
 exports[`SystemCard should not render hasRAM 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-23"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -1425,6 +1583,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -1433,7 +1592,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-68"
+                data-ouia-component-id="OUIA-Generated-Button-plain-108"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1455,11 +1614,13 @@ exports[`SystemCard should not render hasRAM 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -1468,7 +1629,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-69"
+                data-ouia-component-id="OUIA-Generated-Button-plain-109"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1490,10 +1651,16 @@ exports[`SystemCard should not render hasRAM 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-110"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -1513,6 +1680,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -1521,7 +1689,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-70"
+                data-ouia-component-id="OUIA-Generated-Button-plain-111"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1543,10 +1711,16 @@ exports[`SystemCard should not render hasRAM 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-112"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -1566,61 +1740,73 @@ exports[`SystemCard should not render hasRAM 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
@@ -1635,7 +1821,7 @@ exports[`SystemCard should not render hasRAM 1`] = `
 exports[`SystemCard should not render hasSAP 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-17"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -1674,6 +1860,7 @@ exports[`SystemCard should not render hasSAP 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -1682,7 +1869,7 @@ exports[`SystemCard should not render hasSAP 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-50"
+                data-ouia-component-id="OUIA-Generated-Button-plain-78"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1704,11 +1891,13 @@ exports[`SystemCard should not render hasSAP 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -1717,7 +1906,7 @@ exports[`SystemCard should not render hasSAP 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-51"
+                data-ouia-component-id="OUIA-Generated-Button-plain-79"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1739,10 +1928,16 @@ exports[`SystemCard should not render hasSAP 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-80"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -1762,6 +1957,7 @@ exports[`SystemCard should not render hasSAP 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -1770,7 +1966,7 @@ exports[`SystemCard should not render hasSAP 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-52"
+                data-ouia-component-id="OUIA-Generated-Button-plain-81"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1792,10 +1988,16 @@ exports[`SystemCard should not render hasSAP 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-82"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -1815,61 +2017,73 @@ exports[`SystemCard should not render hasSAP 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -1884,7 +2098,7 @@ exports[`SystemCard should not render hasSAP 1`] = `
 exports[`SystemCard should not render hasSockets 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-20"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -1923,6 +2137,7 @@ exports[`SystemCard should not render hasSockets 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -1931,7 +2146,7 @@ exports[`SystemCard should not render hasSockets 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-59"
+                data-ouia-component-id="OUIA-Generated-Button-plain-93"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1953,11 +2168,13 @@ exports[`SystemCard should not render hasSockets 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -1966,7 +2183,7 @@ exports[`SystemCard should not render hasSockets 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-60"
+                data-ouia-component-id="OUIA-Generated-Button-plain-94"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -1988,10 +2205,16 @@ exports[`SystemCard should not render hasSockets 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-95"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -2011,6 +2234,7 @@ exports[`SystemCard should not render hasSockets 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -2019,7 +2243,7 @@ exports[`SystemCard should not render hasSockets 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-61"
+                data-ouia-component-id="OUIA-Generated-Button-plain-96"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -2041,10 +2265,16 @@ exports[`SystemCard should not render hasSockets 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-97"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -2064,61 +2294,73 @@ exports[`SystemCard should not render hasSockets 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -2133,7 +2375,7 @@ exports[`SystemCard should not render hasSockets 1`] = `
 exports[`SystemCard should not render hasSystemPurpose 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-18"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -2172,6 +2414,7 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -2180,7 +2423,7 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-53"
+                data-ouia-component-id="OUIA-Generated-Button-plain-83"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -2202,11 +2445,13 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -2215,7 +2460,7 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-54"
+                data-ouia-component-id="OUIA-Generated-Button-plain-84"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -2237,10 +2482,16 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-85"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -2260,6 +2511,7 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -2268,7 +2520,7 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-55"
+                data-ouia-component-id="OUIA-Generated-Button-plain-86"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -2290,10 +2542,16 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-87"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -2313,61 +2571,73 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -2382,7 +2652,7 @@ exports[`SystemCard should not render hasSystemPurpose 1`] = `
 exports[`SystemCard should render correctly - no data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-1"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -2421,6 +2691,7 @@ exports[`SystemCard should render correctly - no data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -2451,6 +2722,7 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
@@ -2462,6 +2734,7 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -2492,6 +2765,7 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
@@ -2503,6 +2777,7 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -2533,6 +2808,7 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
@@ -2544,11 +2820,13 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -2560,11 +2838,13 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -2576,11 +2856,13 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -2592,11 +2874,13 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -2608,11 +2892,13 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -2624,11 +2910,13 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -2640,11 +2928,13 @@ exports[`SystemCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -2665,7 +2955,7 @@ exports[`SystemCard should render correctly - no data 1`] = `
 exports[`SystemCard should render correctly with SAP IDS 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-3"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -2704,6 +2994,7 @@ exports[`SystemCard should render correctly with SAP IDS 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -2711,94 +3002,6 @@ exports[`SystemCard should render correctly with SAP IDS 1`] = `
               <button
                 aria-disabled="false"
                 aria-label="Action for Host name"
-                class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-7"
-                data-ouia-component-type="PF4/Button"
-                data-ouia-safe="true"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align:-0.125em"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-                  />
-                </svg>
-              </button>
-            </dt>
-            <dd
-              class=""
-            >
-              Not available
-            </dd>
-            <dt
-              class=""
-            >
-              <span>
-                Display name
-              </span>
-              <button
-                aria-disabled="false"
-                aria-label="Action for Display name"
-                class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-8"
-                data-ouia-component-type="PF4/Button"
-                data-ouia-safe="true"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align:-0.125em"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-                  />
-                </svg>
-              </button>
-            </dt>
-            <dd
-              class=""
-            >
-              test-display-name
-              <a
-                class="ins-c-inventory__detail--action"
-                href="http://localhost:5000//display_name"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align:-0.125em"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
-                  />
-                </svg>
-              </a>
-            </dd>
-            <dt
-              class=""
-            >
-              <span>
-                Ansible hostname
-              </span>
-              <button
-                aria-disabled="false"
-                aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
                 data-ouia-component-id="OUIA-Generated-Button-plain-9"
                 data-ouia-component-type="PF4/Button"
@@ -2822,10 +3025,113 @@ exports[`SystemCard should render correctly with SAP IDS 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
+            >
+              Not available
+            </dd>
+            <dt
+              class=""
+              data-ouia-component-id="Display name title"
+            >
+              <span>
+                Display name
+              </span>
+              <button
+                aria-disabled="false"
+                aria-label="Action for Display name"
+                class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align:-0.125em"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                  />
+                </svg>
+              </button>
+            </dt>
+            <dd
+              class=""
+              data-ouia-component-id="Display name value"
+            >
+              test-display-name
+              <a
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                href="http://localhost:5000//display_name"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align:-0.125em"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                  />
+                </svg>
+              </a>
+            </dd>
+            <dt
+              class=""
+              data-ouia-component-id="Ansible hostname title"
+            >
+              <span>
+                Ansible hostname
+              </span>
+              <button
+                aria-disabled="false"
+                aria-label="Action for Ansible hostname"
+                class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align:-0.125em"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                  />
+                </svg>
+              </button>
+            </dt>
+            <dd
+              class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -2845,11 +3151,13 @@ exports[`SystemCard should render correctly with SAP IDS 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               <a
                 href="http://localhost:5000//sap_sids"
@@ -2859,61 +3167,73 @@ exports[`SystemCard should render correctly with SAP IDS 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -2928,7 +3248,7 @@ exports[`SystemCard should render correctly with SAP IDS 1`] = `
 exports[`SystemCard should render correctly with data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-2"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -2967,6 +3287,7 @@ exports[`SystemCard should render correctly with data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -2997,11 +3318,13 @@ exports[`SystemCard should render correctly with data 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -3032,10 +3355,16 @@ exports[`SystemCard should render correctly with data 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -3055,6 +3384,7 @@ exports[`SystemCard should render correctly with data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -3063,7 +3393,7 @@ exports[`SystemCard should render correctly with data 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                data-ouia-component-id="OUIA-Generated-Button-plain-7"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -3085,10 +3415,16 @@ exports[`SystemCard should render correctly with data 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -3108,71 +3444,85 @@ exports[`SystemCard should render correctly with data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
@@ -3187,7 +3537,7 @@ exports[`SystemCard should render correctly with data 1`] = `
 exports[`SystemCard should render correctly with rhsm facts 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-4"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -3226,6 +3576,7 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -3234,7 +3585,7 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                data-ouia-component-id="OUIA-Generated-Button-plain-14"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -3256,11 +3607,13 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -3269,7 +3622,7 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                data-ouia-component-id="OUIA-Generated-Button-plain-15"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -3291,10 +3644,16 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -3314,6 +3673,7 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -3322,7 +3682,7 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                data-ouia-component-id="OUIA-Generated-Button-plain-17"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -3344,10 +3704,16 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -3367,71 +3733,85 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               2
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               2
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               2 GB
             </dd>
@@ -3446,7 +3826,7 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
 exports[`SystemCard should render extra 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-24"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -3485,6 +3865,7 @@ exports[`SystemCard should render extra 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Host name title"
             >
               <span>
                 Host name
@@ -3493,7 +3874,7 @@ exports[`SystemCard should render extra 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Host name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-71"
+                data-ouia-component-id="OUIA-Generated-Button-plain-113"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -3515,11 +3896,13 @@ exports[`SystemCard should render extra 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Host name value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Display name title"
             >
               <span>
                 Display name
@@ -3528,7 +3911,7 @@ exports[`SystemCard should render extra 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Display name"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-72"
+                data-ouia-component-id="OUIA-Generated-Button-plain-114"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -3550,10 +3933,16 @@ exports[`SystemCard should render extra 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Display name value"
             >
               test-display-name
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-115"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//display_name"
               >
                 <svg
@@ -3573,6 +3962,7 @@ exports[`SystemCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Ansible hostname title"
             >
               <span>
                 Ansible hostname
@@ -3581,7 +3971,7 @@ exports[`SystemCard should render extra 1`] = `
                 aria-disabled="false"
                 aria-label="Action for Ansible hostname"
                 class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
-                data-ouia-component-id="OUIA-Generated-Button-plain-73"
+                data-ouia-component-id="OUIA-Generated-Button-plain-116"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe="true"
                 type="button"
@@ -3603,10 +3993,16 @@ exports[`SystemCard should render extra 1`] = `
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Ansible hostname value"
             >
               test-ansible-host
               <a
-                class="ins-c-inventory__detail--action"
+                aria-disabled="false"
+                aria-label="Edit"
+                class="pf-c-button pf-m-plain ins-c-inventory__detail--action"
+                data-ouia-component-id="OUIA-Generated-Button-plain-117"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe="true"
                 href="http://localhost:5000//ansible_name"
               >
                 <svg
@@ -3626,91 +4022,109 @@ exports[`SystemCard should render extra 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="SAP title"
             >
               SAP
             </dt>
             <dd
               class=""
+              data-ouia-component-id="SAP value"
             >
               Not available
             </dd>
             <dt
               class=""
+              data-ouia-component-id="System purpose title"
             >
               System purpose
             </dt>
             <dd
               class=""
+              data-ouia-component-id="System purpose value"
             >
               Production
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Number of CPUs title"
             >
               Number of CPUs
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Number of CPUs value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Sockets title"
             >
               Sockets
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Sockets value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Cores per socket title"
             >
               Cores per socket
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Cores per socket value"
             >
               1
             </dd>
             <dt
               class=""
+              data-ouia-component-id="CPU flags title"
             >
               CPU flags
             </dt>
             <dd
               class=""
+              data-ouia-component-id="CPU flags value"
             >
               0 flags
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RAM title"
             >
               RAM
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RAM value"
             >
               5 MB
             </dd>
             <dt
               class=""
+              data-ouia-component-id="something title"
             >
               something
             </dt>
             <dd
               class=""
+              data-ouia-component-id="something value"
             >
               test
             </dd>
             <dt
               class=""
+              data-ouia-component-id="with click title"
             >
               with click
             </dt>
             <dd
               class=""
+              data-ouia-component-id="with click value"
             >
               <a
                 href="http://localhost:5000//undefined"

--- a/src/components/GeneralInfo/SystemStatusCard/__snapshots__/SystemStatusCard.test.js.snap
+++ b/src/components/GeneralInfo/SystemStatusCard/__snapshots__/SystemStatusCard.test.js.snap
@@ -3,7 +3,7 @@
 exports[`SystemStatusCard should not render hasLastCheckIn 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-4"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -42,31 +42,37 @@ exports[`SystemStatusCard should not render hasLastCheckIn 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Current state title"
             >
               Current state
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Current state value"
             >
               Active
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014 00:00 UTC
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RHC title"
             >
               RHC
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RHC value"
             >
               Connected
             </dd>
@@ -81,7 +87,7 @@ exports[`SystemStatusCard should not render hasLastCheckIn 1`] = `
 exports[`SystemStatusCard should not render hasRHC 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-6"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -120,31 +126,37 @@ exports[`SystemStatusCard should not render hasRHC 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Current state title"
             >
               Current state
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Current state value"
             >
               Active
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014 00:00 UTC
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last upload title"
             >
               Last upload
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last upload value"
             >
               01 Jun 2014 00:00 UTC
             </dd>
@@ -159,7 +171,7 @@ exports[`SystemStatusCard should not render hasRHC 1`] = `
 exports[`SystemStatusCard should not render hasRegistered 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-5"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -198,31 +210,37 @@ exports[`SystemStatusCard should not render hasRegistered 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Current state title"
             >
               Current state
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Current state value"
             >
               Active
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last upload title"
             >
               Last upload
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last upload value"
             >
               01 Jun 2014 00:00 UTC
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RHC title"
             >
               RHC
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RHC value"
             >
               Connected
             </dd>
@@ -237,7 +255,7 @@ exports[`SystemStatusCard should not render hasRegistered 1`] = `
 exports[`SystemStatusCard should not render hasState 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-3"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -276,31 +294,37 @@ exports[`SystemStatusCard should not render hasState 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014 00:00 UTC
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last upload title"
             >
               Last upload
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last upload value"
             >
               01 Jun 2014 00:00 UTC
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RHC title"
             >
               RHC
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RHC value"
             >
               Connected
             </dd>
@@ -315,7 +339,7 @@ exports[`SystemStatusCard should not render hasState 1`] = `
 exports[`SystemStatusCard should render correctly - no data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-1"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -354,11 +378,13 @@ exports[`SystemStatusCard should render correctly - no data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Current state title"
             >
               Current state
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Current state value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -370,11 +396,13 @@ exports[`SystemStatusCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -386,11 +414,13 @@ exports[`SystemStatusCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last upload title"
             >
               Last upload
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last upload value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -402,11 +432,13 @@ exports[`SystemStatusCard should render correctly - no data 1`] = `
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RHC title"
             >
               RHC
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RHC value"
             >
               <div
                 class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -427,7 +459,7 @@ exports[`SystemStatusCard should render correctly - no data 1`] = `
 exports[`SystemStatusCard should render correctly with data 1`] = `
 <article
   class="pf-c-card"
-  data-ouia-component-id="OUIA-Generated-Card-2"
+  data-ouia-component-id="system-properties-card"
   data-ouia-component-type="PF4/Card"
   data-ouia-safe="true"
   id=""
@@ -466,41 +498,49 @@ exports[`SystemStatusCard should render correctly with data 1`] = `
           >
             <dt
               class=""
+              data-ouia-component-id="Current state title"
             >
               Current state
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Current state value"
             >
               Active
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Registered title"
             >
               Registered
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Registered value"
             >
               01 Apr 2014 00:00 UTC
             </dd>
             <dt
               class=""
+              data-ouia-component-id="Last upload title"
             >
               Last upload
             </dt>
             <dd
               class=""
+              data-ouia-component-id="Last upload value"
             >
               01 Jun 2014 00:00 UTC
             </dd>
             <dt
               class=""
+              data-ouia-component-id="RHC title"
             >
               RHC
             </dt>
             <dd
               class=""
+              data-ouia-component-id="RHC value"
             >
               Connected
             </dd>

--- a/src/components/GeneralInfo/TextInputModal/TextInputModal.js
+++ b/src/components/GeneralInfo/TextInputModal/TextInputModal.js
@@ -48,22 +48,23 @@ export default class TextInputModal extends Component {
         onClose={(event) => onCancel(event)}
         actions={[
           <Button
-            key="cancel"
-            data-action="cancel"
-            variant="secondary"
-            onClick={onCancel}
-            ouiaId={cancelOuiaId}
-          >
-            Cancel
-          </Button>,
-          <Button
             key="confirm"
             data-action="confirm"
             variant="primary"
             onClick={() => onSubmit(this.state.value)}
             ouiaId={confirmOuiaId}
+            isDisabled={this.props.value === this.state.value}
           >
             Save
+          </Button>,
+          <Button
+            key="cancel"
+            data-action="cancel"
+            variant="link"
+            onClick={onCancel}
+            ouiaId={cancelOuiaId}
+          >
+            Cancel
           </Button>,
         ]}
       >

--- a/src/components/GeneralInfo/TextInputModal/__snapshots__/TextInputModal.test.js.snap
+++ b/src/components/GeneralInfo/TextInputModal/__snapshots__/TextInputModal.test.js.snap
@@ -12,18 +12,19 @@ exports[`TextInputModal API onSubmit should NOT be called 1`] = `
     actions={
       Array [
         <Button
-          data-action="cancel"
-          onClick={[Function]}
-          variant="secondary"
-        >
-          Cancel
-        </Button>,
-        <Button
           data-action="confirm"
+          isDisabled={false}
           onClick={[Function]}
           variant="primary"
         >
           Save
+        </Button>,
+        <Button
+          data-action="cancel"
+          onClick={[Function]}
+          variant="link"
+        >
+          Cancel
         </Button>,
       ]
     }
@@ -107,17 +108,6 @@ exports[`TextInputModal API onSubmit should NOT be called 1`] = `
                 >
                   <button
                     aria-disabled="false"
-                    class="pf-c-button pf-m-secondary"
-                    data-action="cancel"
-                    data-ouia-component-id="OUIA-Generated-Button-secondary-4"
-                    data-ouia-component-type="PF4/Button"
-                    data-ouia-safe="true"
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    aria-disabled="false"
                     class="pf-c-button pf-m-primary"
                     data-action="confirm"
                     data-ouia-component-id="OUIA-Generated-Button-primary-4"
@@ -126,6 +116,17 @@ exports[`TextInputModal API onSubmit should NOT be called 1`] = `
                     type="button"
                   >
                     Save
+                  </button>
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-link"
+                    data-action="cancel"
+                    data-ouia-component-id="OUIA-Generated-Button-link-4"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    Cancel
                   </button>
                 </footer>
               </div>
@@ -138,18 +139,19 @@ exports[`TextInputModal API onSubmit should NOT be called 1`] = `
         actions={
           Array [
             <Button
-              data-action="cancel"
-              onClick={[Function]}
-              variant="secondary"
-            >
-              Cancel
-            </Button>,
-            <Button
               data-action="confirm"
+              isDisabled={false}
               onClick={[Function]}
               variant="primary"
             >
               Save
+            </Button>,
+            <Button
+              data-action="cancel"
+              onClick={[Function]}
+              variant="link"
+            >
+              Cancel
             </Button>,
           ]
         }
@@ -341,36 +343,8 @@ exports[`TextInputModal API onSubmit should NOT be called 1`] = `
                           className="pf-c-modal-box__footer"
                         >
                           <Button
-                            data-action="cancel"
-                            key="cancel"
-                            onClick={[Function]}
-                            variant="secondary"
-                          >
-                            <ButtonBase
-                              data-action="cancel"
-                              innerRef={null}
-                              onClick={[Function]}
-                              variant="secondary"
-                            >
-                              <button
-                                aria-disabled={false}
-                                aria-label={null}
-                                className="pf-c-button pf-m-secondary"
-                                data-action="cancel"
-                                data-ouia-component-id="OUIA-Generated-Button-secondary-4"
-                                data-ouia-component-type="PF4/Button"
-                                data-ouia-safe={true}
-                                disabled={false}
-                                onClick={[Function]}
-                                role={null}
-                                type="button"
-                              >
-                                Cancel
-                              </button>
-                            </ButtonBase>
-                          </Button>
-                          <Button
                             data-action="confirm"
+                            isDisabled={false}
                             key="confirm"
                             onClick={[Function]}
                             variant="primary"
@@ -378,6 +352,7 @@ exports[`TextInputModal API onSubmit should NOT be called 1`] = `
                             <ButtonBase
                               data-action="confirm"
                               innerRef={null}
+                              isDisabled={false}
                               onClick={[Function]}
                               variant="primary"
                             >
@@ -395,6 +370,35 @@ exports[`TextInputModal API onSubmit should NOT be called 1`] = `
                                 type="button"
                               >
                                 Save
+                              </button>
+                            </ButtonBase>
+                          </Button>
+                          <Button
+                            data-action="cancel"
+                            key="cancel"
+                            onClick={[Function]}
+                            variant="link"
+                          >
+                            <ButtonBase
+                              data-action="cancel"
+                              innerRef={null}
+                              onClick={[Function]}
+                              variant="link"
+                            >
+                              <button
+                                aria-disabled={false}
+                                aria-label={null}
+                                className="pf-c-button pf-m-link"
+                                data-action="cancel"
+                                data-ouia-component-id="OUIA-Generated-Button-link-4"
+                                data-ouia-component-type="PF4/Button"
+                                data-ouia-safe={true}
+                                disabled={false}
+                                onClick={[Function]}
+                                role={null}
+                                type="button"
+                              >
+                                Cancel
                               </button>
                             </ButtonBase>
                           </Button>
@@ -418,18 +422,19 @@ exports[`TextInputModal render should render aria label 1`] = `
   actions={
     Array [
       <Button
-        data-action="cancel"
-        onClick={[Function]}
-        variant="secondary"
-      >
-        Cancel
-      </Button>,
-      <Button
         data-action="confirm"
+        isDisabled={false}
         onClick={[Function]}
         variant="primary"
       >
         Save
+      </Button>,
+      <Button
+        data-action="cancel"
+        onClick={[Function]}
+        variant="link"
+      >
+        Cancel
       </Button>,
     ]
   }
@@ -462,18 +467,19 @@ exports[`TextInputModal render should render open 1`] = `
   actions={
     Array [
       <Button
-        data-action="cancel"
-        onClick={[Function]}
-        variant="secondary"
-      >
-        Cancel
-      </Button>,
-      <Button
         data-action="confirm"
+        isDisabled={false}
         onClick={[Function]}
         variant="primary"
       >
         Save
+      </Button>,
+      <Button
+        data-action="cancel"
+        onClick={[Function]}
+        variant="link"
+      >
+        Cancel
       </Button>,
     ]
   }
@@ -506,18 +512,19 @@ exports[`TextInputModal render should render title 1`] = `
   actions={
     Array [
       <Button
-        data-action="cancel"
-        onClick={[Function]}
-        variant="secondary"
-      >
-        Cancel
-      </Button>,
-      <Button
         data-action="confirm"
+        isDisabled={false}
         onClick={[Function]}
         variant="primary"
       >
         Save
+      </Button>,
+      <Button
+        data-action="cancel"
+        onClick={[Function]}
+        variant="link"
+      >
+        Cancel
       </Button>,
     ]
   }
@@ -550,18 +557,19 @@ exports[`TextInputModal render should render without any props 1`] = `
   actions={
     Array [
       <Button
-        data-action="cancel"
-        onClick={[Function]}
-        variant="secondary"
-      >
-        Cancel
-      </Button>,
-      <Button
         data-action="confirm"
+        isDisabled={true}
         onClick={[Function]}
         variant="primary"
       >
         Save
+      </Button>,
+      <Button
+        data-action="cancel"
+        onClick={[Function]}
+        variant="link"
+      >
+        Cancel
       </Button>,
     ]
   }

--- a/src/components/InventoryDetail/TopBar.js
+++ b/src/components/InventoryDetail/TopBar.js
@@ -16,10 +16,12 @@ import {
   Split,
   SplitItem,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import { redirectToInventoryList } from './helpers';
 import { useDispatch } from 'react-redux';
 import { toggleDrawer } from '../../store/actions';
+import { NO_MODIFY_HOST_TOOLTIP_MESSAGE } from '../../constants';
 
 /**
  * Top inventory bar with title, buttons (namely remove from inventory and inventory detail button) and actions.
@@ -90,18 +92,24 @@ const TopBar = ({
         <SplitItem>
           {loaded ? (
             <Flex>
-              {showDelete && (
-                <FlexItem>
-                  <DeleteWrapper>
+              <FlexItem>
+                <DeleteWrapper>
+                  {showDelete ? (
                     <Button
                       onClick={() => setIsModalOpen(true)}
                       variant="secondary"
                     >
                       Delete
                     </Button>
-                  </DeleteWrapper>
-                </FlexItem>
-              )}
+                  ) : (
+                    <Tooltip content={NO_MODIFY_HOST_TOOLTIP_MESSAGE}>
+                      <Button isAriaDisabled variant="secondary">
+                        Delete
+                      </Button>
+                    </Tooltip>
+                  )}
+                </DeleteWrapper>
+              </FlexItem>
               {inventoryActions?.length > 0 && (
                 <FlexItem>
                   <ActionsWrapper>

--- a/src/constants.js
+++ b/src/constants.js
@@ -195,6 +195,19 @@ export const REQUIRED_PERMISSIONS_TO_MODIFY_GROUP = (groupId) => [
   },
 ];
 
+export const REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP = (groupId) => ({
+  permission: 'inventory:hosts:write',
+  resourceDefinitions: [
+    {
+      attributeFilter: {
+        key: 'group.id',
+        operation: 'equal',
+        value: groupId,
+      },
+    },
+  ],
+});
+
 export const REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS = (groupId) => [
   {
     permission: 'inventory:hosts:read',

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -12,7 +12,6 @@ import {
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 import { routes } from '../Routes';
 import InventoryDetail from '../components/InventoryDetail/InventoryDetail';
-import { useHostsWritePermissions } from '../Utilities/constants';
 import {
   AdvisorTab,
   ComplianceTab,
@@ -21,6 +20,8 @@ import {
   RosTab,
   VulnerabilityTab,
 } from '../components/SystemDetails';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP } from '../constants';
 
 const appList = [
   {
@@ -89,7 +90,7 @@ const Inventory = () => {
   const store = useStore();
   const history = useHistory();
   const dispatch = useDispatch();
-  const writePermissions = useHostsWritePermissions();
+
   const entityLoaded = useSelector(
     ({ entityDetails }) => entityDetails?.loaded
   );
@@ -110,6 +111,13 @@ const Inventory = () => {
     [cloudProvider]
   );
   const clearNotifications = () => dispatch(actions.clearNotifications());
+
+  const { hasAccess: canDeleteHost } = usePermissionsWithContext([
+    'inventory:hosts:write',
+    ...(entity?.groups?.[0]?.id !== undefined // if the host is in a group, then we can check group level access
+      ? [REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP(entity?.groups?.[0]?.id)]
+      : []),
+  ]);
 
   useEffect(() => {
     chrome?.hideGlobalFilter?.(true);
@@ -155,7 +163,7 @@ const Inventory = () => {
     <InventoryDetail
       additionalClasses={additionalClasses}
       hideInvDrawer
-      showDelete={writePermissions}
+      showDelete={canDeleteHost}
       hideInvLink
       hideBack
       inventoryId={inventoryId}


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-5110.

This PR:
- Makes sure we always show **Delete**, **Edit display name** and **Edit Ansible hostname** buttons,
- Introduces more advanced check for the group level access: if user is eligible, the button is enabled, otherwise it is disabled with a helping tooltip,
- When user clicks on edit display name or ansible hostname buttons, the modal now has the Submit and Cancel buttons in the right order (more correct according to PF docs), and also the Submit button is disabled if the input value hasn't been changed.

## How to test

For the RBAC change: 

1. make sure you have an account you adjust RBAC permissions/roles
2. verify, that you are able to press Delete and edit buttons while having just `inventory:hosts:write` permission (with the Inventory Hosts Administrator role, for example)
3. then, try to remove this permissions and set `inventory:hosts:write` with a resource definition where the key is `group.id`, the operation `equal` (or `in`), the value is the ID of the group you can add hosts to (for the `in` operation you have to put the ID in an array)
4. once the host is in a chosen group, you have to be able to press the buttons
5. for the hosts outside of the group, you must be **not** able to do that (the buttons are disabled).

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/61027ad1-ebf8-4efe-966f-779416d6abd0)

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/36dc74c5-4777-4b78-8054-4f9cb1abdaa9)

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/0d72667e-b512-4229-b1aa-fe50ba956710)

