### PR TITLE
fix(ImmutableDevices): add initial loading prop

### DIFF
--- a/src/components/ImmutableDevices/ImmutableDevices.js
+++ b/src/components/ImmutableDevices/ImmutableDevices.js
@@ -46,6 +46,7 @@ const ImmutableDevices = ({
 
   return (
     <InventoryTable
+      initialLoading
       disableDefaultColumns
       onLoad={onLoad}
       hideFilters={hideFilters}


### PR DESCRIPTION
This PR adds [initialLoading](https://github.com/RedHatInsights/insights-inventory-frontend/blob/910cb2c9ebd7311c25d6980b1894132702b372b6/doc/props_table.md?plain=1#L109) prop to make sure tabs do not contain previous content.

To test:
1. run this PR with insights-advisor  [PR](https://github.com/RedHatInsights/insights-advisor-frontend/pull/1193).
2. Go to the recommendation details page that has both conventional and immutable devices. e.g **Decreased performance occurs when KVM and VMWare guests are not running with recommended tuned service configuration**
3. Change tabs
4. Observe that the table shows the initial loading state on the first mount