### PR TITLE
fix(TitleTable): RHINENG-3766: group title page in case inventory user log in

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -12,7 +12,7 @@ import RenderWrapper from './Utilities/Wrapper';
 import useFeatureFlag from './Utilities/useFeatureFlag';
 import LostPage from './components/LostPage';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 import { inventoryHasEdgeSystems } from './Utilities/edge';
 import { inventoryHasConventionalSystems } from './Utilities/conventional';
@@ -121,7 +121,7 @@ export const Routes = () => {
         </Bullseye>
       }
     >
-      <AsynComponent
+      <AsyncComponent
         appId={'inventory_zero_state'}
         appName="dashboard"
         module="./AppZeroState"

--- a/src/Routes.test.js
+++ b/src/Routes.test.js
@@ -1,0 +1,52 @@
+/* eslint-disable react/prop-types */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import React, { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { Routes } from './Routes';
+import useFeatureFlag from './Utilities/useFeatureFlag';
+import InventoryGroups from './components/InventoryGroups';
+
+jest.mock('./Utilities/useFeatureFlag');
+jest.mock('./components/InventoryGroups');
+jest.mock('./Utilities/conventional');
+
+const TestWrapper = ({ route }) => (
+  <MemoryRouter initialEntries={[route]}>
+    <Suspense fallback="Loading">
+      <Routes />
+    </Suspense>
+  </MemoryRouter>
+);
+
+describe('/groups', () => {
+  InventoryGroups.mockReturnValue(<div>Inventory groups component</div>);
+
+  useFeatureFlag.mockImplementation(
+    (flag) =>
+      ({
+        'hbi.ui.inventory-groups': true,
+        'edgeParity.inventory-list': false,
+      }[flag])
+  );
+
+  it('renders fallback on lazy load first', async () => {
+    render(<TestWrapper route={'/groups'} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Loading')).toBeVisible();
+    });
+  });
+
+  it('renders the groups page content', async () => {
+    render(<TestWrapper route={'/groups'} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Groups' })).toBeVisible();
+      expect(
+        screen.getByLabelText('Open Inventory groups popover')
+      ).toBeVisible();
+      expect(screen.getByText('Inventory groups component')).toBeVisible(); // mocked
+    });
+  });
+});

--- a/src/routes/InventoryOrEdgeComponent.js
+++ b/src/routes/InventoryOrEdgeComponent.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import EdgeGroupsView from '../components/InventoryGroups/EdgeGroups';
-import InventoryGroups from '../components/InventoryGroups/InventoryGroups';
+import InventoryGroups from '../routes/InventoryGroups';
 import { inventoryHasConventionalSystems } from '../Utilities/conventional';
 import { inventoryHasEdgeSystems } from '../Utilities/edge';
 import useEdgeGroups from '../Utilities/hooks/useEdgeGroups';


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-3766.

this commit fix the title of group page

<img width="1109" alt="Screenshot 2023-11-21 at 22 30 31" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/73419853/0941e0b8-935d-4bb1-ba77-e00f858fa56e">
