### PR TITLE
fix: Add Inventory groups popover

### DIFF
--- a/src/components/InventoryGroups/SmallComponents/Popover.js
+++ b/src/components/InventoryGroups/SmallComponents/Popover.js
@@ -1,0 +1,40 @@
+import {
+  Button,
+  Popover,
+  Text,
+  TextContent,
+  TextVariants,
+  Title,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+const InventoryGroupsPopover = () => (
+  <Popover
+    aria-label="Inventory Groups popover"
+    headerContent={<Title headingLevel="h4">Inventory groups</Title>}
+    position="right"
+    bodyContent={
+      <TextContent>
+        <Text component={TextVariants.p}>
+          Inventory groups allow you to select specific systems and group them
+          together to better organize your inventory.
+        </Text>
+        <Text component={TextVariants.p}>
+          You can also manage user access to specific inventory groups to
+          enhance security within your organization.
+        </Text>
+      </TextContent>
+    }
+  >
+    <Button
+      variant="plain"
+      aria-label="Open Inventory groups popover"
+      style={{ padding: 0 }}
+    >
+      <OutlinedQuestionCircleIcon />
+    </Button>
+  </Popover>
+);
+
+export default InventoryGroupsPopover;

--- a/src/routes/InventoryGroups.js
+++ b/src/routes/InventoryGroups.js
@@ -5,6 +5,8 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
+import { Flex } from '@patternfly/react-core';
+import InventoryGroupsPopover from '../components/InventoryGroups/SmallComponents/Popover';
 
 const Groups = () => {
   const chrome = useChrome();
@@ -16,7 +18,10 @@ const Groups = () => {
   return (
     <React.Fragment>
       <PageHeader>
-        <PageHeaderTitle title="Groups" />
+        <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+          <PageHeaderTitle title="Groups" />
+          <InventoryGroupsPopover />
+        </Flex>
       </PageHeader>
       <InventoryGroups />
     </React.Fragment>


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHIF-259.

Add a popover to Inventory groups title (/groups page).

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/ed6ae915-23c8-4d51-8477-980dc7556981)
