### PR TITLE
feat(RHINENG-4614): Enable global filter on group details page

### DIFF
--- a/config/overrideChrome.js
+++ b/config/overrideChrome.js
@@ -3,7 +3,7 @@ const chromeMock = {
   isBeta: () => false,
   appAction: () => {},
   appObjectId: () => {},
-  on: () => {},
+  on: () => () => {},
   getApp: () => 'inventory',
   getBundle: () => 'insights',
   getUserPermissions: () => [{ permission: 'inventory:*:*' }],
@@ -25,6 +25,7 @@ const chromeMock = {
         },
       }),
   },
+  hideGlobalFilter: () => {},
 };
 
 export default () => chromeMock;

--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -43,6 +43,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
     getUserPermissions: () => Promise.resolve(['inventory:*:*']),
     getApp: jest.fn(),
     getBundle: jest.fn(),
+    hideGlobalFilter: jest.fn(),
   }),
 }));
 

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -20,6 +20,8 @@ import { clearEntitiesAction } from '../../store/actions';
 import { useBulkSelectConfig } from '../../Utilities/hooks/useBulkSelectConfig';
 import difference from 'lodash/difference';
 import map from 'lodash/map';
+import useGlobalFilter from '../filters/useGlobalFilter';
+
 export const prepareColumns = (
   initialColumns,
   hideGroupColumn,
@@ -74,6 +76,7 @@ export const prepareColumns = (
 
 const GroupSystems = ({ groupName, groupId }) => {
   const dispatch = useDispatch();
+  const globalFilter = useGlobalFilter();
   const [removeHostsFromGroupModalOpen, setRemoveHostsFromGroupModalOpen] =
     useState(false);
   const [currentSystem, setCurrentSystem] = useState([]);
@@ -104,7 +107,7 @@ const GroupSystems = ({ groupName, groupId }) => {
 
   const bulkSelectConfig = useBulkSelectConfig(
     selected,
-    null,
+    globalFilter,
     total,
     rows,
     true,
@@ -220,6 +223,8 @@ const GroupSystems = ({ groupName, groupId }) => {
           showTags
           ref={inventory}
           showCentosVersions
+          customFilters={{ globalFilter }}
+          autoRefresh
         />
       )}
     </div>

--- a/src/components/InventoryGroupDetail/index.js
+++ b/src/components/InventoryGroupDetail/index.js
@@ -1,15 +1,9 @@
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import InventoryGroupDetail from './InventoryGroupDetail';
 
 const InventoryGroupDetailWrapper = () => {
   const { groupId } = useParams();
-  const chrome = useChrome();
-
-  useEffect(() => {
-    chrome?.hideGlobalFilter?.();
-  }, []);
 
   return <InventoryGroupDetail groupId={groupId} />;
 };

--- a/src/components/filters/useGlobalFilter.js
+++ b/src/components/filters/useGlobalFilter.js
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+
+const useGlobalFilter = () => {
+  const chrome = useChrome();
+  const edgeParityFilterDeviceEnabled = useFeatureFlag(
+    'edgeParity.inventory-list-filter'
+  );
+  const [globalFilter, setGlobalFilter] = useState();
+
+  useEffect(() => {
+    chrome.hideGlobalFilter(false);
+    const unlisten = chrome.on('GLOBAL_FILTER_UPDATE', ({ data }) => {
+      const [workloads, SID, tags] = chrome.mapGlobalFilter(data, false, true);
+
+      setGlobalFilter({
+        tags,
+        filter: {
+          ...globalFilter?.filter,
+          system_profile: {
+            ...globalFilter?.filter?.system_profile,
+            ...(workloads?.SAP?.isSelected && { sap_system: true }),
+            ...(workloads &&
+              workloads['Ansible Automation Platform']?.isSelected && {
+                ansible: 'not_nil',
+              }),
+            ...(workloads?.['Microsoft SQL']?.isSelected && {
+              mssql: 'not_nil',
+            }),
+            ...(edgeParityFilterDeviceEnabled && { host_type: 'nil' }),
+            ...(SID?.length > 0 && { sap_sids: SID }),
+          },
+        },
+      });
+    });
+
+    return () => unlisten();
+  }, [edgeParityFilterDeviceEnabled]);
+
+  return globalFilter;
+};
+
+export default useGlobalFilter;


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-4614.

This extracts global filter handling to a separate hook and integrates it with the group details (/groups/%id) and also inventory (/inventory) pages.

## How to test

1. Go to any group and try to filter out systems by workloads, tags and other global parameter. The results should be consistent (apply tags with the global filter => the table should contain only hosts with this tag).
2. Also, since the /inventory view is also refactored, make sure the global filter works there as expected.

## Screenshots

<img width="1512" alt="image" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/669f48c5-02d4-483c-bb09-acfc48f42b93">
