### PR TITLE
fix(RHINENG-1423): Enable sorting by last modified

### DIFF
--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -32,7 +32,7 @@ import GroupsTable from './GroupsTable';
 
 const DEFAULT_ROW_COUNT = 50;
 const TABLE_HEADERS = ['Name', 'Total systems', 'Last modified'];
-const SORTABLE_HEADERS = ['Name', 'Total systems'];
+const SORTABLE_HEADERS = ['Name', 'Total systems', 'Last modified'];
 const ROOT = 'div[id="groups-table"]';
 
 const mountTable = (initialEntry = '/') =>
@@ -192,10 +192,16 @@ describe('url search parameters', () => {
       .should('have.value', '123');
   });
 
-  it('applies sorting', () => {
+  it('applies sorting, hosts count', () => {
     mountTable('/?order_by=host_count&order_how=desc');
 
     checkSorting('Total systems', 'descending', 'host_count');
+  });
+
+  it('applies sorting, last modified', () => {
+    mountTable('/?order_by=host_count&order_how=desc');
+
+    checkSorting('Last modified', 'descending', 'updated');
   });
 });
 
@@ -207,7 +213,7 @@ describe('sorting', () => {
     cy.wait('@getGroups'); // first initial request
   });
 
-  _.zip(['name', 'host_count'], SORTABLE_HEADERS).forEach(
+  _.zip(['name', 'host_count', 'updated'], SORTABLE_HEADERS).forEach(
     ([category, label]) => {
       SORTING_ORDERS.forEach((order) => {
         it(`${order} by ${label}`, () => {

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -66,7 +66,7 @@ const GROUPS_TABLE_COLUMNS = [
   },
   {
     title: 'Last modified',
-    transforms: [cellWidth(20)],
+    transforms: [sortable, cellWidth(20)],
   },
 ];
 
@@ -74,7 +74,7 @@ const GROUPS_TABLE_COLUMNS_TO_URL = {
   0: '', // reserved for selection boxes
   1: 'name',
   2: 'host_count',
-  3: 'updated_at',
+  3: 'updated',
 };
 
 const REQUEST_DEBOUNCE_TIMEOUT = 500;


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-1423.

Adds sorting by last modified on the groups page.

## How to test

1. Go to /inventory/groups
2. Try to sort some groups by the "Last modified" column, verify that the results are correct
3. Make sure the sorting persists after page refresh