### PR TITLE
fix(RHINENG-715): Redirect on non-existent group

### DIFF
--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -41,7 +41,9 @@ const InventoryGroupDetail = ({ groupId }) => {
   );
 
   const dispatch = useDispatch();
-  const { data, fulfilled } = useSelector((state) => state.groupDetail);
+  const { data, fulfilled, rejected, error } = useSelector(
+    (state) => state.groupDetail
+  );
   const navigate = useInsightsNavigate();
 
   const chrome = useChrome();
@@ -107,8 +109,10 @@ const InventoryGroupDetail = ({ groupId }) => {
     }
   }, [data]);
 
-  if (fulfilled && data?.total === 0) {
-    // group does not exist
+  if (
+    (fulfilled && data.total === 0) || // group does not exist
+    (rejected && error.status === 400) // group name not correct
+  ) {
     navigate('/groups');
   }
 

--- a/src/store/groupDetail.js
+++ b/src/store/groupDetail.js
@@ -39,6 +39,9 @@ export default applyReducerHash(
         error: payload,
       };
     },
+    GROUP_DETAIL_RESET: () => {
+      return initialState;
+    },
   },
   initialState
 );


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-715.

Redirect back to /groups if non-existent group is visited.

## How to test

1. Go to any group details page
2. Delete the group
3. Make sure you are redirected to /groups
4. Make sure if you navigate back to the group details page you are again redirected to /groups