### PR TITLE
fix(InventoryTable): RHINENG-2325 - Remove unwanted padding/margin resets

### DIFF
--- a/src/components/InventoryTable/InventoryList.scss
+++ b/src/components/InventoryTable/InventoryList.scss
@@ -8,11 +8,6 @@
 }
 
 .ins-c-inventory__table--toolbar {
-    &.ins-m-footer {
-        margin: 0;
-        padding: 0;
-    }
-
     &:not(.ins-c-inventory__table--toolbar-has-items) {
         .pf-c-toolbar__content {
             .pf-c-toolbar__item:last-child { min-width: 12.5rem; }


### PR DESCRIPTION
This fixes issues colliding with the lightbulb:

Before:
![Screenshot 2023-10-26 at 12 06 55](https://github.com/RedHatInsights/insights-inventory-frontend/assets/7757/ed44a1f1-4621-4f2b-9675-136fc7eb4919)



After:

![Screenshot 2023-10-26 at 12 08 41](https://github.com/RedHatInsights/insights-inventory-frontend/assets/7757/035aacc9-5483-4b03-ae7b-a4ac3d0919c1)
