### PR TITLE
fix(ESSNTL-5418): Trim group name before validate

### DIFF
--- a/src/components/InventoryGroups/Modals/CreateGroupModal.js
+++ b/src/components/InventoryGroups/Modals/CreateGroupModal.js
@@ -7,6 +7,15 @@ import { createGroup, validateGroupName } from '../utils/api';
 import { useDispatch } from 'react-redux';
 import awesomeDebouncePromise from 'awesome-debounce-promise';
 
+export const validate = async (value) => {
+  const results = await validateGroupName(value.trim());
+  if (results === true) {
+    throw 'Group name already exists';
+  }
+
+  return undefined;
+};
+
 const CreateGroupModal = ({
   isModalOpen,
   setIsModalOpen,
@@ -31,17 +40,9 @@ const CreateGroupModal = ({
   );
 
   const schema = useMemo(() => {
-    const check = async (value) => {
-      const results = await validateGroupName(value);
-      if (results === true) {
-        throw 'Group name already exists';
-      }
-
-      return undefined;
-    };
-
-    // eslint-disable-next-line new-cap
-    const d = awesomeDebouncePromise(check, 500, { onlyResolvesLast: false });
+    const d = awesomeDebouncePromise(validate, 500, {
+      onlyResolvesLast: false,
+    });
     return createGroupSchema(d);
   }, []);
 

--- a/src/components/InventoryGroups/Modals/CreateGroupModal.test.js
+++ b/src/components/InventoryGroups/Modals/CreateGroupModal.test.js
@@ -1,0 +1,25 @@
+import { validateGroupName } from '../utils/api';
+import { validate } from './CreateGroupModal';
+
+jest.mock('../utils/api');
+
+describe('validate function', () => {
+  it('works with basic input', async () => {
+    const result = await validate('test');
+
+    expect(result).toBe(undefined);
+    expect(validateGroupName).toHaveBeenCalledWith('test');
+  });
+
+  it('trims input', async () => {
+    const result = await validate(' test ');
+
+    expect(result).toBe(undefined);
+    expect(validateGroupName).toHaveBeenCalledWith('test');
+  });
+
+  it('throws error if the name is present', async () => {
+    validateGroupName.mockResolvedValue(true);
+    await expect(validate('test')).rejects.toBe('Group name already exists');
+  });
+});


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-5418.

## How to test

1. Go to /groups and click create a new group
2. Try to add a name of existing group and also add some whitespaces before/after the name
3. The modal should not allow you to create a group