### PR TITLE
Update Patchman API to v3

### DIFF
--- a/src/api/systemIssues.js
+++ b/src/api/systemIssues.js
@@ -18,7 +18,7 @@ export const cves = async (systemId) => {
 
 export const patch = async (systemId) => {
   try {
-    return await instance.get(`/api/patch/v1/systems/${systemId}`);
+    return await instance.get(`/api/patch/v3/systems/${systemId}`);
   } catch (_e) {
     return {};
   }

--- a/src/api/systemIssues.test.js
+++ b/src/api/systemIssues.test.js
@@ -3,13 +3,13 @@ import { advisor, compliance, cves, patch } from './systemIssues';
 
 describe('patch', () => {
   it('should perform get call', async () => {
-    mock.onGet('/api/patch/v1/systems/test-id').replyOnce(200, 'test');
+    mock.onGet('/api/patch/v3/systems/test-id').replyOnce(200, 'test');
     const data = await patch('test-id');
     expect(data).toBe('test');
   });
 
   it('should not fail', async () => {
-    mock.onGet('/api/patch/v1/systems/test-id').reply(500);
+    mock.onGet('/api/patch/v3/systems/test-id').reply(500);
     const data = await patch('test-id');
     expect(data).toMatchObject({});
   });

--- a/src/components/InventoryDetail/DetailWrapper.test.js
+++ b/src/components/InventoryDetail/DetailWrapper.test.js
@@ -10,7 +10,7 @@ import { mock } from '../../__mocks__/systemIssues';
 import InsightsDisconnected from '../../Utilities/InsightsDisconnected';
 
 describe('DetailWrapper', () => {
-  mock.onGet('/api/patch/v1/systems/test-id').reply(200, 'test');
+  mock.onGet('/api/patch/v3/systems/test-id').reply(200, 'test');
   mock.onGet('/api/insights/v1/system/test-id/reports/').reply(200, 'test');
   mock
     .onGet(

--- a/src/components/InventoryDetailDrawer/SystemIssues.test.js
+++ b/src/components/InventoryDetailDrawer/SystemIssues.test.js
@@ -11,7 +11,7 @@ import { mock } from '../../__mocks__/systemIssues';
 describe('SystemIssues', () => {
   let initialState;
   let mockStore;
-  mock.onGet('/api/patch/v1/systems/test-id').reply(200, 'test');
+  mock.onGet('/api/patch/v3/systems/test-id').reply(200, 'test');
   mock.onGet('/api/insights/v1/system/test-id/reports/').reply(200, 'test');
   mock
     .onGet(


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-3395

Patchman v1 and v2 APIs will be turned off on 01/01/2024 so we need to update the version. The new version is backwards compatible (no parameters are removed/changed, only added).