### PR TITLE
feat(THEEDGE-3585): fixes immutable tab space

### DIFF
--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -271,12 +271,14 @@ const AddSystemsToGroupModal = ({
                 eventKey={1}
                 title={<TabTitleText>Immutable (OSTree)</TabTitleText>}
               >
-                <ImmutableDevicesView
-                  skeletonRowQuantity={15}
-                  hasCheckbox={true}
-                  isSystemsView={false}
-                  selectedItems={setSelectedImmutableDevices}
-                />
+                <section className={'pf-c-toolbar'}>
+                  <ImmutableDevicesView
+                    skeletonRowQuantity={15}
+                    hasCheckbox={true}
+                    isSystemsView={false}
+                    selectedItems={setSelectedImmutableDevices}
+                  />
+                </section>
               </Tab>
             </Tabs>
           ) : (


### PR DESCRIPTION
In the context to Allow immutable systems selection in group details empty state

Fixes the space between the tab and toolbar so it's the same as used in conventional tab.

FIXES: https://issues.redhat.com/browse/THEEDGE-3585

![inventory-group-add-systems-space](https://github.com/RedHatInsights/insights-inventory-frontend/assets/131553/e3a829fe-fb27-4fd7-b480-a344ab0f7aba)


