### PR TITLE
Update table skeleton

### DIFF
--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -190,7 +190,7 @@ describe('sorting', () => {
 
   const checkSorting = (label, order, dataField) => {
     // get appropriate locators
-    const header = `th[data-label="${label}"]`;
+    const header = `.ins-c-entity-table th[data-label="${label}"]`;
     if (order === 'ascending') {
       cy.get(header).find('button').click();
     } else {

--- a/src/components/InventoryTable/EntityTable.js
+++ b/src/components/InventoryTable/EntityTable.js
@@ -9,6 +9,7 @@ import {
   TableGridBreakpoint,
   TableHeader,
   TableVariant,
+  sortable,
 } from '@patternfly/react-table';
 import { SkeletonTable } from '@redhat-cloud-services/frontend-components/SkeletonTable';
 import NoEntitiesFound from './NoEntitiesFound';
@@ -77,6 +78,19 @@ const EntityTable = ({
     );
   };
 
+  const tableSortBy = {
+    //Inventory API has different sortBy key than system_profile
+    index:
+      columns?.findIndex(
+        (item) =>
+          sortBy?.key === item.key ||
+          (sortBy?.key === 'operating_system' && item.key === 'system_profile')
+      ) +
+      Boolean(hasCheckbox) +
+      Boolean(expandable),
+    direction: sortBy?.direction,
+  };
+
   delete tableProps.RowWrapper;
   if (rows?.length === 0) {
     delete tableProps.actionResolver;
@@ -116,19 +130,7 @@ const EntityTable = ({
                 index
               );
             }}
-            sortBy={{
-              //Inventory API has different sortBy key than system_profile
-              index:
-                cells?.findIndex(
-                  (item) =>
-                    sortBy?.key === item.key ||
-                    (sortBy?.key === 'operating_system' &&
-                      item.key === 'system_profile')
-                ) +
-                Boolean(hasCheckbox) +
-                Boolean(expandable),
-              direction: sortBy?.direction,
-            }}
+            sortBy={tableSortBy}
             {...{
               ...(hasCheckbox && rows?.length !== 0
                 ? { onSelect: onItemSelect }
@@ -145,9 +147,18 @@ const EntityTable = ({
         )
       ) : (
         <SkeletonTable
-          colSize={columns?.length || 3}
+          columns={columns.map((column) =>
+            column?.props?.isStatic
+              ? column
+              : {
+                  ...column,
+                  transforms: [...(column.transforms ?? []), sortable],
+                }
+          )}
           rowSize={15}
           variant={variant ?? tableProps.variant}
+          isSelectable={hasCheckbox}
+          sortBy={tableSortBy}
         />
       )}
     </React.Fragment>

--- a/src/components/InventoryTable/InventoryTable.cy.js
+++ b/src/components/InventoryTable/InventoryTable.cy.js
@@ -140,7 +140,7 @@ describe('with default parameters', () => {
   describe('sorting', () => {
     const checkSorting = (label, order, dataField) => {
       // get appropriate locators
-      const header = `th[data-label="${label}"]`;
+      const header = `.ins-c-entity-table th[data-label="${label}"]`;
       if (order === 'ascending') {
         cy.get(header).find('button').click();
       } else {

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -45,7 +45,6 @@ export const defaultColumns = (groupsEnabled = false) => [
     key: 'display_name',
     sortKey: 'display_name',
     title: 'Name',
-    dataLabel: 'Name',
     renderFunc: TitleColumn,
   },
   ...(groupsEnabled
@@ -54,7 +53,6 @@ export const defaultColumns = (groupsEnabled = false) => [
           key: 'groups',
           sortKey: 'groups',
           title: 'Group',
-          dataLabel: 'Group',
           props: { width: 10, isStatic: true },
           // eslint-disable-next-line camelcase
           renderFunc: (groups) => (isEmpty(groups) ? 'N/A' : groups[0].name), // currently, one group at maximum is supported
@@ -65,7 +63,6 @@ export const defaultColumns = (groupsEnabled = false) => [
   {
     key: 'tags',
     title: 'Tags',
-    dataLabel: 'Tags',
     props: { width: 10, isStatic: true },
     // eslint-disable-next-line react/display-name
     renderFunc: (value, systemId) => (
@@ -93,7 +90,6 @@ export const defaultColumns = (groupsEnabled = false) => [
     key: 'updated',
     sortKey: 'updated',
     title: 'Last seen',
-    dataLabel: 'Last seen',
     // eslint-disable-next-line react/display-name
     renderFunc: (
       value,

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -45,6 +45,7 @@ export const defaultColumns = (groupsEnabled = false) => [
     key: 'display_name',
     sortKey: 'display_name',
     title: 'Name',
+    dataLabel: 'Name',
     renderFunc: TitleColumn,
   },
   ...(groupsEnabled
@@ -53,6 +54,7 @@ export const defaultColumns = (groupsEnabled = false) => [
           key: 'groups',
           sortKey: 'groups',
           title: 'Group',
+          dataLabel: 'Group',
           props: { width: 10, isStatic: true },
           // eslint-disable-next-line camelcase
           renderFunc: (groups) => (isEmpty(groups) ? 'N/A' : groups[0].name), // currently, one group at maximum is supported
@@ -63,6 +65,7 @@ export const defaultColumns = (groupsEnabled = false) => [
   {
     key: 'tags',
     title: 'Tags',
+    dataLabel: 'Tags',
     props: { width: 10, isStatic: true },
     // eslint-disable-next-line react/display-name
     renderFunc: (value, systemId) => (
@@ -90,6 +93,7 @@ export const defaultColumns = (groupsEnabled = false) => [
     key: 'updated',
     sortKey: 'updated',
     title: 'Last seen',
+    dataLabel: 'Last seen',
     // eslint-disable-next-line react/display-name
     renderFunc: (
       value,


### PR DESCRIPTION
- Fix columns missing names during loading in mobile view.

## Before:
![Screenshot from 2023-08-22 17-56-06](https://github.com/RedHatInsights/insights-inventory-frontend/assets/8426204/1f001896-6589-4617-9690-e95fabca3ca9)

## After:
![Screenshot from 2023-08-22 17-55-39](https://github.com/RedHatInsights/insights-inventory-frontend/assets/8426204/7573b01a-09ee-4f33-8b4f-da68c2cdcf43)

- Show checkboxes in the table skeleton if the loaded table contains them
- Show table headers when the table is loading
- Show current sort indicator when the table is loading

## Before:
![Screenshot from 2023-08-22 17-56-55](https://github.com/RedHatInsights/insights-inventory-frontend/assets/8426204/021849d8-31f5-4014-bf38-7621227c33b4)

## After:
![Screenshot from 2023-08-22 17-56-48](https://github.com/RedHatInsights/insights-inventory-frontend/assets/8426204/c01e9fc6-28c2-4cef-854a-900de8a2a0eb)


I checked other apps using Inventory table and I could only find one small regression -- Advisor shows double sorting indicator for some columns, I will fix this with PR in Advisor.

![Screenshot from 2023-08-22 17-49-31](https://github.com/RedHatInsights/insights-inventory-frontend/assets/8426204/28a65dd2-ac4c-44d0-9d5b-86f32d6d8da4)
