### PR TITLE
fix(Staleness): Update staleness page to match new backend specs

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -34,7 +34,6 @@ export const staleness = [
   { label: 'Fresh', value: 'fresh' },
   { label: 'Stale', value: 'stale' },
   { label: 'Stale warning', value: 'stale_warning' },
-  { label: 'Unknown', value: 'unknown' },
 ];
 
 export const currentDate = new Date().toISOString();

--- a/src/components/InventoryHostStaleness/HostStalenessCard.js
+++ b/src/components/InventoryHostStaleness/HostStalenessCard.js
@@ -75,6 +75,7 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
     apiKeys.forEach(
       (filterKey) =>
         filterKey !== 'id' &&
+        newFormValues[filterKey] &&
         (apiData[filterKey] = daysToSecondsConversion(newFormValues[filterKey]))
     );
 

--- a/src/components/InventoryHostStaleness/HostStalenessCard.js
+++ b/src/components/InventoryHostStaleness/HostStalenessCard.js
@@ -76,7 +76,10 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
       (filterKey) =>
         filterKey !== 'id' &&
         newFormValues[filterKey] &&
-        (apiData[filterKey] = daysToSecondsConversion(newFormValues[filterKey]))
+        (apiData[filterKey] = daysToSecondsConversion(
+          newFormValues[filterKey],
+          filterKey
+        ))
     );
 
     // system_default means the account has no record, therefor, post for new instance of record.
@@ -92,7 +95,7 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
               dismissable: true,
             })
           );
-          fetchStalenessData();
+          fetchApiStalenessData();
           setIsEditing(!isEditing);
           setIsModalOpen(false);
         })
@@ -118,7 +121,7 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
               dismissable: true,
             })
           );
-          fetchStalenessData();
+          fetchApiStalenessData();
           setIsEditing(!isEditing);
           setIsModalOpen(false);
         })

--- a/src/components/InventoryHostStaleness/HostStalenessNoAccess.js
+++ b/src/components/InventoryHostStaleness/HostStalenessNoAccess.js
@@ -16,8 +16,8 @@ const HostStalenessNoAccess = () => {
         Access permissions needed
       </Title>
       <EmptyStateBody className="pf-u-mb-xl">
-        You do not have the necessary Inventory staleness and deletion viewer
-        role required to view this page.
+        You do not have the necessary Staleness and Deletion viewer role
+        required to view this page.
       </EmptyStateBody>
       <Button
         variant="link"

--- a/src/components/InventoryHostStaleness/constants.js
+++ b/src/components/InventoryHostStaleness/constants.js
@@ -24,6 +24,10 @@ export const secondsToDaysConversion = (seconds) => {
   return seconds / 86400;
 };
 
+export const daysToSecondsConversion = (days) => {
+  return days * 86400;
+};
+
 export const hostStalenessApiKeys = [
   'conventional_staleness_delta',
   'conventional_stale_warning_delta',
@@ -38,10 +42,6 @@ export const conventionalApiKeys = [
   'conventional_stale_warning_delta',
   'conventional_culling_delta',
 ];
-
-export const daysToSecondsConversion = (days) => {
-  return days * 86400;
-};
 
 export const conditionalDropdownError = (newFormValues, dropdownItems) => {
   //this runs on every select every time

--- a/src/components/InventoryHostStaleness/constants.js
+++ b/src/components/InventoryHostStaleness/constants.js
@@ -21,11 +21,20 @@ export const HOST_STALENESS_ADMINISTRATOR_PERMISSIONS = [
 
 //86400 seconds in one day -> divide each by secodns in a day to get day values
 export const secondsToDaysConversion = (seconds) => {
-  return seconds / 86400;
+  if (seconds === 104400) {
+    return 1;
+  } else {
+    return seconds / 86400;
+  }
 };
 
-export const daysToSecondsConversion = (days) => {
-  return days * 86400;
+export const daysToSecondsConversion = (days, filterKey) => {
+  //backend requires a buffer specifically for 1 this option
+  if (filterKey === 'conventional_staleness_delta' && days === 1) {
+    return 104400;
+  } else {
+    return days * 86400;
+  }
 };
 
 export const hostStalenessApiKeys = [

--- a/src/components/InventoryHostStaleness/constants.js
+++ b/src/components/InventoryHostStaleness/constants.js
@@ -225,12 +225,12 @@ export const HostStalenessResetDefaultPopover = ({ activeTabKey }) => {
               - Systems are marked as stale after 2 days since last check-in.
             </span>
             <span className="pf-u-font-size-sm">
-              - Systems are marked as stale warning after 120 days since last
+              - Systems are marked as stale warning after 180 days since last
               check-in.
             </span>
 
             <span className="pf-u-font-size-sm">
-              - Systems are deleted after 180 days since last check-in.
+              - Systems are deleted after 2 years since last check-in.
             </span>
           </Flex>
         ) : (
@@ -314,11 +314,11 @@ export const InventoryHostStalenessPopover = ({ hasEdgeSystems }) => {
                 </p>
               </span>
               <span className="pf-u-font-size-sm">
-                - Systems are marked as stale warning after 120 days since last
+                - Systems are marked as stale warning after 180 days since last
                 check-in.
               </span>
               <span className="pf-u-font-size-sm">
-                - Systems are deleted after 180 days since last check-in.
+                - Systems are deleted after 2 years since last check-in.
               </span>
             </Flex>
           )}

--- a/src/components/InventoryHostStaleness/constants.js
+++ b/src/components/InventoryHostStaleness/constants.js
@@ -10,9 +10,9 @@ export const IMMUTABLE_TAB_TOOLTIP =
   'With OSTree, you can manage the system software by referencing a central image repository. OSTree images contain a complete operating system ready to be remotely installed at scale.  You can track updates to images through commits and enable secure updates that only address changes and keep the operating system unchanged. The updates are quick, and the rollbacks are easy.';
 
 export const GENERAL_HOST_STALENESS_WRITE_PERMISSION =
-  'inventory:staleness:write';
+  'staleness:staleness:write';
 export const GENERAL_HOST_STALENESS_READ_PERMISSION =
-  'inventory:staleness:read';
+  'staleness:staleness:read';
 
 export const HOST_STALENESS_ADMINISTRATOR_PERMISSIONS = [
   GENERAL_HOST_STALENESS_READ_PERMISSION,

--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -40,10 +40,6 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
-              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
@@ -188,10 +184,6 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
               Object {
                 "label": "Stale warning",
                 "value": "stale_warning",
-              },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
               },
             ],
             "onChange": [Function],
@@ -445,10 +437,6 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
               Object {
                 "label": "Stale warning",
                 "value": "stale_warning",
-              },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
               },
             ],
             "onChange": [Function],
@@ -721,10 +709,6 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
-              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
@@ -983,10 +967,6 @@ exports[`EntityTableToolbar DOM should render correctly - with customFilters 1`]
               Object {
                 "label": "Stale warning",
                 "value": "stale_warning",
-              },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
               },
             ],
             "onChange": [Function],
@@ -1272,10 +1252,6 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
-              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
@@ -1518,10 +1494,6 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
               Object {
                 "label": "Stale warning",
                 "value": "stale_warning",
-              },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
               },
             ],
             "onChange": [Function],
