### PR TITLE
fix(ESSNTL-5209): Manage access button and RBAC

### DIFF
--- a/src/components/InventoryGroupDetail/GroupDetailInfo.cy.js
+++ b/src/components/InventoryGroupDetail/GroupDetailInfo.cy.js
@@ -5,7 +5,7 @@ const mountPage = (params) =>
 
 describe('group detail information page', () => {
   before(() => {
-    cy.mockWindowChrome();
+    cy.mockWindowChrome({ userPermissions: ['rbac:*:*'] });
   });
 
   beforeEach(() => {
@@ -22,11 +22,10 @@ describe('group detail information page', () => {
     cy.get('a').contains('Manage access').should('exist');
   });
 
-  it('card text is present', () => {
-    cy.get('div[class="pf-c-card__body"]').should(
-      'have.text',
-      'Manage your inventory group user access configuration under Identity & Access Management > User Access.'
-    );
+  it('link is present', () => {
+    cy.get('div[class="pf-c-card__body"] a')
+      .should('have.length', 1)
+      .and('have.text', 'Identity & Access Management > User Access');
   });
 
   describe('links', () => {
@@ -41,12 +40,20 @@ describe('group detail information page', () => {
     });
   });
 
-  it('button disabled if not enough permissions', () => {
-    cy.mockWindowChrome({ userPermissions: [] });
-    mountPage({ chrome: { isBeta: () => true } });
+  describe('with no user access administrator role', () => {
+    beforeEach(() => {
+      cy.mockWindowChrome({ userPermissions: [] });
+      mountPage({ chrome: { isBeta: () => true } });
+    });
 
-    cy.get('button')
-      .contains('Manage access')
-      .should('have.attr', 'aria-disabled', 'true');
+    it('button disabled if not enough permissions', () => {
+      cy.get('a')
+        .contains('Manage access')
+        .should('have.attr', 'aria-disabled', 'true');
+    });
+
+    it('card text is present', () => {
+      cy.get('div[class="pf-c-card__body"] a').should('not.exist');
+    });
   });
 });

--- a/src/components/InventoryGroupDetail/GroupDetailInfo.js
+++ b/src/components/InventoryGroupDetail/GroupDetailInfo.js
@@ -1,51 +1,57 @@
 import {
-  Button,
   Card,
   CardActions,
   CardBody,
   CardHeader,
   CardTitle,
-  Tooltip,
 } from '@patternfly/react-core';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ChromeLoader from '../../Utilities/ChromeLoader';
-import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import {
-  GROUPS_ADMINISTRATOR_PERMISSIONS,
-  NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+  NO_MANAGE_USER_ACCESS_TOOLTIP_MESSAGE,
+  USER_ACCESS_ADMIN_PERMISSIONS,
 } from '../../constants';
+import { ActionButton } from '../InventoryTable/ActionWithRBAC';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 
 const GroupDetailInfo = ({ chrome }) => {
   const path = `${chrome.isBeta() ? '/preview' : ''}/iam/user-access`;
-  const { hasAccess: isGroupsAdministrator } = usePermissionsWithContext(
-    GROUPS_ADMINISTRATOR_PERMISSIONS,
-    true // should fulfilll all requested permissions
+  const { hasAccess: isUserAccessAdministrator } = usePermissions(
+    'rbac',
+    USER_ACCESS_ADMIN_PERMISSIONS
   );
 
   return (
     <Card>
       <CardHeader>
         <CardActions>
-          {isGroupsAdministrator ? (
-            <Button component="a" href={path} variant="secondary">
-              Manage access
-            </Button>
-          ) : (
-            <Tooltip content={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}>
-              <Button isAriaDisabled variant="secondary">
-                Manage access
-              </Button>
-            </Tooltip>
-          )}
+          <ActionButton
+            component="a"
+            href={path}
+            variant="secondary"
+            override={isUserAccessAdministrator}
+            noAccessTooltip={NO_MANAGE_USER_ACCESS_TOOLTIP_MESSAGE}
+          >
+            Manage access
+          </ActionButton>
         </CardActions>
         <CardTitle className="pf-c-title pf-m-lg card-title">
           User access configuration
         </CardTitle>
       </CardHeader>
       <CardBody>
-        Manage your inventory group user access configuration under
-        <a href={path}> Identity & Access Management {'>'} User Access.</a>
+        {isUserAccessAdministrator ? (
+          <span>
+            Manage your inventory group user access configuration under{' '}
+            <a href={path}>Identity & Access Management {'>'} User Access</a>.
+          </span>
+        ) : (
+          <span>
+            Manage your inventory group user access configuration under Identity
+            & Access Management {'>'} User Access.
+          </span>
+        )}
       </CardBody>
     </Card>
   );

--- a/src/components/InventoryTable/ActionWithRBAC.js
+++ b/src/components/InventoryTable/ActionWithRBAC.js
@@ -1,5 +1,7 @@
 /**
  * This module contains Button and DropdownItem components wrapped by RBAC checks.
+ *
+ * The permissions are checked _only_ within the Inventory app context.
  */
 import React from 'react';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
@@ -10,12 +12,13 @@ export const ActionButton = ({
   requiredPermissions,
   noAccessTooltip,
   checkAll,
+  override,
   ...props
 }) => {
-  const { hasAccess: enabled } = usePermissionsWithContext(
-    requiredPermissions,
-    checkAll
-  );
+  const { hasAccess: enabled } =
+    override !== undefined
+      ? { hasAccess: override }
+      : usePermissionsWithContext(requiredPermissions, checkAll);
 
   return enabled ? (
     <Button {...props} />
@@ -30,6 +33,7 @@ ActionButton.propTypes = {
   requiredPermissions: PropTypes.array,
   noAccessTooltip: PropTypes.string,
   checkAll: PropTypes.bool,
+  override: PropTypes.bool,
 };
 
 ActionButton.defaultProps = {
@@ -39,9 +43,14 @@ ActionButton.defaultProps = {
 export const ActionDropdownItem = ({
   requiredPermissions,
   noAccessTooltip,
+  checkAll,
+  override,
   ...props
 }) => {
-  const { hasAccess: enabled } = usePermissionsWithContext(requiredPermissions);
+  const { hasAccess: enabled } =
+    override !== undefined
+      ? { hasAccess: override }
+      : usePermissionsWithContext(requiredPermissions, checkAll);
 
   return enabled ? (
     <DropdownItem {...props} />
@@ -53,4 +62,10 @@ export const ActionDropdownItem = ({
 ActionDropdownItem.propTypes = {
   requiredPermissions: PropTypes.array,
   noAccessTooltip: PropTypes.string,
+  checkAll: PropTypes.bool,
+  override: PropTypes.bool,
+};
+
+ActionDropdownItem.defaultProps = {
+  checkAll: false,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -231,7 +231,8 @@ export const NO_MODIFY_HOSTS_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify hosts. Contact your organization administrator.';
 export const NO_MODIFY_HOST_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify this host. Contact your organization administrator.';
-
+export const NO_MANAGE_USER_ACCESS_TOOLTIP_MESSAGE =
+  'You must be an organization administrator to modify User Access configuration.';
 export const GENERAL_GROUPS_WRITE_PERMISSION = 'inventory:groups:write';
 export const GENERAL_GROUPS_READ_PERMISSION = 'inventory:groups:read';
 export const GROUPS_ADMINISTRATOR_PERMISSIONS = [
@@ -240,3 +241,4 @@ export const GROUPS_ADMINISTRATOR_PERMISSIONS = [
 ];
 export const GENERAL_HOSTS_READ_PERMISSIONS = 'inventory:hosts:read';
 export const GENERAL_HOSTS_WRITE_PERMISSIONS = 'inventory:hosts:write';
+export const USER_ACCESS_ADMIN_PERMISSIONS = ['rbac:*:*'];


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5209.

Enable the button and the link only when user has User Access Administrator role.

## How to test

1. Find/create a group and navigate to its details page,
2. Add User access administrator role to your user and refresh the page. Make sure, at the Group info tab, you can see the Manage access button enabled.,
3. Remove the role and refresh the page. The button must be disabled.

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/ab407795-a41b-482b-a391-0001dd0611a7)
