### PR TITLE
fix(RHIN-447): Update Staleness form validation

### DIFF
--- a/src/components/InventoryHostStaleness/constants.js
+++ b/src/components/InventoryHostStaleness/constants.js
@@ -50,18 +50,25 @@ export const daysToSecondsConversion = (days) => {
 export const conditionalDropdownError = (newFormValues, dropdownItems) => {
   //this runs on every select every time
   let apiKey = dropdownItems[0].apiKey;
-  let formValue = newFormValues[apiKey];
+  let formValue =
+    newFormValues[apiKey] === 'Never' ? maxSafeInt : newFormValues[apiKey];
 
   if (apiKey === 'conventional_staleness_delta') {
     if (formValue > newFormValues['conventional_stale_warning_delta']) {
       return (
-        <p className="pf-u-font-size-sm pf-v5-u-danger-color-100">
+        <p
+          className="pf-u-font-size-sm pf-v5-u-danger-color-100"
+          style={{ width: '200px' }}
+        >
           Staleness must be before stale warning
         </p>
       );
     } else if (formValue > newFormValues['conventional_culling_delta']) {
       return (
-        <p className="pf-u-font-size-sm pf-v5-u-danger-color-100">
+        <p
+          className="pf-u-font-size-sm pf-v5-u-danger-color-100"
+          style={{ width: '200px' }}
+        >
           Staleness must be before culling
         </p>
       );
@@ -499,32 +506,34 @@ export const systemCullingItems = (activeTabKey) => {
 
 export const formValidation = async (newFormValues, setIsFormValid) => {
   for (let i = 0; i < hostStalenessApiKeys.length; i++) {
-    const formKey = hostStalenessApiKeys[i];
-    let value = newFormValues[formKey];
+    const apiKey = hostStalenessApiKeys[i];
+    let formValue =
+      newFormValues[apiKey] === 'Never' ? maxSafeInt : newFormValues[apiKey];
+
     if (
-      formKey === 'conventional_staleness_delta' &&
-      value > newFormValues['conventional_stale_warning_delta']
+      apiKey === 'conventional_staleness_delta' &&
+      formValue > newFormValues['conventional_stale_warning_delta']
     ) {
       setIsFormValid(false);
       break;
     }
     if (
-      formKey === 'immutable_staleness_delta' &&
-      value > newFormValues['immutable_stale_warning_delta']
+      apiKey === 'immutable_staleness_delta' &&
+      formValue > newFormValues['immutable_stale_warning_delta']
     ) {
       setIsFormValid(false);
       break;
     }
     if (
-      formKey === 'conventional_stale_warning_delta' &&
-      value > newFormValues['conventional_culling_delta']
+      apiKey === 'conventional_stale_warning_delta' &&
+      formValue > newFormValues['conventional_culling_delta']
     ) {
       setIsFormValid(false);
       break;
     }
     if (
-      formKey === 'immutable_stale_warning_delta' &&
-      value > newFormValues['immutable_culling_delta']
+      apiKey === 'immutable_stale_warning_delta' &&
+      formValue > newFormValues['immutable_culling_delta']
     ) {
       setIsFormValid(false);
       break;


### PR DESCRIPTION
The 'Never' string wasnt converted in the form validations, so error messages/validation wasnt working as it should.
This PR updates var names and adds that conversion + styling on error messages for the first dropdowns.

To test navigate to the staleness and cullings page 
play around with the dropdowns.
The dropdown to the left should never be allowed to go higher than the dropdown to its right.
Staleness < Stale warning < Culling 