### PR TITLE
fix: Do not add history entry on host details page

### DIFF
--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector, useStore } from 'react-redux';
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import './inventory.scss';
 import * as actions from '../store/actions';
@@ -21,7 +21,6 @@ import {
 } from '../components/SystemDetails';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP } from '../constants';
-import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
 
 const appList = [
   {
@@ -87,7 +86,7 @@ const Inventory = () => {
   const { search } = useLocation();
   const searchParams = new URLSearchParams(search);
   const store = useStore();
-  const navigate = useInsightsNavigate();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
 
   const entityLoaded = useSelector(
@@ -113,9 +112,12 @@ const Inventory = () => {
   useEffect(() => {
     if (searchParams.get('appName') === null) {
       searchParams.set('appName', appList[0].name);
-      navigate({
-        search: searchParams.toString(),
-      });
+      navigate(
+        {
+          search: searchParams.toString(),
+        },
+        { replace: true }
+      );
     }
   }, []);
 
@@ -150,9 +152,12 @@ const Inventory = () => {
 
   const onTabSelect = useCallback(
     (_, __, appName) => {
-      navigate({
-        search: `?appName=${appName}`,
-      });
+      navigate(
+        {
+          search: `?appName=${appName}`,
+        },
+        { replace: true }
+      );
     },
     [searchParams]
   );

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -1,7 +1,12 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector, useStore } from 'react-redux';
-import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from 'react-router-dom';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import './inventory.scss';
 import * as actions from '../store/actions';
@@ -83,8 +88,7 @@ const BreadcrumbWrapper = ({ entity, inventoryId, entityLoaded }) => (
 const Inventory = () => {
   const chrome = useChrome();
   const { inventoryId } = useParams();
-  const { search } = useLocation();
-  const searchParams = new URLSearchParams(search);
+  const [searchParams, setSearchParams] = useSearchParams();
   const store = useStore();
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -111,7 +115,7 @@ const Inventory = () => {
 
   useEffect(() => {
     if (searchParams.get('appName') === null) {
-      searchParams.set('appName', appList[0].name);
+      setSearchParams('appName', appList[0].name);
       navigate(
         {
           search: searchParams.toString(),


### PR DESCRIPTION
(no jira)

This improves how the system details page change the browser history on navigating between tabs. Users used to stay on the same host details page if they clicked on different tabs like Advisor or Patch and then tried to click on browser's Back/Forward button. This is not really comfortable, and pressing Back should navigate to the previous page instead. To do this, the current browser's history entry should be replaced instead of adding a new one.

## How to test

Go to /inventory and navigate to any host details page. Click on tabs, then click Back in your browser and make sure you are navigated back to /inventory table (users used to stay on host details page which is not expected behaviour).