### PR TITLE
fix(RHINENG-767): Fix add systems modal

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -188,7 +188,11 @@ export async function getEntities(
       orderDirection,
       undefined,
       undefined,
-      { cancelToken: controller && controller.token }
+      {
+        ...(controller?.signal !== undefined
+          ? { signal: controller.signal }
+          : {}),
+      }
     );
     if (fields && Object.keys(fields).length) {
       try {
@@ -201,7 +205,9 @@ export async function getEntities(
           undefined,
           undefined,
           {
-            cancelToken: controller && controller.token,
+            ...(controller?.signal !== undefined
+              ? { signal: controller.signal }
+              : {}),
             query: generateFilter(fields, 'fields'),
           }
         );
@@ -258,7 +264,9 @@ export async function getEntities(
         undefined,
         undefined,
         {
-          cancelToken: controller && controller.token,
+          ...(controller?.signal !== undefined
+            ? { signal: controller.signal }
+            : {}),
           query: {
             ...(options?.globalFilter?.filter &&
               generateFilter(options.globalFilter.filter)),

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -4,7 +4,7 @@ import map from 'lodash/map';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { clearFilters, selectEntity } from '../../store/inventory-actions';
+import { selectEntity } from '../../store/inventory-actions';
 import AddSystemsToGroupModal from '../InventoryGroups/Modals/AddSystemsToGroupModal';
 import InventoryTable from '../InventoryTable/InventoryTable';
 import { Link } from 'react-router-dom';
@@ -18,6 +18,7 @@ import {
   ActionButton,
   ActionDropdownItem,
 } from '../InventoryTable/ActionWithRBAC';
+import { clearEntitiesAction } from '../../store/actions';
 
 export const bulkSelectConfig = (
   dispatch,
@@ -114,14 +115,9 @@ const GroupSystems = ({ groupName, groupId }) => {
     REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(groupId)
   );
 
-  const resetTable = () => {
-    dispatch(clearFilters());
-    dispatch(selectEntity(-1, false));
-  };
-
   useEffect(() => {
     return () => {
-      resetTable();
+      dispatch(clearEntitiesAction());
     };
   }, []);
 
@@ -133,6 +129,7 @@ const GroupSystems = ({ groupName, groupId }) => {
         <AddSystemsToGroupModal
           isModalOpen={addToGroupModalOpen}
           setIsModalOpen={(value) => {
+            dispatch(clearEntitiesAction());
             setAddToGroupModalOpen(value);
           }}
           groupId={groupId}
@@ -208,7 +205,7 @@ const GroupSystems = ({ groupName, groupId }) => {
                 )}
                 noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
                 onClick={() => {
-                  resetTable();
+                  dispatch(clearEntitiesAction());
                   setAddToGroupModalOpen(true);
                 }}
                 ouiaId="add-systems-button"

--- a/src/components/InventoryTable/InventoryTable.cy.js
+++ b/src/components/InventoryTable/InventoryTable.cy.js
@@ -231,7 +231,6 @@ describe('with default parameters', () => {
       });
 
       it('triggers new request', () => {
-        cy.wait('@getHosts');
         cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
         cy.get(DROPDOWN_ITEM).contains('Group').click();
         cy.ouiaId('Filter by group').click();

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -81,6 +81,7 @@ const InventoryTable = forwardRef(
       isRbacEnabled,
       hasCheckbox,
       onRowClick,
+      abortOnUnmount = true,
       ...props
     },
     ref
@@ -121,6 +122,8 @@ const InventoryTable = forwardRef(
         : entities?.loaded
     );
 
+    const controller = useRef(new AbortController());
+
     /**
      * If initialLoading is set to true, then the component should be in loading state until
      * entities.loaded is false (and then we can use the redux loading state and forget this one)
@@ -136,6 +139,12 @@ const InventoryTable = forwardRef(
 
     const dispatch = useDispatch();
     const store = useStore();
+
+    useEffect(() => {
+      return () => {
+        abortOnUnmount && controller.current.abort();
+      };
+    }, []);
 
     const cache = useRef(inventoryCache());
     cache.current.updateProps({
@@ -189,7 +198,7 @@ const InventoryTable = forwardRef(
           onRefresh(newParams, (options) => {
             dispatch(
               loadSystems(
-                { ...newParams, ...options },
+                { ...newParams, ...options, controller: controller.current },
                 cachedProps.showTags,
                 cachedProps.getEntities
               )
@@ -198,7 +207,7 @@ const InventoryTable = forwardRef(
         } else {
           dispatch(
             loadSystems(
-              newParams,
+              { ...newParams, controller: controller.current },
               cachedProps.showTags,
               cachedProps.getEntities
             )
@@ -317,6 +326,7 @@ InventoryTable.propTypes = {
   isRbacEnabled: PropTypes.bool,
   hasCheckbox: PropTypes.bool,
   onRowClick: PropTypes.func,
+  abortOnUnmount: PropTypes.bool,
 };
 
 export default InventoryTable;

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -193,6 +193,10 @@ function entitiesLoaded(
     return state;
   }
 
+  if (meta?.controller?.signal?.aborted === true) {
+    return defaultState;
+  }
+
   return {
     ...state,
     activeFilters: filters || [],

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -103,6 +103,7 @@ export const loadEntities = (
     meta: {
       showTags,
       lastDateRequest,
+      controller: config.controller,
     },
   };
 };

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -81,6 +81,10 @@ function onEntitiesLoaded(state, { payload, meta }) {
     return state;
   }
 
+  if (meta?.controller?.signal?.aborted === true) {
+    return defaultState;
+  }
+
   return {
     ...state,
     rows: mergeArraysByKey([


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-767.

This improves the behavior of the "Add systems" modal and fixes a couple of bugs:
- the modal now doesn't show all the unfiltered values if users click on Cancel or X before the entities are loaded in the modal,
- the modal now resets filters on close so that the settings are not wrongly propagated to the group systems table.

## How to test

1) Navigate to any group details page where your group has at least one host
2) Click "Add systems", and while it is loading, quickly close the modal with X or Cancel. You should see the group hosts only again
3) Again click "Add systems" and try to apply any filters
4) Close the modal with Cancel or X. You shouldn't see the filters from modal applied to the group systems table (what was one of the bugs).

Screencasts of the bugs:

[Screencast from 2023-08-23 18-21-33.webm](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/73f1f611-ae21-491c-84e3-f0d72813bb3a)

[Screencast from 2023-08-23 18-21-42.webm](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/80097d95-58d6-4644-9a70-61362e75bf74)
