### PR TITLE
feat(THEEDGE-3581): add tab controls to display detail groups

### DIFF
--- a/src/components/InventoryGroupDetail/GroupTabDetails.js
+++ b/src/components/InventoryGroupDetail/GroupTabDetails.js
@@ -1,0 +1,104 @@
+import {
+  Bullseye,
+  PageSection,
+  Spinner,
+  Tab,
+  TabTitleText,
+  Tabs,
+} from '@patternfly/react-core';
+import React, { Suspense, lazy, useState } from 'react';
+import { hybridInventoryTabKeys } from '../../Utilities/constants';
+import GroupSystems from '../GroupSystems';
+import PropTypes from 'prop-types';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import { REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS } from '../../constants';
+import ImmutableDevicesView from '../InventoryTabs/ImmutableDevices/EdgeDevicesView';
+import { EmptyStateNoAccessToSystems } from './EmptyStateNoAccess';
+
+const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
+
+const GroupTabDetailsWrapper = ({
+  groupId,
+  groupName,
+  activeTab,
+  hasEdgeImages,
+}) => {
+  const [tab, setTab] = useState(0);
+  const { hasAccess: canViewHosts } = usePermissionsWithContext(
+    REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId)
+  );
+
+  const handleTabClick = (_event, tabIndex) => {
+    setTab(tabIndex);
+  };
+
+  const [activeTabKey, setActiveTabKey] = useState(0);
+
+  return (
+    <Tabs
+      activeKey={activeTabKey}
+      onSelect={(event, value) => setActiveTabKey(value)}
+      aria-label="Group tabs"
+      role="region"
+      inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
+      mountOnEnter
+      unmountOnExit
+    >
+      <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
+        <PageSection>
+          {canViewHosts && hasEdgeImages ? (
+            <Tabs
+              className="pf-m-light pf-c-table"
+              activeKey={activeTab && tab == 0 ? activeTab : tab}
+              onSelect={handleTabClick}
+              aria-label="Hybrid inventory tabs"
+            >
+              <Tab
+                eventKey={hybridInventoryTabKeys.conventional.key}
+                title={<TabTitleText>Conventional (RPM-DNF)</TabTitleText>}
+              >
+                <GroupSystems groupName={groupName} groupId={groupId} />
+              </Tab>
+              <Tab
+                eventKey={hybridInventoryTabKeys.immutable.key}
+                title={<TabTitleText>Immutable (OSTree)</TabTitleText>}
+              >
+                <ImmutableDevicesView
+                  groupUUID={groupId}
+                  isSystemsView={true}
+                />
+              </Tab>
+            </Tabs>
+          ) : canViewHosts ? (
+            <GroupSystems groupName={groupName} groupId={groupId} />
+          ) : (
+            <EmptyStateNoAccessToSystems />
+          )}
+        </PageSection>
+      </Tab>
+      <Tab eventKey={1} title="Group info" aria-label="Group info tab">
+        {activeTabKey === 1 && ( // helps to lazy load the component
+          <PageSection>
+            <Suspense
+              fallback={
+                <Bullseye>
+                  <Spinner />
+                </Bullseye>
+              }
+            >
+              <GroupDetailInfo />
+            </Suspense>
+          </PageSection>
+        )}
+      </Tab>
+    </Tabs>
+  );
+};
+
+GroupTabDetailsWrapper.propTypes = {
+  groupName: PropTypes.string.isRequired,
+  groupId: PropTypes.string.isRequired,
+  activeTab: PropTypes.string,
+  hasEdgeImages: PropTypes.bool,
+};
+export default GroupTabDetailsWrapper;

--- a/src/components/InventoryGroupDetail/GroupTabDetails.js
+++ b/src/components/InventoryGroupDetail/GroupTabDetails.js
@@ -12,7 +12,7 @@ import GroupSystems from '../GroupSystems';
 import PropTypes from 'prop-types';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS } from '../../constants';
-import ImmutableDevicesView from '../InventoryTabs/ImmutableDevices/EdgeDevicesView';
+import EdgeDeviceGroupiew from '../InventoryTabs/ImmutableDevices/EdgeDevicesGroupView';
 import { EmptyStateNoAccessToSystems } from './EmptyStateNoAccess';
 
 const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
