### PR TITLE
fix(RHIF-313): fix not seeding url param page in Inventory page

### DIFF
--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -175,7 +175,7 @@ const InventoryTable = forwardRef(
         options?.per_page || options?.perPage || cachedProps.perPage;
 
       const newParams = {
-        page: cachedProps.page,
+        page,
         per_page: currPerPage,
         items: cachedProps.items,
         sortBy: cachedProps.sortBy,


### PR DESCRIPTION
RESOLVES: https://issues.redhat.com/browse/RHIF-313
Fixes the table not reflecting the active page parameter in the URL. 

Other URL parameters also need to be tested. I did not face issues with them except OS. I have observed that the active OS URL parameter is not reflected in the table, but this is not related to the hybrid tab as other apps are nicely handled. Recent CentOS filtering might have some influence. Created a bug for this: https://issues.redhat.com/browse/RHIF-314

To test: 
1. Navigate to stage/preview env
2. navigate to the insights-inventory 
3. apply some filters and change a page
4. Observe that URL params are added into the URL
5. Copy the URL and open the same page using copied URLs in another tab
6. observe that the URL params, especially the page param, are not applied to the conventional systems tab