### PR TITLE
fix(InventoryGroupDetails): THEEDGE-3707 implement edge group details expostion

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -16,6 +16,9 @@ import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComp
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 import { inventoryHasEdgeSystems } from './Utilities/edge';
 import { inventoryHasConventionalSystems } from './Utilities/conventional';
+const InventoryOrEdgeGroupDetailsView = lazy(() =>
+  import('./routes/InventoryOrEdgeGroupDetailsComponent')
+);
 const InventoryOrEdgeView = lazy(() =>
   import('./routes/InventoryOrEdgeComponent')
 );
@@ -25,9 +28,6 @@ const InventoryHostStaleness = lazy(() =>
   import('./routes/InventoryHostStaleness')
 );
 
-const InventoryGroupDetail = lazy(() =>
-  import('./routes/InventoryGroupDetail')
-);
 const EdgeInventoryUpdate = lazy(() => import('./routes/SystemUpdate'));
 
 export const routes = {
@@ -82,7 +82,11 @@ export const Routes = () => {
     },
     {
       path: '/groups/:groupId',
-      element: groupsEnabled ? <InventoryGroupDetail /> : <LostPage />,
+      element: groupsEnabled ? (
+        <InventoryOrEdgeGroupDetailsView />
+      ) : (
+        <LostPage />
+      ),
     },
     {
       path: '/:inventoryId/update',

--- a/src/Utilities/hooks/useEdgeGroups.js
+++ b/src/Utilities/hooks/useEdgeGroups.js
@@ -4,7 +4,7 @@ import { fetchEdgeEnforceGroups } from '../../api';
 
 const useEdgeGroups = () => {
   const [data, setData] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   const edgeParityInventoryGroupsEnabled = useFeatureFlag(
     'edgeParity.inventory-groups-enabled'

--- a/src/components/InventoryGroupDetail/EdgeGroupDetails.js
+++ b/src/components/InventoryGroupDetail/EdgeGroupDetails.js
@@ -6,17 +6,17 @@ import { getNotificationProp } from '../../Utilities/edge';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
-const EdgeGroupsView = (props) => {
+const EdgeGroupsDetailsView = (props) => {
   const dispatch = useDispatch();
   const notificationProp = getNotificationProp(dispatch);
   return (
     <AsyncComponent
       appName="edge"
-      module="./Groups"
+      module="./GroupsDetails"
       ErrorComponent={<ErrorState />}
       navigateProp={useNavigate}
       locationProp={useLocation}
-      useParams={useParams}
+      paramsProp={useParams}
       notificationProp={notificationProp}
       pathPrefix={resolveRelPath('')}
       {...props}
@@ -24,4 +24,4 @@ const EdgeGroupsView = (props) => {
   );
 };
 
-export default EdgeGroupsView;
+export default EdgeGroupsDetailsView;

--- a/src/routes/InventoryOrEdgeGroupDetailsComponent.js
+++ b/src/routes/InventoryOrEdgeGroupDetailsComponent.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { inventoryHasConventionalSystems } from '../Utilities/conventional';
+import { inventoryHasEdgeSystems } from '../Utilities/edge';
+import useEdgeGroups from '../Utilities/hooks/useEdgeGroups';
+import useFeatureFlag from '../Utilities/useFeatureFlag';
+import PropTypes from 'prop-types';
+import { Spinner } from '@patternfly/react-core';
+import EdgeGroupsDetailsView from '../components/InventoryGroupDetail/EdgeGroupDetails';
+import InventoryGroupDetail from './InventoryGroupDetail';
+
+const InventoryOrEdgeGroupDetailsView = () => {
+  const [enforceEdgeGroups, isLoading] = useEdgeGroups();
+  const [hasConventionalSystems, setHasConventionalSystems] = useState(true);
+  const [hasEdgeDevices, setHasEdgeDevices] = useState(true);
+  const edgeParityInventoryListEnabled = useFeatureFlag(
+    'edgeParity.inventory-list'
+  );
+
+  useEffect(() => {
+    try {
+      (async () => {
+        const hasConventionalSystems = await inventoryHasConventionalSystems();
+        if (edgeParityInventoryListEnabled) {
+          const hasEdgeSystems = await inventoryHasEdgeSystems();
+          setHasConventionalSystems(hasConventionalSystems);
+          setHasEdgeDevices(hasEdgeSystems);
+        }
+      })();
+    } catch (e) {
+      console.log(e);
+    }
+  }, []);
+
+  const GroupsDetailComponents = enforceEdgeGroups
+    ? EdgeGroupsDetailsView
+    : InventoryGroupDetail;
+  if (!isLoading) {
+    return (
+      <GroupsDetailComponents
+        hasConventionalSystems={hasConventionalSystems}
+        hasEdgeDevices={hasEdgeDevices}
+      />
+    );
+  } else {
+    return <Spinner />;
+  }
+};
+
+InventoryOrEdgeGroupDetailsView.prototype = {
+  enforceEdgeGroups: PropTypes.bool,
+  isLoading: PropTypes.bool,
+};
+
+export default InventoryOrEdgeGroupDetailsView;

--- a/src/routes/InventoryOrEdgeGroupDetailsComponent.js
+++ b/src/routes/InventoryOrEdgeGroupDetailsComponent.js
@@ -4,7 +4,7 @@ import { inventoryHasEdgeSystems } from '../Utilities/edge';
 import useEdgeGroups from '../Utilities/hooks/useEdgeGroups';
 import useFeatureFlag from '../Utilities/useFeatureFlag';
 import PropTypes from 'prop-types';
-import { Spinner } from '@patternfly/react-core';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import EdgeGroupsDetailsView from '../components/InventoryGroupDetail/EdgeGroupDetails';
 import InventoryGroupDetail from './InventoryGroupDetail';
 
@@ -27,7 +27,7 @@ const InventoryOrEdgeGroupDetailsView = () => {
         }
       })();
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
   }, []);
 
@@ -42,7 +42,11 @@ const InventoryOrEdgeGroupDetailsView = () => {
       />
     );
   } else {
-    return <Spinner />;
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
   }
 };
 


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/THEEDGE-3707

this commit expose edge group details component from edge,
and give the ability if important customer log in to the system and navigate to group details screen from edge group screen, he will see edge group list instead of inventory and then be able to open group details