### PR TITLE
fix(inventory groups): bug with usepermissions hook

### DIFF
--- a/src/Utilities/Wrapper.js
+++ b/src/Utilities/Wrapper.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 
 const RenderWrapper = ({
   cmp: Component,
@@ -9,7 +9,10 @@ const RenderWrapper = ({
   store,
   ...props
 }) => {
-  const { hasAccess } = usePermissions('inventory', ['inventory:hosts:read']);
+  const { hasAccess } = usePermissionsWithContext([
+    'inventory:*:read',
+    'inventory:hosts:read',
+  ]);
 
   return (
     <Component


### PR DESCRIPTION
This reverts the change to granular hosts read permissions.
It caused issues in the service apps

To confirm the issue try running service apps locally using proxy instruction
https://github.com/RedHatInsights/frontend-components/blob/a7976ed5d7d88f1cfd47a78159222da0994be758/packages/config/README.md?plain=1#L214