### PR TITLE
fix(ESSNTL-4924): Fetch all groups when building groups filter

### DIFF
--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -333,6 +333,7 @@ describe('actions', () => {
     cy.intercept('*', { statusCode: 200 });
     hostsInterceptors.successful();
     featureFlagsInterceptors.successful(); // make Groups col available
+    groupsInterceptors['successful with some items']();
 
     mountTable();
     waitForTable(true);

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -1,29 +1,21 @@
 /* eslint-disable rulesdir/disallow-fec-relative-imports */
-import { mount } from '@cypress/react';
 
-import FlagProvider from '@unleash/proxy-client-react';
-import _ from 'lodash';
-import React from 'react';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import {
-  featureFlagsInterceptors,
-  groupDetailInterceptors,
-  hostsFixtures,
-  hostsInterceptors,
-} from '../../../../cypress/support/interceptors';
-import {
-  selectRowN,
-  unleashDummyConfig,
-} from '../../../../cypress/support/utils';
-import { getStore } from '../../../store';
-import AddSystemsToGroupModal from './AddSystemsToGroupModal';
 import {
   DROPDOWN_ITEM,
   TABLE,
   checkTableHeaders,
   ouiaId,
 } from '@redhat-cloud-services/frontend-components-utilities';
+import _ from 'lodash';
+import {
+  featureFlagsInterceptors,
+  groupDetailInterceptors,
+  groupsInterceptors,
+  hostsFixtures,
+  hostsInterceptors,
+} from '../../../../cypress/support/interceptors';
+import { selectRowN } from '../../../../cypress/support/utils';
+import AddSystemsToGroupModal from './AddSystemsToGroupModal';
 
 const TABLE_HEADERS = [
   'Name',
@@ -52,18 +44,14 @@ before(() => {
 });
 
 const mountModal = () =>
-  mount(
-    <FlagProvider config={unleashDummyConfig}>
-      <Provider store={getStore()}>
-        <MemoryRouter>
-          <AddSystemsToGroupModal
-            isModalOpen={true}
-            groupId="620f9ae75A8F6b83d78F3B55Af1c4b2C"
-            setIsModalOpen={() => {}} // TODO: test that the func is called on close
-          />
-        </MemoryRouter>
-      </Provider>
-    </FlagProvider>
+  cy.mountWithContext(
+    AddSystemsToGroupModal,
+    {},
+    {
+      groupId: '620f9ae75A8F6b83d78F3B55Af1c4b2C',
+      isModalOpen: true,
+      setIsModalOpen: () => {},
+    }
   );
 
 describe('test data', () => {
@@ -90,6 +78,7 @@ describe('AddSystemsToGroupModal', () => {
     cy.intercept('*', { statusCode: 200 });
     hostsInterceptors.successful(); // default hosts list
     featureFlagsInterceptors.successful(); // to enable the Group column
+    groupsInterceptors['successful with some items']();
   });
 
   it('renders correct header and buttons', () => {

--- a/src/components/filters/__snapshots__/useGroupFilter.test.js.snap
+++ b/src/components/filters/__snapshots__/useGroupFilter.test.js.snap
@@ -1,23 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useGroupFilter with groups loaded should match snapshot 1`] = `
-Array [
-  Object {
-    "filterValues": Object {
-      "items": Array [],
-      "onChange": [Function],
-      "value": Array [],
-    },
-    "label": "Group",
-    "type": "checkbox",
-    "value": "group-host-filter",
-  },
-  Array [],
-  Array [],
-  [Function],
-]
-`;
-
 exports[`useGroupFilter with groups loaded should return correct chips array, current value and value setter 1`] = `
 Array [
   Object {
@@ -30,24 +12,6 @@ Array [
     ],
     "type": "group_name",
   },
-]
-`;
-
-exports[`useGroupFilter with groups loaded should return empty state value if no groups obtained 1`] = `
-Array [
-  Object {
-    "filterValues": Object {
-      "items": Array [],
-      "onChange": [Function],
-      "value": Array [],
-    },
-    "label": "Group",
-    "type": "checkbox",
-    "value": "group-host-filter",
-  },
-  Array [],
-  Array [],
-  [Function],
 ]
 `;
 

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -42,8 +42,12 @@ const useGroupFilter = () => {
 
   useEffect(() => {
     const fetchOptions = async () => {
-      const firstRequest = await getGroups(undefined, { page: 1, per_page: 1 });
-      const groups = await fetchBatched(getGroups, firstRequest.total);
+      const firstRequest = !ignore
+        ? await getGroups(undefined, { page: 1, per_page: 1 })
+        : { total: 0 };
+      const groups = !ignore
+        ? await fetchBatched(getGroups, firstRequest.total)
+        : [];
       !ignore && setGroups(groups.flatMap(({ results }) => results));
     };
 

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 import union from 'lodash/union';
-import { useEffect, useMemo, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { fetchGroupsForEntities } from '../../store/inventory-actions';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import useFetchBatched from '../../Utilities/hooks/useFetchBatched';
 import { HOST_GROUP_CHIP } from '../../Utilities/index';
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
-//for attaching this filter to the redux
+import { getGroups } from '../InventoryGroups/utils/api';
+
 export const groupFilterState = { hostGroupFilter: null };
 export const GROUP_FILTER = 'GROUP_FILTER';
 export const groupFilterReducer = (_state, { type, payload }) => ({
@@ -14,9 +14,7 @@ export const groupFilterReducer = (_state, { type, payload }) => ({
   }),
 });
 
-//receive the array of selected groups and return chips based on the name of selected groups
 export const buildHostGroupChips = (selectedGroups = []) => {
-  //we use new Set to make sure that chips are unique
   const chips = [...selectedGroups]?.map((group) => ({
     name: group,
     value: group,
@@ -32,39 +30,37 @@ export const buildHostGroupChips = (selectedGroups = []) => {
     : [];
 };
 
-const useGroupFilter = (apiParams = []) => {
-  const dispatch = useDispatch();
+const useGroupFilter = () => {
   const groupsEnabled = useFeatureFlag('hbi.ui.inventory-groups');
+  const { fetchBatched } = useFetchBatched();
+  const [groups, setGroups] = useState([]);
+  const [selected, setSelected] = useState([]);
+
+  const onHostGroupsChange = useCallback((event, selection, item) => {
+    setSelected(union(selection, item));
+  }, []);
 
   useEffect(() => {
-    if (groupsEnabled === true) {
-      dispatch(fetchGroupsForEntities(apiParams)); // TODO: make the request paginated (to show all the groups)
+    const fetchOptions = async () => {
+      const firstRequest = await getGroups(undefined, { page: 1, per_page: 1 });
+      const groups = await fetchBatched(getGroups, firstRequest.total);
+      !ignore && setGroups(groups.flatMap(({ results }) => results));
+    };
+
+    let ignore = false;
+
+    if (groupsEnabled) {
+      fetchOptions();
     }
+
+    return () => {
+      ignore = true;
+    };
   }, [groupsEnabled]);
-  //fetched values
-  const fetchedValues = useSelector(({ entities }) => entities?.groups);
-  //selected are the groups we selected
-  const [selected, setSelected] = useState([]);
-  //buildHostGroupsValues build an array of objects to populate dropdown
-  const [buildHostGroupsValues, setBuildHostGroupsValues] = useState([]);
-  //hostGroupValue is used for config items
-  useEffect(() => {
-    setBuildHostGroupsValues(
-      (fetchedValues || []).reduce((acc, group) => {
-        acc.push({ label: group.name, value: group.name });
-        return acc;
-      }, [])
-    );
-  }, [fetchedValues, selected]);
-  //this is used in the filter config as a way to select values onChange
-  const onHostGroupsChange = (event, selection, item) => {
-    setSelected(union(selection, item));
-  };
 
   const chips = useMemo(() => buildHostGroupChips(selected), [selected]);
-  //chips that is built for the filter config
 
-  //hostGroupConfig is a config that we use in EntityTableToolbar.js
+  // hostGroupConfig is used in EntityTableToolbar.js
   const hostGroupConfig = useMemo(
     () => ({
       label: 'Group',
@@ -75,13 +71,15 @@ const useGroupFilter = (apiParams = []) => {
           onHostGroupsChange(event, value, item);
         },
         value: selected,
-        items: buildHostGroupsValues,
+        items: groups.reduce((acc, { name }) => {
+          acc.push({ label: name, value: name });
+          return acc;
+        }, []),
       },
     }),
-    [selected, buildHostGroupsValues]
+    [groups, selected]
   );
 
-  //setSelectedValues is used for selecting and deleting values
   const setSelectedValues = (currentValue = []) => {
     setSelected(currentValue);
   };

--- a/src/components/filters/useGroupFilter.test.js
+++ b/src/components/filters/useGroupFilter.test.js
@@ -1,150 +1,55 @@
 /* eslint-disable camelcase */
-import React from 'react';
 import { act, renderHook } from '@testing-library/react-hooks';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import { createPromise as promiseMiddleware } from 'redux-promise-middleware';
-import { mockSystemProfile } from '../../__mocks__/hostApi';
 import useGroupFilter from './useGroupFilter';
+import { waitFor } from '@testing-library/react';
 
 jest.mock('../../Utilities/useFeatureFlag', () => ({
   __esModule: true,
   default: () => true,
 }));
 
+jest.mock('../InventoryGroups/utils/api', () => ({
+  __esModule: true,
+  getGroups: () =>
+    new Promise((resolve) =>
+      resolve({
+        total: 10,
+      })
+    ),
+}));
+
+jest.mock('../../Utilities/hooks/useFetchBatched', () => ({
+  __esModule: true,
+  default: () => ({
+    fetchBatched: () =>
+      new Promise((resolve) => resolve([{ results: [{ name: 'group-1' }] }])),
+  }),
+}));
+
 describe('useGroupFilter', () => {
-  const mockStore = configureStore([promiseMiddleware()]);
-  beforeEach(() => {
-    mockSystemProfile.onGet().replyOnce(200);
-  });
-
   describe('with groups yet not loaded', () => {
-    const wrapper = ({ children }) => (
-      <Provider store={mockStore({})}>{children}</Provider>
-    );
-
     it('should return empty state value', () => {
-      const { result } = renderHook(useGroupFilter, { wrapper });
+      const { result } = renderHook(useGroupFilter);
       expect(result.current).toMatchSnapshot();
     });
   });
 
   describe('with groups loaded', () => {
-    const wrapper = ({ children }) => (
-      <Provider
-        store={mockStore({
-          groups: {
-            data: {
-              page: 1,
-              count: 50,
-              results: [
-                {
-                  created_at: '2019-02-18T23:00:00.0Z',
-                  id: '4f5B88dBe1D4eB732B388abc1Baa4BAc',
-                  updated_at: '1960-11-06T23:00:00.0Z',
-                  org_id: 'nostrud in deserunt',
-                  account: 'ullamco dolore pariatur sint',
-                  host_ids: [
-                    '5f20569C-9E96-C794-887c-1Cb5D6e220b2',
-                    'D34e68beFc2d4fF1C19CF4CaF913d1b6',
-                    '76D3AcBB-5B4C-8BB8-f3BB-69808CcFa84A',
-                    '185dC76d-D6B8-059b-1bCb-685D2edd0CEa',
-                    '50E0cAaDCace55e07AebC7Bcc40cfdAD',
-                    'be8e0A09AdEE9a23fe65972F43D31bDA',
-                    '8B6764001Bf6d0bA4E6aEdCAf207bf71',
-                    '80CffFbd-04C9-cBB6-5Bf5-Dc0eBbDBba70',
-                    '55d8323C-dEbC-B10e-f88e-23ba37068C9f',
-                    'C5A8Fd55a0B6fa3A3a748cb0a4cc20BB',
-                    '1dF767C34BF222E65BD46BcC3A62de4b',
-                    '4d44747b1D8D1648EC5713e983984a6C',
-                    'b89A20e9da89Eb9862502748ca9aa0bf',
-                    'F24dc6A1548B40dF453FdBEa4DD5CbEB',
-                    '2Ba0BCE6-F8cC-FAFE-Ed72-f7BF01dC60A4',
-                    '1f255AB7-d49f-f8Ff-48eD-B9c6E4674Fe2',
-                    '8277DD2f3Fc0aaE89D601400E86E4E86',
-                    '3Be6b8FE-8B32-240d-9C0f-0c074baC5EBb',
-                    '94c4bBCB31D0dfa37e955Dc94eAd3Dc0',
-                    '2B0725BE87671E4DffE19F0f7fc8aFe7',
-                  ],
-                  name: 'nisi ut consequat ad',
-                },
-                {
-                  created_at: '2019-02-18T23:00:00.0Z',
-                  id: '4f5B88dBe1D4eB732B388abc1Baa4BAc',
-                  updated_at: '1960-11-06T23:00:00.0Z',
-                  org_id: 'nostrud in deserunt',
-                  account: 'ullamco dolore pariatur sint',
-                  host_ids: [
-                    '5f20569C-9E96-C794-887c-1Cb5D6e220b2',
-                    'D34e68beFc2d4fF1C19CF4CaF913d1b6',
-                    '76D3AcBB-5B4C-8BB8-f3BB-69808CcFa84A',
-                    '185dC76d-D6B8-059b-1bCb-685D2edd0CEa',
-                    '50E0cAaDCace55e07AebC7Bcc40cfdAD',
-                    'be8e0A09AdEE9a23fe65972F43D31bDA',
-                    '8B6764001Bf6d0bA4E6aEdCAf207bf71',
-                    '80CffFbd-04C9-cBB6-5Bf5-Dc0eBbDBba70',
-                    '55d8323C-dEbC-B10e-f88e-23ba37068C9f',
-                    'C5A8Fd55a0B6fa3A3a748cb0a4cc20BB',
-                    '1dF767C34BF222E65BD46BcC3A62de4b',
-                    '4d44747b1D8D1648EC5713e983984a6C',
-                    'b89A20e9da89Eb9862502748ca9aa0bf',
-                    'F24dc6A1548B40dF453FdBEa4DD5CbEB',
-                    '2Ba0BCE6-F8cC-FAFE-Ed72-f7BF01dC60A4',
-                    '1f255AB7-d49f-f8Ff-48eD-B9c6E4674Fe2',
-                    '8277DD2f3Fc0aaE89D601400E86E4E86',
-                    '3Be6b8FE-8B32-240d-9C0f-0c074baC5EBb',
-                    '94c4bBCB31D0dfa37e955Dc94eAd3Dc0',
-                    '2B0725BE87671E4DffE19F0f7fc8aFe7',
-                  ],
-                  name: 'nisi ut consequat ad1',
-                },
-                {
-                  created_at: '2019-02-18T23:00:00.0Z',
-                  id: '4f5B88dBe1D4eB732B388abc1Baa4BAc',
-                  updated_at: '1960-11-06T23:00:00.0Z',
-                  org_id: 'nostrud in deserunt',
-                  account: 'ullamco dolore pariatur sint',
-                  host_ids: [
-                    '5f20569C-9E96-C794-887c-1Cb5D6e220b2',
-                    'D34e68beFc2d4fF1C19CF4CaF913d1b6',
-                    '76D3AcBB-5B4C-8BB8-f3BB-69808CcFa84A',
-                    '185dC76d-D6B8-059b-1bCb-685D2edd0CEa',
-                    '50E0cAaDCace55e07AebC7Bcc40cfdAD',
-                    'be8e0A09AdEE9a23fe65972F43D31bDA',
-                    '8B6764001Bf6d0bA4E6aEdCAf207bf71',
-                    '80CffFbd-04C9-cBB6-5Bf5-Dc0eBbDBba70',
-                    '55d8323C-dEbC-B10e-f88e-23ba37068C9f',
-                    'C5A8Fd55a0B6fa3A3a748cb0a4cc20BB',
-                    '1dF767C34BF222E65BD46BcC3A62de4b',
-                    '4d44747b1D8D1648EC5713e983984a6C',
-                    'b89A20e9da89Eb9862502748ca9aa0bf',
-                    'F24dc6A1548B40dF453FdBEa4DD5CbEB',
-                    '2Ba0BCE6-F8cC-FAFE-Ed72-f7BF01dC60A4',
-                    '1f255AB7-d49f-f8Ff-48eD-B9c6E4674Fe2',
-                    '8277DD2f3Fc0aaE89D601400E86E4E86',
-                    '3Be6b8FE-8B32-240d-9C0f-0c074baC5EBb',
-                    '94c4bBCB31D0dfa37e955Dc94eAd3Dc0',
-                    '2B0725BE87671E4DffE19F0f7fc8aFe7',
-                  ],
-                  name: 'nisi ut consequat ad2',
-                },
-              ],
-              total: 100,
-            },
-          },
-        })}
-      >
-        {children}
-      </Provider>
-    );
+    it('fills the filter items', async () => {
+      const { result } = renderHook(useGroupFilter);
 
-    it('should match snapshot', () => {
-      const { result } = renderHook(useGroupFilter, { wrapper });
-      expect(result.current).toMatchSnapshot();
+      await waitFor(() => {
+        expect(result.current[0].filterValues.items).toEqual([
+          {
+            label: 'group-1',
+            value: 'group-1',
+          },
+        ]);
+      });
     });
 
     it('should return correct chips array, current value and value setter', () => {
-      const { result } = renderHook(useGroupFilter, { wrapper });
+      const { result } = renderHook(useGroupFilter);
       const [, chips, value, setValue] = result.current;
       expect(chips.length).toBe(0);
       expect(value.length).toBe(0);
@@ -155,27 +60,6 @@ describe('useGroupFilter', () => {
       expect(chipsUpdated.length).toBe(1);
       expect(valueUpdated).toEqual(['nisi ut consequat ad1']);
       expect(chipsUpdated).toMatchSnapshot();
-    });
-
-    it('should return empty state value if no groups obtained', () => {
-      const wrapper = ({ children }) => (
-        <Provider
-          store={mockStore({
-            groups: {
-              data: {
-                page: 1,
-                count: 50,
-                results: [],
-                total: 100,
-              },
-            },
-          })}
-        >
-          {children}
-        </Provider>
-      );
-      const { result } = renderHook(useGroupFilter, { wrapper });
-      expect(result.current).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-4924.

This should fix the groups filter: now the filter must fetch all available groups. Before, it was fetching only first 50 items.

## How to test

Go to /inventory: the filter should display all of the available groups. Better to test with account having more groups.

Also, it is necessary to check some of the applications importing InventoryTable: if the filter still works well there with this update.