### PR TITLE
fix(ESSNTL-5468): Check for ungrouped hosts in DetailRenderer

### DIFF
--- a/src/components/InventoryDetail/DetailRenderer.js
+++ b/src/components/InventoryDetail/DetailRenderer.js
@@ -4,19 +4,17 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import AccessDenied from '../../Utilities/AccessDenied';
 import { hosts } from '../../api';
-import {
-  GENERAL_HOSTS_READ_PERMISSIONS,
-  REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS,
-} from '../../constants';
+import { REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS } from '../../constants';
 import DetailWrapper from './DetailWrapper';
 
 const DetailRenderer = ({ isRbacEnabled, ...props }) => {
   const [hostGroupId, setHostGroupId] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const { hasAccess } = usePermissionsWithContext(
-    hostGroupId !== null
-      ? REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(hostGroupId)
-      : [GENERAL_HOSTS_READ_PERMISSIONS]
+    /**
+     * hostGroupId can be null, and the ungrouped hosts permissions will be checked in that case
+     */
+    REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(hostGroupId)
   );
 
   useEffect(() => {
@@ -51,11 +49,10 @@ const DetailRenderer = ({ isRbacEnabled, ...props }) => {
     };
   }, [props.inventoryId]);
 
-  if (isRbacEnabled === false) {
-    return <DetailWrapper {...props} />;
-  }
-
-  if (isLoading) {
+  if (isLoading === true) {
+    /**
+     * TODO: test different scenarios once RTL migration is complete
+     */
     return (
       <Flex direction={{ default: 'column' }}>
         <Skeleton width="66%" fontSize="2xl" />
@@ -63,12 +60,16 @@ const DetailRenderer = ({ isRbacEnabled, ...props }) => {
         <Skeleton width="33%" />
       </Flex>
     );
-  }
-
-  if (hasAccess === false) {
-    return <AccessDenied />;
   } else {
-    return <DetailWrapper {...props} />;
+    if (isRbacEnabled === true) {
+      if (hasAccess === false) {
+        return <AccessDenied />;
+      } else {
+        return <DetailWrapper {...props} />;
+      }
+    } else {
+      return <DetailWrapper {...props} />;
+    }
   }
 };
 

--- a/src/components/InventoryDetail/DetailWrapper.js
+++ b/src/components/InventoryDetail/DetailWrapper.js
@@ -23,7 +23,6 @@ const DetailWrapper = ({
   showTags,
   Wrapper,
   className,
-  hasAccess,
   appName,
   inventoryId,
   ...props
@@ -96,7 +95,6 @@ DetailWrapper.propTypes = {
   ]),
   className: PropTypes.string,
   Wrapper: PropTypes.elementType,
-  hasAccess: PropTypes.bool,
   inventoryId: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5468, https://issues.redhat.com/browse/ESSNTL-5469, https://issues.redhat.com/browse/ESSNTL-5470.

The DetailRenderer component shows a header with system basic information. The component is shared across more apps (see the attached tickets), and there has been an issue validating permissions for ungrouped systems. For ungrouped hosts, the component was wrongly checking for general hosts:write permissions instead of using `null` in resource definition as a minimum required permission.

Now, when a host is not a part of any group, the header renders correct information if the user has enough permissions.

## How to test

The easiest way to test is to merge this PR and see it deployed in stage-preview :D Or to run some of the apps locally together with Inventory thru `LOCAL_API` settings.