### PR TITLE
feat(ESSNTL-4485): Fix BulkSelect text

### DIFF
--- a/src/Utilities/hooks/useBulkSelectConfig.js
+++ b/src/Utilities/hooks/useBulkSelectConfig.js
@@ -61,7 +61,7 @@ export const useBulkSelectConfig = (
     id: 'bulk-select-systems',
     items: [
       {
-        title: 'Select none (0)',
+        title: 'Select none (0 items)',
         onClick: () => onSelectRows(-1, false),
         props: { isDisabled: noneSelected },
       },
@@ -70,7 +70,7 @@ export const useBulkSelectConfig = (
           ? {
               title: `${pageSelected ? 'Deselect' : 'Select'} page (${
                 rows.length
-              } items)`,
+              } ${rows.length === 1 ? 'item' : 'items'})`,
               onClick: () => onSelectRows(0, !pageSelected),
             }
           : {}),
@@ -78,7 +78,7 @@ export const useBulkSelectConfig = (
       {
         ...(loaded && rows && rows.length > 0
           ? {
-              title: `Select all (${total})`,
+              title: `Select all (${total} ${total === 1 ? 'item' : 'items'})`,
               onClick: async () => {
                 await selectAllIds();
               },


### PR DESCRIPTION
[ESSNTL-4485](https://issues.redhat.com/browse/ESSNTL-4485)

Changed bulk select text in parentheses. Now it should be eg. (5 items) and (1 item) if there is only one.
It's described in the doc inside the ticket.

How to test:
1. Make sure the text is correct
2. Verify for a single item it should say "Select page/all (1 item)", easiest is to use a inventory group with a single system inside

| Before               | After               |
| ---------------------- | ---------------------- |
| ![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/20592948/bdf7c885-a1e7-44de-95cc-0aa58cf8da35) | ![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/20592948/d7b170cd-75ca-4884-93ba-d494de4c26bb)|
