### PR TITLE
fix(THEEDGE-3757): add validation to imageset

### DIFF
--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -187,7 +187,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
 
   //enable disable bulk update based on selection, must refactor
   useEffect(() => {
-    if (selected.size > 0) {
+    if (selected.size > 0 && deviceImageSet?.size > 0) {
       return () => {
         [...selected.keys()].map((s) => {
           const img = deviceImageSet[s];

--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -201,7 +201,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
         setUpdateImageSet(imageSet);
       };
     }
-  }, [deviceData, selected]);
+  }, [deviceData, selected, deviceImageSet]);
   return (
     <div id="group-systems-table">
       {addToGroupModalOpen && (


### PR DESCRIPTION
Fix validation to avoid exception for navigate.
Check if deviceImageSet is filled before find the imae value
![THEEDGE-3757](https://github.com/RedHatInsights/insights-inventory-frontend/assets/5039367/595c3ded-acd3-4d74-a7aa-7ccb6762a5cb)
