### PR TITLE
fix(EntityTable): properly remove actions resolver when there is not …

### DIFF
--- a/src/components/InventoryTable/EntityTable.js
+++ b/src/components/InventoryTable/EntityTable.js
@@ -93,10 +93,15 @@ const EntityTable = ({
     direction: sortBy?.direction,
   };
 
-  delete tableProps.RowWrapper;
-  if (rows?.length === 0) {
-    delete tableProps.actionResolver;
-  }
+  const modifiedTableProps = useMemo(() => {
+    const { RowWrapper, ...withoutRowWrapper } = tableProps;
+    if (rows?.length === 0) {
+      const { actionResolver, ...filteredTableProps } = withoutRowWrapper;
+
+      return filteredTableProps;
+    }
+    return withoutRowWrapper;
+  }, [rows, tableProps]);
 
   return (
     <React.Fragment>
@@ -141,7 +146,7 @@ const EntityTable = ({
               ...(actions && rows?.length > 0 && { actions }),
             }}
             isStickyHeader
-            {...tableProps}
+            {...modifiedTableProps}
           >
             <TableHeader />
             <TableBody />
@@ -158,7 +163,7 @@ const EntityTable = ({
                 }
           )}
           rowSize={15}
-          variant={variant ?? tableProps.variant}
+          variant={variant ?? modifiedTableProps.variant}
           isSelectable={hasCheckbox}
           sortBy={tableSortBy}
         />


### PR DESCRIPTION
Properly removes actionsResolver when there is table is empty and 'No systems' empty state is shown. This fixes issues that happened with the advisor application when recommendation is disabled and then re-enabled the actionResolver was deleted unwantedly. Now, with the useMemo, it gets removed only when it is needed.

To test:
1. Run the app with advisor
2. Go to advisor recommendation detail page that has immutable systems
3. Disable recommendation using the actions dropdown in the header
4. Reenable the recommendation by using the 'Enable recommendation'. You can see it in the screenshot. This banner might not show up due to race condition in the API.
5. Observer that the table action in immutable systems table is always persent
6. Search for non existing systems so that you have empty state
7. observe that there is no action kebab in the table 

