### PR TITLE
fix(RHINENG-3653): Replace Group Column text field

### DIFF
--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -56,7 +56,12 @@ export const defaultColumns = () => [
     title: 'Group',
     props: { width: 10 },
     // eslint-disable-next-line camelcase
-    renderFunc: (groups) => (isEmpty(groups) ? 'N/A' : groups[0].name), // currently, one group at maximum is supported
+    renderFunc: (groups) =>
+      isEmpty(groups) ? (
+        <div className="pf-v5-u-disabled-color-100">No group </div>
+      ) : (
+        groups[0].name
+      ), // currently, one group at maximum is supported
     transforms: [fitContent],
   },
   {


### PR DESCRIPTION
This changes the text for when a system has no group from 'N/A' to 'No group' in grey wording. 

https://issues.redhat.com/browse/RHINENG-3653 