### PR TITLE
chore(RHIF-277): expose HybridInventoryTabs as fed-mod, preserve URLs

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -151,6 +151,10 @@ plugins.push(
           '../src/store/systemProfileStore.js'
         ),
         './DeleteModal': resolve(__dirname, '../src/Utilities/DeleteModal.js'),
+        './HybridInventoryTabs': resolve(
+          __dirname,
+          '../src/modules/HybridInventoryTabs.js'
+        ),
       },
       shared: [
         {

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -101,6 +101,10 @@ plugins.push(
           '../src/store/systemProfileStore.js'
         ),
         './DeleteModal': resolve(__dirname, '../src/Utilities/DeleteModal.js'),
+        './HybridInventoryTabs': resolve(
+          __dirname,
+          '../src/modules/HybridInventoryTabs.js'
+        ),
       },
       shared: [
         {

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -261,7 +261,7 @@ export const allStaleFilters = ['fresh', 'stale', 'stale_warning', 'unknown'];
 export const hybridInventoryTabKeys = {
   conventional: {
     key: 'conventional',
-    url: '/',
+    url: '',
   },
   immutable: {
     key: 'immutable',

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.test.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.test.js
@@ -6,22 +6,22 @@ import { act } from 'react-dom/test-utils';
 import * as ReactRouterDOM from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 
-import InventoryTable from './InventoryTable';
-import { calculatePagination } from '../components/InventoryTabs/ConventionalSystems/Utilities';
-import DeleteModal from '../Utilities/DeleteModal';
-import { hosts } from '../api';
-import createXhrMock from '../Utilities/__mocks__/xhrMock';
+import ConventionalSystemsTab from './ConventionalSystemsTab';
+import { calculatePagination } from './Utilities';
+import DeleteModal from '../../../Utilities/DeleteModal';
+import { hosts } from '../../../api';
+import createXhrMock from '../../../Utilities/__mocks__/xhrMock';
 
-import { useGetRegistry } from '../Utilities/constants';
-import { mockSystemProfile } from '../__mocks__/hostApi';
+import { useGetRegistry } from '../../../Utilities/constants';
+import { mockSystemProfile } from '../../../__mocks__/hostApi';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => () => jest.fn(),
 }));
 
-jest.mock('../Utilities/constants', () => ({
-  ...jest.requireActual('../Utilities/constants'),
+jest.mock('../../../Utilities//constants', () => ({
+  ...jest.requireActual('../../../Utilities/constants'),
   useGetRegistry: jest.fn(() => ({
     getRegistry: () => ({}),
   })),
@@ -35,9 +35,9 @@ jest.mock(
   })
 );
 
-jest.mock('../Utilities/useFeatureFlag');
+jest.mock('../../../Utilities/useFeatureFlag');
 
-describe('InventoryTable', () => {
+describe('ConventionalSystemsTab', () => {
   let mockStore;
 
   const system1 = {
@@ -143,7 +143,7 @@ describe('InventoryTable', () => {
     let wrapper;
 
     await act(async () => {
-      wrapper = mount(<InventoryTable initialLoading={false} />, store);
+      wrapper = mount(<ConventionalSystemsTab initialLoading={false} />, store);
     });
     wrapper.update();
 
@@ -167,7 +167,7 @@ describe('InventoryTable', () => {
     const store = mockStore(initialStore);
 
     await act(async () => {
-      wrapper = mount(<InventoryTable initialLoading={false} />, store);
+      wrapper = mount(<ConventionalSystemsTab initialLoading={false} />, store);
     });
     wrapper.update();
 
@@ -209,7 +209,7 @@ describe('InventoryTable', () => {
     });
 
     await act(async () => {
-      wrapper = mount(<InventoryTable initialLoading={false} />, store);
+      wrapper = mount(<ConventionalSystemsTab initialLoading={false} />, store);
     });
     wrapper.update();
 

--- a/src/components/InventoryTabs/HybridInventoryTabs.js
+++ b/src/components/InventoryTabs/HybridInventoryTabs.js
@@ -74,8 +74,6 @@ const HybridInventoryTabs = ({
     }
   };
 
-  console.log('Hellooo');
-
   return EdgeParityEnabled && hasEdgeImages ? (
     <Tabs
       className="pf-m-light pf-c-table"

--- a/src/components/InventoryTabs/HybridInventoryTabs.js
+++ b/src/components/InventoryTabs/HybridInventoryTabs.js
@@ -80,6 +80,8 @@ const HybridInventoryTabs = ({
           : hybridInventoryTabKeys.conventional.key
       }
       aria-label="Hybrid inventory tabs"
+      mountOnEnter
+      unmountOnExit
     >
       <Tab
         eventKey={hybridInventoryTabKeys.conventional.key}

--- a/src/components/InventoryTabs/HybridInventoryTabs.js
+++ b/src/components/InventoryTabs/HybridInventoryTabs.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
@@ -18,8 +18,44 @@ const HybridInventoryTabs = ({
   tabPathname,
   isImmutableTabOpen,
 }) => {
-  const { search, state } = useLocation();
+  const { search } = useLocation();
+  //used to hold URL params across tab changes
+  const prevSearchRef = useRef('');
   const navigate = useNavigate();
+  const [hasEdgeImages, setHasEdgeImages] = useState(false);
+  const EdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
+
+  useEffect(() => {
+    if (EdgeParityEnabled) {
+      try {
+        axios
+          .get(
+            `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_EDGE_PARAMS}`
+          )
+          .then((result) => {
+            const accountHasEdgeImages = result?.data?.total > 0;
+            setHasEdgeImages(accountHasEdgeImages);
+            axios
+              .get(
+                `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS}`
+              )
+              .then((conventionalImages) => {
+                const accountHasConventionalImages =
+                  conventionalImages?.data?.total > 0;
+                if (accountHasEdgeImages && !accountHasConventionalImages) {
+                  handleTabClick(
+                    undefined,
+                    hybridInventoryTabKeys.immutable.key
+                  );
+                }
+              });
+          });
+      } catch (e) {
+        console.log(e);
+      }
+    }
+  }, []);
+
   const activeTab = isImmutableTabOpen
     ? hybridInventoryTabKeys.immutable.key
     : hybridInventoryTabKeys.conventional.key;
@@ -28,57 +64,23 @@ const HybridInventoryTabs = ({
     const pathWithParams =
       tabPathname +
       hybridInventoryTabKeys[tabIndex].url +
-      (state?.prevSearch || '');
+      (prevSearchRef.current || '');
 
     if (tabIndex !== activeTab) {
+      prevSearchRef.current = search.toString();
       navigate(pathWithParams, {
         replace: true,
-        state: { prevSearch: search },
       });
     }
   };
 
-  const [hasEdgeImages, setHasEdgeImages] = useState(false);
-  const [isOstreeTabFocusPriority, setIsOstreeTabFocusPriority] =
-    useState(false);
-  const EdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
-  if (EdgeParityEnabled) {
-    try {
-      axios
-        .get(
-          `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_EDGE_PARAMS}`
-        )
-        .then((result) => {
-          const accountHasEdgeImages = result?.data?.total > 0;
-          setHasEdgeImages(accountHasEdgeImages);
-          axios
-            .get(
-              `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS}`
-            )
-            .then((conventionalImages) => {
-              const accountHasConventionalImages =
-                conventionalImages?.data?.total > 0;
-              if (accountHasEdgeImages && !accountHasConventionalImages) {
-                handleTabClick(undefined, hybridInventoryTabKeys.immutable.key);
-                setIsOstreeTabFocusPriority(true);
-              }
-            });
-        });
-    } catch (e) {
-      console.log(e);
-    }
-  }
+  console.log('Hellooo');
 
   return EdgeParityEnabled && hasEdgeImages ? (
     <Tabs
       className="pf-m-light pf-c-table"
       activeKey={activeTab}
       onSelect={handleTabClick}
-      defaultActiveKey={
-        isOstreeTabFocusPriority
-          ? hybridInventoryTabKeys.immutable.key
-          : hybridInventoryTabKeys.conventional.key
-      }
       aria-label="Hybrid inventory tabs"
       mountOnEnter
       unmountOnExit

--- a/src/modules/HybridInventoryTabs.js
+++ b/src/modules/HybridInventoryTabs.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import HybridInventoryTabs from '../components/InventoryTabs/HybridInventoryTabs';
+
+const ForwardComponent = (props, ref) => (
+  <HybridInventoryTabs {...props} innerRef={ref} />
+);
+const HybridInventoryTabsModule = React.forwardRef(ForwardComponent);
+
+export default HybridInventoryTabsModule;

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import PropTypes from 'prop-types';
 import './inventory.scss';
 import {
@@ -6,10 +6,29 @@ import {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 import Main from '@redhat-cloud-services/frontend-components/Main';
-import ConventionalSystemsTab from '../components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab';
-import ImmutableDevicesTab from '../components/InventoryTabs/ImmutableDevices/EdgeDevicesTab';
 import HybridInventoryTabs from '../components/InventoryTabs/HybridInventoryTabs';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
+const ConventionalSystemsTab = lazy(() =>
+  import(
+    '../components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab'
+  )
+);
+const ImmutableDevicesTab = lazy(() =>
+  import('../components/InventoryTabs/ImmutableDevices/EdgeDevicesTab')
+);
+
+const SuspenseWrapper = ({ children }) => (
+  <Suspense
+    fallback={
+      <Bullseye>
+        <Spinner size="xl" />
+      </Bullseye>
+    }
+  >
+    {children}
+  </Suspense>
+);
 const Inventory = (props) => {
   return (
     <React.Fragment>
@@ -18,8 +37,16 @@ const Inventory = (props) => {
       </PageHeader>
       <Main>
         <HybridInventoryTabs
-          ConventionalSystemsTab={<ConventionalSystemsTab {...props} />}
-          ImmutableDevicesTab={<ImmutableDevicesTab />}
+          ConventionalSystemsTab={
+            <SuspenseWrapper>
+              <ConventionalSystemsTab {...props} />
+            </SuspenseWrapper>
+          }
+          ImmutableDevicesTab={
+            <SuspenseWrapper>
+              <ImmutableDevicesTab />
+            </SuspenseWrapper>
+          }
           isImmutableTabOpen={props.isImmutableTabOpen}
         />
       </Main>
@@ -33,5 +60,8 @@ Inventory.defaultProps = {
 };
 Inventory.propTypes = {
   isImmutableTabOpen: PropTypes.bool,
+};
+SuspenseWrapper.propTypes = {
+  children: PropTypes.element,
 };
 export default Inventory;

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import './inventory.scss';
 import {
@@ -8,7 +8,8 @@ import {
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import HybridInventoryTabs from '../components/InventoryTabs/HybridInventoryTabs';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-
+import { useLocation } from 'react-router-dom';
+import { getSearchParams } from '../constants';
 const ConventionalSystemsTab = lazy(() =>
   import(
     '../components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab'
@@ -30,6 +31,8 @@ const SuspenseWrapper = ({ children }) => (
   </Suspense>
 );
 const Inventory = (props) => {
+  const { search } = useLocation();
+  const searchParams = useMemo(() => getSearchParams(), [search.toString()]);
   return (
     <React.Fragment>
       <PageHeader className="pf-m-light">
@@ -39,7 +42,7 @@ const Inventory = (props) => {
         <HybridInventoryTabs
           ConventionalSystemsTab={
             <SuspenseWrapper>
-              <ConventionalSystemsTab {...props} />
+              <ConventionalSystemsTab {...searchParams} />
             </SuspenseWrapper>
           }
           ImmutableDevicesTab={

--- a/src/routes/InventoryTable.test.js
+++ b/src/routes/InventoryTable.test.js
@@ -15,6 +15,11 @@ import createXhrMock from '../Utilities/__mocks__/xhrMock';
 import { useGetRegistry } from '../Utilities/constants';
 import { mockSystemProfile } from '../__mocks__/hostApi';
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => () => jest.fn(),
+}));
+
 jest.mock('../Utilities/constants', () => ({
   ...jest.requireActual('../Utilities/constants'),
   useGetRegistry: jest.fn(() => ({


### PR DESCRIPTION
This exposes the new HybirdInventoryTabs though fed-mods so that other apps can consume. Also preserves the URL parameters when a user comes back from another tab.

To test:
1. open Systems page
2. on conventional systems tab, change a page so that there is URL parameter active
3. navigate to immutable devices tab
4. navigate back to conventional tab
5. observe that the URL parameters  are still present in the URL in the conventional systems tab