### PR TITLE
fix(ESSNTL-5253): Fix the broken inventory details tabs

### DIFF
--- a/src/ApplicationTab.js
+++ b/src/ApplicationTab.js
@@ -11,7 +11,7 @@ import {
 } from './components/SystemDetails';
 import { TAB_REQUIRED_PERMISSIONS } from './constants';
 
-const ApplicationTab = ({ appName, title }) => {
+const ApplicationTab = ({ appName, title, ...props }) => {
   const { hasAccess } = usePermissionsWithContext(
     TAB_REQUIRED_PERMISSIONS[appName]
   );
@@ -27,7 +27,7 @@ const ApplicationTab = ({ appName, title }) => {
   const Tab = tabs[appName];
 
   return hasAccess ? (
-    <Tab />
+    <Tab {...props} />
   ) : (
     <AccessDenied
       requiredPermission={TAB_REQUIRED_PERMISSIONS[appName].join(', ')}

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -32,32 +32,42 @@ const appList = [
   {
     title: 'Advisor',
     name: 'advisor',
-    component: () => <ApplicationTab appName="advisor" title="Advisor" />,
+    component: (props) => (
+      <ApplicationTab appName="advisor" title="Advisor" {...props} />
+    ),
   },
   {
     title: 'Vulnerability',
     name: 'vulnerabilities',
-    component: () => (
-      <ApplicationTab appName="vulnerability" title="Vulnerability" />
+    component: (props) => (
+      <ApplicationTab
+        appName="vulnerability"
+        title="Vulnerability"
+        {...props}
+      />
     ),
   },
   {
     title: 'Compliance',
     name: 'compliance',
-    component: () => <ApplicationTab appName="compliance" title="Compliance" />,
+    component: (props) => (
+      <ApplicationTab appName="compliance" title="Compliance" {...props} />
+    ),
     nonEdge: true,
   },
   {
     title: 'Patch',
     name: 'patch',
-    component: () => <ApplicationTab appName="patch" title="Patch" />,
+    component: (props) => (
+      <ApplicationTab appName="patch" title="Patch" {...props} />
+    ),
     nonEdge: true,
   },
   {
     title: 'Resource Optimization',
     name: 'ros',
     isVisible: false,
-    component: () => <ApplicationTab appName="ros" />,
+    component: (props) => <ApplicationTab appName="ros" {...props} />,
     nonEdge: true,
   },
 ];


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5253.

This is another patch for ESSNTL-5253 that makes sure that all of the params are passed to the tabs components and the tabs are loaded correctly.

## How to test

Go to any system details page, access the Patch or other tabs: there shouldn't be any errors and the tabs are not breaking. You can compare with stage-preview where the bug is still reproducible.