### PR TITLE
fix(THEEDGE-3764): fixes LoadingCard component

### DIFF
--- a/src/components/GeneralInfo/BiosCard/__snapshots__/BiosCard.test.js.snap
+++ b/src/components/GeneralInfo/BiosCard/__snapshots__/BiosCard.test.js.snap
@@ -1311,11 +1311,10 @@ exports[`BiosCard should render extra 1`] = `
                                           value="1 tests"
                                         >
                                           <Link
-                                            to="./undefined"
+                                            to="localhost:3000/example/path/undefined"
                                           >
                                             <a
-                                              href="/undefined"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/undefined"
                                             >
                                               1 tests
                                             </a>

--- a/src/components/GeneralInfo/CollectionCard/__snapshots__/CollectionCard.test.js.snap
+++ b/src/components/GeneralInfo/CollectionCard/__snapshots__/CollectionCard.test.js.snap
@@ -2839,11 +2839,10 @@ exports[`CollectionCard should render extra 1`] = `
                                           value="1 tests"
                                         >
                                           <Link
-                                            to="./undefined"
+                                            to="localhost:3000/example/path/undefined"
                                           >
                                             <a
-                                              href="/undefined"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/undefined"
                                             >
                                               1 tests
                                             </a>

--- a/src/components/GeneralInfo/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
+++ b/src/components/GeneralInfo/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
@@ -52,8 +52,7 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
             >
               <div>
                 <a
-                  href="/installed_packages"
-                  onClick={[Function]}
+                  href="localhost:3000/example/path/installed_packages"
                 >
                   1 package
                 </a>
@@ -71,8 +70,7 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
             >
               <div>
                 <a
-                  href="/services"
-                  onClick={[Function]}
+                  href="localhost:3000/example/path/services"
                 >
                   1 service
                 </a>
@@ -90,8 +88,7 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
             >
               <div>
                 <a
-                  href="/running_processes"
-                  onClick={[Function]}
+                  href="localhost:3000/example/path/running_processes"
                 >
                   1 process
                 </a>
@@ -109,8 +106,7 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
             >
               <div>
                 <a
-                  href="/repositories"
-                  onClick={[Function]}
+                  href="localhost:3000/example/path/repositories"
                 >
                   1 enabled
                 </a>
