### PR TITLE
Inventory table: check RBAC on the group level when enabling actions

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -1,6 +1,4 @@
 import { createContext } from 'react';
-import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
-import { GENERAL_HOSTS_WRITE_PERMISSIONS } from '../constants';
 
 export const TEXT_FILTER = 'hostname_or_id';
 export const TEXTUAL_CHIP = 'textual';
@@ -250,13 +248,5 @@ export const generateFilter = (
         : [hostGroupFilter],
     },
   ].filter(Boolean);
-
-export const useHostsWritePermissions = () => {
-  const { hasAccess } = usePermissionsWithContext([
-    GENERAL_HOSTS_WRITE_PERMISSIONS,
-  ]);
-
-  return hasAccess;
-};
 
 export const allStaleFilters = ['fresh', 'stale', 'stale_warning', 'unknown'];

--- a/src/components/InventoryTable/ActionWithRBAC.js
+++ b/src/components/InventoryTable/ActionWithRBAC.js
@@ -1,6 +1,5 @@
 /**
  * This module contains Button and DropdownItem components wrapped by RBAC checks.
- * If host is in a group, then a minimum required RBAC permission is the group-level inventory:hosts:write.
  */
 import React from 'react';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
@@ -10,9 +9,13 @@ import PropTypes from 'prop-types';
 export const ActionButton = ({
   requiredPermissions,
   noAccessTooltip,
+  checkAll,
   ...props
 }) => {
-  const { hasAccess: enabled } = usePermissionsWithContext(requiredPermissions);
+  const { hasAccess: enabled } = usePermissionsWithContext(
+    requiredPermissions,
+    checkAll
+  );
 
   return enabled ? (
     <Button {...props} />
@@ -26,6 +29,11 @@ export const ActionButton = ({
 ActionButton.propTypes = {
   requiredPermissions: PropTypes.array,
   noAccessTooltip: PropTypes.string,
+  checkAll: PropTypes.bool,
+};
+
+ActionButton.defaultProps = {
+  checkAll: false,
 };
 
 export const ActionDropdownItem = ({

--- a/src/components/InventoryTable/ActionWithRBAC.js
+++ b/src/components/InventoryTable/ActionWithRBAC.js
@@ -1,0 +1,48 @@
+/**
+ * This module contains Button and DropdownItem components wrapped by RBAC checks.
+ * If host is in a group, then a minimum required RBAC permission is the group-level inventory:hosts:write.
+ */
+import React from 'react';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+
+export const ActionButton = ({
+  requiredPermissions,
+  noAccessTooltip,
+  ...props
+}) => {
+  const { hasAccess: enabled } = usePermissionsWithContext(requiredPermissions);
+
+  return enabled ? (
+    <Button {...props} />
+  ) : (
+    <Tooltip content={noAccessTooltip}>
+      <Button {...props} isAriaDisabled />
+    </Tooltip>
+  );
+};
+
+ActionButton.propTypes = {
+  requiredPermissions: PropTypes.array,
+  noAccessTooltip: PropTypes.string,
+};
+
+export const ActionDropdownItem = ({
+  requiredPermissions,
+  noAccessTooltip,
+  ...props
+}) => {
+  const { hasAccess: enabled } = usePermissionsWithContext(requiredPermissions);
+
+  return enabled ? (
+    <DropdownItem {...props} />
+  ) : (
+    <DropdownItem {...props} isAriaDisabled tooltip={noAccessTooltip} />
+  );
+};
+
+ActionDropdownItem.propTypes = {
+  requiredPermissions: PropTypes.array,
+  noAccessTooltip: PropTypes.string,
+};

--- a/src/routes/InventoryTable.cy.js
+++ b/src/routes/InventoryTable.cy.js
@@ -22,7 +22,8 @@ import {
   ROW,
 } from '@redhat-cloud-services/frontend-components-utilities';
 
-const TEST_GROUP = 'ancd';
+const TEST_GROUP_NAME = 'ancd';
+const TEST_GROUP_ID = '54b302e4-07d2-45c5-b2f8-92a286847f9d';
 
 const mountTable = () => {
   cy.mountWithContext(Inventory);
@@ -47,21 +48,22 @@ before(() => {
 });
 
 describe('test data', () => {
-  it(`first two hosts in the group ${TEST_GROUP}`, () => {
+  it(`first two hosts in the group ${TEST_GROUP_NAME}`, () => {
     expect(
       hostsFixtures.results
         .slice(0, 2)
-        .every(({ groups }) => groups[0].name === TEST_GROUP)
+        .every(({ groups }) => groups[0].name === TEST_GROUP_NAME)
     ).to.be.true;
   });
 
-  it(`the third host has a group differente that ${TEST_GROUP}`, () => {
-    expect(hostsFixtures.results[2].groups[0].name !== TEST_GROUP).to.be.true;
+  it(`the third host has a group different to ${TEST_GROUP_NAME}`, () => {
+    expect(hostsFixtures.results[2].groups[0].name !== TEST_GROUP_NAME).to.be
+      .true;
   });
 
-  it(`groups has the group ${TEST_GROUP}`, () => {
-    expect(groupsFixtures.results.some(({ name }) => name === TEST_GROUP)).to.be
-      .true;
+  it(`groups has the group ${TEST_GROUP_NAME}`, () => {
+    expect(groupsFixtures.results.some(({ name }) => name === TEST_GROUP_NAME))
+      .to.be.true;
   });
 
   it('the fourth host is not in a group', () => {
@@ -92,7 +94,7 @@ describe('inventory table', () => {
   describe('has groups actions', () => {
     it('cannot add host to another group', () => {
       cy.get(ROW).eq(1).find(DROPDOWN).click();
-      cy.get(DROPDOWN_ITEM)
+      cy.get(`${DROPDOWN_ITEM} a`)
         .contains('Add to group')
         .should('have.attr', 'aria-disabled', 'true');
     });
@@ -120,7 +122,7 @@ describe('inventory table', () => {
         `/api/inventory/v1/groups/${hostsFixtures.results[0].groups[0].id}/hosts/${hostsFixtures.results[0].id}`
       ).as('request');
       cy.get(ROW).eq(1).find(DROPDOWN).click();
-      cy.get(DROPDOWN_ITEM).contains('Remove from group').click();
+      cy.get(`${DROPDOWN_ITEM} a`).contains('Remove from group').click();
       cy.get(MODAL).within(() => {
         cy.get('h1').should('have.text', 'Remove from group');
         cy.get('button[type="submit"]').click();
@@ -135,7 +137,7 @@ describe('inventory table', () => {
         `/api/inventory/v1/groups/${groupsFixtures.results[0].id}/hosts`
       ).as('request');
       cy.get(ROW).eq(4).find(DROPDOWN).click();
-      cy.get(DROPDOWN_ITEM).contains('Add to group').click();
+      cy.get(`${DROPDOWN_ITEM} a`).contains('Add to group').click();
       cy.get(MODAL).within(() => {
         cy.get('h1').should('have.text', 'Add to group');
         cy.wait('@getGroups');
@@ -191,7 +193,8 @@ describe('inventory table', () => {
       cy.intercept(
         'POST',
         `/api/inventory/v1/groups/${
-          groupsFixtures.results.find(({ name }) => name === TEST_GROUP)?.id
+          groupsFixtures.results.find(({ name }) => name === TEST_GROUP_NAME)
+            ?.id
         }/hosts`
       ).as('request');
 
@@ -207,7 +210,7 @@ describe('inventory table', () => {
         cy.get('h1').should('have.text', 'Add to group');
         cy.wait('@getGroups');
         cy.get('.pf-c-select__toggle').click(); // TODO: implement ouia selector for this component
-        cy.get('.pf-c-select__menu-item').contains(TEST_GROUP).click();
+        cy.get('.pf-c-select__menu-item').contains(TEST_GROUP_NAME).click();
         cy.get('button[type="submit"]').click();
         cy.wait('@request')
           .its('request.body')
@@ -240,7 +243,7 @@ describe('inventory table', () => {
 
       it('all per-row actions are disabled', () => {
         cy.get(ROW).eq(1).find(DROPDOWN).click();
-        cy.get(DROPDOWN_ITEM).each(($el) =>
+        cy.get(`${DROPDOWN_ITEM} a`).each(($el) =>
           cy.wrap($el).should('have.attr', 'aria-disabled', 'true')
         );
       });
@@ -261,6 +264,59 @@ describe('inventory table', () => {
 
         cy.get(DROPDOWN_ITEM)
           .contains('Add to group')
+          .should('have.attr', 'aria-disabled', 'true');
+      });
+    });
+
+    describe('with group-level hosts write permissions', () => {
+      before(() => {
+        cy.mockWindowChrome({
+          userPermissions: [
+            'inventory:*:read',
+            {
+              permission: 'inventory:hosts:write',
+              resourceDefinitions: [
+                {
+                  attributeFilter: {
+                    key: 'group.id',
+                    operation: 'equal',
+                    value: TEST_GROUP_ID,
+                  },
+                },
+              ],
+            },
+          ],
+        });
+      });
+
+      beforeEach(prepareTest);
+
+      it('can edit hosts that in the test group', () => {
+        cy.get(ROW).eq(1).find(DROPDOWN).click();
+        cy.get(`${DROPDOWN_ITEM} a`)
+          .contains('Edit')
+          .should('have.attr', 'aria-disabled', 'false')
+          .click();
+        cy.get('button').contains('Cancel').click();
+        cy.get(ROW).eq(1).find(DROPDOWN).click();
+      });
+
+      it('can delete hosts in the test group', () => {
+        cy.get(ROW).eq(1).find(DROPDOWN).click();
+        cy.get(`${DROPDOWN_ITEM} a`)
+          .contains('Delete')
+          .should('have.attr', 'aria-disabled', 'false')
+          .click();
+        cy.get('button').contains('Cancel').click();
+      });
+
+      it('cannot edit nor delete hosts that are not in the test group', () => {
+        cy.get(ROW).eq(3).find(DROPDOWN).click();
+        cy.get(`${DROPDOWN_ITEM} a`)
+          .contains('Edit')
+          .should('have.attr', 'aria-disabled', 'true');
+        cy.get(`${DROPDOWN_ITEM} a`)
+          .contains('Delete')
           .should('have.attr', 'aria-disabled', 'true');
       });
     });

--- a/src/routes/InventoryTable.cy.js
+++ b/src/routes/InventoryTable.cy.js
@@ -249,6 +249,8 @@ describe('inventory table', () => {
       });
 
       it('bulk actions are disabled', () => {
+        cy.get(ROW).find('[type="checkbox"]').eq(0).click();
+
         cy.get('button')
           .contains('Delete')
           .should('have.attr', 'aria-disabled', 'true');
@@ -319,6 +321,26 @@ describe('inventory table', () => {
           .contains('Delete')
           .should('have.attr', 'aria-disabled', 'true');
       });
+
+      it('can delete hosts that are in the test group', () => {
+        cy.get(ROW).find('[type="checkbox"]').eq(0).click();
+        cy.get(ROW).find('[type="checkbox"]').eq(1).click();
+
+        cy.get('button')
+          .contains('Delete')
+          .should('have.attr', 'aria-disabled', 'false')
+          .click();
+      });
+
+      it('cannot delete hosts that are not in the test group', () => {
+        cy.get(ROW).find('[type="checkbox"]').eq(2).click();
+
+        cy.get('button')
+          .contains('Delete')
+          .should('have.attr', 'aria-disabled', 'true');
+      });
     });
+
+    // TODO: test group bulk actions once granular RBAC is implemented there too
   });
 });

--- a/src/routes/InventoryTable.test.js
+++ b/src/routes/InventoryTable.test.js
@@ -12,15 +12,11 @@ import DeleteModal from '../Utilities/DeleteModal';
 import { hosts } from '../api';
 import createXhrMock from '../Utilities/__mocks__/xhrMock';
 
-import {
-  useGetRegistry,
-  useHostsWritePermissions,
-} from '../Utilities/constants';
+import { useGetRegistry } from '../Utilities/constants';
 import { mockSystemProfile } from '../__mocks__/hostApi';
 
 jest.mock('../Utilities/constants', () => ({
   ...jest.requireActual('../Utilities/constants'),
-  useHostsWritePermissions: jest.fn(() => true),
   useGetRegistry: jest.fn(() => ({
     getRegistry: () => ({}),
   })),
@@ -133,7 +129,6 @@ describe('InventoryTable', () => {
 
   beforeEach(() => {
     mockStore = configureStore();
-    useHostsWritePermissions.mockImplementation(() => true);
     useGetRegistry.mockImplementation(() => () => ({ register: () => ({}) }));
     mockSystemProfile.onGet().reply(200, { results: [] });
   });
@@ -164,7 +159,6 @@ describe('InventoryTable', () => {
 
   it('renders correctly when no write permissions', async () => {
     let wrapper;
-    useHostsWritePermissions.mockImplementation(() => false);
     const store = mockStore(initialStore);
 
     await act(async () => {
@@ -277,48 +271,6 @@ describe('InventoryTable', () => {
       type: 'REMOVE_ENTITY',
     });
 
-    window.XMLHttpRequest = tmp;
-  });
-
-  it('can select and delete items from kebab', async () => {
-    let wrapper;
-
-    const tmp = window.XMLHttpRequest;
-
-    window.XMLHttpRequest = jest.fn().mockImplementation(createXhrMock());
-    const store = mockStore(initialStore);
-
-    await act(async () => {
-      wrapper = mount(<InventoryTable initialLoading={false} />, store);
-    });
-    wrapper.update();
-
-    expect(wrapper.find(DeleteModal).props().isModalOpen).toEqual(false);
-
-    expect(wrapper.find('DropdownMenu')).toHaveLength(0);
-
-    await act(async () => {
-      wrapper.find('KebabToggle').at(1).simulate('click');
-    });
-    wrapper.update();
-
-    expect(wrapper.find('DropdownMenu')).toHaveLength(1);
-
-    await act(async () => {
-      const dropdownItems = wrapper.find('DropdownItem');
-      const deleteDropdown = dropdownItems.at(1);
-      deleteDropdown.find('button').simulate('click');
-    });
-
-    wrapper.update();
-
-    expect(wrapper.find(DeleteModal).props().isModalOpen).toEqual(true);
-    expect(
-      wrapper.find(DeleteModal).props().currentSytems.display_name
-    ).toEqual('RHIQE.31ea86a9-a439-4422-9516-27c879057535.test');
-    expect(wrapper.find(DeleteModal).props().currentSytems.id).toEqual(
-      'ed190a06-de88-4d62-aba1-88ad402720a8'
-    );
     window.XMLHttpRequest = tmp;
   });
 });


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-5206. The PR should be rebased, not squashed.

This makes the Inventory table Edit/Delete actions compliant with RBAC implementation requirements and Inventory groups:

<b style="font-weight:normal;" id="docs-internal-guid-398828c7-7fff-d2b3-b931-b4c0f06c8705"><div dir="ltr" style="margin-left:0pt;" align="left">

Edit | Enable if user has hosts:write for system selected (group-level RD check); disable otherwise
-- | --
Delete system | Enable if I have hosts:write for ALL systems selected (group-level RD check); disable otherwise

</div></b>

## How to test

1. Leave only `inventory:hosts:read` permission for your user,
2. In the user access settings, for your username, set `inventory:hosts:write` to a specific group (the RBAC UI should allow that). So that you have the write permissions only for hosts in the selected group,
3. Navigate to /inventory and make sure you have at least one host in the selected group,
4. Verify that you are able to Edit or Delete the hosts in that group, but can't do it for any other hosts.

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/0f2f981a-f127-4d43-99e6-2a9cf5503cda)

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/04dbe437-29fb-46f1-8c05-957393281185)

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/16c53419-d621-4e73-97ca-2c793f2c3698)