@@ -63,10 +63,7 @@ const GroupTabDetailsWrapper = ({
                 eventKey={hybridInventoryTabKeys.immutable.key}
                 title={<TabTitleText>Immutable (OSTree)</TabTitleText>}
               >
-                <ImmutableDevicesView
-                  groupUUID={groupId}
-                  isSystemsView={true}
-                />
+                <EdgeDeviceGroupiew groupUUID={groupId} isSystemsView={true} />
               </Tab>
             </Tabs>
           ) : canViewHosts ? (

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -124,7 +124,7 @@ const InventoryGroupDetail = ({ groupId }) => {
       }
     }
   }, [data]);
-  return hasEdgeImages && canViewGroup ? (
+  return hasEdgeImages && canViewGroup && EdgeParityEnabled ? (
     <React.Fragment>
       <GroupDetailHeader groupId={groupId} />
       {canViewGroup ? (

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -11,6 +11,7 @@ import React, { Suspense, lazy, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchGroupDetail } from '../../store/inventory-actions';
 import GroupSystems from '../GroupSystems';
+import GroupTabDetails from './GroupTabDetails';
 import GroupDetailHeader from './GroupDetailHeader';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import {
@@ -22,10 +23,50 @@ import {
   EmptyStateNoAccessToSystems,
 } from './EmptyStateNoAccess';
 
-const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
+// import { useLocation, useNavigate } from 'react-router-dom';
+// import { resolveRelPath } from '../../Utilities/path';
+// import {
+//   getNotificationProp,
+//   manageEdgeInventoryUrlName,
+// } from '../../Utilities/edge';
+// import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+// import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
+import axios from 'axios';
+import {
+  INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS,
+  INVENTORY_TOTAL_FETCH_EDGE_PARAMS,
+  INVENTORY_TOTAL_FETCH_URL_SERVER,
+  hybridInventoryTabKeys,
+} from '../../Utilities/constants';
+
+const SuspenseWrapper = ({ children }) => (
+  <Suspense
+    fallback={
+      <Bullseye>
+        <Spinner size="xl" />
+      </Bullseye>
+    }
+  >
+    {children}
+  </Suspense>
+);
+
+const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
 const InventoryGroupDetail = ({ groupId }) => {
+  const [activeTabKey, setActiveTabKey] = useState(0);
+
+  // const handleTabClick = (_event, tabIndex) => {
+  //   setActiveTabKey(tabIndex);
+  // };
+
+  const [activeTab, setActiveTab] = useState(
+    hybridInventoryTabKeys.conventional.key
+  );
+
   const dispatch = useDispatch();
+  // const notificationProp = getNotificationProp(dispatch);
   const { data } = useSelector((state) => state.groupDetail);
   const chrome = useChrome();
   const groupName = data?.results?.[0]?.name;
@@ -33,7 +74,6 @@ const InventoryGroupDetail = ({ groupId }) => {
   const { hasAccess: canViewGroup } = usePermissionsWithContext(
     REQUIRED_PERMISSIONS_TO_READ_GROUP(groupId)
   );
-
   const { hasAccess: canViewHosts } = usePermissionsWithContext(
     REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId)
   );
@@ -51,47 +91,50 @@ const InventoryGroupDetail = ({ groupId }) => {
     );
   }, [data]);
 
-  const [activeTabKey, setActiveTabKey] = useState(0);
-
   // TODO: append search parameter to identify the active tab
 
-  return (
+  const [hasEdgeImages, setHasEdgeImages] = useState(false);
+  const EdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
+  useEffect(() => {
+    if (EdgeParityEnabled) {
+      try {
+        axios
+          .get(
+            `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_EDGE_PARAMS}&group_name=${groupName}`
+          )
+          .then((result) => {
+            const accountHasEdgeImages = result?.data?.total > 0;
+            setHasEdgeImages(accountHasEdgeImages);
+            axios
+              .get(
+                `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS}&group_name=${groupName}`
+              )
+              .then((conventionalImages) => {
+                const accountHasConventionalImages =
+                  conventionalImages?.data?.total > 0;
+                if (accountHasEdgeImages && !accountHasConventionalImages) {
+                  setActiveTab(hybridInventoryTabKeys.immutable.key);
+                } else {
+                  setActiveTab(hybridInventoryTabKeys.conventional.key);
+                }
+              });
+          });
+      } catch (e) {
+        console.log('>>>> ' + e);
+      }
+    }
+  }, [data]);
+  return hasEdgeImages && canViewGroup ? (
     <React.Fragment>
       <GroupDetailHeader groupId={groupId} />
       {canViewGroup ? (
         <PageSection variant="light" type="tabs">
-          <Tabs
-            activeKey={activeTabKey}
-            onSelect={(event, value) => setActiveTabKey(value)}
-            aria-label="Group tabs"
-            role="region"
-            inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
-          >
-            <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
-              <PageSection>
-                {canViewHosts ? (
-                  <GroupSystems groupName={groupName} groupId={groupId} />
-                ) : (
-                  <EmptyStateNoAccessToSystems />
-                )}
-              </PageSection>
-            </Tab>
-            <Tab eventKey={1} title="Group info" aria-label="Group info tab">
-              {activeTabKey === 1 && ( // helps to lazy load the component
-                <PageSection>
-                  <Suspense
-                    fallback={
-                      <Bullseye>
-                        <Spinner />
-                      </Bullseye>
-                    }
-                  >
-                    <GroupDetailInfo />
-                  </Suspense>
-                </PageSection>
-              )}
-            </Tab>
-          </Tabs>
+          <GroupTabDetails
+            groupId={groupId}
+            groupName={groupName}
+            activeTab={activeTab}
+            hasEdgeImages={hasEdgeImages}
+          />
         </PageSection>
       ) : (
         <PageSection>
@@ -99,11 +142,54 @@ const InventoryGroupDetail = ({ groupId }) => {
         </PageSection>
       )}
     </React.Fragment>
+  ) : (
+    <React.Fragment>
+      <GroupDetailHeader groupId={groupId} />
+      <PageSection variant="light" type="tabs">
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={(event, value) => setActiveTabKey(value)}
+          aria-label="Group tabs"
+          role="region"
+          inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
+        >
+          <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
+            <PageSection>
+              {canViewHosts ? (
+                <GroupSystems groupName={groupName} groupId={groupId} />
+              ) : (
+                <EmptyStateNoAccessToSystems />
+              )}
+            </PageSection>
+          </Tab>
+          <Tab eventKey={1} title="Group info" aria-label="Group info tab">
+            {activeTabKey === 1 && ( // helps to lazy load the component
+              <PageSection>
+                <Suspense
+                  fallback={
+                    <Bullseye>
+                      <Spinner />
+                    </Bullseye>
+                  }
+                >
+                  <GroupDetailInfo />
+                </Suspense>
+              </PageSection>
+            )}
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </React.Fragment>
   );
 };
 
 InventoryGroupDetail.propTypes = {
   groupId: PropTypes.string.isRequired,
+  groupName: PropTypes.string,
+};
+
+SuspenseWrapper.propTypes = {
+  children: PropTypes.element,
 };
 
 export default InventoryGroupDetail;

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -105,7 +105,8 @@ const InventoryGroupDetail = ({ groupId }) => {
               });
           });
       } catch (e) {
-        console.log('>>>> ' + e);
+        setHasEdgeImages(false);
+        setActiveTab(hybridInventoryTabKeys.conventional.key);
       }
     }
   }, [data]);

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -145,40 +145,46 @@ const InventoryGroupDetail = ({ groupId }) => {
   ) : (
     <React.Fragment>
       <GroupDetailHeader groupId={groupId} />
-      <PageSection variant="light" type="tabs">
-        <Tabs
-          activeKey={activeTabKey}
-          onSelect={(event, value) => setActiveTabKey(value)}
-          aria-label="Group tabs"
-          role="region"
-          inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
-        >
-          <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
-            <PageSection>
-              {canViewHosts ? (
-                <GroupSystems groupName={groupName} groupId={groupId} />
-              ) : (
-                <EmptyStateNoAccessToSystems />
-              )}
-            </PageSection>
-          </Tab>
-          <Tab eventKey={1} title="Group info" aria-label="Group info tab">
-            {activeTabKey === 1 && ( // helps to lazy load the component
+      {canViewGroup ? (
+        <PageSection variant="light" type="tabs">
+          <Tabs
+            activeKey={activeTabKey}
+            onSelect={(event, value) => setActiveTabKey(value)}
+            aria-label="Group tabs"
+            role="region"
+            inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
+          >
+            <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
               <PageSection>
-                <Suspense
-                  fallback={
-                    <Bullseye>
-                      <Spinner />
-                    </Bullseye>
-                  }
-                >
-                  <GroupDetailInfo />
-                </Suspense>
+                {canViewHosts ? (
+                  <GroupSystems groupName={groupName} groupId={groupId} />
+                ) : (
+                  <EmptyStateNoAccessToSystems />
+                )}
               </PageSection>
-            )}
-          </Tab>
-        </Tabs>
-      </PageSection>
+            </Tab>
+            <Tab eventKey={1} title="Group info" aria-label="Group info tab">
+              {activeTabKey === 1 && ( // helps to lazy load the component
+                <PageSection>
+                  <Suspense
+                    fallback={
+                      <Bullseye>
+                        <Spinner />
+                      </Bullseye>
+                    }
+                  >
+                    <GroupDetailInfo />
+                  </Suspense>
+                </PageSection>
+              )}
+            </Tab>
+          </Tabs>
+        </PageSection>
+      ) : (
+        <PageSection>
+          <EmptyStateNoAccessToGroup />
+        </PageSection>
+      )}
     </React.Fragment>
   );
 };

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -22,16 +22,6 @@ import {
   EmptyStateNoAccessToGroup,
   EmptyStateNoAccessToSystems,
 } from './EmptyStateNoAccess';
