### PR TITLE
fix(RHINENG-715): Reroute to groups page if group is deleted

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -9,7 +9,7 @@ const { config: webpackConfig, plugins } = config({
     https: true,
     useProxy: true,
     proxyVerbose: true,
-    env: `${process.env.ENVIRONMENT || 'stage'}-${
+    env: `${process.env.ENVIRONMENT || 'prod'}-${
       process.env.BETA ? 'beta' : 'stable'
     }`, // for accessing prod-beta start your app with ENVIRONMENT=prod and BETA=true
     appUrl: process.env.BETA

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -66,6 +66,7 @@ const GroupDetailHeader = ({ groupId }) => {
             await getInventoryGroupDevicesUpdateInfo(groupId);
           setEdgeDeviceUpdateInfo(groupEdgeDevicesUpdateInfo);
         } catch (error) {
+          navigate('/groups');
           console.error(error);
         }
       })();

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -66,7 +66,6 @@ const GroupDetailHeader = ({ groupId }) => {
             await getInventoryGroupDevicesUpdateInfo(groupId);
           setEdgeDeviceUpdateInfo(groupEdgeDevicesUpdateInfo);
         } catch (error) {
-          navigate('/groups');
           console.error(error);
         }
       })();

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -30,6 +30,7 @@ import {
   INVENTORY_TOTAL_FETCH_URL_SERVER,
   hybridInventoryTabKeys,
 } from '../../Utilities/constants';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 
 const SuspenseWrapper = ({ children }) => (
   <Suspense
@@ -52,7 +53,9 @@ const InventoryGroupDetail = ({ groupId }) => {
   );
 
   const dispatch = useDispatch();
-  const { data } = useSelector((state) => state.groupDetail);
+  const { data, fulfilled } = useSelector((state) => state.groupDetail);
+  const navigate = useInsightsNavigate();
+
   const chrome = useChrome();
   const groupName = data?.results?.[0]?.name;
 
@@ -70,6 +73,8 @@ const InventoryGroupDetail = ({ groupId }) => {
   }, [canViewGroup]);
 
   useEffect(() => {
+    fulfilled && data?.total === 0 && navigate('/groups');
+
     // if available, change ID to the group's name in the window title
     chrome?.updateDocumentTitle?.(
       `${groupName || groupId} - Inventory Groups | Red Hat Insights`


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-715 
Currently theres a bug where if you 
1. create group
2. open this group in 2 tabs
3. delete group in first tab
4. go to second tab and refresh page
The page would still load with the id. This PR reroutes to /groups if the api request fails. most/all of the functionality will not properly work if the request  doesnt work as is so this also avoids that issue. 