@@ -338,11 +334,10 @@ exports[`ConfigurationCard should not render hasPackages 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./services"
+                                            to="localhost:3000/example/path/services"
                                           >
                                             <a
-                                              href="/services"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/services"
                                             >
                                               1 service
                                             </a>
@@ -379,11 +374,10 @@ exports[`ConfigurationCard should not render hasPackages 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./running_processes"
+                                            to="localhost:3000/example/path/running_processes"
                                           >
                                             <a
-                                              href="/running_processes"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/running_processes"
                                             >
                                               1 process
                                             </a>
@@ -418,11 +412,10 @@ exports[`ConfigurationCard should not render hasPackages 1`] = `
                                           value="1 enabled"
                                         >
                                           <Link
-                                            to="./repositories"
+                                            to="localhost:3000/example/path/repositories"
                                           >
                                             <a
-                                              href="/repositories"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/repositories"
                                             >
                                               1 enabled
                                             </a>
@@ -663,11 +656,10 @@ exports[`ConfigurationCard should not render hasProcesses 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./installed_packages"
+                                            to="localhost:3000/example/path/installed_packages"
                                           >
                                             <a
-                                              href="/installed_packages"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/installed_packages"
                                             >
                                               1 package
                                             </a>
@@ -703,11 +695,10 @@ exports[`ConfigurationCard should not render hasProcesses 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./services"
+                                            to="localhost:3000/example/path/services"
                                           >
                                             <a
-                                              href="/services"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/services"
                                             >
                                               1 service
                                             </a>
@@ -742,11 +733,10 @@ exports[`ConfigurationCard should not render hasProcesses 1`] = `
                                           value="1 enabled"
                                         >
                                           <Link
-                                            to="./repositories"
+                                            to="localhost:3000/example/path/repositories"
                                           >
                                             <a
-                                              href="/repositories"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/repositories"
                                             >
                                               1 enabled
                                             </a>
@@ -989,11 +979,10 @@ exports[`ConfigurationCard should not render hasRepositories 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./installed_packages"
+                                            to="localhost:3000/example/path/installed_packages"
                                           >
                                             <a
-                                              href="/installed_packages"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/installed_packages"
                                             >
                                               1 package
                                             </a>
@@ -1029,11 +1018,10 @@ exports[`ConfigurationCard should not render hasRepositories 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./services"
+                                            to="localhost:3000/example/path/services"
                                           >
                                             <a
-                                              href="/services"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/services"
                                             >
                                               1 service
                                             </a>
@@ -1070,11 +1058,10 @@ exports[`ConfigurationCard should not render hasRepositories 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./running_processes"
+                                            to="localhost:3000/example/path/running_processes"
                                           >
                                             <a
-                                              href="/running_processes"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/running_processes"
                                             >
                                               1 process
                                             </a>
@@ -1316,11 +1303,10 @@ exports[`ConfigurationCard should not render hasServices 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./installed_packages"
+                                            to="localhost:3000/example/path/installed_packages"
                                           >
                                             <a
-                                              href="/installed_packages"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/installed_packages"
                                             >
                                               1 package
                                             </a>
@@ -1357,11 +1343,10 @@ exports[`ConfigurationCard should not render hasServices 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./running_processes"
+                                            to="localhost:3000/example/path/running_processes"
                                           >
                                             <a
-                                              href="/running_processes"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/running_processes"
                                             >
                                               1 process
                                             </a>
@@ -1396,11 +1381,10 @@ exports[`ConfigurationCard should not render hasServices 1`] = `
                                           value="1 enabled"
                                         >
                                           <Link
-                                            to="./repositories"
+                                            to="localhost:3000/example/path/repositories"
                                           >
                                             <a
-                                              href="/repositories"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/repositories"
                                             >
                                               1 enabled
                                             </a>
@@ -1990,11 +1974,10 @@ exports[`ConfigurationCard should render correctly with data 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./installed_packages"
+                                            to="localhost:3000/example/path/installed_packages"
                                           >
                                             <a
-                                              href="/installed_packages"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/installed_packages"
                                             >
                                               1 package
                                             </a>
@@ -2030,11 +2013,10 @@ exports[`ConfigurationCard should render correctly with data 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./services"
+                                            to="localhost:3000/example/path/services"
                                           >
                                             <a
-                                              href="/services"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/services"
                                             >
                                               1 service
                                             </a>
@@ -2071,11 +2053,10 @@ exports[`ConfigurationCard should render correctly with data 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./running_processes"
+                                            to="localhost:3000/example/path/running_processes"
                                           >
                                             <a
-                                              href="/running_processes"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/running_processes"
                                             >
                                               1 process
                                             </a>
@@ -2110,11 +2091,10 @@ exports[`ConfigurationCard should render correctly with data 1`] = `
                                           value="1 enabled"
                                         >
                                           <Link
-                                            to="./repositories"
+                                            to="localhost:3000/example/path/repositories"
                                           >
                                             <a
-                                              href="/repositories"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/repositories"
                                             >
                                               1 enabled
                                             </a>
@@ -2360,11 +2340,10 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./installed_packages"
+                                            to="localhost:3000/example/path/installed_packages"
                                           >
                                             <a
-                                              href="/installed_packages"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/installed_packages"
                                             >
                                               1 package
                                             </a>
@@ -2400,11 +2379,10 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./services"
+                                            to="localhost:3000/example/path/services"
                                           >
                                             <a
-                                              href="/services"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/services"
                                             >
                                               1 service
                                             </a>
@@ -2441,11 +2419,10 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./running_processes"
+                                            to="localhost:3000/example/path/running_processes"
                                           >
                                             <a
-                                              href="/running_processes"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/running_processes"
                                             >
                                               1 process
                                             </a>
@@ -2480,11 +2457,10 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
                                           value="1 enabled / 1 disabled"
                                         >
                                           <Link
-                                            to="./repositories"
+                                            to="localhost:3000/example/path/repositories"
                                           >
                                             <a
-                                              href="/repositories"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/repositories"
                                             >
                                               1 enabled / 1 disabled
                                             </a>
@@ -2766,11 +2742,10 @@ exports[`ConfigurationCard should render extra 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./installed_packages"
+                                            to="localhost:3000/example/path/installed_packages"
                                           >
                                             <a
-                                              href="/installed_packages"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/installed_packages"
                                             >
                                               1 package
                                             </a>
@@ -2806,11 +2781,10 @@ exports[`ConfigurationCard should render extra 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./services"
+                                            to="localhost:3000/example/path/services"
                                           >
                                             <a
-                                              href="/services"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/services"
                                             >
                                               1 service
                                             </a>
@@ -2847,11 +2821,10 @@ exports[`ConfigurationCard should render extra 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./running_processes"
+                                            to="localhost:3000/example/path/running_processes"
                                           >
                                             <a
-                                              href="/running_processes"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/running_processes"
                                             >
                                               1 process
                                             </a>
@@ -2886,11 +2859,10 @@ exports[`ConfigurationCard should render extra 1`] = `
                                           value="1 enabled"
                                         >
                                           <Link
-                                            to="./repositories"
+                                            to="localhost:3000/example/path/repositories"
                                           >
                                             <a
-                                              href="/repositories"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/repositories"
                                             >
                                               1 enabled
                                             </a>
@@ -2946,11 +2918,10 @@ exports[`ConfigurationCard should render extra 1`] = `
                                           value="1 tests"
                                         >
                                           <Link
-                                            to="./undefined"
+                                            to="localhost:3000/example/path/undefined"
                                           >
                                             <a
-                                              href="/undefined"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/undefined"
                                             >
                                               1 tests
                                             </a>

--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.test.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.test.js
@@ -34,7 +34,6 @@ jest.mock(
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => location,
-  useParams: jest.fn(() => ({ modalId: 'running_processes' })),
 }));
 
 const location = {};
@@ -178,7 +177,7 @@ describe('GeneralInformation', () => {
 
     it('should open modal', () => {
       const store = mockStore(initialState);
-
+      location.pathname = 'localhost:3000/example/running_processes';
       const wrapper = mount(
         <MemoryRouter>
           <Provider store={store}>
@@ -199,6 +198,7 @@ describe('GeneralInformation', () => {
 
     it('should open modal', () => {
       const store = mockStore(initialState);
+      location.pathname = 'localhost:3000/example/running_processes';
       const wrapper = mount(
         <MemoryRouter>
           <Provider store={store}>

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -380,7 +380,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -398,7 +398,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -416,7 +416,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -1018,7 +1018,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -1036,7 +1036,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -1054,7 +1054,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -1072,7 +1072,7 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -1471,7 +1471,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -1489,7 +1489,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -1507,7 +1507,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -2194,7 +2194,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -2212,7 +2212,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -2230,7 +2230,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -2248,7 +2248,7 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -2647,7 +2647,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -2665,7 +2665,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -2683,7 +2683,7 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -4298,7 +4298,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -4316,7 +4316,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -4334,7 +4334,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -4352,7 +4352,7 @@ exports[`GeneralInformation custom components should not render InfrastructureCa
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -4751,7 +4751,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -4769,7 +4769,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -4787,7 +4787,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -5363,7 +5363,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -5381,7 +5381,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -5399,7 +5399,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -5417,7 +5417,7 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -5527,7 +5527,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -5545,7 +5545,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -5563,7 +5563,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -6250,7 +6250,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -6268,7 +6268,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -6286,7 +6286,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -6304,7 +6304,7 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -6703,7 +6703,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -6721,7 +6721,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -6739,7 +6739,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -7348,7 +7348,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -7366,7 +7366,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -7384,7 +7384,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -7402,7 +7402,7 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -7801,7 +7801,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -7819,7 +7819,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -7837,7 +7837,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -8524,7 +8524,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -8542,7 +8542,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -8560,7 +8560,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -8578,7 +8578,7 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -8984,7 +8984,7 @@ exports[`GeneralInformation custom components should render custom Configuration
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -9002,7 +9002,7 @@ exports[`GeneralInformation custom components should render custom Configuration
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -9020,7 +9020,7 @@ exports[`GeneralInformation custom components should render custom Configuration
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -10649,7 +10649,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -10667,7 +10667,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -10685,7 +10685,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -10703,7 +10703,7 @@ exports[`GeneralInformation custom components should render custom Infrastructur
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -11102,7 +11102,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -11120,7 +11120,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -11138,7 +11138,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -11721,7 +11721,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -11739,7 +11739,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -11757,7 +11757,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -11775,7 +11775,7 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -11892,7 +11892,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -11910,7 +11910,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -11928,7 +11928,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -12615,7 +12615,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -12633,7 +12633,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -12651,7 +12651,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -12669,7 +12669,7 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>
@@ -14341,7 +14341,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <div>
                           <a
-                            href="/ipv4"
+                            href="localhost:3000/example/path/ipv4"
                           >
                             2 addresses
                           </a>
@@ -14359,7 +14359,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <div>
                           <a
-                            href="/ipv6"
+                            href="localhost:3000/example/path/ipv6"
                           >
                             2 addresses
                           </a>
@@ -14377,7 +14377,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <div>
                           <a
-                            href="/interfaces"
+                            href="localhost:3000/example/path/interfaces"
                           >
                             2 NICs
                           </a>
@@ -15064,7 +15064,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <div>
                           <a
-                            href="/installed_packages"
+                            href="localhost:3000/example/path/installed_packages"
                           >
                             1 package
                           </a>
@@ -15082,7 +15082,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <div>
                           <a
-                            href="/services"
+                            href="localhost:3000/example/path/services"
                           >
                             1 service
                           </a>
@@ -15100,7 +15100,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <div>
                           <a
-                            href="/running_processes"
+                            href="localhost:3000/example/path/running_processes"
                           >
                             1 process
                           </a>
@@ -15118,7 +15118,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <div>
                           <a
-                            href="/repositories"
+                            href="localhost:3000/example/path/repositories"
                           >
                             1 enabled
                           </a>

--- a/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
+++ b/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
@@ -254,11 +254,10 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv6"
+                                            to="localhost:3000/example/path/ipv6"
                                           >
                                             <a
-                                              href="/ipv6"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv6"
                                             >
                                               1 address
                                             </a>
@@ -294,11 +293,10 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./interfaces"
+                                            to="localhost:3000/example/path/interfaces"
                                           >
                                             <a
-                                              href="/interfaces"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/interfaces"
                                             >
                                               1 NIC
                                             </a>
@@ -580,11 +578,10 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv4"
+                                            to="localhost:3000/example/path/ipv4"
                                           >
                                             <a
-                                              href="/ipv4"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv4"
                                             >
                                               1 address
                                             </a>
@@ -620,11 +617,10 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./interfaces"
+                                            to="localhost:3000/example/path/interfaces"
                                           >
                                             <a
-                                              href="/interfaces"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/interfaces"
                                             >
                                               1 NIC
                                             </a>
@@ -907,11 +903,10 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv4"
+                                            to="localhost:3000/example/path/ipv4"
                                           >
                                             <a
-                                              href="/ipv4"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv4"
                                             >
                                               1 address
                                             </a>
@@ -948,11 +943,10 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv6"
+                                            to="localhost:3000/example/path/ipv6"
                                           >
                                             <a
-                                              href="/ipv6"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv6"
                                             >
                                               1 address
                                             </a>
@@ -1216,11 +1210,10 @@ exports[`InfrastructureCard should not render hasType 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv4"
+                                            to="localhost:3000/example/path/ipv4"
                                           >
                                             <a
-                                              href="/ipv4"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv4"
                                             >
                                               1 address
                                             </a>
@@ -1257,11 +1250,10 @@ exports[`InfrastructureCard should not render hasType 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv6"
+                                            to="localhost:3000/example/path/ipv6"
                                           >
                                             <a
-                                              href="/ipv6"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv6"
                                             >
                                               1 address
                                             </a>
@@ -1297,11 +1289,10 @@ exports[`InfrastructureCard should not render hasType 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./interfaces"
+                                            to="localhost:3000/example/path/interfaces"
                                           >
                                             <a
-                                              href="/interfaces"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/interfaces"
                                             >
                                               1 NIC
                                             </a>
@@ -1565,11 +1556,10 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv4"
+                                            to="localhost:3000/example/path/ipv4"
                                           >
                                             <a
-                                              href="/ipv4"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv4"
                                             >
                                               1 address
                                             </a>
@@ -1606,11 +1596,10 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv6"
+                                            to="localhost:3000/example/path/ipv6"
                                           >
                                             <a
-                                              href="/ipv6"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv6"
                                             >
                                               1 address
                                             </a>
@@ -1646,11 +1635,10 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./interfaces"
+                                            to="localhost:3000/example/path/interfaces"
                                           >
                                             <a
-                                              href="/interfaces"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/interfaces"
                                             >
                                               1 NIC
                                             </a>
@@ -2323,11 +2311,10 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv4"
+                                            to="localhost:3000/example/path/ipv4"
                                           >
                                             <a
-                                              href="/ipv4"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv4"
                                             >
                                               1 address
                                             </a>
@@ -2364,11 +2351,10 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv6"
+                                            to="localhost:3000/example/path/ipv6"
                                           >
                                             <a
-                                              href="/ipv6"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv6"
                                             >
                                               1 address
                                             </a>
@@ -2404,11 +2390,10 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./interfaces"
+                                            to="localhost:3000/example/path/interfaces"
                                           >
                                             <a
-                                              href="/interfaces"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/interfaces"
                                             >
                                               1 NIC
                                             </a>
@@ -3011,11 +2996,10 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv4"
+                                            to="localhost:3000/example/path/ipv4"
                                           >
                                             <a
-                                              href="/ipv4"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv4"
                                             >
                                               1 address
                                             </a>
@@ -3052,11 +3036,10 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv6"
+                                            to="localhost:3000/example/path/ipv6"
                                           >
                                             <a
-                                              href="/ipv6"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv6"
                                             >
                                               1 address
                                             </a>
@@ -3092,11 +3075,10 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./interfaces"
+                                            to="localhost:3000/example/path/interfaces"
                                           >
                                             <a
-                                              href="/interfaces"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/interfaces"
                                             >
                                               1 NIC
                                             </a>
@@ -3419,11 +3401,10 @@ exports[`InfrastructureCard should render extra 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv4"
+                                            to="localhost:3000/example/path/ipv4"
                                           >
                                             <a
-                                              href="/ipv4"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv4"
                                             >
                                               1 address
                                             </a>
@@ -3460,11 +3441,10 @@ exports[`InfrastructureCard should render extra 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./ipv6"
+                                            to="localhost:3000/example/path/ipv6"
                                           >
                                             <a
-                                              href="/ipv6"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/ipv6"
                                             >
                                               1 address
                                             </a>
@@ -3500,11 +3480,10 @@ exports[`InfrastructureCard should render extra 1`] = `
                                           value={1}
                                         >
                                           <Link
-                                            to="./interfaces"
+                                            to="localhost:3000/example/path/interfaces"
                                           >
                                             <a
-                                              href="/interfaces"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/interfaces"
                                             >
                                               1 NIC
                                             </a>
@@ -3560,11 +3539,10 @@ exports[`InfrastructureCard should render extra 1`] = `
                                           value="1 tests"
                                         >
                                           <Link
-                                            to="./undefined"
+                                            to="localhost:3000/example/path/undefined"
                                           >
                                             <a
-                                              href="/undefined"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/undefined"
                                             >
                                               1 tests
                                             </a>

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -17,7 +17,7 @@ import {
   Skeleton,
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/Skeleton';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 const valueToText = (value, singular, plural) => {
   if ((value || value === 0) && singular) {
@@ -34,14 +34,20 @@ const valueToText = (value, singular, plural) => {
 };
 
 export const Clickable = ({ value, target, plural, singular, onClick }) => {
-  const { modalId } = useParams();
+  const { pathname } = useLocation();
+  // const { modalId } = useParams(); is causing regression when using LoadingCard derived components in Federated mode
+  const modalId = pathname.split('/').pop();
   useEffect(() => {
     if (target === modalId) {
       onClick({ value, target });
     }
   }, [modalId, target]);
 
-  return <Link to={`./${target}`}>{valueToText(value, singular, plural)}</Link>;
+  return (
+    <Link to={`${pathname}/${target}`}>
+      {valueToText(value, singular, plural)}
+    </Link>
+  );
 };
 
 Clickable.propTypes = {

--- a/src/components/GeneralInfo/LoadingCard/__snapshots__/LoadingCard.test.js.snap
+++ b/src/components/GeneralInfo/LoadingCard/__snapshots__/LoadingCard.test.js.snap
@@ -40,11 +40,10 @@ exports[`LoadingCard Clickable should render - 0 value 1`] = `
       value={0}
     >
       <Link
-        to="./some-target"
+        to="localhost:3000/example/path/some-target"
       >
         <a
-          href="/some-target"
-          onClick={[Function]}
+          href="localhost:3000/example/path/some-target"
         >
           None
         </a>
@@ -92,11 +91,10 @@ exports[`LoadingCard Clickable should render - no data 1`] = `
       onClick={[MockFunction]}
     >
       <Link
-        to="./undefined"
+        to="localhost:3000/example/path/undefined"
       >
         <a
-          href="/undefined"
-          onClick={[Function]}
+          href="localhost:3000/example/path/undefined"
         >
           Not available
         </a>
@@ -447,11 +445,10 @@ exports[`LoadingCard Loading card render 1`] = `
                                       value="some value"
                                     >
                                       <Link
-                                        to="./undefined"
+                                        to="localhost:3000/example/path/undefined"
                                       >
                                         <a
-                                          href="/undefined"
-                                          onClick={[Function]}
+                                          href="localhost:3000/example/path/undefined"
                                         >
                                           some value
                                         </a>

--- a/src/components/GeneralInfo/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
+++ b/src/components/GeneralInfo/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
@@ -3234,11 +3234,10 @@ exports[`OperatingSystemCard should render extra 1`] = `
                                           value="1 tests"
                                         >
                                           <Link
-                                            to="./undefined"
+                                            to="localhost:3000/example/path/undefined"
                                           >
                                             <a
-                                              href="/undefined"
-                                              onClick={[Function]}
+                                              href="localhost:3000/example/path/undefined"
                                             >
                                               1 tests
                                             </a>

--- a/src/components/GeneralInfo/SystemCard/__snapshots__/SystemCard.test.js.snap
+++ b/src/components/GeneralInfo/SystemCard/__snapshots__/SystemCard.test.js.snap
@@ -4013,8 +4013,7 @@ Array [
               >
                 <div>
                   <a
-                    href="/sap_sids"
-                    onClick={[Function]}
+                    href="localhost:3000/example/path/sap_sids"
                   >
                     2 identifiers
                   </a>
@@ -5142,8 +5141,7 @@ Array [
               >
                 <div>
                   <a
-                    href="/undefined"
-                    onClick={[Function]}
+                    href="localhost:3000/example/path/undefined"
                   >
                     1 tests
                   </a>


### PR DESCRIPTION
A regression happened from latest changes (https://github.com/RedHatInsights/insights-inventory-frontend/pull/1968) when used in federated mode, preventing the model dialogs to open, as no way in federated mode to find the modelId. 

This PR revert the change related of using useParams in function "Clickable" and add the full pathname to the url, also needed as in federated mode the path was truncated for example when used in edge-management app the path was "/edge/ipv4", with this change the path is correct and looks like "/edge/inventory/9ea55e32-6e30-4288-bf08-0a877c7fd306/ipv4" 

FIXES: https://issues.redhat.com/browse/THEEDGE-3764


![fixes-inventory-loading-card-component-2023-12-14 11-23](https://github.com/RedHatInsights/insights-inventory-frontend/assets/131553/6abacefa-aa03-4a0e-8e3a-6a1de358bc31)

