### PR TITLE
feat(RHIF-282): Connect Inventory groups quick-starts

### DIFF
--- a/src/components/InventoryGroups/GetHelpExpandable.js
+++ b/src/components/InventoryGroups/GetHelpExpandable.js
@@ -10,10 +10,12 @@ import { ArrowRightIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { USER_ACCESS_ADMIN_PERMISSIONS } from '../../constants';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const GetHelpExpandable = () => {
   const { hasAccess: isUserAccessAdministrator, isOrgAdmin } =
     usePermissionsWithContext(USER_ACCESS_ADMIN_PERMISSIONS);
+  const { quickStarts } = useChrome();
 
   return (
     <ExpandableSection
@@ -27,6 +29,9 @@ const GetHelpExpandable = () => {
             variant="link"
             className="ins-c-groups-help-expandable__link"
             isLarge
+            onClick={() =>
+              quickStarts.activateQuickstart('insights-inventory-groups')
+            }
           >
             Create an Inventory group <ArrowRightIcon />
           </Button>
@@ -37,6 +42,9 @@ const GetHelpExpandable = () => {
               variant="link"
               className="ins-c-groups-help-expandable__link"
               isLarge
+              onClick={() =>
+                quickStarts.activateQuickstart('insights-inventory-groups-rbac')
+              }
             >
               Configure User Access for your Inventory groups <ArrowRightIcon />
             </Button>


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHIF-282.

This connects the links in the Inventory groups "Get help" expandable with the right quick-starts IDs (see https://github.com/RedHatInsights/quickstarts/tree/main/docs/quickstarts).

## How to test

Go to /inventory/groups; and try to click on both links. The quick-starts should pop up in the right page section.

## Screenshots

<img width="1396" alt="Screenshot 2023-09-22 at 12 38 11" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/76dd367f-d4ab-4b7f-9363-9eaf62c739fc">
