### PR TITLE
fix(RHIF-72): Fix InventoryTable font size and actions button padding

### DIFF
--- a/src/components/InventoryTable/InventoryList.scss
+++ b/src/components/InventoryTable/InventoryList.scss
@@ -90,10 +90,6 @@
             font-size: var(--pf-global--FontSize--sm);
         }
 
-        * {
-            font-size: var(	--pf-global--FontSize--lg);
-        }
-
         .ins-composed-col {
             cursor: pointer;
         }

--- a/src/components/InventoryTable/InventoryList.scss
+++ b/src/components/InventoryTable/InventoryList.scss
@@ -99,12 +99,6 @@
         display: inline-block;
     }
 
-    .pf-c-table__action .pf-c-dropdown {
-        position: relative;
-        left: 10px;
-        top: 3px;
-    }
-
     .ins-composed-col div {
         word-wrap: break-word;
         word-break:break-all;

--- a/src/components/InventoryTable/InventoryList.scss
+++ b/src/components/InventoryTable/InventoryList.scss
@@ -115,3 +115,9 @@
 }
 
 .ins-c-inventory__no-access { background-color: var(--pf-global--BackgroundColor--100); }
+
+.pf-c-table__action {
+    .pf-c-dropdown__toggle.pf-m-plain {
+        padding-right: var(--pf-global--spacer--lg);
+    }
+}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHIF-72.

- Changes the InventoryTable rows text to have font size 14 px.
- Fixes the actions (kebab) button styling so that it is equally distanced from both sides.

Before

<img width="1512" alt="Screenshot 2023-11-03 at 17 47 54" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/a6c2dea9-08ef-4064-a0b0-1ed3af996cb2">

After

<img width="1512" alt="Screenshot 2023-11-03 at 17 45 56" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/cef13878-e344-4f86-83a5-3b6257db954b">

