### PR TITLE
feat(RHINENG-4606): Synchronise URL with applied table filters - group systems table

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,11 +3,9 @@ import React, {
   createContext,
   lazy,
   useEffect,
-  useMemo,
   useState,
 } from 'react';
 import { Navigate, useRoutes } from 'react-router-dom';
-import { getSearchParams } from './constants';
 import RenderWrapper from './Utilities/Wrapper';
 import useFeatureFlag from './Utilities/useFeatureFlag';
 import { Bullseye, Spinner } from '@patternfly/react-core';
@@ -47,7 +45,6 @@ export const AccountStatContext = createContext({
 });
 
 export const Routes = () => {
-  const searchParams = useMemo(() => getSearchParams(), []);
   const [hasConventionalSystems, setHasConventionalSystems] = useState(true);
   const [hasEdgeDevices, setHasEdgeDevices] = useState(true);
   const edgeParityInventoryListEnabled = useFeatureFlag(
@@ -74,7 +71,7 @@ export const Routes = () => {
   let element = useRoutes([
     {
       path: '/',
-      element: <RenderWrapper cmp={InventoryTable} {...searchParams} />,
+      element: <RenderWrapper cmp={InventoryTable} />,
     },
     { path: '/:inventoryId', element: <InventoryDetail /> },
     { path: '/:inventoryId/:modalId', element: <InventoryDetail /> },
@@ -93,12 +90,7 @@ export const Routes = () => {
     {
       path: '/manage-edge-inventory',
       element: (
-        <RenderWrapper
-          cmp={InventoryTable}
-          isRbacEnabled
-          {...searchParams}
-          isImmutableTabOpen
-        />
+        <RenderWrapper cmp={InventoryTable} isRbacEnabled isImmutableTabOpen />
       ),
     },
     {

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -187,12 +187,10 @@ const InventoryTable = forwardRef(
     ) => {
       const { activeFilters } = store.getState().entities;
       const cachedProps = cache.current?.getProps() || {};
-      const currPerPage =
-        options?.per_page || options?.perPage || cachedProps.perPage;
 
       const newParams = {
-        page,
-        per_page: currPerPage,
+        page: options?.page || cachedProps.page,
+        per_page: options?.per_page || options?.perPage || cachedProps.perPage,
         items: cachedProps.items,
         sortBy: cachedProps.sortBy,
         hideFilters: cachedProps.hideFilters,
@@ -235,7 +233,7 @@ const InventoryTable = forwardRef(
     const prevFilters = useRef(customFilters);
     useEffect(() => {
       if (autoRefresh && !isEqual(prevFilters.current, customFilters)) {
-        onRefreshData({ page: 1 });
+        onRefreshData();
         prevFilters.current = customFilters;
       }
     });

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -23,10 +23,9 @@ import {
   ActionDropdownItem,
 } from '../../InventoryTable/ActionWithRBAC';
 import uniq from 'lodash/uniq';
-import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
 import useTableActions from './useTableActions';
-import { calculateFilters, calculatePagination } from './Utilities';
 import useGlobalFilter from '../../filters/useGlobalFilter';
+import useOnRefresh from '../../filters/useOnRefresh';
 
 const BulkDeleteButton = ({ selectedSystems, ...props }) => {
   const requiredPermissions = selectedSystems.map(({ groups }) =>
@@ -65,7 +64,6 @@ const ConventionalSystemsTab = ({
   hasAccess,
   hostGroupFilter,
 }) => {
-  const navigate = useInsightsNavigate();
   const chrome = useChrome();
   const inventory = useRef(null);
   const [isModalOpen, handleModalToggle] = useState(false);
@@ -101,22 +99,9 @@ const ConventionalSystemsTab = ({
     loaded
   );
 
-  const onRefresh = (options, callback) => {
+  const onRefresh = useOnRefresh((options) => {
     onSetfilters(options?.filters);
-    const searchParams = new URLSearchParams();
-    calculateFilters(searchParams, options?.filters);
-    // eslint-disable-next-line camelcase
-    calculatePagination(searchParams, options?.page, options?.per_page);
-    const search = searchParams.toString();
-    navigate({
-      search,
-      hash: location.hash,
-    });
-
-    if (callback) {
-      callback(options);
-    }
-  };
+  });
 
   useEffect(() => {
     chrome.updateDocumentTitle('Systems | Red Hat Insights');

--- a/src/components/filters/useOnRefresh.js
+++ b/src/components/filters/useOnRefresh.js
@@ -1,0 +1,32 @@
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+import {
+  calculateFilters,
+  calculatePagination,
+} from '../InventoryTabs/ConventionalSystems/Utilities';
+import { useLocation } from 'react-router-dom';
+
+const useOnRefresh = (extraCallback) => {
+  const navigate = useInsightsNavigate();
+  const location = useLocation();
+
+  return (options, defaultCallback) => {
+    const searchParams = new URLSearchParams();
+    calculateFilters(searchParams, options?.filters);
+    calculatePagination(searchParams, options?.page, options?.per_page);
+    const search = searchParams.toString();
+    navigate({
+      search,
+      hash: location.hash,
+    });
+
+    if (defaultCallback) {
+      defaultCallback(options);
+    }
+
+    if (extraCallback) {
+      extraCallback(options);
+    }
+  };
+};
+
+export default useOnRefresh;

--- a/src/components/filters/useOnRefresh.test.js
+++ b/src/components/filters/useOnRefresh.test.js
@@ -1,0 +1,64 @@
+import useOnRefresh from './useOnRefresh';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+describe('useOnRefresh', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('triggers navigate on filter', () => {
+    const { result } = renderHook(useOnRefresh, {
+      wrapper: MemoryRouter,
+    });
+
+    act(() =>
+      result.current({ filters: [{ value: 'hostname_or_id', filter: 'test' }] })
+    );
+    expect(mockNavigate).toHaveBeenCalledWith({
+      hash: '',
+      pathname: '',
+      search: 'hostname_or_id=test',
+    });
+  });
+
+  it('triggers navigate on pagination change', () => {
+    const { result } = renderHook(useOnRefresh, {
+      wrapper: MemoryRouter,
+    });
+
+    act(() => result.current({ page: 10, per_page: 100 }));
+    expect(mockNavigate).toHaveBeenCalledWith({
+      hash: '',
+      pathname: '',
+      search: 'page=10&per_page=100',
+    });
+  });
+
+  it('calls custom callback', () => {
+    const mockCallback = jest.fn();
+    const { result } = renderHook(() => useOnRefresh(mockCallback), {
+      wrapper: MemoryRouter,
+    });
+
+    act(() => result.current());
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls default callback', () => {
+    const mockCallback = jest.fn();
+    const { result } = renderHook(useOnRefresh, {
+      wrapper: MemoryRouter,
+    });
+
+    act(() => result.current({}, mockCallback));
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -132,8 +132,7 @@ export const extraShape = PropTypes.shape({
   onClick: PropTypes.func,
 });
 
-export const getSearchParams = () => {
-  const searchParams = new URLSearchParams(location.search);
+export const getSearchParams = (searchParams) => {
   const status = searchParams.getAll('status');
   const source = searchParams.getAll('source');
   const filterbyName = searchParams.getAll('hostname_or_id');

--- a/src/constants.js
+++ b/src/constants.js
@@ -155,8 +155,8 @@ export const getSearchParams = (searchParams) => {
   const rhcdFilter = searchParams.getAll(RHCD_FILTER_KEY);
   const updateMethodFilter = searchParams.getAll(UPDATE_METHOD_KEY);
   const hostGroupFilter = searchParams.getAll(HOST_GROUP_CHIP);
-  const page = searchParams.getAll('page');
-  const perPage = searchParams.getAll('per_page');
+  const page = searchParams.get('page');
+  const perPage = searchParams.get('per_page');
   const lastSeenFilter = searchParams.getAll('last_seen');
   return {
     status,

--- a/src/routes/InventoryTable.js
+++ b/src/routes/InventoryTable.js
@@ -8,7 +8,7 @@ import {
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import HybridInventoryTabs from '../components/InventoryTabs/HybridInventoryTabs';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { getSearchParams } from '../constants';
 import useFeatureFlag from '../Utilities/useFeatureFlag';
 import { AccountStatContext } from '../Routes';
@@ -34,9 +34,12 @@ const SuspenseWrapper = ({ children }) => (
   </Suspense>
 );
 const Inventory = (props) => {
-  const { search } = useLocation();
-  const searchParams = useMemo(() => getSearchParams(), [search.toString()]);
-  const fullProps = { ...props, ...searchParams };
+  const [searchParams] = useSearchParams();
+  const parsedSearchParams = useMemo(
+    () => getSearchParams(searchParams),
+    [searchParams.toString()]
+  );
+  const fullProps = { ...props, ...parsedSearchParams };
   const isEdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
   const { hasEdgeDevices, hasConventionalSystems } =
     useContext(AccountStatContext);
@@ -49,12 +52,12 @@ const Inventory = (props) => {
         <HybridInventoryTabs
           ConventionalSystemsTab={
             <SuspenseWrapper>
-              <ConventionalSystemsTab {...fullProps} />
+              <ConventionalSystemsTab {...fullProps} {...parsedSearchParams} />
             </SuspenseWrapper>
           }
           ImmutableDevicesTab={
             <SuspenseWrapper>
-              <ImmutableDevicesTab {...fullProps} />
+              <ImmutableDevicesTab {...fullProps} {...parsedSearchParams} />
             </SuspenseWrapper>
           }
           isImmutableTabOpen={props.isImmutableTabOpen}

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -109,10 +109,11 @@ function onSetFilter(state, { payload }) {
 function onSetPagination(state, { payload }) {
   const perPage = parseInt(payload.perPage, 10);
   const page = parseInt(payload.page, 10);
+
   return {
     ...state,
-    perPage: isNaN(perPage) ? 50 : perPage,
-    page: isNaN(page) ? 1 : page,
+    perPage: isNaN(perPage) ? state.perPage : perPage,
+    page: isNaN(page) ? state.page : page,
   };
 }
 


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-4606.

This enables URL updates on the group details page when filtering or pagination changes. Also, the filters are built on page refresh if there are any parameters present in URL.

## How to test

1. Go to any group details page
2. Apply any filter, pagination and make sure it is reflected in URL
3. Refresh the page and verify that the same filters are applied.