### PR TITLE
fix(ESSNTL-5253): Change required permissions for tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@patternfly/react-core": "^4.276.11",
         "@patternfly/react-icons": "^4.93.7",
         "@patternfly/react-table": "^4.113.3",
-        "@redhat-cloud-services/frontend-components": "^3.11.3",
+        "@redhat-cloud-services/frontend-components": "^3.11.6",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.16",
         "@redhat-cloud-services/frontend-components-utilities": "^3.7.6",
         "@redhat-cloud-services/host-inventory-client": "1.2.3",
@@ -4684,9 +4684,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.11.3.tgz",
-      "integrity": "sha512-KP8B8ggHVxoxKiLGHcWct7gnbXKL1oqket02qDrm+asSAfMKjABxif/gm9DOGj8lub6lRoRLM2/XW2cKRxSFzA==",
+      "version": "3.11.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.11.7.tgz",
+      "integrity": "sha512-duFjBf8kTnJ6gYdQpGwTG2GPkye3WHpsUkqn0vsPJi/xccey4/m0wVWmCTD2U08wbOBNzqsymCcMGrnZaRumRg==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
         "@redhat-cloud-services/types": "^0.0.24",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@patternfly/react-table": "^4.113.3",
     "@patternfly/react-core": "^4.276.11",
     "@patternfly/react-icons": "^4.93.7",
-    "@redhat-cloud-services/frontend-components": "^3.11.3",
+    "@redhat-cloud-services/frontend-components": "^3.11.6",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.16",
     "@redhat-cloud-services/frontend-components-utilities": "^3.7.6",
     "@redhat-cloud-services/host-inventory-client": "1.2.3",

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ const App = () => {
   return (
     <div className="inventory">
       <NotificationsPortal />
-      <RBACProvider appName="inventory" checkResourceDefinitions>
+      <RBACProvider checkResourceDefinitions>
         <Routes />
       </RBACProvider>
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,10 @@ const App = () => {
   return (
     <div className="inventory">
       <NotificationsPortal />
-      <RBACProvider checkResourceDefinitions>
+      <RBACProvider
+        appName={null /* fetch permissions from all scopes */}
+        checkResourceDefinitions
+      >
         <Routes />
       </RBACProvider>
     </div>

--- a/src/ApplicationTab.js
+++ b/src/ApplicationTab.js
@@ -12,8 +12,10 @@ import {
 import { TAB_REQUIRED_PERMISSIONS } from './constants';
 
 const ApplicationTab = ({ appName, title, ...props }) => {
-  const { hasAccess } = usePermissionsWithContext(
-    TAB_REQUIRED_PERMISSIONS[appName]
+  const { hasAccess, isOrgAdmin } = usePermissionsWithContext(
+    TAB_REQUIRED_PERMISSIONS[appName],
+    true,
+    false
   );
 
   const tabs = {
@@ -26,7 +28,7 @@ const ApplicationTab = ({ appName, title, ...props }) => {
 
   const Tab = tabs[appName];
 
-  return hasAccess ? (
+  return hasAccess || isOrgAdmin ? (
     <Tab {...props} />
   ) : (
     <AccessDenied

--- a/src/constants.js
+++ b/src/constants.js
@@ -249,24 +249,22 @@ export const USER_ACCESS_ADMIN_PERMISSIONS = ['rbac:*:*'];
 export const TAB_REQUIRED_PERMISSIONS = {
   /**
    * Should be up to date with
-   * https://github.com/RedHatInsights/rbac-config/tree/88ab3a3adb9526d3dcdb0e1e26c30cc98f51f76e/configs/prod/roles
+   * https://github.com/RedHatInsights/rbac-config/tree/master/configs/stage/roles
    * viewer roles.
    */
-  advisor: ['advisor:*:*', 'inventory:*:read'],
+  advisor: [],
   vulnerability: [
     'vulnerability:vulnerability_results:read',
     'vulnerability:system.opt_out:read',
     'vulnerability:report_and_export:read',
-    'inventory:*:read',
     'vulnerability:advanced_report:read',
   ],
   compliance: [
     'compliance:policy:read',
     'compliance:report:read',
     'compliance:system:read',
-    'inventory:*:read',
     'remediations:remediation:read',
   ],
-  patch: ['patch:*:read', 'inventory:*:read'],
-  ros: ['ros:*:read', 'inventory:*:read'],
+  patch: ['patch:*:read'],
+  ros: ['ros:*:read'],
 };


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5253. Should be merged after https://github.com/RedHatInsights/frontend-components/pull/1900 is released.

With this PR, Inventory fetches permissions for all applications, not only from the inventory scope. This way, we can read all the required permissions before rendering contents of each tab on the System details page (Advisor, Vulnerability, etc.). This also updates the list of permissions according to the stage, not prod, RBAC config, and makes exception for org. admins to always show the tab contents.

## How to test

Have an account for which you can alter roles/permissions. Go to /inventory and any system's details page. Leave only the Inventory Read role, and verify that all tabs except General and Advisor are unavailable (should write no access). Try to add some viewer roles for each app and check that the tabs are now viewable.