### PR TITLE
fix(ESSNTL-5537): Update RBAC for staleness page + tab conditional

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -393,5 +393,9 @@ export const patchStalenessData = (data) => {
 };
 
 export const fetchEdgeSystem = () => {
-  return instance.get(`${EDGE_API_BASE}/devices/devicesview?limit=1`);
+  try {
+    return instance.get(`${EDGE_API_BASE}/devices/devicesview?limit=1`);
+  } catch (err) {
+    console.log(err);
+  }
 };

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,5 +1,6 @@
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
 export const INVENTORY_API_BASE = '/api/inventory/v1';
+export const EDGE_API_BASE = '/api/edge/v1';
 import flatMap from 'lodash/flatMap';
 
 import instance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
@@ -389,4 +390,8 @@ export const postStalenessData = (data) => {
 };
 export const patchStalenessData = (data) => {
   return instance.patch(`${INVENTORY_API_BASE}/account/staleness`, data);
+};
+
+export const fetchEdgeSystem = () => {
+  return instance.get(`${EDGE_API_BASE}/devices/devicesview?limit=1`);
 };

--- a/src/components/InventoryHostStaleness/HostStalenessCard.js
+++ b/src/components/InventoryHostStaleness/HostStalenessCard.js
@@ -45,6 +45,7 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isFormValid, setIsFormValid] = useState(true);
   const [hasEdgeSystems, setHasEdgeSystems] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [hostStalenessImmutableDefaults, setHostStalenessImmutableDefaults] =
     useState({});
   const [
@@ -52,7 +53,6 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
     setHostStalenessConventionalDefaults,
   ] = useState({});
 
-  const [isLoading, setIsLoading] = useState(true);
   const dispatch = useDispatch();
 
   const handleTabClick = (_event, tabIndex) => {
@@ -169,9 +169,12 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
       ...immutableFilter,
     });
   };
