### PR TITLE
chore(HybridTabs): allow consumers send edge flag

### DIFF
--- a/src/components/InventoryTabs/HybridInventoryTabs.cy.js
+++ b/src/components/InventoryTabs/HybridInventoryTabs.cy.js
@@ -25,6 +25,7 @@ const defaultProps = {
   ImmutableDevicesTab: <MockImmutableTab />,
   ConventionalSystemsTab: <MockConventionalTab />,
 };
+const edgeEnabledProps = { ...defaultProps, isEdgeParityEnabled: true };
 
 const mountWithProps = (props) => {
   return cy.mountWithContext(
@@ -48,19 +49,19 @@ describe('When edge parity feature is enabled', () => {
   });
 
   it('renders conventional tab correctly for Inventory frontend without tabPath', () => {
-    mountWithProps(defaultProps);
+    mountWithProps(edgeEnabledProps);
     cy.get('div[id="conventional"]').should('have.length', 1);
     cy.get('div[id="immutable"]').should('not.exist');
   });
 
   it('renders conventional tab correctly for Inventory frontend without tabPath', () => {
-    mountWithProps({ isImmutableTabOpen: true, ...defaultProps });
+    mountWithProps({ isImmutableTabOpen: true, ...edgeEnabledProps });
     cy.get('div[id="conventional"]').should('not.exist');
     cy.get('div[id="immutable"]').should('have.length', 1);
   });
 
   it('should change to immutable tab correctly from conventional', () => {
-    mountWithProps(defaultProps);
+    mountWithProps(edgeEnabledProps);
 
     //conventional tab should be default
     cy.get('div[id="conventional"]').should('have.length', 1);
@@ -77,7 +78,7 @@ describe('When edge parity feature is enabled', () => {
       {
         routerProps: { initialEntries: [tabPathname] },
       },
-      { ...defaultProps, path: tabPathname, tabPathname: tabPathname }
+      { ...edgeEnabledProps, path: tabPathname, tabPathname: tabPathname }
     );
 
     cy.get('div[id="conventional"]').should('have.length', 1);
@@ -94,7 +95,7 @@ describe('When there are edge devices, but no conventional systems', () => {
     featureFlagsInterceptors.edgeParitySuccessful();
   });
   it('should open immutable tab as default when there are edge devices, but not conventional', () => {
-    mountWithProps(defaultProps);
+    mountWithProps(edgeEnabledProps);
 
     cy.get('div[id="conventional"]').should('not.exist');
     cy.get('div[id="immutable"]').should('have.length', 1);
@@ -108,6 +109,7 @@ describe('When edge parity feature is disabled', () => {
   });
 
   it('should render only conventional systems without tab wrapper', () => {
+    defaultProps.isEdgeParityEnabled = false;
     mountWithProps(defaultProps);
 
     cy.get('div[id="conventional"]').should('have.length', 1);

--- a/src/components/InventoryTabs/HybridInventoryTabs.js
+++ b/src/components/InventoryTabs/HybridInventoryTabs.js
@@ -3,7 +3,6 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import { Tab, TabTitleText, Tabs } from '@patternfly/react-core';
-import useFeatureFlag from '../../Utilities/useFeatureFlag';
 import {
   INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS,
   INVENTORY_TOTAL_FETCH_EDGE_PARAMS,
@@ -17,15 +16,15 @@ const HybridInventoryTabs = ({
   ImmutableDevicesTab,
   tabPathname,
   isImmutableTabOpen,
+  isEdgeParityEnabled,
 }) => {
   const { search } = useLocation();
   //used to hold URL params across tab changes
   const prevSearchRef = useRef('');
   const navigate = useNavigate();
   const [hasEdgeImages, setHasEdgeImages] = useState(false);
-  const EdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
   useEffect(() => {
-    if (EdgeParityEnabled) {
+    if (isEdgeParityEnabled) {
       try {
         axios
           .get(
@@ -54,7 +53,7 @@ const HybridInventoryTabs = ({
         console.log(e);
       }
     }
-  }, [EdgeParityEnabled]);
+  }, [isEdgeParityEnabled]);
 
   const activeTab = isImmutableTabOpen
     ? hybridInventoryTabKeys.immutable.key
@@ -74,7 +73,7 @@ const HybridInventoryTabs = ({
     }
   };
 
-  return EdgeParityEnabled && hasEdgeImages ? (
+  return isEdgeParityEnabled && hasEdgeImages ? (
     <Tabs
       className="pf-m-light pf-c-table"
       activeKey={activeTab}
@@ -108,6 +107,7 @@ HybridInventoryTabs.propTypes = {
   ImmutableDevicesTab: PropTypes.element.isRequired,
   isImmutableTabOpen: PropTypes.bool,
   tabPathname: PropTypes.string,
+  isEdgeParityEnabled: PropTypes.bool,
 };
 
 HybridInventoryTabs.defaultProps = {

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -10,6 +10,7 @@ import HybridInventoryTabs from '../components/InventoryTabs/HybridInventoryTabs
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useLocation } from 'react-router-dom';
 import { getSearchParams } from '../constants';
+import useFeatureFlag from '../Utilities/useFeatureFlag';
 const ConventionalSystemsTab = lazy(() =>
   import(
     '../components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab'
@@ -34,6 +35,7 @@ const Inventory = (props) => {
   const { search } = useLocation();
   const searchParams = useMemo(() => getSearchParams(), [search.toString()]);
   const fullProps = { ...props, ...searchParams };
+  const isEdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
   return (
     <React.Fragment>
       <PageHeader className="pf-m-light">
@@ -52,6 +54,7 @@ const Inventory = (props) => {
             </SuspenseWrapper>
           }
           isImmutableTabOpen={props.isImmutableTabOpen}
+          isEdgeParityEnabled={isEdgeParityEnabled}
         />
       </Main>
     </React.Fragment>


### PR DESCRIPTION
This PR allows HybridTabs consumer apps (vuln, advisor) to pass their edge flag so that each app can use different flags.

