### PR TITLE
feat(RHINENG-1850): Filtering ungrouped hosts

### DIFF
--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -160,6 +160,7 @@ const AddSystemsToGroupModal = ({
       initialLoading={true}
       showTags
       showCentosVersions
+      showNoGroupOption
     />
   );
 

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -167,7 +167,7 @@ const EntityTableToolbar = ({
     setUpdateMethodValue,
   ] = useUpdateMethodFilter(reducer);
   const [hostGroupConfig, hostGroupChips, hostGroupValue, setHostGroupValue] =
-    useGroupFilter();
+    useGroupFilter(props.showNoGroupOption);
 
   const isUpdateMethodEnabled = useFeatureFlag('hbi.ui.system-update-method');
   const groupsEnabled = useFeatureFlag('hbi.ui.inventory-groups');
@@ -647,6 +647,7 @@ EntityTableToolbar.propTypes = {
   showTagModal: PropTypes.bool,
   disableDefaultColumns: PropTypes.any,
   showCentosVersions: PropTypes.bool,
+  showNoGroupOption: PropTypes.bool,
 };
 
 EntityTableToolbar.defaultProps = {
@@ -654,6 +655,7 @@ EntityTableToolbar.defaultProps = {
   hasAccess: true,
   activeFiltersConfig: {},
   hideFilters: {},
+  showNoGroupOption: false,
 };
 
 export default EntityTableToolbar;

--- a/src/components/InventoryTable/InventoryTable.cy.js
+++ b/src/components/InventoryTable/InventoryTable.cy.js
@@ -46,11 +46,7 @@ const waitForTable = (waitNetwork = false) => {
   }
 
   // indicating the table is loaded
-  cy.get('table[aria-label="Host inventory"]').should(
-    'have.attr',
-    'data-ouia-safe',
-    'true'
-  );
+  cy.contains(hostsFixtures.results[0].id);
 };
 
 const shorterGroupsFixtures = {
@@ -298,5 +294,40 @@ describe('hiding filters', () => {
     waitForTable();
     cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
     cy.get(DROPDOWN_ITEM).should('not.contain', 'Last seen');
+  });
+});
+
+describe('with no group filter option', () => {
+  before(() => {
+    cy.mockWindowChrome();
+  });
+
+  beforeEach(() => {
+    setTableInterceptors();
+    mountTable({ showNoGroupOption: true });
+    waitForTable(true);
+  });
+
+  it('no group is the first option', () => {
+    cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
+    cy.get(DROPDOWN_ITEM).contains('Group').click();
+    cy.ouiaId('FilterByGroup').click();
+    cy.ouiaId('FilterByGroupOption').first().should('have.text', 'No group');
+  });
+
+  it('creates no group chip', () => {
+    cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
+    cy.get(DROPDOWN_ITEM).contains('Group').click();
+    cy.ouiaId('FilterByGroup').click();
+    cy.ouiaId('FilterByGroupOption').eq(0).click();
+    hasChip('Group', 'No group');
+  });
+
+  it('triggers new request with empty parameter', () => {
+    cy.get('button[data-ouia-component-id="ConditionalFilter"]').click();
+    cy.get(DROPDOWN_ITEM).contains('Group').click();
+    cy.ouiaId('FilterByGroup').click();
+    cy.ouiaId('FilterByGroupOption').eq(0).click();
+    cy.wait('@getHosts').its('request.url').should('include', `group_name=`);
   });
 });

--- a/src/components/InventoryTable/InventoryTable.cy.js
+++ b/src/components/InventoryTable/InventoryTable.cy.js
@@ -299,7 +299,7 @@ describe('hiding filters', () => {
 
 describe('with no group filter option', () => {
   before(() => {
-    cy.mockWindowChrome();
+    cy.mockWindowInsights();
   });
 
   beforeEach(() => {

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -343,6 +343,7 @@ InventoryTable.propTypes = {
   hasCheckbox: PropTypes.bool,
   abortOnUnmount: PropTypes.bool,
   showCentosVersions: PropTypes.bool,
+  showNoGroupOption: PropTypes.bool, // group filter option
 };
 
 export default InventoryTable;

--- a/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/EntityTableToolbar.test.js.snap
@@ -143,6 +143,7 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
       size="lg"
     />
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -384,6 +385,7 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
       "perPage": undefined,
     }
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -667,6 +669,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
       "perPage": undefined,
     }
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -915,6 +918,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
       "perPage": undefined,
     }
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -1199,6 +1203,7 @@ exports[`EntityTableToolbar DOM should render correctly - with customFilters 1`]
       "perPage": undefined,
     }
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -1453,6 +1458,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
       "perPage": undefined,
     }
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -1694,6 +1700,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
       "perPage": undefined,
     }
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -1716,6 +1723,7 @@ exports[`EntityTableToolbar DOM should render correctly - with items 1`] = `
       "perPage": undefined,
     }
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -1951,6 +1959,7 @@ exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
       "perPage": undefined,
     }
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -2230,6 +2239,7 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
       "perPage": undefined,
     }
   }
+  showNoGroupOption={false}
 />
 `;
 
@@ -2479,5 +2489,6 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
       "perPage": 50,
     }
   }
