### PR TITLE
fix(RHINENG-1420): Fix options duplicates in group search

### DIFF
--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
@@ -18,7 +18,7 @@ const AddSelectedHostsToGroupModal = ({
 
   const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
   const handleAddDevices = (values) => {
-    const { group } = values;
+    const group = JSON.parse(values.group); // parse is a workaround for https://github.com/data-driven-forms/react-forms/issues/1401
     const statusMessages = {
       onSuccess: {
         title: 'Success',

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -60,24 +60,13 @@ const createDescription = (hosts) => {
 //it allows to create custom item types in the modal
 
 const loadOptions = awesomeDebouncePromise(
-  async (searchValue = '') => {
-    // add a slight delay for scenarios when a new group has been just created
-    const data = await awesomeDebouncePromise(
-      () => getGroups({ name: searchValue }, {}),
-      500
-    )();
-    // TODO: make the getGroups requests paginated
-    return (data?.results || []).reduce((acc, { name, id }) => {
-      if (name.toLowerCase().includes(searchValue.trim().toLowerCase())) {
-        return [
-          ...acc,
-          {
-            label: name,
-            value: { name, id },
-          },
-        ];
-      }
-    }, []);
+  (searchValue = '') => {
+    return getGroups({ name: searchValue }).then((data) => {
+      return data.results.map(({ name, id }) => ({
+        label: name,
+        value: JSON.stringify({ id, name }), // stringify is a workaround for https://github.com/data-driven-forms/react-forms/issues/1401
+      }));
+    });
   },
   500,
   { onlyResolvesLast: false }
@@ -100,6 +89,7 @@ export const addHostSchema = (hosts) => ({
       isClearable: true,
       placeholder: 'Type or click to select a group',
       loadOptions,
+      options: [],
       validate: [{ type: validatorTypes.REQUIRED }],
     },
     {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-1420.

The add hosts to group modal was behaving weirdly when searching for groups: creating duplicates of the same results with each input change from user. This bug is caused by improper handling of objects as values for data-driven-form options: https://github.com/data-driven-forms/react-forms/issues/1401. This creates a workaround to fix this issue.

## How to test

Go to /inventory and try to add any host to a new group. In the modal, make sure that the search for group works correctly and provides correct results.