### PR TITLE
fix(ESSNTL-5252): In Add system modal, load writable groups

### DIFF
--- a/config/overrideChrome.js
+++ b/config/overrideChrome.js
@@ -6,4 +6,5 @@ export default () => ({
   on: () => {},
   getApp: () => 'inventory',
   getBundle: () => 'rhel',
+  getUserPermissions: () => [{ permission: 'inventory:*:*' }],
 });

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
@@ -31,14 +31,6 @@ describe('AddSelectedHostsToGroupModal', () => {
       mountModal();
     });
 
-    it('makes separate requests when searching groups', () => {
-      cy.wait('@getGroups'); // must make initial call
-      cy.get('input').type('abc');
-      cy.wait('@getGroups').its('request.url').should('contain', '?name=abc');
-      cy.get('input').type('d');
-      cy.wait('@getGroups').its('request.url').should('contain', '?name=abcd');
-    });
-
     it('create group button is hidden', () => {
       cy.get('button').contains('Create a new group').should('not.exist');
     });
@@ -78,6 +70,14 @@ describe('AddSelectedHostsToGroupModal', () => {
     beforeEach(() => {
       groupsInterceptors['successful with some items']();
       mountModal();
+    });
+
+    it('makes separate requests when searching groups', () => {
+      cy.wait('@getGroups'); // must make initial call
+      cy.get('input').type('abc');
+      cy.wait('@getGroups').its('request.url').should('contain', '?name=abc');
+      cy.get('input').type('d');
+      cy.wait('@getGroups').its('request.url').should('contain', '?name=abcd');
     });
 
     it('create group button is visible', () => {

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
@@ -9,6 +9,7 @@ import { useDispatch } from 'react-redux';
 import { CreateGroupButton } from '../SmallComponents/CreateGroupButton';
 import { addHostSchema } from './ModalSchemas/schemes';
 import CreateGroupModal from './CreateGroupModal';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const AddSelectedHostsToGroupModal = ({
   isModalOpen,
@@ -17,7 +18,7 @@ const AddSelectedHostsToGroupModal = ({
   reloadData,
 }) => {
   const dispatch = useDispatch();
-
+  const chrome = useChrome();
   const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
   const handleAddDevices = (values) => {
     const group = JSON.parse(values.group); // parse is a workaround for https://github.com/data-driven-forms/react-forms/issues/1401
@@ -53,7 +54,7 @@ const AddSelectedHostsToGroupModal = ({
           closeModal={() => setIsModalOpen(false)}
           title="Add to group"
           submitLabel="Add"
-          schema={addHostSchema(hosts)}
+          schema={addHostSchema(hosts, chrome)}
           additionalMappers={{
             'create-group-btn': {
               component: CreateGroupButton,

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -95,6 +95,8 @@ export const addHostSchema = (hosts, chrome) => ({
       loadOptions: (searchValue) => loadOptions(searchValue, chrome),
       options: [],
       validate: [{ type: validatorTypes.REQUIRED }],
+      updatingMessage: 'Loading groups...',
+      loadingMessage: 'Loading groups...',
     },
     {
       component: 'create-group-btn',

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -3,8 +3,8 @@ import validatorTypes from '@data-driven-forms/react-form-renderer/validator-typ
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import { nameValidator } from '../../helpers/validate';
 import { Text } from '@patternfly/react-core';
-import { getGroups } from '../../utils/api';
 import awesomeDebouncePromise from 'awesome-debounce-promise';
+import { getWritableGroups } from '../../utils/api';
 
 export const createGroupSchema = (namePresenceValidator) => ({
   fields: [
@@ -60,19 +60,23 @@ const createDescription = (hosts) => {
 //it allows to create custom item types in the modal
 
 const loadOptions = awesomeDebouncePromise(
-  (searchValue = '') => {
-    return getGroups({ name: searchValue }).then((data) => {
-      return data.results.map(({ name, id }) => ({
-        label: name,
-        value: JSON.stringify({ id, name }), // stringify is a workaround for https://github.com/data-driven-forms/react-forms/issues/1401
-      }));
-    });
+  async (searchValue, chrome) => {
+    const fetchedGroups = await getWritableGroups(
+      searchValue,
+      { page: 1, per_page: 100 }, // TODO: make the list paginated
+      () => chrome.getUserPermissions('inventory')
+    );
+
+    return fetchedGroups.map(({ name, id }) => ({
+      label: name,
+      value: JSON.stringify({ id, name }), // stringify is a workaround for https://github.com/data-driven-forms/react-forms/issues/1401
+    }));
   },
-  500,
+  250,
   { onlyResolvesLast: false }
 );
 
-export const addHostSchema = (hosts) => ({
+export const addHostSchema = (hosts, chrome) => ({
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,
@@ -88,7 +92,7 @@ export const addHostSchema = (hosts) => ({
       isRequired: true,
       isClearable: true,
       placeholder: 'Type or click to select a group',
-      loadOptions,
+      loadOptions: (searchValue) => loadOptions(searchValue, chrome),
       options: [],
       validate: [{ type: validatorTypes.REQUIRED }],
     },

--- a/src/constants.js
+++ b/src/constants.js
@@ -234,6 +234,9 @@ export const NO_MODIFY_HOST_TOOLTIP_MESSAGE =
 export const NO_MANAGE_USER_ACCESS_TOOLTIP_MESSAGE =
   'You must be an organization administrator to modify User Access configuration.';
 export const GENERAL_GROUPS_WRITE_PERMISSION = 'inventory:groups:write';
+export const GROUPS_WILDCARD = 'inventory:groups:*';
+export const INVENTORY_WILDCARD = 'inventory:*:*';
+export const INVENTORY_WRITE_WILDCARD = 'inventory:*:write';
 export const GENERAL_GROUPS_READ_PERMISSION = 'inventory:groups:read';
 export const GROUPS_ADMINISTRATOR_PERMISSIONS = [
   GENERAL_GROUPS_READ_PERMISSION,


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5252.

While adding systems to existing group, provide to user only the groups that they have inventory:hosts:write permission. This help avoid errors when users accidentally add a host to the group they don't have access.

Also changing debounce timeout from 500 to 250 ms to make the UX a bit faster.

## How to test

Limit your groups write permission to only specific groups. Navigate to /inventory and make sure, while adding a host to group, that you see only the groups you have write access to. Try to apply general write permissions and check that you see all of the groups available for your account.