### PR TITLE
fix(RHINENG-2392): Show refresh link in group notifications

### DIFF
--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -2,7 +2,6 @@ import { TableVariant } from '@patternfly/react-table';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { selectEntity } from '../../store/inventory-actions';
 import AddSystemsToGroupModal from '../InventoryGroups/Modals/AddSystemsToGroupModal';
 import InventoryTable from '../InventoryTable/InventoryTable';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -222,14 +221,6 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
           isModalOpen={removeHostsFromGroupModalOpen}
           setIsModalOpen={setRemoveHostsFromGroupModalOpen}
           modalState={currentSystem}
-          reloadTimeout={1000}
-          reloadData={() => {
-            if (calculateSelected() > 0) {
-              dispatch(selectEntity(-1, false));
-            }
-
-            inventory.current.onRefreshData({}, false, true);
-          }}
         />
       )}
       {updateDevice && (

--- a/src/components/GroupSystems/GroupSystems.cy.js
+++ b/src/components/GroupSystems/GroupSystems.cy.js
@@ -382,7 +382,6 @@ describe('actions', () => {
       cy.get('button[type="submit"]').click();
       cy.wait('@request');
     });
-    cy.wait('@getHosts'); // data must be reloaded
   });
 });
 

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -2,7 +2,6 @@ import { TableVariant, fitContent } from '@patternfly/react-table';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { selectEntity } from '../../store/inventory-actions';
 import AddSystemsToGroupModal from '../InventoryGroups/Modals/AddSystemsToGroupModal';
 import InventoryTable from '../InventoryTable/InventoryTable';
 import { Link } from 'react-router-dom';
@@ -136,14 +135,6 @@ const GroupSystems = ({ groupName, groupId }) => {
           isModalOpen={removeHostsFromGroupModalOpen}
           setIsModalOpen={setRemoveHostsFromGroupModalOpen}
           modalState={currentSystem}
-          reloadTimeout={1000}
-          reloadData={() => {
-            if (calculateSelected() > 0) {
-              dispatch(selectEntity(-1, false));
-            }
-
-            inventory.current.onRefreshData({}, false, true);
-          }}
         />
       )}
       {!addToGroupModalOpen && (

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -1,5 +1,6 @@
 import {
   Alert,
+  AlertActionLink,
   Button,
   Flex,
   FlexItem,
@@ -81,6 +82,11 @@ const AddSystemsToGroupModal = ({
           description: `${hostIds.length > 1 ? 'Systems' : 'System'} added to ${
             groupName || groupId
           }`,
+          actionLinks: (
+            <AlertActionLink onClick={() => window.location.reload()}>
+              Refresh
+            </AlertActionLink>
+          ),
         },
         onError: {
           title: 'Error',
@@ -176,9 +182,8 @@ const AddSystemsToGroupModal = ({
         {/** confirmation modal */}
         <ConfirmSystemsAddModal
           isModalOpen={confirmationModalOpen}
-          onSubmit={async () => {
-            await handleSystemAddition(overallSelectedKeys);
-            setTimeout(() => dispatch(fetchGroupDetail(groupId)), 500); // refetch data for this group
+          onSubmit={() => {
+            handleSystemAddition(overallSelectedKeys);
             setIsModalOpen(false);
           }}
           onBack={() => {

--- a/src/components/InventoryGroups/Modals/RemoveHostsFromGroupModal.js
+++ b/src/components/InventoryGroups/Modals/RemoveHostsFromGroupModal.js
@@ -5,7 +5,7 @@ import apiWithToast from '../utils/apiWithToast';
 import { useDispatch } from 'react-redux';
 import { removeHostsFromGroup } from '../utils/api';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
-import { Text } from '@patternfly/react-core';
+import { AlertActionLink, Text } from '@patternfly/react-core';
 
 const schema = (hosts) => {
   const hostsInGroup = hosts.filter(({ groups }) => groups.length > 0); // selection can contain ungroupped hosts
@@ -43,6 +43,11 @@ const statusMessages = (hosts) => {
     ? {
         onSuccess: {
           title: `1 system removed from ${groupName}`,
+          actionLinks: (
+            <AlertActionLink onClick={() => window.location.reload()}>
+              Refresh
+            </AlertActionLink>
+          ),
         },
         onError: {
           title: `Failed to remove 1 system from ${groupName}`,
@@ -51,6 +56,11 @@ const statusMessages = (hosts) => {
     : {
         onSuccess: {
           title: `${hostsInGroup.length} systems removed from ${groupName}`,
+          actionLinks: (
+            <AlertActionLink onClick={() => window.location.reload()}>
+              Refresh
+            </AlertActionLink>
+          ),
         },
         onError: {
           title: `Failed to remove ${hostsInGroup.length} systems from ${groupName}`,


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-2392.

This adds a refresh link to the success notification when systems are added or removed from a group. The data is no longer reloaded automatically due to possible inconsistency in the results.

⚠️ When adding new systems, the view is still refreshed under submit. This will be fixed in a separate PR/ticket.

## How to test

1. Go to any group details page
2. Try to remove or add new systems
3. Check that the success notification has a refresh action and on click the page is reloaded with updated results

## Screenshots

<img width="878" alt="image" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/f956e46b-9e3b-4d76-adcb-fda34a7a5afb">
