### PR TITLE
chore(HybridInventoryTab): accept host counts instead of API request

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,4 +1,11 @@
-import React, { Suspense, lazy, useEffect, useMemo, useState } from 'react';
+import React, {
+  Suspense,
+  createContext,
+  lazy,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { Navigate, useRoutes } from 'react-router-dom';
 import { getSearchParams } from './constants';
 import RenderWrapper from './Utilities/Wrapper';
@@ -33,10 +40,16 @@ export const routes = {
   staleness: '/staleness-and-deletion',
 };
 
+export const AccountStatContext = createContext({
+  hasConventionalSystems: true,
+  hasEdgeDevices: false,
+});
+
 export const Routes = () => {
   const searchParams = useMemo(() => getSearchParams(), []);
   const groupsEnabled = useFeatureFlag('hbi.ui.inventory-groups');
-  const [hasSystems, setHasSystems] = useState(true);
+  const [hasConventionalSystems, setHasConventionalSystems] = useState(true);
+  const [hasEdgeDevices, setHasEdgeDevices] = useState(true);
   const edgeParityInventoryListEnabled = useFeatureFlag(
     'edgeParity.inventory-list'
   );
@@ -46,15 +59,14 @@ export const Routes = () => {
         const hasConventionalSystems = await inventoryHasConventionalSystems();
         if (edgeParityInventoryListEnabled) {
           const hasEdgeSystems = await inventoryHasEdgeSystems();
-          setHasSystems(hasConventionalSystems || hasEdgeSystems);
-        } else {
-          setHasSystems(hasConventionalSystems);
+          setHasConventionalSystems(hasConventionalSystems);
+          setHasEdgeDevices(hasEdgeSystems);
         }
       })();
     } catch (e) {
       console.log(e);
     }
