### PR TITLE
chore(prodConfig): enable beta/stable difference for deployments

### DIFF
--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -5,6 +5,7 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
+  ...(process.env.BETA === 'true' && { deployment: 'beta/apps' }),
 });
 
 plugins.push(


### PR DESCRIPTION
Attempt to fix the current broken inventory UI. Theoretically, this should be the cause of the issue as we are using only one container for both types of code. But, let's try this out

This makes sure beta assets are fetched from `beta/apps` path.  