### PR TITLE
feat(RHIF-276): hide update method filter when edge parity is enabled

### DIFF
--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -122,6 +122,7 @@ const ConventionalSystemsTab = ({
   const EdgeParityFilterDeviceEnabled = useFeatureFlag(
     'edgeParity.inventory-list-filter'
   );
+  const EdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
 
   useEffect(() => {
     chrome.updateDocumentTitle('Systems | Red Hat Insights');
@@ -212,6 +213,7 @@ const ConventionalSystemsTab = ({
         autoRefresh
         ignoreRefresh
         initialLoading={initialLoading}
+        hideFilters={{ updateMethodFilter: EdgeParityEnabled }}
         ref={inventory}
         tableProps={{
           actionResolver: tableActions,

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.test.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.test.js
@@ -14,6 +14,8 @@ import createXhrMock from '../../../Utilities/__mocks__/xhrMock';
 
 import { useGetRegistry } from '../../../Utilities/constants';
 import { mockSystemProfile } from '../../../__mocks__/hostApi';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
+import ConditionalFilter from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -277,6 +279,27 @@ describe('ConventionalSystemsTab', () => {
     });
 
     window.XMLHttpRequest = tmp;
+  });
+
+  it('hides system update method filter when edge parity feature is enabled', async () => {
+    let wrapper;
+    const store = mockStore(initialStore);
+    useFeatureFlag.mockImplementation(() => true);
+    await act(async () => {
+      wrapper = mount(<ConventionalSystemsTab initialLoading={false} />, store);
+    });
+    wrapper.update();
+
+    await act(async () => {
+      wrapper.find('button[aria-label="Conditional filter"]').props('click');
+    });
+    wrapper.update();
+    const availableFilters = wrapper.find(ConditionalFilter).props().items;
+    const updateMethodFilter = availableFilters.filter(
+      (filter) => filter.label === 'System Update Method'
+    );
+
+    expect(updateMethodFilter).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHIF-276

Hides the system update method filter when edge parity feature is enabled.

To test:
1. visit inventory page
2. Verify that edge parity feature is disabled in stage env
3. Open filters dropdown
4. Observe that the filter is hidden
5. Enable the filter in stage env and verify its not hidden
