### PR TITLE
feat(ESSNTL-4494): Implement searchable group filter

### DIFF
--- a/src/components/InventoryTable/InventoryTable.cy.js
+++ b/src/components/InventoryTable/InventoryTable.cy.js
@@ -213,8 +213,8 @@ describe('with default parameters', () => {
       it('options are populated correctly', () => {
         cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
         cy.get(DROPDOWN_ITEM).contains('Group').click();
-        cy.ouiaId('Filter by group').click();
-        cy.get('.pf-c-check__label').should(
+        cy.ouiaId('FilterByGroup').click();
+        cy.ouiaId('FilterByGroupOption').should(
           'have.text',
           shorterGroupsFixtures.results.map(({ name }) => name).join('')
         );
@@ -225,16 +225,16 @@ describe('with default parameters', () => {
       it('creates a chip', () => {
         cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
         cy.get(DROPDOWN_ITEM).contains('Group').click();
-        cy.ouiaId('Filter by group').click();
-        cy.get('.pf-c-check__label').eq(0).click();
+        cy.ouiaId('FilterByGroup').click();
+        cy.ouiaId('FilterByGroupOption').eq(0).click();
         hasChip('Group', firstGroupName);
       });
 
       it('triggers new request', () => {
         cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
         cy.get(DROPDOWN_ITEM).contains('Group').click();
-        cy.ouiaId('Filter by group').click();
-        cy.get('.pf-c-check__label').eq(0).click();
+        cy.ouiaId('FilterByGroup').click();
+        cy.ouiaId('FilterByGroupOption').eq(0).click();
         cy.wait('@getHosts')
           .its('request.url')
           .should('include', `group_name=${firstGroupName}`);

--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   MenuToggle,
   TextInputGroup,
@@ -13,10 +13,15 @@ const SearchableGroupFilter = ({
   selectedGroupNames,
   setSelectedGroupNames,
 }) => {
-  const initialValues = initialGroups.map(({ name }) => ({
-    itemId: name, // group name is unique by design
-    children: name,
-  }));
+  const initialValues = useMemo(
+    () =>
+      initialGroups.map(({ name }) => ({
+        itemId: name, // group name is unique by design
+        children: name,
+      })),
+    [initialGroups]
+  );
+
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [selectOptions, setSelectOptions] = useState(initialValues);

--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -1,0 +1,189 @@
+import React, { useEffect, useState } from 'react';
+import {
+  MenuToggle,
+  TextInputGroup,
+  TextInputGroupMain,
+} from '@patternfly/react-core';
+import { Select, SelectList, SelectOption } from '@patternfly/react-core/next';
+import xor from 'lodash/xor';
+import PropTypes from 'prop-types';
+
+const SearchableGroupFilter = ({
+  initialGroups,
+  selectedGroupNames,
+  setSelectedGroupNames,
+}) => {
+  const initialValues = initialGroups.map(({ name }) => ({
+    itemId: name, // group name is unique by design
+    children: name,
+  }));
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [selectOptions, setSelectOptions] = useState(initialValues);
+  const [focusedItemIndex, setFocusedItemIndex] = useState(null);
+  const placeholder = `${selectedGroupNames.length} groups selected`;
+
+  useEffect(() => {
+    let newSelectOptions = initialValues;
+
+    // filter menu items based on the text input value when one exists
+    if (inputValue) {
+      newSelectOptions = initialValues.filter((menuItem) =>
+        String(menuItem.children)
+          .toLowerCase()
+          .includes(inputValue.toLowerCase())
+      );
+
+      // when no options are found after filtering, display 'No groups found'
+      if (!newSelectOptions.length) {
+        newSelectOptions = [{ isDisabled: true, children: 'No groups found' }];
+      }
+    }
+
+    setSelectOptions(newSelectOptions);
+    setFocusedItemIndex(0);
+  }, [inputValue]);
+
+  const handleMenuArrowKeys = (key) => {
+    let indexToFocus;
+
+    if (isOpen) {
+      if (key === 'ArrowUp') {
+        // when no index is set or at the first index, focus to the last, otherwise decrement focus index
+        if (focusedItemIndex === null || focusedItemIndex === 0) {
+          indexToFocus = selectOptions.length - 1;
+        } else {
+          indexToFocus = focusedItemIndex - 1;
+        }
+      }
+
+      if (key === 'ArrowDown') {
+        // when no index is set or at the last index, focus to the first, otherwise increment focus index
+        if (
+          focusedItemIndex === null ||
+          focusedItemIndex === selectOptions.length - 1
+        ) {
+          indexToFocus = 0;
+        } else {
+          indexToFocus = focusedItemIndex + 1;
+        }
+      }
+
+      setFocusedItemIndex(indexToFocus);
+    }
+  };
+
+  const onInputKeyDown = (event) => {
+    const enabledMenuItems = selectOptions.filter(
+      (menuItem) => !menuItem.isDisabled
+    );
+    const [firstMenuItem] = enabledMenuItems;
+    const focusedItem = focusedItemIndex
+      ? enabledMenuItems[focusedItemIndex]
+      : firstMenuItem;
+
+    switch (event.key) {
+      // select the first available option
+      case 'Enter':
+        if (!isOpen) {
+          setIsOpen((prevIsOpen) => !prevIsOpen);
+          setInputValue('');
+        } else {
+          onSelect(focusedItem.itemId);
+        }
+        break;
+      case 'Tab':
+      case 'Escape':
+        setIsOpen(false);
+        setInputValue('');
+        break;
+      case 'ArrowUp':
+      case 'ArrowDown':
+        handleMenuArrowKeys(event.key);
+        break;
+      default:
+        !isOpen && setIsOpen(true);
+    }
+  };
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+    setInputValue('');
+  };
+
+  const onTextInputChange = (_event, value) => {
+    setInputValue(value);
+  };
+
+  const onSelect = (itemId) => {
+    if (itemId) {
+      setSelectedGroupNames(xor(selectedGroupNames, [itemId]));
+    }
+  };
+
+  const toggle = (toggleRef) => (
+    <MenuToggle
+      variant="typeahead"
+      onClick={onToggleClick}
+      innerRef={toggleRef}
+      isExpanded={isOpen}
+      style={{ minWidth: '261px' }} // align width with the tags filter width
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={inputValue}
+          onClick={onToggleClick}
+          onChange={onTextInputChange}
+          onKeyDown={onInputKeyDown}
+          id="multi-typeahead-select-input"
+          autoComplete="off"
+          placeholder={placeholder}
+        />
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <div data-ouia-component-id="FilterByGroup">
+      <Select
+        id="groups-filter-select"
+        ouiaId="Filter by group"
+        isOpen={isOpen}
+        selected={selectedGroupNames}
+        onSelect={(ev, selection) => onSelect(selection)}
+        onOpenChange={() => {
+          setIsOpen(false);
+          setInputValue('');
+        }}
+        toggle={toggle}
+      >
+        <SelectList isAriaMultiselectable>
+          {selectOptions.map((option, index) => (
+            <SelectOption
+              {...(!option.isDisabled && { hasCheck: true })}
+              isSelected={selectedGroupNames.includes(option.itemId)}
+              key={option.itemId || option.children}
+              isFocused={focusedItemIndex === index}
+              className={option.className}
+              data-ouia-component-id="FilterByGroupOption"
+              {...option}
+            />
+          ))}
+        </SelectList>
+      </Select>
+    </div>
+  );
+};
+
+SearchableGroupFilter.propTypes = {
+  initialGroups: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      id: PropTypes.string,
+    }).isRequired
+  ),
+  selectedGroupNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  setSelectedGroupNames: PropTypes.func.isRequired,
+};
+
+export default SearchableGroupFilter;

--- a/src/components/filters/__snapshots__/useGroupFilter.test.js.snap
+++ b/src/components/filters/__snapshots__/useGroupFilter.test.js.snap
@@ -19,12 +19,14 @@ exports[`useGroupFilter with groups yet not loaded should return empty state val
 Array [
   Object {
     "filterValues": Object {
-      "items": Array [],
-      "onChange": [Function],
-      "value": Array [],
+      "children": <SearchableGroupFilter
+        initialGroups={Array []}
+        selectedGroupNames={Array []}
+        setSelectedGroupNames={[Function]}
+      />,
     },
     "label": "Group",
-    "type": "checkbox",
+    "type": "custom",
     "value": "group-host-filter",
   },
   Array [],

--- a/src/components/filters/useGroupFilter.test.js
+++ b/src/components/filters/useGroupFilter.test.js
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 import { act, renderHook } from '@testing-library/react-hooks';
 import useGroupFilter from './useGroupFilter';
-import { waitFor } from '@testing-library/react';
 
 jest.mock('../../Utilities/useFeatureFlag', () => ({
   __esModule: true,
@@ -35,19 +34,6 @@ describe('useGroupFilter', () => {
   });
 
   describe('with groups loaded', () => {
-    it('fills the filter items', async () => {
-      const { result } = renderHook(useGroupFilter);
-
-      await waitFor(() => {
-        expect(result.current[0].filterValues.items).toEqual([
-          {
-            label: 'group-1',
-            value: 'group-1',
-          },
-        ]);
-      });
-    });
-
     it('should return correct chips array, current value and value setter', () => {
       const { result } = renderHook(useGroupFilter);
       const [, chips, value, setValue] = result.current;


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-4494.

This enhances the group filter for InventoryTable: the group options are now can be searched.

This changes the filter type to 'custom', but I tried to keep all of the input/return values of `useGroupFilter` untouched so that it's easier to integrate.

## How to test

Try to search for your groups using this filter and apply any of them and check whether the table is filtered correctly. You can also use keyboard (arrows, tab, enter) to navigate within the filter. The placeholder text also should show correct values in different scenarios when there are items found or not. The filter chips must be synchronised with the filter selected values too.

The filter is updated also at the group details view, add to group modal (everywhere where InventoryTable is used with default filters).

## Screenshots

<img width="1271" alt="Screenshot 2023-08-31 at 10 44 33" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/26480c5c-07b6-4262-98be-4823b605904f">

<img width="1271" alt="Screenshot 2023-08-31 at 10 44 39" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/dae95837-0e73-4eb8-aadd-8e4ca91bd2e5">

