### PR TITLE
fix(THEEDGE-3629): should not display Zero state when has edge systems

### DIFF
--- a/src/Utilities/conventional.js
+++ b/src/Utilities/conventional.js
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import {
+  INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS,
+  INVENTORY_TOTAL_FETCH_URL_SERVER,
+} from './constants';
+
+const inventoryHasConventionalSystems = async () => {
+  const result = await axios.get(
+    `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS}`
+  );
+  return result?.data?.total > 0;
+};
+
+export { inventoryHasConventionalSystems };


### PR DESCRIPTION
 Inventory Systems should not display Zero state when account has immutable systems

FIXES: https://issues.redhat.com/browse/THEEDGE-3629

![bug-edge-only-systems-inventory-2023-10-23 12-15](https://github.com/RedHatInsights/insights-inventory-frontend/assets/131553/a676e6be-2c55-40cb-95eb-91f1dd18a608)