-  }, [hasSystems]);
+  }, []);
 
   let element = useRoutes([
     {
@@ -95,6 +107,10 @@ export const Routes = () => {
       element: groupsEnabled ? <InventoryHostStaleness /> : <LostPage />,
     },
   ]);
+
+  const hasSystems = edgeParityInventoryListEnabled
+    ? hasEdgeDevices || hasConventionalSystems
+    : hasConventionalSystems;
 
   return !hasSystems ? (
     <Suspense

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { TableVariant } from '@patternfly/react-table';
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   clearFilters,
@@ -30,7 +30,7 @@ import ImmutableDevicesView from '../../InventoryTabs/ImmutableDevices/EdgeDevic
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { InfoCircleIcon } from '@patternfly/react-icons';
-import { inventoryHasEdgeSystems } from '../../../Utilities/edge';
+import { AccountStatContext } from '../../../Routes';
 
 const AddSystemsToGroupModal = ({
   isModalOpen,
@@ -134,17 +134,7 @@ const AddSystemsToGroupModal = ({
   const showWarning =
     alreadyHasGroup.length > 0 || immutableDevicesAlreadyHasGroup.length > 0;
 
-  const [hasImmutableSystems, setHasImmutableSystems] = useState(false);
-
-  useEffect(() => {
-    if (edgeParityEnabled) {
-      (async () => {
-        const hasEdgeSystems = await inventoryHasEdgeSystems();
-        setHasImmutableSystems(hasEdgeSystems);
-      })();
-    }
-  }, []);
-
+  const { hasEdgeDevices } = useContext(AccountStatContext);
   const [activeTab, setActiveTab] = useState(0);
 
   const handleTabClick = (_event, tabIndex) => {
@@ -254,7 +244,7 @@ const AddSystemsToGroupModal = ({
           }
           variant="large" // required to accomodate the systems table
         >
-          {edgeParityEnabled && hasImmutableSystems ? (
+          {edgeParityEnabled && hasEdgeDevices ? (
             <Tabs
               className="pf-m-light pf-c-table"
               activeKey={activeTab}

--- a/src/components/InventoryTabs/HybridInventoryTabs.cy.js
+++ b/src/components/InventoryTabs/HybridInventoryTabs.cy.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import HybridInventoryTabs from './HybridInventoryTabs';
-import {
-  featureFlagsInterceptors,
-  hostsInterceptors,
-} from '../../../cypress/support/interceptors';
+import { featureFlagsInterceptors } from '../../../cypress/support/interceptors';
 import { Route, Routes } from 'react-router-dom';
 
 const MockConventionalTab = () => (
@@ -24,6 +21,8 @@ const MockRouter = ({ path = '/insights/inventory', ...props }) => (
 const defaultProps = {
   ImmutableDevicesTab: <MockImmutableTab />,
   ConventionalSystemsTab: <MockConventionalTab />,
+  hasConventionalSystems: true,
+  accountHasEdgeImages: true,
 };
 const edgeEnabledProps = { ...defaultProps, isEdgeParityEnabled: true };
 
@@ -44,7 +43,6 @@ before(() => {
 describe('When edge parity feature is enabled', () => {
   beforeEach(() => {
     cy.intercept('*', { statusCode: 200, body: { results: [] } });
-    hostsInterceptors.successful();
     featureFlagsInterceptors.edgeParitySuccessful();
   });
 
@@ -91,11 +89,10 @@ describe('When edge parity feature is enabled', () => {
 describe('When there are edge devices, but no conventional systems', () => {
   beforeEach(() => {
     cy.intercept('*', { statusCode: 200, body: { results: [] } });
-    hostsInterceptors.successHybridSystems();
     featureFlagsInterceptors.edgeParitySuccessful();
   });
   it('should open immutable tab as default when there are edge devices, but not conventional', () => {
-    mountWithProps(edgeEnabledProps);
+    mountWithProps({ ...edgeEnabledProps, hasConventionalSystems: false });
 
     cy.get('div[id="conventional"]').should('not.exist');
     cy.get('div[id="immutable"]').should('have.length', 1);

--- a/src/components/InventoryTabs/HybridInventoryTabs.js
+++ b/src/components/InventoryTabs/HybridInventoryTabs.js
@@ -1,14 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react';
-import axios from 'axios';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import { Tab, TabTitleText, Tabs } from '@patternfly/react-core';
-import {
-  INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS,
-  INVENTORY_TOTAL_FETCH_EDGE_PARAMS,
-  INVENTORY_TOTAL_FETCH_URL_SERVER,
-  hybridInventoryTabKeys,
-} from '../../Utilities/constants';
+import { hybridInventoryTabKeys } from '../../Utilities/constants';
 import { useNavigate } from 'react-router-dom';
 
 const HybridInventoryTabs = ({
@@ -17,43 +11,19 @@ const HybridInventoryTabs = ({
   tabPathname,
   isImmutableTabOpen,
   isEdgeParityEnabled,
+  accountHasEdgeImages,
+  hasConventionalSystems,
 }) => {
   const { search } = useLocation();
   //used to hold URL params across tab changes
   const prevSearchRef = useRef('');
   const navigate = useNavigate();
-  const [hasEdgeImages, setHasEdgeImages] = useState(false);
-  useEffect(() => {
-    if (isEdgeParityEnabled) {
-      try {
-        axios
-          .get(
-            `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_EDGE_PARAMS}`
-          )
-          .then((result) => {
-            const accountHasEdgeImages = result?.data?.total > 0;
-            setHasEdgeImages(accountHasEdgeImages);
-            axios
-              .get(
-                `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS}`
-              )
-              .then((conventionalImages) => {
-                const accountHasConventionalImages =
-                  conventionalImages?.data?.total > 0;
 
-                if (accountHasEdgeImages && !accountHasConventionalImages) {
-                  handleTabClick(
-                    undefined,
-                    hybridInventoryTabKeys.immutable.key
-                  );
-                }
-              });
-          });
-      } catch (e) {
-        console.log(e);
-      }
+  useEffect(() => {
+    if (accountHasEdgeImages && !hasConventionalSystems) {
+      handleTabClick(undefined, hybridInventoryTabKeys.immutable.key);
     }
-  }, [isEdgeParityEnabled]);
+  }, [accountHasEdgeImages, hasConventionalSystems]);
 
   const activeTab = isImmutableTabOpen
     ? hybridInventoryTabKeys.immutable.key
@@ -73,7 +43,7 @@ const HybridInventoryTabs = ({
     }
   };
 
-  return isEdgeParityEnabled && hasEdgeImages ? (
+  return isEdgeParityEnabled && accountHasEdgeImages ? (
     <Tabs
       className="pf-m-light pf-c-table"
       activeKey={activeTab}
@@ -108,9 +78,13 @@ HybridInventoryTabs.propTypes = {
   isImmutableTabOpen: PropTypes.bool,
   tabPathname: PropTypes.string,
   isEdgeParityEnabled: PropTypes.bool,
+  hasConventionalSystems: PropTypes.bool,
+  accountHasEdgeImages: PropTypes.bool,
 };
 
 HybridInventoryTabs.defaultProps = {
   tabPathname: '/insights/inventory',
+  hasConventionalSystems: true,
+  accountHasEdgeImages: true,
 };
 export default HybridInventoryTabs;

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useMemo } from 'react';
+import React, { Suspense, lazy, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import './inventory.scss';
 import {
@@ -11,6 +11,8 @@ import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useLocation } from 'react-router-dom';
 import { getSearchParams } from '../constants';
 import useFeatureFlag from '../Utilities/useFeatureFlag';
+import { AccountStatContext } from '../Routes';
+
 const ConventionalSystemsTab = lazy(() =>
   import(
     '../components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab'
@@ -36,6 +38,8 @@ const Inventory = (props) => {
   const searchParams = useMemo(() => getSearchParams(), [search.toString()]);
   const fullProps = { ...props, ...searchParams };
   const isEdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
+  const { hasEdgeDevices, hasConventionalSystems } =
+    useContext(AccountStatContext);
   return (
     <React.Fragment>
       <PageHeader className="pf-m-light">
@@ -55,6 +59,8 @@ const Inventory = (props) => {
           }
           isImmutableTabOpen={props.isImmutableTabOpen}
           isEdgeParityEnabled={isEdgeParityEnabled}
+          accountHasEdgeImages={hasEdgeDevices}
+          hasConventionalSystems={hasConventionalSystems}
         />
       </Main>
     </React.Fragment>


### PR DESCRIPTION
Improves the API requests scattered around components to check the presence of conventional and edge systems by sharing one request result through the react context provider.