### PR TITLE
feat(TitleColumn): RHINENG-3112 - Allow passing in a link via href prop

### DIFF
--- a/src/components/ImmutableDevices/ImmutableDevices.cy.js
+++ b/src/components/ImmutableDevices/ImmutableDevices.cy.js
@@ -174,8 +174,8 @@ describe('ImmutableDevices', () => {
 
     cy.get('td[data-label="Name"]')
       .first()
-      .find('.ins-composed-col > :nth-child(2) > a')
-      .trigger('click');
+      .find('.ins-composed-col > div > a')
+      .click();
 
     cy.get('#mock-detail-page');
   });

--- a/src/components/ImmutableDevices/ImmutableDevices.js
+++ b/src/components/ImmutableDevices/ImmutableDevices.js
@@ -4,7 +4,6 @@ import React, { useEffect } from 'react';
 import { TableVariant } from '@patternfly/react-table';
 import { InventoryTable } from '../InventoryTable';
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
-import { useNavigate } from 'react-router-dom';
 import { edgeColumns } from './columns';
 
 const ImmutableDevices = ({
@@ -22,7 +21,6 @@ const ImmutableDevices = ({
   ...props
 }) => {
   const dispatch = useDispatch();
-  const navigate = useNavigate();
   const inventoryGroupsEnabled = useFeatureFlag('hbi.ui.inventory-groups');
 
   const totalItems = useSelector(({ entities }) => entities?.total);
@@ -42,10 +40,6 @@ const ImmutableDevices = ({
     );
 
     return [...mergeAppColumns(filteredColumns), ...edgeColumns];
-  };
-
-  const onRowClick = (_key, systemId) => {
-    navigate(`/insights/inventory/${systemId}?appName=vulnerabilities`);
   };
 
   return (
@@ -73,7 +67,6 @@ const ImmutableDevices = ({
       getEntities={getEntities}
       filterConfig={filterConfig}
       activeFiltersConfig={activeFiltersConfig}
-      onRowClick={onRowClick}
       showTags
       onRefresh={onRefresh}
       actionsConfig={actionsConfig}

--- a/src/components/InventoryTable/EntityTable.js
+++ b/src/components/InventoryTable/EntityTable.js
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { selectEntity, setSort } from '../../store/actions';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
 import {
   Table as PfTable,
   TableBody,
@@ -15,7 +14,7 @@ import { SkeletonTable } from '@redhat-cloud-services/frontend-components/Skelet
 import NoEntitiesFound from './NoEntitiesFound';
 import { createColumns, createRows } from './helpers';
 import useColumns from './hooks/useColumns';
-import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
+
 /**
  * The actual (PF)table component. It calculates each cell and every table property.
  * It uses rows, columns and loaded from redux to show correct data.
@@ -43,7 +42,6 @@ const EntityTable = ({
   columnsCounter,
 }) => {
   const dispatch = useDispatch();
-  const location = useLocation();
   const columns = useColumns(
     columnsProp,
     disableDefaultColumns,
@@ -51,7 +49,6 @@ const EntityTable = ({
     columnsCounter
   );
   const rows = useSelector(({ entities: { rows } }) => rows);
-  const navigate = useInsightsNavigate();
   const onItemSelect = (_event, checked, rowId) => {
     const row = isExpandable ? rows[rowId / 2] : rows[rowId];
     dispatch(selectEntity(rowId === -1 ? 0 : row.id, checked));
@@ -69,14 +66,6 @@ const EntityTable = ({
     () => loaded && createColumns(columns, hasItems, rows, isExpandable),
     [loaded, columns, hasItems, rows, isExpandable]
   );
-
-  const defaultRowClick = (_event, key) => {
-    navigate(
-      `${location.pathname}${
-        location.pathname.slice(-1) === '/' ? '' : '/'
-      }${key}`
-    );
-  };
 
   const tableSortBy = {
     index:
@@ -110,7 +99,7 @@ const EntityTable = ({
               actions,
               expandable,
               loaded,
-              onRowClick: onRowClick || defaultRowClick,
+              onRowClick,
               noDetail,
               sortBy,
               noSystemsTable,

--- a/src/components/InventoryTable/EntityTable.test.js
+++ b/src/components/InventoryTable/EntityTable.test.js
@@ -2,6 +2,10 @@
 /* eslint-disable camelcase */
 /* eslint-disable react/display-name */
 import React from 'react';
+import {
+  fireEvent,
+  render as rederWithTestingLibrary,
+} from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import EntityTable from './EntityTable';
 import { mount, render } from 'enzyme';
@@ -34,7 +38,16 @@ describe('EntityTable', () => {
           },
         ],
         columns: [
-          { key: 'one', sortKey: 'one', title: 'One', renderFunc: TitleColumn },
+          {
+            key: 'one',
+            sortKey: 'one',
+            title: 'One',
+            renderFunc: (display_name, id, item, props) => (
+              <TitleColumn {...{ ...props, id, item }}>
+                {display_name}
+              </TitleColumn>
+            ),
+          },
         ],
         page: 1,
         perPage: 50,
@@ -636,31 +649,23 @@ describe('EntityTable', () => {
 
   describe('API', () => {
     jest.mock('../../Utilities/useFeatureFlag');
-    it('should call default onRowClick', () => {
-      // const history = createMemoryHistory();
-      // const store = mockStore(initialState);
-      // const wrapper = mount(
-      //   <MemoryRouter history={history}>
-      //     <Provider store={store}>
-      //       <EntityTable loaded disableDefaultColumns />
-      //     </Provider>
-      //   </MemoryRouter>
-      // );
-      // wrapper.find('table tbody tr a[widget="col"]').first().simulate('click');
-      // expect(history.location.pathname).toBe('/testing-id');
-    });
 
     it('should call onRowClick', () => {
       const onRowClick = jest.fn();
       const store = mockStore(initialState);
-      const wrapper = mount(
+      const { container } = rederWithTestingLibrary(
         <MemoryRouter>
           <Provider store={store}>
             <EntityTable loaded disableDefaultColumns onRowClick={onRowClick} />
           </Provider>
         </MemoryRouter>
       );
-      wrapper.find('table tbody tr a[widget="col"]').first().simulate('click');
+
+      const link = container.querySelector('table tbody tr a');
+      act(() => {
+        fireEvent.click(link);
+      });
+
       expect(onRowClick).toHaveBeenCalled();
     });
 

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -42,7 +42,17 @@ describe('EntityTableToolbar', () => {
             one: 'data',
           },
         ],
-        columns: [{ key: 'one', title: 'One', renderFunc: TitleColumn }],
+        columns: [
+          {
+            key: 'one',
+            title: 'One',
+            renderFunc: (display_name, id, item, props) => (
+              <TitleColumn {...{ ...props, id, item }}>
+                {display_name}
+              </TitleColumn>
+            ),
+          },
+        ],
         page: 1,
         perPage: 50,
         total: 500,

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -82,7 +82,6 @@ const InventoryTable = forwardRef(
       tableProps,
       isRbacEnabled,
       hasCheckbox,
-      onRowClick,
       abortOnUnmount = true,
       showCentosVersions = false,
       ...props
@@ -281,7 +280,6 @@ const InventoryTable = forwardRef(
         <InventoryList
           {...props}
           hasCheckbox={hasCheckbox}
-          onRowClick={onRowClick}
           tableProps={tableProps}
           customFilters={customFilters}
           hasAccess={hasAccess}
@@ -343,7 +341,6 @@ InventoryTable.propTypes = {
   tableProps: PropTypes.object,
   isRbacEnabled: PropTypes.bool,
   hasCheckbox: PropTypes.bool,
-  onRowClick: PropTypes.func,
   abortOnUnmount: PropTypes.bool,
   showCentosVersions: PropTypes.bool,
 };

--- a/src/components/InventoryTable/TitleColumn.js
+++ b/src/components/InventoryTable/TitleColumn.js
@@ -1,6 +1,6 @@
-/* eslint-disable camelcase */
 /* eslint-disable react/prop-types */
 import React from 'react';
+import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 /**
  * Helper function to proprly calculate what to do when user clicks on first cell.
@@ -9,13 +9,13 @@ import React from 'react';
  * @param {*} key inventory UUID.
  * @param {*} props additional props from `EntityTable` - loaded, onRowClick and noDetail.
  */
-const onRowClick = (event, key, { loaded, onRowClick: rowClick, noDetail }) => {
+const onRowClick = (event, id, { loaded, onRowClick: rowClick, noDetail }) => {
   if (loaded && !noDetail) {
     const isMetaKey = event.ctrlKey || event.metaKey || event.which === 2;
     if (isMetaKey) {
       return;
     } else if (rowClick) {
-      rowClick(event, key, isMetaKey);
+      rowClick(event, id, isMetaKey);
     }
   }
 
@@ -24,32 +24,35 @@ const onRowClick = (event, key, { loaded, onRowClick: rowClick, noDetail }) => {
 };
 
 /**
- * Helper function to generate first cell in plain inventory either with clickable detail or just data from attribut.
+ * Helper component to generate first cell in plain inventory either with clickable detail or just data from attribut.
  * This is later on used in redux in `renderFunc`.
- * @param {React.node} data React node with information that will be shown to user as column title.
+ * @param {React.node} children React node with information that will be shown to user as column title.
  * @param {string} id inventory UUID, used to navigate to correct URL.
  * @param {*} item row data, holds every information from redux store for currecnt row.
  * @param {*} props additional props passed from `EntityTable` - holds any props passed to inventory table.
  */
-const TitleColumn = (data, id, item, props) => (
+const TitleColumn = ({ children, id, item, ...props }) => (
   <div className="ins-composed-col sentry-mask data-hj-suppress">
-    <div key="os_release">{item?.os_release}</div>
+    {item?.os_release && <div key="os_release">{item?.os_release}</div>}
     <div key="data" className={props?.noDetail ? 'ins-m-nodetail' : ''}>
       {props?.noDetail ? (
-        data
+        children
       ) : (
-        <a
-          // eslint-disable-next-line react/no-unknown-property
-          widget="col"
-          href={`${location.pathname}${
-            location.pathname.substr(-1) === '/' ? '' : '/'
-          }${id}`}
-          onClick={(event) => {
-            onRowClick(event, id, props);
+        <Link
+          to={item?.href || id}
+          {...{
+            ...(!item?.href ? { app: 'inventory' } : {}),
+            ...(props?.onRowClick
+              ? {
+                  onClick: (event) => {
+                    onRowClick(event, id, props);
+                  },
+                }
+              : {}),
           }}
         >
-          {data}
-        </a>
+          {children}
+        </Link>
       )}
     </div>
   </div>

--- a/src/components/InventoryTable/TitleColumn.js
+++ b/src/components/InventoryTable/TitleColumn.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { Link } from 'react-router-dom';
 
 /**
  * Helper function to proprly calculate what to do when user clicks on first cell.
@@ -39,9 +39,8 @@ const TitleColumn = ({ children, id, item, ...props }) => (
         children
       ) : (
         <Link
-          to={item?.href || id}
+          to={item?.href || item?.to || id}
           {...{
-            ...(!item?.href ? { app: 'inventory' } : {}),
             ...(props?.onRowClick
               ? {
                   onClick: (event) => {

--- a/src/components/InventoryTable/TitleColumn.test.js
+++ b/src/components/InventoryTable/TitleColumn.test.js
@@ -4,7 +4,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  Link: ({ children, ...props }) => <a {...props}>{children}</a>, // eslint-disable-line
+  Link: ({ children, ...props }) => <a class="fakeLink" {...props}>{children}</a>, // eslint-disable-line
 }));
 
 describe('TitleColumn', () => {
@@ -33,6 +33,16 @@ describe('TitleColumn', () => {
   it('should render correctly with href', () => {
     const { asFragment } = render(
       <TitleColumn id="testId" item={{ href: '/link/to/item' }}>
+        something
+      </TitleColumn>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with to', () => {
+    const { asFragment } = render(
+      <TitleColumn id="testId" item={{ to: { pathname: '/link/to/item' } }}>
         something
       </TitleColumn>
     );

--- a/src/components/InventoryTable/TitleColumn.test.js
+++ b/src/components/InventoryTable/TitleColumn.test.js
@@ -1,71 +1,97 @@
-/* eslint-disable new-cap */
-/* eslint-disable camelcase */
 import React from 'react';
 import TitleColumn from './TitleColumn';
-import { mount } from 'enzyme';
-import toJson from 'enzyme-to-json';
+import { act, fireEvent, render } from '@testing-library/react';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Link: ({ children, ...props }) => <a {...props}>{children}</a>, // eslint-disable-line
+}));
 
 describe('TitleColumn', () => {
   it('should render correctly with NO data', () => {
-    const Cmp = () => TitleColumn();
-    const wrapper = mount(<Cmp />);
-    expect(toJson(wrapper)).toMatchSnapshot();
+    const { asFragment } = render(<TitleColumn />);
+    expect(asFragment()).toMatchSnapshot();
   });
 
   it('should render correctly with data', () => {
-    const Cmp = () =>
-      TitleColumn('something', 'some-id', { os_release: 'os_release' });
-    const wrapper = mount(<Cmp />);
-    expect(toJson(wrapper)).toMatchSnapshot();
+    const { asFragment } = render(
+      <TitleColumn id="testId">something</TitleColumn>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with os_release', () => {
+    const { asFragment } = render(
+      <TitleColumn id="testId" item={{ os_release: 'os_release' }}>
+        something
+      </TitleColumn>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with href', () => {
+    const { asFragment } = render(
+      <TitleColumn id="testId" item={{ href: '/link/to/item' }}>
+        something
+      </TitleColumn>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
   });
 
   it('should render correctly no detail with data', () => {
-    const Cmp = () =>
-      TitleColumn(
-        'something',
-        'some-id',
-        { os_release: 'os_release' },
-        { noDetail: true }
-      );
-    const wrapper = mount(<Cmp />);
-    expect(toJson(wrapper)).toMatchSnapshot();
+    const { asFragment } = render(
+      <TitleColumn
+        id="testId"
+        item={{ os_release: 'os_release' }}
+        noDetail={true}
+      >
+        something
+      </TitleColumn>
+    );
+    expect(asFragment()).toMatchSnapshot();
   });
 
   describe('API', () => {
-    const open = jest.fn();
-
-    beforeEach(() => {
-      Object.defineProperty(window, 'open', {
-        writable: true,
-        value: open,
-      });
-    });
-
     it('should call onClick', () => {
       const onClick = jest.fn();
-      const Cmp = () =>
-        TitleColumn(
-          'something',
-          'some-id',
-          { os_release: 'os_release' },
-          { onRowClick: onClick, loaded: true }
-        );
-      const wrapper = mount(<Cmp />);
-      wrapper.find('a').first().simulate('click');
+      const { container } = render(
+        <TitleColumn
+          id="testId"
+          item={{ os_release: 'os_release' }}
+          onRowClick={onClick}
+          loaded
+        >
+          something
+        </TitleColumn>
+      );
+
+      const link = container.querySelector('a');
+      act(() => {
+        fireEvent.click(link);
+      });
+
       expect(onClick).toHaveBeenCalled();
     });
 
-    it('should NOT call onClick', () => {
+    it('should not call onClick if not loaded', () => {
       const onClick = jest.fn();
-      const Cmp = () =>
-        TitleColumn(
-          'something',
-          'some-id',
-          { os_release: 'os_release' },
-          { onRowClick: onClick }
-        );
-      const wrapper = mount(<Cmp />);
-      wrapper.find('a').first().simulate('click');
+      const { container } = render(
+        <TitleColumn
+          id="testId"
+          item={{ os_release: 'os_release' }}
+          onRowClick={onClick}
+        >
+          something
+        </TitleColumn>
+      );
+
+      const link = container.querySelector('a');
+      act(() => {
+        fireEvent.click(link);
+      });
+
       expect(onClick).not.toHaveBeenCalled();
     });
   });

--- a/src/components/InventoryTable/__snapshots__/EntityTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTable.test.js.snap
@@ -104,13 +104,11 @@ exports[`EntityTable DOM should render correctly - compact 1`] = `
         <div
           class="ins-composed-col sentry-mask data-hj-suppress"
         >
-          <div />
           <div
             class=""
           >
             <a
               href="/testing-id"
-              widget="col"
             >
               data
             </a>
@@ -284,22 +282,19 @@ exports[`EntityTable DOM should render correctly - is expandable 1`] = `
         },
         "cells": Array [
           <React.Fragment>
-            <div
-              className="ins-composed-col sentry-mask data-hj-suppress"
+            <TitleColumn
+              id="testing-id"
+              item={
+                Object {
+                  "id": "testing-id",
+                  "one": "data",
+                  "system_profile": Object {},
+                }
+              }
+              loaded={true}
             >
-              <div />
-              <div
-                className=""
-              >
-                <a
-                  href="/testing-id"
-                  onClick={[Function]}
-                  widget="col"
-                >
-                  data
-                </a>
-              </div>
-            </div>
+              data
+            </TitleColumn>
           </React.Fragment>,
         ],
         "id": "testing-id",
@@ -470,22 +465,19 @@ exports[`EntityTable DOM should render correctly - with actions 1`] = `
         },
         "cells": Array [
           <React.Fragment>
-            <div
-              className="ins-composed-col sentry-mask data-hj-suppress"
+            <TitleColumn
+              id="testing-id"
+              item={
+                Object {
+                  "id": "testing-id",
+                  "one": "data",
+                  "system_profile": Object {},
+                }
+              }
+              loaded={true}
             >
-              <div />
-              <div
-                className=""
-              >
-                <a
-                  href="/testing-id"
-                  onClick={[Function]}
-                  widget="col"
-                >
-                  data
-                </a>
-              </div>
-            </div>
+              data
+            </TitleColumn>
           </React.Fragment>,
         ],
         "id": "testing-id",
@@ -604,22 +596,19 @@ exports[`EntityTable DOM should render correctly - without checkbox 1`] = `
         },
         "cells": Array [
           <React.Fragment>
-            <div
-              className="ins-composed-col sentry-mask data-hj-suppress"
+            <TitleColumn
+              id="testing-id"
+              item={
+                Object {
+                  "id": "testing-id",
+                  "one": "data",
+                  "system_profile": Object {},
+                }
+              }
+              loaded={true}
             >
-              <div />
-              <div
-                className=""
-              >
-                <a
-                  href="/testing-id"
-                  onClick={[Function]}
-                  widget="col"
-                >
-                  data
-                </a>
-              </div>
-            </div>
+              data
+            </TitleColumn>
           </React.Fragment>,
         ],
         "id": "testing-id",
@@ -743,13 +732,11 @@ exports[`EntityTable DOM should render correctly 1`] = `
         <div
           class="ins-composed-col sentry-mask data-hj-suppress"
         >
-          <div />
           <div
             class=""
           >
             <a
               href="/testing-id"
-              widget="col"
             >
               data
             </a>
@@ -812,22 +799,25 @@ exports[`EntityTable DOM sort by should render correctly - is expandable 1`] = `
         },
         "cells": Array [
           <React.Fragment>
-            <div
-              className="ins-composed-col sentry-mask data-hj-suppress"
+            <TitleColumn
+              id="testing-id"
+              item={
+                Object {
+                  "id": "testing-id",
+                  "one": "data",
+                  "system_profile": Object {},
+                }
+              }
+              loaded={true}
+              sortBy={
+                Object {
+                  "directions": "asc",
+                  "key": "one",
+                }
+              }
             >
-              <div />
-              <div
-                className=""
-              >
-                <a
-                  href="/testing-id"
-                  onClick={[Function]}
-                  widget="col"
-                >
-                  data
-                </a>
-              </div>
-            </div>
+              data
+            </TitleColumn>
           </React.Fragment>,
         ],
         "id": "testing-id",
@@ -892,22 +882,25 @@ exports[`EntityTable DOM sort by should render correctly - without checkbox 1`] 
         },
         "cells": Array [
           <React.Fragment>
-            <div
-              className="ins-composed-col sentry-mask data-hj-suppress"
+            <TitleColumn
+              id="testing-id"
+              item={
+                Object {
+                  "id": "testing-id",
+                  "one": "data",
+                  "system_profile": Object {},
+                }
+              }
+              loaded={true}
+              sortBy={
+                Object {
+                  "directions": "asc",
+                  "key": "one",
+                }
+              }
             >
-              <div />
-              <div
-                className=""
-              >
-                <a
-                  href="/testing-id"
-                  onClick={[Function]}
-                  widget="col"
-                >
-                  data
-                </a>
-              </div>
-            </div>
+              data
+            </TitleColumn>
           </React.Fragment>,
         ],
         "id": "testing-id",
@@ -973,22 +966,26 @@ exports[`EntityTable DOM sort by should render correctly 1`] = `
         },
         "cells": Array [
           <React.Fragment>
-            <div
-              className="ins-composed-col sentry-mask data-hj-suppress"
+            <TitleColumn
+              id="testing-id"
+              item={
+                Object {
+                  "id": "testing-id",
+                  "one": "data",
+                  "system_profile": Object {},
+                }
+              }
+              loaded={true}
+              sortBy={
+                Object {
+                  "directions": "asc",
+                  "key": "one",
+                  "sortKey": "one",
+                }
+              }
             >
-              <div />
-              <div
-                className=""
-              >
-                <a
-                  href="/testing-id"
-                  onClick={[Function]}
-                  widget="col"
-                >
-                  data
-                </a>
-              </div>
-            </div>
+              data
+            </TitleColumn>
           </React.Fragment>,
         ],
         "id": "testing-id",

--- a/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
@@ -1,69 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TitleColumn should render correctly no detail with data 1`] = `
-<Cmp>
+<DocumentFragment>
   <div
-    className="ins-composed-col sentry-mask data-hj-suppress"
+    class="ins-composed-col sentry-mask data-hj-suppress"
   >
-    <div
-      key="os_release"
-    >
+    <div>
       os_release
     </div>
     <div
-      className="ins-m-nodetail"
-      key="data"
+      class="ins-m-nodetail"
     >
       something
     </div>
   </div>
-</Cmp>
+</DocumentFragment>
 `;
 
 exports[`TitleColumn should render correctly with NO data 1`] = `
-<Cmp>
+<DocumentFragment>
   <div
-    className="ins-composed-col sentry-mask data-hj-suppress"
+    class="ins-composed-col sentry-mask data-hj-suppress"
   >
     <div
-      key="os_release"
-    />
-    <div
-      className=""
-      key="data"
+      class=""
     >
       <a
-        href="/undefined"
-        onClick={[Function]}
-        widget="col"
+        to=""
       />
     </div>
   </div>
-</Cmp>
+</DocumentFragment>
 `;
 
 exports[`TitleColumn should render correctly with data 1`] = `
-<Cmp>
+<DocumentFragment>
   <div
-    className="ins-composed-col sentry-mask data-hj-suppress"
+    class="ins-composed-col sentry-mask data-hj-suppress"
   >
     <div
-      key="os_release"
-    >
-      os_release
-    </div>
-    <div
-      className=""
-      key="data"
+      class=""
     >
       <a
-        href="/some-id"
-        onClick={[Function]}
-        widget="col"
+        to="testId"
       >
         something
       </a>
     </div>
   </div>
-</Cmp>
+</DocumentFragment>
+`;
+
+exports[`TitleColumn should render correctly with href 1`] = `
+<DocumentFragment>
+  <div
+    class="ins-composed-col sentry-mask data-hj-suppress"
+  >
+    <div
+      class=""
+    >
+      <a
+        to="///link/to/item"
+      >
+        something
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`TitleColumn should render correctly with os_release 1`] = `
+<DocumentFragment>
+  <div
+    class="ins-composed-col sentry-mask data-hj-suppress"
+  >
+    <div>
+      os_release
+    </div>
+    <div
+      class=""
+    >
+      <a
+        to="testId"
+      >
+        something
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
 `;

--- a/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
@@ -26,7 +26,7 @@ exports[`TitleColumn should render correctly with NO data 1`] = `
       class=""
     >
       <a
-        to=""
+        class="fakeLink"
       />
     </div>
   </div>
@@ -42,6 +42,7 @@ exports[`TitleColumn should render correctly with data 1`] = `
       class=""
     >
       <a
+        class="fakeLink"
         to="testId"
       >
         something
@@ -60,7 +61,8 @@ exports[`TitleColumn should render correctly with href 1`] = `
       class=""
     >
       <a
-        to="///link/to/item"
+        class="fakeLink"
+        to="/link/to/item"
       >
         something
       </a>
@@ -81,7 +83,27 @@ exports[`TitleColumn should render correctly with os_release 1`] = `
       class=""
     >
       <a
+        class="fakeLink"
         to="testId"
+      >
+        something
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`TitleColumn should render correctly with to 1`] = `
+<DocumentFragment>
+  <div
+    class="ins-composed-col sentry-mask data-hj-suppress"
+  >
+    <div
+      class=""
+    >
+      <a
+        class="fakeLink"
+        to="[object Object]"
       >
         something
       </a>

--- a/src/components/InventoryTable/helpers.js
+++ b/src/components/InventoryTable/helpers.js
@@ -8,15 +8,11 @@ import { Skeleton } from '@patternfly/react-core';
 
 export const buildCells = (item, columns, extra) => {
   return columns.map(({ key, composed, renderFunc }) => {
-    // eslint-disable-next-line new-cap
     const data = composed ? (
       <Fragment>
-        {TitleColumn(
-          composed.map((key) => get(item, key, ' ')),
-          item.id,
-          item,
-          extra
-        )}
+        <TitleColumn id={item.id} item={item} {...extra}>
+          {composed.map((key) => get(item, key, ' '))}
+        </TitleColumn>
       </Fragment>
     ) : (
       get(item, key, ' ')

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -295,7 +295,6 @@ const ConventionalSystemsTab = ({
           ],
         }}
         bulkSelect={bulkSelectConfig}
-        onRowClick={(_e, id, app) => navigate(`/${id}${app ? `/${app}` : ''}`)}
         showCentosVersions={true}
       />
 

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -46,7 +46,9 @@ export const defaultColumns = (groupsEnabled = false) => [
     key: 'display_name',
     sortKey: 'display_name',
     title: 'Name',
-    renderFunc: TitleColumn,
+    renderFunc: (display_name, id, item, props) => (
+      <TitleColumn {...{ ...props, id, item }}>{display_name}</TitleColumn>
+    ),
   },
   ...(groupsEnabled
     ? [


### PR DESCRIPTION
This changes the `a` tag used to a proper react router `Link` component and allows entities to have a `href` prop that the Inventory should link the `display_name` (example in compliance[0]).


[0] https://github.com/RedHatInsights/compliance-frontend/pull/2012/files#diff-09ae52efeffb58d25e728921c02f75f65b9f249855e9eea936ce9e913d6997e1R145