### PR TITLE
fix(ESSNTL-5315): Fix last seen filter

### DIFF
--- a/src/components/filters/useLastSeenFilter.js
+++ b/src/components/filters/useLastSeenFilter.js
@@ -92,7 +92,7 @@ export const useLastSeenFilter = (
   };
 
   //This date comes from patternfly component. This manages the 1st date picker
-  const onFromChange = (date) => {
+  const onFromChange = (_event, date) => {
     const newToDate = moment(endDate).endOf('day');
     const todaysDate = moment().endOf('day');
     const selectedFromDate = moment(date).startOf('day');
@@ -116,7 +116,7 @@ export const useLastSeenFilter = (
   };
 
   //This date comes from patternfly component. This manages the 2nd date picker
-  const onToChange = (date) => {
+  const onToChange = (_event, date) => {
     if (
       (!containsSpecialChars(date) && date.length > DEFAULT_DATE_LENGTH) ||
       date.length === 0


### PR DESCRIPTION
A patternfly updated affected the params that the datepicker uses, causing the component not to work anymore with just the 'date' param. This PR fixes that.

To test simply head to /systems page, enable the custom filter, and make sure the filter works as expected