### PR TITLE
fix(ESSNTL-4667): Disable global filter at groups views

### DIFF
--- a/src/components/InventoryGroupDetail/index.js
+++ b/src/components/InventoryGroupDetail/index.js
@@ -1,9 +1,15 @@
-import React from 'react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import InventoryGroupDetail from './InventoryGroupDetail';
 
 const InventoryGroupDetailWrapper = () => {
   const { groupId } = useParams();
+  const chrome = useChrome();
+
+  useEffect(() => {
+    chrome?.hideGlobalFilter?.();
+  }, []);
 
   return <InventoryGroupDetail groupId={groupId} />;
 };

--- a/src/routes/InventoryGroups.js
+++ b/src/routes/InventoryGroups.js
@@ -12,8 +12,9 @@ const Groups = () => {
   const chrome = useChrome();
 
   useEffect(() => {
+    chrome?.hideGlobalFilter?.();
     chrome?.updateDocumentTitle?.('Inventory Groups | Red Hat Insights');
-  }, [chrome]);
+  }, []);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-4667.

Keep the global filter always disabled at /groups and /groups/%id.

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/dce3272d-fe0f-499f-bfb2-b8eea9dddc2b)
