### PR TITLE
fix(THEEDGE-3756): when removing the latest immutable systems from group

### DIFF
--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -133,7 +133,10 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
     setDeviceData(updateInfo?.update_devices_uuids);
     setDeviceImageSet(updateInfo?.device_image_set_info);
     const mapDeviceIds = Object.keys(updateInfo?.device_image_set_info);
-    const customResult = await fetchImagesData({ devices_uuid: mapDeviceIds });
+    const customResult =
+      mapDeviceIds.length > 0
+        ? await fetchImagesData({ devices_uuid: mapDeviceIds })
+        : { data: { devices: [] } };
     const rowInfo = [];
     customResult?.data?.devices.forEach((row) => {
       rowInfo.push({ ...row, id: row.DeviceUUID });


### PR DESCRIPTION
deviceview with post need devices uuids list to not be empty otherwise return http status 400, check the length of devices before calling the endpoint api.

FIXES: https://issues.redhat.com/browse/THEEDGE-3756

![inventory-group-remove-lastest-edge-devices](https://github.com/RedHatInsights/insights-inventory-frontend/assets/131553/ed53e657-aff9-445c-8be5-76522c9bbb0a)
