### PR TITLE
fix(RHINENG-462-2): hide centos versions in os filter

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -368,7 +368,7 @@ export const getOperatingSystems = async (params = [], showCentosVersions) => {
     ...params
   );
   if (!showCentosVersions) {
-    let newResults = operatingSystems?.results.filter(
+    const newResults = operatingSystems.results.filter(
       ({ value }) => !value.name.toLowerCase().startsWith('centos')
     );
     operatingSystems.results = newResults;

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -363,9 +363,18 @@ export function getAllTags(search, pagination = {}) {
   );
 }
 
-export function getOperatingSystems(params = []) {
-  return systemProfile.apiSystemProfileGetOperatingSystem(...params);
-}
+export const getOperatingSystems = async (params = [], showCentosVersions) => {
+  let operatingSystems = await systemProfile.apiSystemProfileGetOperatingSystem(
+    ...params
+  );
+  if (!showCentosVersions) {
+    let newResults = operatingSystems?.results.filter(
+      ({ value }) => !value.name.toLowerCase().startsWith('centos')
+    );
+    operatingSystems.results = newResults;
+  }
+  return operatingSystems;
+};
 
 export const fetchDefaultStalenessValues = () => {
   return instance.get(`${INVENTORY_API_BASE}/account/staleness/defaults`);

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -220,6 +220,7 @@ const GroupSystems = ({ groupName, groupId }) => {
           bulkSelect={bulkSelectConfig}
           showTags
           ref={inventory}
+          showCentosVersions
         />
       )}
     </div>

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.cy.js
@@ -1,4 +1,7 @@
-import { groupsInterceptors } from '../../../../cypress/support/interceptors';
+import {
+  groupsInterceptors,
+  systemProfileInterceptors,
+} from '../../../../cypress/support/interceptors';
 import AddSelectedHostsToGroupModal from './AddSelectedHostsToGroupModal';
 
 const mountModal = (
@@ -28,6 +31,7 @@ describe('AddSelectedHostsToGroupModal', () => {
 
     beforeEach(() => {
       groupsInterceptors['successful with some items']();
+      systemProfileInterceptors['operating system, successful empty']();
       mountModal();
     });
 

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -13,6 +13,7 @@ import {
   groupsInterceptors,
   hostsFixtures,
   hostsInterceptors,
+  systemProfileInterceptors,
 } from '../../../../cypress/support/interceptors';
 import { selectRowN } from '../../../../cypress/support/utils';
 import AddSystemsToGroupModal from './AddSystemsToGroupModal';
@@ -79,6 +80,7 @@ describe('AddSystemsToGroupModal', () => {
     hostsInterceptors.successful(); // default hosts list
     featureFlagsInterceptors.successful(); // to enable the Group column
     groupsInterceptors['successful with some items']();
+    systemProfileInterceptors['operating system, successful empty']();
   });
 
   it('renders correct header and buttons', () => {

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -166,6 +166,7 @@ const AddSystemsToGroupModal = ({
             bulkSelect={bulkSelectConfig}
             initialLoading={true}
             showTags
+            showCentosVersions
           />
         </Modal>
       </>

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -93,6 +93,7 @@ const EntityTableToolbar = ({
   onRefreshData,
   loaded,
   showTagModal,
+  showCentosVersions,
   ...props
 }) => {
   const dispatch = useDispatch();
@@ -158,7 +159,7 @@ const EntityTableToolbar = ({
     setEndDate,
   ] = useLastSeenFilter(reducer);
   const [osFilterConfig, osFilterChips, osFilterValue, setOsFilterValue] =
-    useOperatingSystemFilter([], hasAccess);
+    useOperatingSystemFilter([], hasAccess, showCentosVersions);
   const [
     updateMethodConfig,
     updateMethodChips,
@@ -645,6 +646,7 @@ EntityTableToolbar.propTypes = {
   bulkSelect: PropTypes.object,
   showTagModal: PropTypes.bool,
   disableDefaultColumns: PropTypes.any,
+  showCentosVersions: PropTypes.bool,
 };
 
 EntityTableToolbar.defaultProps = {

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -82,6 +82,7 @@ const InventoryTable = forwardRef(
       hasCheckbox,
       onRowClick,
       abortOnUnmount = true,
+      showCentosVersions = false,
       ...props
     },
     ref
@@ -257,6 +258,7 @@ const InventoryTable = forwardRef(
             deleteTitle: 'Reset filters',
             ...activeFiltersConfig,
           }}
+          showCentosVersions={showCentosVersions}
         >
           {children}
         </EntityTableToolbar>
@@ -327,6 +329,7 @@ InventoryTable.propTypes = {
   hasCheckbox: PropTypes.bool,
   onRowClick: PropTypes.func,
   abortOnUnmount: PropTypes.bool,
+  showCentosVersions: PropTypes.bool,
 };
 
 export default InventoryTable;

--- a/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
@@ -14,6 +14,7 @@ exports[`InventoryTable should render correctly - no data 1`] = `
     onRefreshData={[Function]}
     page={1}
     perPage={50}
+    showCentosVersions={false}
     showTags={false}
   />
   <ForwardRef
@@ -55,6 +56,7 @@ exports[`InventoryTable should render correctly - with no access 1`] = `
     onRefreshData={[Function]}
     page={1}
     perPage={50}
+    showCentosVersions={false}
     showTags={false}
     sortBy={
       Object {
@@ -134,6 +136,7 @@ exports[`InventoryTable should render correctly 1`] = `
     onRefreshData={[Function]}
     page={1}
     perPage={50}
+    showCentosVersions={false}
     showTags={false}
     sortBy={
       Object {
@@ -251,6 +254,7 @@ exports[`InventoryTable should render correctly with items 1`] = `
     onRefreshData={[Function]}
     page={5}
     perPage={20}
+    showCentosVersions={false}
     showTags={false}
     sortBy={
       Object {
@@ -361,6 +365,7 @@ exports[`InventoryTable should render correctly with items no totla 1`] = `
     onRefreshData={[Function]}
     page={5}
     perPage={20}
+    showCentosVersions={false}
     showTags={false}
     sortBy={
       Object {

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -296,6 +296,7 @@ const ConventionalSystemsTab = ({
         }}
         bulkSelect={bulkSelectConfig}
         onRowClick={(_e, id, app) => navigate(`/${id}${app ? `/${app}` : ''}`)}
+        showCentosVersions={true}
       />
 
       <DeleteModal

--- a/src/components/filters/useOperatingSystemFilter.js
+++ b/src/components/filters/useOperatingSystemFilter.js
@@ -21,7 +21,11 @@ export const operatingSystemFilterReducer = (_state, { type, payload }) => ({
  * @param {Array} apiParams - an array containing parameters for GET /system_profile/operating_system call
  * @return {Array} An array containing config object, chips array and value setter function.
  */
-const useOperatingSystemFilter = (apiParams = [], hasAccess) => {
+const useOperatingSystemFilter = (
+  apiParams = [],
+  hasAccess,
+  showCentosVersions
+) => {
   const dispatch = useDispatch();
   const operatingSystems = useSelector(
     ({ entities }) => entities?.operatingSystems
@@ -35,9 +39,9 @@ const useOperatingSystemFilter = (apiParams = [], hasAccess) => {
 
   useEffect(() => {
     if (typeof hasAccess === 'undefined') {
-      dispatch(fetchOperatingSystems(apiParams));
+      dispatch(fetchOperatingSystems(apiParams, showCentosVersions));
     } else if (typeof hasAccess !== 'undefined' && hasAccess === true) {
-      dispatch(fetchOperatingSystems(apiParams));
+      dispatch(fetchOperatingSystems(apiParams, showCentosVersions));
     }
   }, []);
 

--- a/src/components/filters/useOperatingSystemFilter.test.js
+++ b/src/components/filters/useOperatingSystemFilter.test.js
@@ -21,7 +21,7 @@ describe('useOperatingSystemFilter', () => {
     );
 
     it('should initiate an API request', async () => {
-      renderHook(useOperatingSystemFilter, { wrapper });
+      renderHook(() => useOperatingSystemFilter([], true, true), { wrapper });
       await waitFor(() => {
         expect(mockSystemProfile.history.get.length).toBe(1);
       });
@@ -29,7 +29,10 @@ describe('useOperatingSystemFilter', () => {
     });
 
     it('should return empty state value', () => {
-      const { result } = renderHook(useOperatingSystemFilter, { wrapper });
+      const { result } = renderHook(
+        () => useOperatingSystemFilter([], true, true),
+        { wrapper }
+      );
       expect(result.current).toMatchSnapshot();
     });
   });
@@ -49,12 +52,18 @@ describe('useOperatingSystemFilter', () => {
     );
 
     it('should match snapshot', () => {
-      const { result } = renderHook(useOperatingSystemFilter, { wrapper });
+      const { result } = renderHook(
+        () => useOperatingSystemFilter([], true, true),
+        { wrapper }
+      );
       expect(result.current).toMatchSnapshot();
     });
 
     it('should return correct filter config', () => {
-      const { result } = renderHook(useOperatingSystemFilter, { wrapper });
+      const { result } = renderHook(
+        () => useOperatingSystemFilter([], true, true),
+        { wrapper }
+      );
       const [config] = result.current;
       expect(config.filterValues.groups.length).toBe(5);
       expect(config.label).toBe('Operating System'); // should be all caps
@@ -62,7 +71,10 @@ describe('useOperatingSystemFilter', () => {
     });
 
     it('should return correct chips array, current value and value setter', () => {
-      const { result } = renderHook(useOperatingSystemFilter, { wrapper });
+      const { result } = renderHook(
+        () => useOperatingSystemFilter([], true, true),
+        { wrapper }
+      );
       const [, chips, value, setValue] = result.current;
       expect(chips.length).toBe(0);
       expect(value.length).toBe(0);
@@ -94,7 +106,10 @@ describe('useOperatingSystemFilter', () => {
           {children}
         </Provider>
       );
-      const { result } = renderHook(useOperatingSystemFilter, { wrapper });
+      const { result } = renderHook(
+        () => useOperatingSystemFilter([], true, true),
+        { wrapper }
+      );
       expect(result.current).toMatchSnapshot();
     });
   });

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -222,9 +222,9 @@ export const fetchGroupDetail = (groupId) => ({
   payload: getGroupDetail(groupId),
 });
 
-export const fetchOperatingSystems = (params = []) => ({
+export const fetchOperatingSystems = (params = [], showCentosVersions) => ({
   type: ACTION_TYPES.OPERATING_SYSTEMS,
-  payload: getOperatingSystems(params),
+  payload: getOperatingSystems(params, showCentosVersions),
 });
 
 export const deleteEntity = (systems, displayName) => ({


### PR DESCRIPTION
Only inventory and tasks need to see centos versions in the operating system filter on the inventory table. All other apps will not be fetching centos systems, so they don't need them in the dropdown.

You can test this by running inventory with tasks and any other apps to make sure they show or are hidden.