@@ -1780,10 +1752,6 @@ exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
                 "label": "Stale warning",
                 "value": "stale_warning",
               },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
-              },
             ],
             "onChange": [Function],
             "placeholder": "Filter by status",
@@ -2032,10 +2000,6 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
               Object {
                 "label": "Stale warning",
                 "value": "stale_warning",
-              },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
               },
             ],
             "onChange": [Function],
@@ -2315,10 +2279,6 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
               Object {
                 "label": "Stale warning",
                 "value": "stale_warning",
-              },
-              Object {
-                "label": "Unknown",
-                "value": "unknown",
               },
             ],
             "onChange": [Function],


### PR DESCRIPTION
This PR adds an additional check to only send values that have been altered to the api.
It also removes 'unknown' as an option for the status filter.
[fix(](https://github.com/RedHatInsights/insights-inventory-frontend/commit/9b129838b85eee3a74807f20c83fa08c25f0c6d3)[RHINENG-2911](https://issues.redhat.com/browse/RHINENG-2911)[): Update values in staleness api request](https://github.com/RedHatInsights/insights-inventory-frontend/commit/9b129838b85eee3a74807f20c83fa08c25f0c6d3)

[fix(](https://github.com/RedHatInsights/insights-inventory-frontend/commit/19a7b0b16c868fec88a104134be31ef259a0a7c1)[ESSNTL-5595](https://issues.redhat.com/browse/ESSNTL-5595)[): remove unknown option in status filter](https://github.com/RedHatInsights/insights-inventory-frontend/commit/19a7b0b16c868fec88a104134be31ef259a0a7c1)

   [ESSNTL-5538: Update RBAC roles & Add buffer to api Values](https://issues.redhat.com/browse/ESSNTL-5538)
   
   https://issues.redhat.com/browse/ESSNTL-5605 : [UI] Update custom staleness defaults for edge systems 