+  const edgeSystemCheck = () => {
+    fetchEdgeSystem().then((res) => setHasEdgeSystems(res.data.total > 0));
+  };
 
   const batchedApi = async () => {
-    fetchEdgeSystem().then((res) => setHasEdgeSystems(res.data.total > 0));
+    edgeSystemCheck();
     fetchApiStalenessData();
     fetchDefaultValues();
     setIsLoading(false);

--- a/src/components/InventoryHostStaleness/__test__/InventoryHostStaleness.test.js
+++ b/src/components/InventoryHostStaleness/__test__/InventoryHostStaleness.test.js
@@ -2,17 +2,36 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import HostStalenessCard from '../HostStalenessCard';
-
-jest.mock('react-redux', () => {
-  return {
-    ...jest.requireActual('react-redux'),
-    useDispatch: () => {},
-  };
-});
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { getStore } from '../../../store';
+import MockAdapter from 'axios-mock-adapter';
+import { instance } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 
 describe('Table Renders', () => {
+  const mock = new MockAdapter(instance);
+  const stalenessData = {
+    conventional_staleness_delta: 86400,
+    conventional_stale_warning_delta: 604800,
+    conventional_culling_delta: 1209600,
+    immutable_staleness_delta: 172800,
+    immutable_stale_warning_delta: 1290600,
+    immutable_culling_delta: 15552000,
+    id: 'system_default',
+  };
+
   it('Renders table with two tabs and updates when edit is selected', () => {
-    render(<HostStalenessCard canModifyHostStaleness={true} />);
+    render(
+      <MemoryRouter>
+        <Provider store={getStore()}>
+          <HostStalenessCard canModifyHostStaleness={true} />
+        </Provider>
+      </MemoryRouter>
+    );
+    mock
+      .onGet(`/api/edge/v1/devices/devicesview?limit=1`)
+      .reply(200, { data: { total: 1 } });
+    mock.onGet('/api/inventory/v1/account/staleness').reply(200, stalenessData);
 
     expect(
       screen.getByRole('tab', { name: 'Conventional (RPM-DNF)' })

--- a/src/components/InventoryHostStaleness/constants.js
+++ b/src/components/InventoryHostStaleness/constants.js
@@ -33,6 +33,12 @@ export const hostStalenessApiKeys = [
   'immutable_culling_delta',
 ];
 
+export const conventionalApiKeys = [
+  'conventional_staleness_delta',
+  'conventional_stale_warning_delta',
+  'conventional_culling_delta',
+];
+
 export const daysToSecondsConversion = (days) => {
   return days * 86400;
 };
@@ -258,7 +264,7 @@ export const HostStalenessResetDefaultPopover = ({ activeTabKey }) => {
   );
 };
 
-export const InventoryHostStalenessPopover = () => {
+export const InventoryHostStalenessPopover = ({ hasEdgeSystems }) => {
   return (
     <Popover
       aria-label="Orginization level popover"
@@ -293,26 +299,29 @@ export const InventoryHostStalenessPopover = () => {
               - Systems are deleted after 14 days since last check-in.
             </span>
           </Flex>
-          <Flex
-            direction={{ default: 'column' }}
-            spaceItems={{ default: 'spaceItemsNone' }}
-          >
-            <span className="pf-u-font-size-sm">
-              Default for Immutable systems (OSTree):
-            </span>
-            <span className="pf-u-font-size-sm">
-              <p>
-                - Systems are marked as stale after 2 days since last check-in.
-              </p>
-            </span>
-            <span className="pf-u-font-size-sm">
-              - Systems are marked as stale warning after 120 days since last
-              check-in.
-            </span>
-            <span className="pf-u-font-size-sm">
-              - Systems are deleted after 180 days since last check-in.
-            </span>
-          </Flex>
+          {hasEdgeSystems && (
+            <Flex
+              direction={{ default: 'column' }}
+              spaceItems={{ default: 'spaceItemsNone' }}
+            >
+              <span className="pf-u-font-size-sm">
+                Default for Immutable systems (OSTree):
+              </span>
+              <span className="pf-u-font-size-sm">
+                <p>
+                  - Systems are marked as stale after 2 days since last
+                  check-in.
+                </p>
+              </span>
+              <span className="pf-u-font-size-sm">
+                - Systems are marked as stale warning after 120 days since last
+                check-in.
+              </span>
+              <span className="pf-u-font-size-sm">
+                - Systems are deleted after 180 days since last check-in.
+              </span>
+            </Flex>
+          )}
         </Flex>
       }
     >
@@ -573,4 +582,8 @@ export const formValidation = async (newFormValues, setIsFormValid) => {
 
 HostStalenessResetDefaultPopover.propTypes = {
   activeTabKey: PropTypes.number,
+};
+
+InventoryHostStalenessPopover.propTypes = {
+  hasEdgeSystems: PropTypes.bool,
 };

--- a/src/routes/InventoryHostStaleness.js
+++ b/src/routes/InventoryHostStaleness.js
@@ -9,12 +9,8 @@ import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-compo
 import { GENERAL_HOST_STALENESS_READ_PERMISSION } from '../components/InventoryHostStaleness/constants';
 import { Page, PageSection } from '@patternfly/react-core';
 import HostStalenessNoAccess from '../components/InventoryHostStaleness/HostStalenessNoAccess';
-import { GENERAL_HOSTS_READ_PERMISSIONS } from '../constants';
 
-const REQUIRED_PERMISSIONS = [
-  GENERAL_HOST_STALENESS_READ_PERMISSION,
-  GENERAL_HOSTS_READ_PERMISSIONS,
-];
+const REQUIRED_PERMISSIONS = [GENERAL_HOST_STALENESS_READ_PERMISSION];
 
 const HostStaleness = () => {
   const chrome = useChrome();


### PR DESCRIPTION
This updates the page to use the new RBAC checks from the mocks : https://miro.com/app/board/uXjVMzdWSVk=/
and also renders the tabs conditionally based on if the user has edge systems or not.
It also updates the tool tip with correct admin permission text 