-
-// import { useLocation, useNavigate } from 'react-router-dom';
-// import { resolveRelPath } from '../../Utilities/path';
-// import {
-//   getNotificationProp,
-//   manageEdgeInventoryUrlName,
-// } from '../../Utilities/edge';
-// import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
-// import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
-
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
 import axios from 'axios';
 import {
@@ -57,16 +47,11 @@ const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
 const InventoryGroupDetail = ({ groupId }) => {
   const [activeTabKey, setActiveTabKey] = useState(0);
 
-  // const handleTabClick = (_event, tabIndex) => {
-  //   setActiveTabKey(tabIndex);
-  // };
-
   const [activeTab, setActiveTab] = useState(
     hybridInventoryTabKeys.conventional.key
   );
 
   const dispatch = useDispatch();
-  // const notificationProp = getNotificationProp(dispatch);
   const { data } = useSelector((state) => state.groupDetail);
   const chrome = useChrome();
   const groupName = data?.results?.[0]?.name;

--- a/src/components/InventoryTabs/ImmutableDevices/EdgeDevicesGroupView.js
+++ b/src/components/InventoryTabs/ImmutableDevices/EdgeDevicesGroupView.js
@@ -10,7 +10,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
 const EdgeDeviceGroupiew = (props) => {
-  console.log(props);
   const dispatch = useDispatch();
   const notificationProp = getNotificationProp(dispatch);
   return (

--- a/src/components/InventoryTabs/ImmutableDevices/EdgeDevicesGroupView.js
+++ b/src/components/InventoryTabs/ImmutableDevices/EdgeDevicesGroupView.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
+import { resolveRelPath } from '../../../Utilities/path';
+import {
+  getNotificationProp,
+  manageEdgeInventoryUrlName,
+} from '../../../Utilities/edge';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+
+const EdgeDeviceGroupiew = (props) => {
+  console.log(props);
+  const dispatch = useDispatch();
+  const notificationProp = getNotificationProp(dispatch);
+  return (
+    <AsyncComponent
+      appName="edge"
+      module="./DevicesGroupDetail"
+      ErrorComponent={<ErrorState />}
+      navigateProp={useNavigate}
+      locationProp={useLocation}
+      showHeaderProp={false}
+      pathPrefix={resolveRelPath('')}
+      urlName={manageEdgeInventoryUrlName}
+      notificationProp={notificationProp}
+      {...props}
+    />
+  );
+};
+
+export default EdgeDeviceGroupiew;


### PR DESCRIPTION
This PR add a tab to group details when exists an edge host added to the group.
In case only edge devices the focus will be on immutable
In case only conventional, no tabs displayed

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/5039367/9efb442c-5aa3-4c2d-9995-8f5dfdac997c)
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/5039367/925da5a2-bcff-4fb4-b131-58df73956ce1)
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/5039367/9369181d-3bec-4783-8df9-97c60e8a7a30)
