### PR TITLE
feat(RHIF-282): Render get help expandable

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -5,3 +5,7 @@ table.ins-entity-table th {
     padding: 1rem;
     padding-left: 2rem;
 }
+
+.inventory {
+  height: 100%;
+}

--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -393,10 +393,10 @@ describe('actions', () => {
   });
 
   it('can create a group', () => {
-    cy.get(TOOLBAR).find('button').contains('Create group').click();
-    cy.get(MODAL).find('h1').should('contain.text', 'Create group');
-
-    cy.wait('@getGroups'); // validate request
+    cy.get(TOOLBAR)
+      .find('button')
+      .contains('Create group')
+      .shouldHaveAriaEnabled();
   });
 });
 

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -21,7 +21,7 @@ import flatten from 'lodash/flatten';
 import map from 'lodash/map';
 import union from 'lodash/union';
 import upperCase from 'lodash/upperCase';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import {
@@ -33,7 +33,6 @@ import {
 } from '../../constants';
 import { fetchGroups } from '../../store/inventory-actions';
 import useFetchBatched from '../../Utilities/hooks/useFetchBatched';
-import CreateGroupModal from '../InventoryGroups/Modals/CreateGroupModal';
 import DeleteGroupModal from '../InventoryGroups/Modals/DeleteGroupModal';
 import RenameGroupModal from '../InventoryGroups/Modals/RenameGroupModal';
 import { getGroups } from '../InventoryGroups/utils/api';
@@ -49,6 +48,7 @@ import {
   ActionButton,
   ActionDropdownItem,
 } from '../InventoryTable/ActionWithRBAC';
+import PropTypes from 'prop-types';
 
 const GROUPS_TABLE_INITIAL_STATE = {
   perPage: TABLE_DEFAULT_PAGINATION,
@@ -106,7 +106,7 @@ const groupsTableFiltersConfig = {
   },
 };
 
-const GroupsTable = () => {
+const GroupsTable = ({ onCreateGroupClick }) => {
   const dispatch = useDispatch();
   const { rejected, uninitialized, loading, fulfilled, data } = useSelector(
     (state) => state.groups
@@ -120,7 +120,6 @@ const GroupsTable = () => {
   const [rows, setRows] = useState([]);
   const [selectedIds, setSelectedIds] = useState([]);
   const [selectedGroup, setSelectedGroup] = useState(undefined); // for per-row actions
-  const [createModalOpen, setCreateModalOpen] = useState(false);
   const [renameModalOpen, setRenameModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const groups = useMemo(() => data?.results || [], [data]);
@@ -366,15 +365,6 @@ const GroupsTable = () => {
 
   return (
     <div id="groups-table">
-      {createModalOpen && (
-        <CreateGroupModal
-          isModalOpen={createModalOpen}
-          setIsModalOpen={setCreateModalOpen}
-          reloadData={() => {
-            fetchData(filters);
-          }}
-        />
-      )}
       {renameModalOpen && (
         <RenameGroupModal
           isModalOpen={renameModalOpen}
@@ -473,7 +463,7 @@ const GroupsTable = () => {
                 <ActionButton
                   requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
                   noAccessTooltip={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}
-                  onClick={() => setCreateModalOpen(true)}
+                  onClick={onCreateGroupClick}
                 >
                   Create group
                 </ActionButton>
@@ -543,4 +533,8 @@ const GroupsTable = () => {
   );
 };
 
-export default GroupsTable;
+GroupsTable.propTypes = {
+  onCreateGroupClick: PropTypes.func,
+};
+
+export default memo(GroupsTable);

--- a/src/components/InventoryGroups/GetHelpExpandable.js
+++ b/src/components/InventoryGroups/GetHelpExpandable.js
@@ -1,0 +1,52 @@
+import './GetHelpExpandable.scss';
+
+import {
+  Button,
+  ExpandableSection,
+  List,
+  ListItem,
+} from '@patternfly/react-core';
+import { ArrowRightIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { USER_ACCESS_ADMIN_PERMISSIONS } from '../../constants';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+
+const GetHelpExpandable = () => {
+  const { hasAccess: isUserAccessAdministrator, isOrgAdmin } =
+    usePermissionsWithContext(USER_ACCESS_ADMIN_PERMISSIONS);
+
+  return (
+    <ExpandableSection
+      toggleText="Help get started with new features"
+      displaySize="large"
+      className="ins-c-groups-help-expandable"
+    >
+      <List isPlain>
+        <ListItem>
+          <Button
+            variant="link"
+            className="ins-c-groups-help-expandable__link"
+            isLarge
+          >
+            Create an Inventory group <ArrowRightIcon />
+          </Button>
+        </ListItem>
+        {isUserAccessAdministrator || isOrgAdmin ? (
+          <ListItem>
+            <Button
+              variant="link"
+              className="ins-c-groups-help-expandable__link"
+              isLarge
+            >
+              Configure User Access for your Inventory groups <ArrowRightIcon />
+            </Button>
+          </ListItem>
+        ) : (
+          <></>
+        )}
+      </List>
+    </ExpandableSection>
+  );
+};
+
+export default GetHelpExpandable;

--- a/src/components/InventoryGroups/GetHelpExpandable.scss
+++ b/src/components/InventoryGroups/GetHelpExpandable.scss
@@ -1,0 +1,9 @@
+
+.ins-c-groups-help-expandable {
+  margin: 0 0 24px 0;
+  background-color: var(--pf-global--BackgroundColor--100);
+
+  &__link {
+    padding: 0;
+  }
+}

--- a/src/components/InventoryGroups/InventoryGroups.cy.js
+++ b/src/components/InventoryGroups/InventoryGroups.cy.js
@@ -47,9 +47,7 @@ describe('groups table page', () => {
       cy.mockWindowChrome({ userPermissions: [] });
       mountPage();
 
-      cy.get('button')
-        .contains('Create group')
-        .should('have.attr', 'aria-disabled', 'true');
+      cy.ouiaId('CreateGroupButton').shouldHaveAriaDisabled();
     });
   });
 });

--- a/src/components/InventoryGroups/InventoryGroups.js
+++ b/src/components/InventoryGroups/InventoryGroups.js
@@ -1,21 +1,26 @@
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import GroupsTable from '../GroupsTable/GroupsTable';
 import { getGroups } from '../InventoryGroups/utils/api';
 import NoGroupsEmptyState from './NoGroupsEmptyState';
 import { EmptyStateNoAccessToGroups } from '../InventoryGroupDetail/EmptyStateNoAccess';
+import GetHelpExpandable from './GetHelpExpandable';
+import CreateGroupModal from './Modals/CreateGroupModal';
 
 const InventoryGroups = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasGroups, setHasGroups] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [error, setError] = useState(null);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
 
   const ignore = useRef(false); // https://react.dev/learn/synchronizing-with-effects#fetching-data
 
   const handleLoading = async () => {
+    setIsLoading(true);
+
     // make initial request to check if there is at least one group available
     try {
       const { total } = await getGroups();
@@ -33,6 +38,10 @@ const InventoryGroups = () => {
     !ignore.current && setIsLoading(false);
   };
 
+  const onCreateGroupClick = useCallback(() => {
+    setCreateModalOpen(true);
+  }, []);
+
   useEffect(() => {
     handleLoading();
 
@@ -45,7 +54,16 @@ const InventoryGroups = () => {
     <section
       className="pf-l-page__main-section pf-c-page__main-section"
       data-ouia-component-id="groups-table-wrapper"
+      style={{ height: '100%' }}
     >
+      {createModalOpen && (
+        <CreateGroupModal
+          isModalOpen={createModalOpen}
+          setIsModalOpen={setCreateModalOpen}
+          reloadData={handleLoading}
+        />
+      )}
+      <GetHelpExpandable />
       {hasError ? (
         error?.status === 403 || error?.response?.status === 403 ? (
           <EmptyStateNoAccessToGroups />
@@ -57,9 +75,9 @@ const InventoryGroups = () => {
           <Spinner />
         </Bullseye>
       ) : hasGroups ? (
-        <GroupsTable />
+        <GroupsTable onCreateGroupClick={onCreateGroupClick} />
       ) : (
-        <NoGroupsEmptyState reloadData={handleLoading} />
+        <NoGroupsEmptyState onCreateGroupClick={onCreateGroupClick} />
       )}
     </section>
   );

--- a/src/components/InventoryGroups/NoGroupsEmptyState.js
+++ b/src/components/InventoryGroups/NoGroupsEmptyState.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Button,
   EmptyState,
@@ -11,14 +11,12 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 
 import { global_palette_black_600 as globalPaletteBlack600 } from '@patternfly/react-tokens/dist/js/global_palette_black_600';
-import CreateGroupModal from './Modals/CreateGroupModal';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { GENERAL_GROUPS_WRITE_PERMISSION } from '../../constants';
 
 const REQUIRED_PERMISSIONS = [GENERAL_GROUPS_WRITE_PERMISSION];
 
-const NoGroupsEmptyState = ({ reloadData }) => {
-  const [createGroupModalOpen, setCreateGroupModalOpen] = useState(false);
+const NoGroupsEmptyState = ({ onCreateGroupClick }) => {
   const { hasAccess: canModifyGroups } =
     usePermissionsWithContext(REQUIRED_PERMISSIONS);
 
@@ -28,11 +26,6 @@ const NoGroupsEmptyState = ({ reloadData }) => {
       data-ouia-component-type="PF4/EmptyState"
       data-ouia-safe={true}
     >
-      <CreateGroupModal
-        isModalOpen={createGroupModalOpen}
-        setIsModalOpen={setCreateGroupModalOpen}
-        reloadData={reloadData}
-      />
       <EmptyStateIcon
         icon={PlusCircleIcon}
         color={globalPaletteBlack600.value}
@@ -44,12 +37,16 @@ const NoGroupsEmptyState = ({ reloadData }) => {
         Manage device operations efficiently by creating inventory groups.
       </EmptyStateBody>
       {canModifyGroups ? (
-        <Button variant="primary" onClick={() => setCreateGroupModalOpen(true)}>
+        <Button
+          variant="primary"
+          onClick={onCreateGroupClick}
+          ouiaId="CreateGroupButton"
+        >
           Create group
         </Button>
       ) : (
         <Tooltip content="You do not have the necessary permissions to modify groups. Contact your organization administrator.">
-          <Button variant="primary" isAriaDisabled>
+          <Button variant="primary" isAriaDisabled ouiaId="CreateGroupButton">
             Create group
           </Button>
         </Tooltip>
@@ -59,7 +56,7 @@ const NoGroupsEmptyState = ({ reloadData }) => {
 };
 
 NoGroupsEmptyState.propTypes = {
-  reloadData: PropTypes.func,
+  onCreateGroupClick: PropTypes.func,
 };
 
 export default NoGroupsEmptyState;

--- a/src/routes/InventoryGroups.test.js
+++ b/src/routes/InventoryGroups.test.js
@@ -3,6 +3,21 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import InventoryGroups from './InventoryGroups';
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/RBACHook',
+  () => ({
+    ...jest.requireActual(
+      '@redhat-cloud-services/frontend-components-utilities/RBACHook'
+    ),
+    usePermissionsWithContext: () => ({ hasAccess: true }),
+  })
+);
+
 describe('inventory groups route', () => {
   it('renders header and table wrapper', () => {
     const { container } = render(<InventoryGroups />);
@@ -10,6 +25,15 @@ describe('inventory groups route', () => {
     expect(container.querySelector('h1')).toHaveTextContent('Groups');
     expect(
       container.querySelector('[data-ouia-component-id="groups-table-wrapper"]')
+    ).toBeInTheDocument();
+  });
+
+  it('should contain get help expandable', () => {
+    const { getByText } = render(<InventoryGroups />);
+    expect(getByText('Help get started with new features')).toBeInTheDocument();
+    expect(getByText('Create an Inventory group')).toBeInTheDocument();
+    expect(
+      getByText('Configure User Access for your Inventory groups')
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHIF-282.

This adds some helping notes on the top of the groups table. The second link must be hidden if user is not an org admin nor user access adminstrator.

## Screenshots

<img width="1271" alt="Screenshot 2023-09-01 at 12 45 07" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/0110b7dc-106d-4cee-82e1-8dc3f337db2c">
