### PR TITLE
fix(ESSNTL-5252): Hide Create a new group button if not permitted

### DIFF
--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
@@ -39,15 +39,13 @@ describe('AddSelectedHostsToGroupModal', () => {
       cy.wait('@getGroups').its('request.url').should('contain', '?name=abcd');
     });
 
-    it('create group button is disabled', () => {
-      cy.get('button')
-        .contains('Create a new group')
-        .should('have.attr', 'aria-disabled', 'true');
+    it('create group button is hidden', () => {
+      cy.get('button').contains('Create a new group').should('not.exist');
     });
   });
 
   describe('with limited groups write permissions', () => {
-    it('should still disable the create group button', () => {
+    it('should still hide the create group button', () => {
       cy.mockWindowChrome({
         userPermissions: [
           {
@@ -66,9 +64,7 @@ describe('AddSelectedHostsToGroupModal', () => {
       });
 
       mountModal();
-      cy.get('button')
-        .contains('Create a new group')
-        .should('have.attr', 'aria-disabled', 'true');
+      cy.get('button').contains('Create a new group').should('not.exist');
     });
   });
 
@@ -84,10 +80,9 @@ describe('AddSelectedHostsToGroupModal', () => {
       mountModal();
     });
 
-    it('create group button is enabled', () => {
-      cy.get('button')
-        .contains('Create a new group')
-        .not('have.attr', 'aria-disabled', 'true');
+    it('create group button is visible', () => {
+      cy.get('button').contains('Create a new group').should('exist');
+      cy.get('button').contains('Create a new group').shouldHaveAriaEnabled();
     });
   });
 });

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
@@ -1,3 +1,5 @@
+import './AddSelectedHostsToGroupModal.scss';
+
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from './Modal';
@@ -60,6 +62,7 @@ const AddSelectedHostsToGroupModal = ({
           }}
           onSubmit={handleAddDevices}
           reloadData={reloadData}
+          modalClassName="add-selected-to-group-modal"
         />
       )}
       {isCreateGroupModalOpen && (

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.scss
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.scss
@@ -1,0 +1,10 @@
+.add-selected-to-group-modal {
+    .pf-c-select__menu {
+        max-height: 350px;
+        overflow: auto;
+    }
+
+    .pf-c-modal-box__body {
+        overflow: visible;
+    }
+}

--- a/src/components/InventoryGroups/Modals/Modal.js
+++ b/src/components/InventoryGroups/Modals/Modal.js
@@ -24,7 +24,10 @@ const RepoModal = ({
 }) => {
   return (
     <Modal
-      appendTo={() => document.body.querySelector('.inventory')} // required to support the app's stylesheets
+      ouiaId="group-modal"
+      appendTo={() =>
+        document.body.querySelector('.inventory') || document.body
+      } // required to support the app's stylesheets
       variant={size ?? 'small'}
       title={title}
       titleIconVariant={titleIconVariant ?? null}

--- a/src/components/InventoryGroups/Modals/Modal.js
+++ b/src/components/InventoryGroups/Modals/Modal.js
@@ -20,15 +20,17 @@ const RepoModal = ({
   onSubmit,
   customFormTemplate,
   additionalMappers,
+  modalClassName,
 }) => {
   return (
     <Modal
-      ouiaId="group-modal"
+      appendTo={() => document.body.querySelector('.inventory')} // required to support the app's stylesheets
       variant={size ?? 'small'}
       title={title}
       titleIconVariant={titleIconVariant ?? null}
       isOpen={isModalOpen}
       onClose={closeModal}
+      className={modalClassName}
     >
       <FormRenderer
         schema={schema}
@@ -88,6 +90,7 @@ RepoModal.propTypes = {
   titleIconVariant: PropTypes.any,
   customFormTemplate: PropTypes.node,
   reloadTimeout: PropTypes.number,
+  modalClassName: PropTypes.string,
 };
 
 RepoModal.defaultProps = {

--- a/src/components/InventoryGroups/SmallComponents/CreateGroupButton.js
+++ b/src/components/InventoryGroups/SmallComponents/CreateGroupButton.js
@@ -1,29 +1,23 @@
 import React from 'react';
-import { Button, Text, Tooltip } from '@patternfly/react-core';
+import { Button, Text } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
-import { NO_MODIFY_GROUPS_TOOLTIP_MESSAGE } from '../../../constants';
+import { GENERAL_GROUPS_WRITE_PERMISSION } from '../../../constants';
 
 export const CreateGroupButton = ({ closeModal }) => {
   const { hasAccess: canModifyGroups } = usePermissionsWithContext([
-    'inventory:groups:write',
+    GENERAL_GROUPS_WRITE_PERMISSION,
   ]);
 
-  return (
+  return canModifyGroups ? (
     <>
       <Text>Or</Text>
-      {canModifyGroups ? (
-        <Button variant="secondary" className="pf-u-w-50" onClick={closeModal}>
-          Create a new group
-        </Button>
-      ) : (
-        <Tooltip content={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}>
-          <Button variant="secondary" className="pf-u-w-50" isAriaDisabled>
-            Create a new group
-          </Button>
-        </Tooltip>
-      )}
+      <Button variant="secondary" className="pf-u-w-50" onClick={closeModal}>
+        Create a new group
+      </Button>
     </>
+  ) : (
+    <></>
   );
 };
 

--- a/src/components/InventoryTable/InventoryTable.cy.js
+++ b/src/components/InventoryTable/InventoryTable.cy.js
@@ -70,7 +70,7 @@ const AVAILABLE_FILTER_NAMES = [
   'Group',
 ];
 
-const setTableInterceptos = () => {
+const setTableInterceptors = () => {
   featureFlagsInterceptors.successful();
   systemProfileInterceptors['operating system, successful empty']();
   groupsInterceptors['successful with some items'](shorterGroupsFixtures);
@@ -83,7 +83,7 @@ describe('with default parameters', () => {
   });
 
   beforeEach(() => {
-    setTableInterceptos();
+    setTableInterceptors();
     mountTable();
     waitForTable(true);
   });
@@ -249,10 +249,11 @@ describe('with default parameters', () => {
 describe('hiding filters', () => {
   before(cy.mockWindowChrome);
 
-  beforeEach(setTableInterceptos);
+  beforeEach(() => setTableInterceptors());
 
   it('can hide all filters', () => {
     mountTable({ hasAccess: true, hideFilters: { all: true } });
+    waitForTable();
     cy.get('button[data-ouia-component-id="ConditionalFilter"]').should(
       'not.exist'
     );
@@ -260,36 +261,42 @@ describe('hiding filters', () => {
 
   it('can hide groups filter', () => {
     mountTable({ hasAccess: true, hideFilters: { hostGroupFilter: true } });
+    waitForTable();
     cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
     cy.get(DROPDOWN_ITEM).should('not.contain', 'Group');
   });
 
   it('can hide name filter', () => {
     mountTable({ hasAccess: true, hideFilters: { name: true } });
+    waitForTable();
     cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
     cy.get(DROPDOWN_ITEM).should('not.contain', 'Name');
   });
 
   it('can hide data collector filter', () => {
     mountTable({ hasAccess: true, hideFilters: { registeredWith: true } });
+    waitForTable();
     cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
     cy.get(DROPDOWN_ITEM).should('not.contain', 'Data Collector');
   });
 
   it('can hide rhcd filter', () => {
     mountTable({ hasAccess: true, hideFilters: { rhcdFilter: true } });
+    waitForTable();
     cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
     cy.get(DROPDOWN_ITEM).should('not.contain', 'RHC status');
   });
 
   it('can hide os filter', () => {
     mountTable({ hasAccess: true, hideFilters: { operatingSystem: true } });
+    waitForTable();
     cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
     cy.get(DROPDOWN_ITEM).should('not.contain', 'Operating System');
   });
 
   it('can hide last seen filter', () => {
     mountTable({ hasAccess: true, hideFilters: { lastSeen: true } });
+    waitForTable();
     cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
     cy.get(DROPDOWN_ITEM).should('not.contain', 'Last seen');
   });


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5252.

This PR:
- makes the "Add selected hosts to group" modal hide the create group button when the user doesn't have general groups write permission.
- corrects the style for the modal so that the list of available groups is visible and can be easily scrolled.

## How to test

Remove general `inventory:groups:write` from your account. Navigate to /inventory and try to add any host to a group. In the modal, you shouldn't see the "Create a new group" button.

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/58664510-54c7-4131-819f-b268ebb328ea)

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/b8455f47-41a3-48d2-8f41-dc60463643df)