+  showNoGroupOption={false}
 />
 `;

--- a/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/InventoryTable.test.js.snap
@@ -15,6 +15,7 @@ exports[`InventoryTable should render correctly - no data 1`] = `
     page={1}
     perPage={50}
     showCentosVersions={false}
+    showNoGroupOption={false}
     showTags={false}
   />
   <ForwardRef
@@ -57,6 +58,7 @@ exports[`InventoryTable should render correctly - with no access 1`] = `
     page={1}
     perPage={50}
     showCentosVersions={false}
+    showNoGroupOption={false}
     showTags={false}
     sortBy={
       Object {
@@ -137,6 +139,7 @@ exports[`InventoryTable should render correctly 1`] = `
     page={1}
     perPage={50}
     showCentosVersions={false}
+    showNoGroupOption={false}
     showTags={false}
     sortBy={
       Object {
@@ -255,6 +258,7 @@ exports[`InventoryTable should render correctly with items 1`] = `
     page={5}
     perPage={20}
     showCentosVersions={false}
+    showNoGroupOption={false}
     showTags={false}
     sortBy={
       Object {
@@ -366,6 +370,7 @@ exports[`InventoryTable should render correctly with items no totla 1`] = `
     page={5}
     perPage={20}
     showCentosVersions={false}
+    showNoGroupOption={false}
     showTags={false}
     sortBy={
       Object {

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -295,7 +295,8 @@ const ConventionalSystemsTab = ({
           ],
         }}
         bulkSelect={bulkSelectConfig}
-        showCentosVersions={true}
+        showCentosVersions
+        showNoGroupOption
       />
 
       <DeleteModal

--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
+  Divider,
   MenuToggle,
   TextInputGroup,
   TextInputGroupMain,
@@ -12,13 +13,23 @@ const SearchableGroupFilter = ({
   initialGroups,
   selectedGroupNames,
   setSelectedGroupNames,
+  showNoGroupOption = false,
 }) => {
   const initialValues = useMemo(
-    () =>
-      initialGroups.map(({ name }) => ({
+    () => [
+      ...(showNoGroupOption
+        ? [
+            {
+              itemId: '',
+              children: 'No group',
+            },
+          ]
+        : []),
+      ...initialGroups.map(({ name }) => ({
         itemId: name, // group name is unique by design
         children: name,
       })),
+    ],
     [initialGroups]
   );
 
@@ -120,9 +131,7 @@ const SearchableGroupFilter = ({
   };
 
   const onSelect = (itemId) => {
-    if (itemId) {
-      setSelectedGroupNames(xor(selectedGroupNames, [itemId]));
-    }
+    setSelectedGroupNames(xor(selectedGroupNames, [itemId]));
   };
 
   const toggle = (toggleRef) => (
@@ -154,7 +163,7 @@ const SearchableGroupFilter = ({
         ouiaId="Filter by group"
         isOpen={isOpen}
         selected={selectedGroupNames}
-        onSelect={(ev, selection) => onSelect(selection)}
+        onSelect={(event, selection) => onSelect(selection)}
         onOpenChange={() => {
           setIsOpen(false);
           setInputValue('');
@@ -163,18 +172,21 @@ const SearchableGroupFilter = ({
       >
         <SelectList isAriaMultiselectable>
           {selectOptions.length === 0 ? (
-            <SelectOption>No groups available</SelectOption>
+            <SelectOption key="none">No groups available</SelectOption>
           ) : (
             selectOptions.map((option, index) => (
-              <SelectOption
-                {...(!option.isDisabled && { hasCheck: true })}
-                isSelected={selectedGroupNames.includes(option.itemId)}
-                key={option.itemId || option.children}
-                isFocused={focusedItemIndex === index}
-                className={option.className}
-                data-ouia-component-id="FilterByGroupOption"
-                {...option}
-              />
+              <div key={option.itemId || option.children}>
+                <SelectOption
+                  {...(!option.isDisabled && { hasCheck: true })}
+                  isSelected={selectedGroupNames.includes(option.itemId)}
+                  key={option.itemId || option.children}
+                  isFocused={focusedItemIndex === index}
+                  className={option.className}
+                  data-ouia-component-id="FilterByGroupOption"
+                  {...option}
+                />
+                {option.itemId === '' && <Divider />}
+              </div>
             ))
           )}
         </SelectList>
@@ -192,6 +204,7 @@ SearchableGroupFilter.propTypes = {
   ),
   selectedGroupNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   setSelectedGroupNames: PropTypes.func.isRequired,
+  showNoGroupOption: PropTypes.bool,
 };
 
 export default SearchableGroupFilter;

--- a/src/components/filters/SearchableGroupFilter.test.js
+++ b/src/components/filters/SearchableGroupFilter.test.js
@@ -78,3 +78,86 @@ it('selected groups are checked', async () => {
   );
   expect(screen.getAllByRole('checkbox')[0]).toBeChecked();
 });
+
+it('shows no group option', async () => {
+  render(
+    <SearchableGroupFilter
+      initialGroups={[{ name: 'group-1' }, { name: 'group-2' }]}
+      selectedGroupNames={[]}
+      setSelectedGroupNames={setter}
+      showNoGroupOption={true}
+    />
+  );
+
+  await userEvent.click(
+    screen.getByRole('button', {
+      name: /menu toggle/i,
+    })
+  );
+  expect(
+    screen.getByRole('menuitem', {
+      name: /no group/i,
+    })
+  ).toBeVisible();
+});
+
+it('can select no group option', async () => {
+  render(
+    <SearchableGroupFilter
+      initialGroups={[{ name: 'group-1' }, { name: 'group-2' }]}
+      selectedGroupNames={[]}
+      setSelectedGroupNames={setter}
+      showNoGroupOption={true}
+    />
+  );
+
+  await userEvent.click(
+    screen.getByRole('button', {
+      name: /menu toggle/i,
+    })
+  );
+  await userEvent.click(screen.getByText('No group'));
+  expect(setter).toBeCalledWith(['']);
+});
+
+it('can select no group option with pre-selected item', async () => {
+  render(
+    <SearchableGroupFilter
+      initialGroups={[{ name: 'group-1' }, { name: 'group-2' }]}
+      selectedGroupNames={['group-1']}
+      setSelectedGroupNames={setter}
+      showNoGroupOption={true}
+    />
+  );
+
+  await userEvent.click(
+    screen.getByRole('button', {
+      name: /menu toggle/i,
+    })
+  );
+  await userEvent.click(screen.getByText('No group'));
+  expect(setter).toBeCalledWith(['group-1', '']);
+});
+
+it('shows no group as the only option', async () => {
+  render(
+    <SearchableGroupFilter
+      initialGroups={[]}
+      selectedGroupNames={[]}
+      setSelectedGroupNames={setter}
+      showNoGroupOption={true}
+    />
+  );
+
+  await userEvent.click(
+    screen.getByRole('button', {
+      name: /menu toggle/i,
+    })
+  );
+  expect(
+    screen.getByRole('menuitem', {
+      name: /no group/i,
+    })
+  ).toBeVisible();
+  expect(screen.getAllByRole('menuitem').length).toBe(1);
+});

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
-import React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import useFetchBatched from '../../Utilities/hooks/useFetchBatched';
 import { HOST_GROUP_CHIP } from '../../Utilities/index';
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
@@ -16,10 +15,17 @@ export const groupFilterReducer = (_state, { type, payload }) => ({
 });
 
 export const buildHostGroupChips = (selectedGroups = []) => {
-  const chips = [...selectedGroups]?.map((group) => ({
-    name: group,
-    value: group,
-  }));
+  const chips = [...selectedGroups]?.map((group) =>
+    group === ''
+      ? {
+          name: 'No group',
+          value: '',
+        }
+      : {
+          name: group,
+          value: group,
+        }
+  );
   return chips?.length > 0
     ? [
         {
@@ -31,7 +37,7 @@ export const buildHostGroupChips = (selectedGroups = []) => {
     : [];
 };
 
-const useGroupFilter = () => {
+const useGroupFilter = (showNoGroupOption = false) => {
   const groupsEnabled = useFeatureFlag('hbi.ui.inventory-groups');
   const { fetchBatched } = useFetchBatched();
   const [fetchedGroups, setFetchedGroups] = useState([]);
@@ -76,6 +82,7 @@ const useGroupFilter = () => {
             initialGroups={fetchedGroups}
             selectedGroupNames={selectedGroupNames}
             setSelectedGroupNames={setSelectedGroupNames}
+            showNoGroupOption={showNoGroupOption}
           />
         ),
       },

--- a/src/components/filters/useGroupFilter.test.js
+++ b/src/components/filters/useGroupFilter.test.js
@@ -37,12 +37,13 @@ describe('some groups available', () => {
       expect(chips.length).toBe(0);
       expect(value.length).toBe(0);
       expect(config.filterValues.children).toMatchInlineSnapshot(`
-          <SearchableGroupFilter
-            initialGroups={Array []}
-            selectedGroupNames={Array []}
-            setSelectedGroupNames={[Function]}
-          />
-        `);
+        <SearchableGroupFilter
+          initialGroups={Array []}
+          selectedGroupNames={Array []}
+          setSelectedGroupNames={[Function]}
+          showNoGroupOption={false}
+        />
+      `);
     });
   });
 
@@ -63,6 +64,7 @@ describe('some groups available', () => {
           }
           selectedGroupNames={Array []}
           setSelectedGroupNames={[Function]}
+          showNoGroupOption={false}
         />
       `);
     });
@@ -89,6 +91,52 @@ describe('some groups available', () => {
               Object {
                 "name": "group-1",
                 "value": "group-1",
+              },
+            ],
+            "type": "group_name",
+          },
+        ]
+      `);
+    });
+  });
+
+  it('can enable no group option', async () => {
+    const { result } = renderHook(() => useGroupFilter(true));
+
+    await waitFor(() => {
+      const [config] = result.current;
+      expect(config.filterValues.children).toMatchInlineSnapshot(`
+        <SearchableGroupFilter
+          initialGroups={Array []}
+          selectedGroupNames={Array []}
+          setSelectedGroupNames={[Function]}
+          showNoGroupOption={true}
+        />
+      `);
+    });
+  });
+
+  it('can select no group option', async () => {
+    const { result } = renderHook(useGroupFilter);
+    const [, , , setValue] = result.current;
+
+    act(() => {
+      setValue(['']);
+    });
+
+    const [, chips, value] = result.current;
+
+    await waitFor(() => {
+      expect(chips.length).toBe(1);
+      expect(value).toEqual(['']);
+      expect(chips).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "category": "Group",
+            "chips": Array [
+              Object {
+                "name": "No group",
+                "value": "",
               },
             ],
             "type": "group_name",


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-1850.

This updates the `useGroupFilter` hook to support the no group option. The /inventory and /groups/%id (in the Add systems modal) tables are updated and now allow users to filter out hosts that are not a part of any group.

⚠️ The option is disabled by default: this means it will not appear in other applications by default because non-HBI services do not yet support this feature.

## How to test

1. Go to /inventory or /groups/%id (in the Add systems modal) and check that you can filter out ungrouped hosts
2. Try to reload the page (/inventory only) and make sure that the filter is still there.

## Screenshots

<img width="1214" alt="image" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/604b0b5f-266a-46d9-aa2e-96f5796e31d4">
