### PR TITLE
Feat(RHINENG-4796): Add Public IP & FQDN to Infrastructure Card in Host Details Page

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -164,7 +164,9 @@ export const calculateSystemProfile = ({
     systemProfile['host_type'] = hostTypeFilter;
   }
 
-  return generateFilter({ system_profile: systemProfile });
+  return generateFilter({
+    system_profile: systemProfile,
+  });
 };
 
 export const filtersReducer = (acc, filter = {}) => ({
@@ -249,7 +251,7 @@ export async function getEntities(
           ),
         };
       } catch (e) {
-                console.error(e); // eslint-disable-line
+        console.error(e); // eslint-disable-line
       }
     }
 

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -370,6 +370,18 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -403,6 +415,18 @@ exports[`GeneralInformation custom components should not render BiosCardWrapper 
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -1461,6 +1485,18 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -1494,6 +1530,18 @@ exports[`GeneralInformation custom components should not render CollectionCardWr
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -2637,6 +2685,18 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -2670,6 +2730,18 @@ exports[`GeneralInformation custom components should not render ConfigurationCar
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -4741,6 +4813,18 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -4774,6 +4858,18 @@ exports[`GeneralInformation custom components should not render OperatingSystemC
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -5517,6 +5613,18 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -5550,6 +5658,18 @@ exports[`GeneralInformation custom components should not render SystemCardWrappe
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -6693,6 +6813,18 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -6726,6 +6858,18 @@ exports[`GeneralInformation custom components should render custom BiosCardWrapp
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -7791,6 +7935,18 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -7824,6 +7980,18 @@ exports[`GeneralInformation custom components should render custom CollectionCar
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -8974,6 +9142,18 @@ exports[`GeneralInformation custom components should render custom Configuration
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -9007,6 +9187,18 @@ exports[`GeneralInformation custom components should render custom Configuration
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -11092,6 +11284,18 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -11125,6 +11329,18 @@ exports[`GeneralInformation custom components should render custom OperatingSyst
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -11882,6 +12098,18 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -11915,6 +12143,18 @@ exports[`GeneralInformation custom components should render custom SystemCardWra
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""
@@ -13085,6 +13325,24 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        <div
+                          class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                        >
+                          <span
+                            class="pf-u-screen-reader"
+                          />
+                        </div>
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -13110,6 +13368,24 @@ exports[`GeneralInformation should render correctly - no data 1`] = `
                       <dd
                         class=""
                         data-ouia-component-id="IPv6 addresses value"
+                      >
+                        <div
+                          class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                        >
+                          <span
+                            class="pf-u-screen-reader"
+                          />
+                        </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
                       >
                         <div
                           class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
@@ -14331,6 +14607,18 @@ exports[`GeneralInformation should render correctly 1`] = `
                       </dd>
                       <dt
                         class=""
+                        data-ouia-component-id="Public IP title"
+                      >
+                        Public IP
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="Public IP value"
+                      >
+                        Not available
+                      </dd>
+                      <dt
+                        class=""
                         data-ouia-component-id="IPv4 addresses title"
                       >
                         IPv4 addresses
@@ -14364,6 +14652,18 @@ exports[`GeneralInformation should render correctly 1`] = `
                             2 addresses
                           </a>
                         </div>
+                      </dd>
+                      <dt
+                        class=""
+                        data-ouia-component-id="FQDN title"
+                      >
+                        FQDN
+                      </dt>
+                      <dd
+                        class=""
+                        data-ouia-component-id="FQDN value"
+                      >
+                        Not available
                       </dd>
                       <dt
                         class=""

--- a/src/components/GeneralInfo/InfrastructureCard/InfrastructureCard.js
+++ b/src/components/GeneralInfo/InfrastructureCard/InfrastructureCard.js
@@ -12,8 +12,10 @@ const InfrastructureCardCore = ({
   detailLoaded,
   hasType,
   hasVendor,
+  hasPublicIp,
   hasIPv4,
   hasIPv6,
+  hasFqdn,
   hasInterfaces,
   extra,
 }) => (
@@ -23,6 +25,18 @@ const InfrastructureCardCore = ({
     items={[
       ...(hasType ? [{ title: 'Type', value: infrastructure.type }] : []),
       ...(hasVendor ? [{ title: 'Vendor', value: infrastructure.vendor }] : []),
+      ...(hasPublicIp
+        ? [
+            {
+              title: 'Public IP',
+              value:
+                Array.isArray(infrastructure.public_ipv4_addresses) &&
+                infrastructure.public_ipv4_addresses.length > 0
+                  ? infrastructure.public_ipv4_addresses[0]
+                  : 'Not available',
+            },
+          ]
+        : []),
       ...(hasIPv4
         ? [
             {
@@ -57,6 +71,18 @@ const InfrastructureCardCore = ({
             },
           ]
         : []),
+      ...(hasFqdn
+        ? [
+            {
+              title: 'FQDN',
+              value:
+                Array.isArray(infrastructure.fqdn) &&
+                infrastructure.fqdn.length > 0
+                  ? infrastructure.fqdn[0]
+                  : 'Not available',
+            },
+          ]
+        : []),
       ...(hasInterfaces
         ? [
             {
@@ -88,14 +114,18 @@ InfrastructureCardCore.propTypes = {
   infrastructure: PropTypes.shape({
     type: PropTypes.string,
     vendor: PropTypes.string,
+    public_ipv4_addresses: PropTypes.arrayOf(PropTypes.string),
     ipv4: PropTypes.array,
     ipv6: PropTypes.array,
+    fqdn: PropTypes.arrayOf(PropTypes.string),
     nics: PropTypes.array,
   }),
   hasType: PropTypes.bool,
   hasVendor: PropTypes.bool,
+  hasPublicIp: PropTypes.bool,
   hasIPv4: PropTypes.bool,
   hasIPv6: PropTypes.bool,
+  hasFqdn: PropTypes.bool,
   hasInterfaces: PropTypes.bool,
   extra: PropTypes.arrayOf(extraShape),
 };
@@ -104,18 +134,25 @@ InfrastructureCardCore.defaultProps = {
   handleClick: () => undefined,
   hasType: true,
   hasVendor: true,
+  hasPublicIp: true,
   hasIPv4: true,
   hasIPv6: true,
+  hasFqdn: true,
   hasInterfaces: true,
   extra: [],
 };
 
-export const InfrastructureCard = connect(
-  ({ entityDetails: { entity }, systemProfileStore: { systemProfile } }) => ({
-    detailLoaded: systemProfile && systemProfile.loaded,
-    infrastructure: infrastructureSelector(systemProfile, entity),
-  })
-)(InfrastructureCardCore);
+const mapStateToProps = ({
+  entityDetails: { entity },
+  systemProfileStore: { systemProfile },
+}) => ({
+  detailLoaded: systemProfile && systemProfile.loaded,
+  infrastructure: infrastructureSelector(systemProfile, entity),
+});
+
+export const InfrastructureCard = connect(mapStateToProps)(
+  InfrastructureCardCore
+);
 
 InfrastructureCard.propTypes = InfrastructureCardCore.propTypes;
 InfrastructureCard.defaultProps = InfrastructureCardCore.defaultProps;

--- a/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
+++ b/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
@@ -38,9 +38,11 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
       detailLoaded={false}
       extra={Array []}
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={false}
       hasIPv6={true}
       hasInterfaces={true}
+      hasPublicIp={true}
       hasType={true}
       hasVendor={true}
       store={
@@ -59,13 +61,16 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
         dispatch={[Function]}
         extra={Array []}
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={false}
         hasIPv6={true}
         hasInterfaces={true}
+        hasPublicIp={true}
         hasType={true}
         hasVendor={true}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": Array [
               "1",
             ],
@@ -75,6 +80,7 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
             "nics": Array [
               "test",
             ],
+            "public_ipv4_addresses": undefined,
             "type": "test-type",
             "vendor": "test-vendor",
           }
@@ -103,12 +109,20 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
                 "value": "test-vendor",
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
                 "target": "ipv6",
                 "title": "IPv6 addresses",
                 "value": 1,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
               Object {
                 "onClick": [Function],
@@ -228,6 +242,28 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv6 addresses title"
                                   >
                                     <dt
@@ -264,6 +300,28 @@ exports[`InfrastructureCard should not render hasIPv4 1`] = `
                                           </Link>
                                         </Clickable>
                                       </div>
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
+                                    >
+                                      Not available
                                     </dd>
                                   </TextListItem>
                                   <TextListItem
@@ -362,9 +420,11 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
       detailLoaded={false}
       extra={Array []}
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={true}
       hasIPv6={false}
       hasInterfaces={true}
+      hasPublicIp={true}
       hasType={true}
       hasVendor={true}
       store={
@@ -383,13 +443,16 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
         dispatch={[Function]}
         extra={Array []}
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={true}
         hasIPv6={false}
         hasInterfaces={true}
+        hasPublicIp={true}
         hasType={true}
         hasVendor={true}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": Array [
               "1",
             ],
@@ -399,6 +462,7 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
             "nics": Array [
               "test",
             ],
+            "public_ipv4_addresses": undefined,
             "type": "test-type",
             "vendor": "test-vendor",
           }
@@ -427,12 +491,20 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
                 "value": "test-vendor",
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
                 "target": "ipv4",
                 "title": "IPv4 addresses",
                 "value": 1,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
               Object {
                 "onClick": [Function],
@@ -552,6 +624,28 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv4 addresses title"
                                   >
                                     <dt
@@ -588,6 +682,28 @@ exports[`InfrastructureCard should not render hasIPv6 1`] = `
                                           </Link>
                                         </Clickable>
                                       </div>
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
+                                    >
+                                      Not available
                                     </dd>
                                   </TextListItem>
                                   <TextListItem
@@ -686,9 +802,11 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
       detailLoaded={false}
       extra={Array []}
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={true}
       hasIPv6={true}
       hasInterfaces={false}
+      hasPublicIp={true}
       hasType={true}
       hasVendor={true}
       store={
@@ -707,13 +825,16 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
         dispatch={[Function]}
         extra={Array []}
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={true}
         hasIPv6={true}
         hasInterfaces={false}
+        hasPublicIp={true}
         hasType={true}
         hasVendor={true}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": Array [
               "1",
             ],
@@ -723,6 +844,7 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
             "nics": Array [
               "test",
             ],
+            "public_ipv4_addresses": undefined,
             "type": "test-type",
             "vendor": "test-vendor",
           }
@@ -751,6 +873,10 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
                 "value": "test-vendor",
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
@@ -765,6 +891,10 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
                 "target": "ipv6",
                 "title": "IPv6 addresses",
                 "value": 1,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
             ]
           }
@@ -877,6 +1007,28 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv4 addresses title"
                                   >
                                     <dt
@@ -955,6 +1107,28 @@ exports[`InfrastructureCard should not render hasInterfaces 1`] = `
                                       </div>
                                     </dd>
                                   </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
                                 </dl>
                               </TextList>
                             </div>
@@ -1012,9 +1186,11 @@ exports[`InfrastructureCard should not render hasType 1`] = `
       detailLoaded={false}
       extra={Array []}
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={true}
       hasIPv6={true}
       hasInterfaces={true}
+      hasPublicIp={true}
       hasType={false}
       hasVendor={true}
       store={
@@ -1033,13 +1209,16 @@ exports[`InfrastructureCard should not render hasType 1`] = `
         dispatch={[Function]}
         extra={Array []}
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={true}
         hasIPv6={true}
         hasInterfaces={true}
+        hasPublicIp={true}
         hasType={false}
         hasVendor={true}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": Array [
               "1",
             ],
@@ -1049,6 +1228,7 @@ exports[`InfrastructureCard should not render hasType 1`] = `
             "nics": Array [
               "test",
             ],
+            "public_ipv4_addresses": undefined,
             "type": "test-type",
             "vendor": "test-vendor",
           }
@@ -1073,6 +1253,10 @@ exports[`InfrastructureCard should not render hasType 1`] = `
                 "value": "test-vendor",
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
@@ -1087,6 +1271,10 @@ exports[`InfrastructureCard should not render hasType 1`] = `
                 "target": "ipv6",
                 "title": "IPv6 addresses",
                 "value": 1,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
               Object {
                 "onClick": [Function],
@@ -1184,6 +1372,28 @@ exports[`InfrastructureCard should not render hasType 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv4 addresses title"
                                   >
                                     <dt
@@ -1260,6 +1470,28 @@ exports[`InfrastructureCard should not render hasType 1`] = `
                                           </Link>
                                         </Clickable>
                                       </div>
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
+                                    >
+                                      Not available
                                     </dd>
                                   </TextListItem>
                                   <TextListItem
@@ -1358,9 +1590,11 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
       detailLoaded={false}
       extra={Array []}
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={true}
       hasIPv6={true}
       hasInterfaces={true}
+      hasPublicIp={true}
       hasType={true}
       hasVendor={false}
       store={
@@ -1379,13 +1613,16 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
         dispatch={[Function]}
         extra={Array []}
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={true}
         hasIPv6={true}
         hasInterfaces={true}
+        hasPublicIp={true}
         hasType={true}
         hasVendor={false}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": Array [
               "1",
             ],
@@ -1395,6 +1632,7 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
             "nics": Array [
               "test",
             ],
+            "public_ipv4_addresses": undefined,
             "type": "test-type",
             "vendor": "test-vendor",
           }
@@ -1419,6 +1657,10 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
                 "value": "test-type",
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
@@ -1433,6 +1675,10 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
                 "target": "ipv6",
                 "title": "IPv6 addresses",
                 "value": 1,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
               Object {
                 "onClick": [Function],
@@ -1530,6 +1776,28 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv4 addresses title"
                                   >
                                     <dt
@@ -1606,6 +1874,28 @@ exports[`InfrastructureCard should not render hasVendor 1`] = `
                                           </Link>
                                         </Clickable>
                                       </div>
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
+                                    >
+                                      Not available
                                     </dd>
                                   </TextListItem>
                                   <TextListItem
@@ -1704,9 +1994,11 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
       detailLoaded={false}
       extra={Array []}
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={true}
       hasIPv6={true}
       hasInterfaces={true}
+      hasPublicIp={true}
       hasType={true}
       hasVendor={true}
       store={
@@ -1725,16 +2017,20 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
         dispatch={[Function]}
         extra={Array []}
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={true}
         hasIPv6={true}
         hasInterfaces={true}
+        hasPublicIp={true}
         hasType={true}
         hasVendor={true}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": undefined,
             "ipv6": undefined,
             "nics": undefined,
+            "public_ipv4_addresses": undefined,
             "type": undefined,
             "vendor": undefined,
           }
@@ -1763,6 +2059,10 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
                 "value": undefined,
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
@@ -1777,6 +2077,10 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
                 "target": "ipv6",
                 "title": "IPv6 addresses",
                 "value": undefined,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
               Object {
                 "onClick": [Function],
@@ -1924,6 +2228,42 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      <Skeleton
+                                        size="sm"
+                                      >
+                                        <Skeleton
+                                          className="ins-c-skeleton ins-c-skeleton__sm"
+                                        >
+                                          <div
+                                            className="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                                          >
+                                            <span
+                                              className="pf-u-screen-reader"
+                                            />
+                                          </div>
+                                        </Skeleton>
+                                      </Skeleton>
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv4 addresses title"
                                   >
                                     <dt
@@ -1976,6 +2316,42 @@ exports[`InfrastructureCard should render correctly - no data 1`] = `
                                     <dd
                                       className=""
                                       data-ouia-component-id="IPv6 addresses value"
+                                    >
+                                      <Skeleton
+                                        size="sm"
+                                      >
+                                        <Skeleton
+                                          className="ins-c-skeleton ins-c-skeleton__sm"
+                                        >
+                                          <div
+                                            className="pf-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                                          >
+                                            <span
+                                              className="pf-u-screen-reader"
+                                            />
+                                          </div>
+                                        </Skeleton>
+                                      </Skeleton>
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
                                     >
                                       <Skeleton
                                         size="sm"
@@ -2087,9 +2463,11 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
       detailLoaded={false}
       extra={Array []}
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={true}
       hasIPv6={true}
       hasInterfaces={true}
+      hasPublicIp={true}
       hasType={true}
       hasVendor={true}
       store={
@@ -2108,13 +2486,16 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
         dispatch={[Function]}
         extra={Array []}
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={true}
         hasIPv6={true}
         hasInterfaces={true}
+        hasPublicIp={true}
         hasType={true}
         hasVendor={true}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": Array [
               "1",
             ],
@@ -2124,6 +2505,7 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
             "nics": Array [
               "test",
             ],
+            "public_ipv4_addresses": undefined,
             "type": "test-type",
             "vendor": "test-vendor",
           }
@@ -2152,6 +2534,10 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
                 "value": "test-vendor",
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
@@ -2166,6 +2552,10 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
                 "target": "ipv6",
                 "title": "IPv6 addresses",
                 "value": 1,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
               Object {
                 "onClick": [Function],
@@ -2285,6 +2675,28 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv4 addresses title"
                                   >
                                     <dt
@@ -2361,6 +2773,28 @@ exports[`InfrastructureCard should render correctly with data 1`] = `
                                           </Link>
                                         </Clickable>
                                       </div>
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
+                                    >
+                                      Not available
                                     </dd>
                                   </TextListItem>
                                   <TextListItem
@@ -2459,9 +2893,11 @@ exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
       detailLoaded={false}
       extra={Array []}
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={true}
       hasIPv6={true}
       hasInterfaces={true}
+      hasPublicIp={true}
       hasType={true}
       hasVendor={true}
       store={
@@ -2480,16 +2916,20 @@ exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
         dispatch={[Function]}
         extra={Array []}
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={true}
         hasIPv6={true}
         hasInterfaces={true}
+        hasPublicIp={true}
         hasType={true}
         hasVendor={true}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": undefined,
             "ipv6": undefined,
             "nics": undefined,
+            "public_ipv4_addresses": undefined,
             "type": "virtual",
             "vendor": undefined,
           }
@@ -2518,6 +2958,10 @@ exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
                 "value": undefined,
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
@@ -2532,6 +2976,10 @@ exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
                 "target": "ipv6",
                 "title": "IPv6 addresses",
                 "value": undefined,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
               Object {
                 "onClick": [Function],
@@ -2651,6 +3099,28 @@ exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv4 addresses title"
                                   >
                                     <dt
@@ -2689,6 +3159,28 @@ exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
                                     <dd
                                       className=""
                                       data-ouia-component-id="IPv6 addresses value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
                                     >
                                       Not available
                                     </dd>
@@ -2772,9 +3264,11 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
       detailLoaded={false}
       extra={Array []}
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={true}
       hasIPv6={true}
       hasInterfaces={true}
+      hasPublicIp={true}
       hasType={true}
       hasVendor={true}
       store={
@@ -2793,13 +3287,16 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
         dispatch={[Function]}
         extra={Array []}
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={true}
         hasIPv6={true}
         hasInterfaces={true}
+        hasPublicIp={true}
         hasType={true}
         hasVendor={true}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": Array [
               "1",
             ],
@@ -2809,6 +3306,7 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
             "nics": Array [
               "test",
             ],
+            "public_ipv4_addresses": undefined,
             "type": "test-type",
             "vendor": "test-vendor",
           }
@@ -2837,6 +3335,10 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
                 "value": "test-vendor",
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
@@ -2851,6 +3353,10 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
                 "target": "ipv6",
                 "title": "IPv6 addresses",
                 "value": 1,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
               Object {
                 "onClick": [Function],
@@ -2970,6 +3476,28 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv4 addresses title"
                                   >
                                     <dt
@@ -3046,6 +3574,28 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
                                           </Link>
                                         </Clickable>
                                       </div>
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
+                                    >
+                                      Not available
                                     </dd>
                                   </TextListItem>
                                   <TextListItem
@@ -3156,9 +3706,11 @@ exports[`InfrastructureCard should render extra 1`] = `
         ]
       }
       handleClick={[Function]}
+      hasFqdn={true}
       hasIPv4={true}
       hasIPv6={true}
       hasInterfaces={true}
+      hasPublicIp={true}
       hasType={true}
       hasVendor={true}
       store={
@@ -3189,13 +3741,16 @@ exports[`InfrastructureCard should render extra 1`] = `
           ]
         }
         handleClick={[Function]}
+        hasFqdn={true}
         hasIPv4={true}
         hasIPv6={true}
         hasInterfaces={true}
+        hasPublicIp={true}
         hasType={true}
         hasVendor={true}
         infrastructure={
           Object {
+            "fqdn": undefined,
             "ipv4": Array [
               "1",
             ],
@@ -3205,6 +3760,7 @@ exports[`InfrastructureCard should render extra 1`] = `
             "nics": Array [
               "test",
             ],
+            "public_ipv4_addresses": undefined,
             "type": "test-type",
             "vendor": "test-vendor",
           }
@@ -3233,6 +3789,10 @@ exports[`InfrastructureCard should render extra 1`] = `
                 "value": "test-vendor",
               },
               Object {
+                "title": "Public IP",
+                "value": "Not available",
+              },
+              Object {
                 "onClick": [Function],
                 "plural": "addresses",
                 "singular": "address",
@@ -3247,6 +3807,10 @@ exports[`InfrastructureCard should render extra 1`] = `
                 "target": "ipv6",
                 "title": "IPv6 addresses",
                 "value": 1,
+              },
+              Object {
+                "title": "FQDN",
+                "value": "Not available",
               },
               Object {
                 "onClick": [Function],
@@ -3375,6 +3939,28 @@ exports[`InfrastructureCard should render extra 1`] = `
                                   </TextListItem>
                                   <TextListItem
                                     component="dt"
+                                    data-ouia-component-id="Public IP title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="Public IP title"
+                                    >
+                                      Public IP
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="Public IP value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="Public IP value"
+                                    >
+                                      Not available
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
                                     data-ouia-component-id="IPv4 addresses title"
                                   >
                                     <dt
@@ -3451,6 +4037,28 @@ exports[`InfrastructureCard should render extra 1`] = `
                                           </Link>
                                         </Clickable>
                                       </div>
+                                    </dd>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dt"
+                                    data-ouia-component-id="FQDN title"
+                                  >
+                                    <dt
+                                      className=""
+                                      data-ouia-component-id="FQDN title"
+                                    >
+                                      FQDN
+                                    </dt>
+                                  </TextListItem>
+                                  <TextListItem
+                                    component="dd"
+                                    data-ouia-component-id="FQDN value"
+                                  >
+                                    <dd
+                                      className=""
+                                      data-ouia-component-id="FQDN value"
+                                    >
+                                      Not available
                                     </dd>
                                   </TextListItem>
                                   <TextListItem

--- a/src/components/GeneralInfo/selectors/selectors.js
+++ b/src/components/GeneralInfo/selectors/selectors.js
@@ -75,7 +75,13 @@ export const biosSelector = ({
 });
 
 export const infrastructureSelector = (
-  { infrastructure_type, infrastructure_vendor, network = {} } = {},
+  {
+    infrastructure_type,
+    infrastructure_vendor,
+    public_ipv4_addresses,
+    public_dns,
+    network = {},
+  } = {},
   { facts } = {}
 ) => ({
   type:
@@ -84,9 +90,11 @@ export const infrastructureSelector = (
       (facts?.rhsm?.IS_VIRTUAL ? 'virtual' : 'physical')) ||
     undefined,
   vendor: infrastructure_vendor,
+  public_ipv4_addresses: public_ipv4_addresses,
   ipv4: network.ipv4,
   ipv6: network.ipv6,
   nics: network.interfaces,
+  fqdn: public_dns,
 });
 
 export const configurationSelector = ({


### PR DESCRIPTION
# Description

Add Public IP & FQDN to Infrastructure Card in Host Details Page
The necessary changes that address the issue described on the ticket

Associated Jira ticket: [#RHINENG-4796](https://issues.redhat.com/browse/RHINENG-4796) 

# How to test the PR

Ensure a host containing the properties `public_ipv4_addresses` (& `public_dns`) is presenting those properties on its Infrastructure Card in its Host Details page
(It could also be with two different hosts that each contain one property)

Expected Functionality: 
- Hosts that have a property, should present it.
- Hosts that do not have a property, should present 'Not available' instead.

To test, you can search for a host named `lior_test_ip-172-31-89-28.ec2.internal` on `insights-qa` account. 
This host contains the necessary `public_ipv4_addresses` property that should be presented on the Infrastructure Card.

### Please Read
*However, because we are not yet collecting the `public_dns`, we can not create a host that contain this property.
Because both of these properties are part of the same SystemProfile object that is received in the relevant API response, both properties have the same implementation in this PR, which should work.*

*Here is a link to the scheme of `SystemProfile` that is being returned:
https://github.com/lzap/inventory-schemas/blob/fe94ba7ab5561abf1e1d644645b0110d6e64fbc0/schemas/system_profile/v1.yaml#L389-L406*

*The API endpoint that receives SystemProfile that SHOULD contain both properties, but now containing only 1 because this host does not contain the `public_dns` property (see the screenshots attached):*

![Screenshot from 2024-01-08 15-18-50](https://github.com/RedHatInsights/insights-inventory-frontend/assets/93318917/e93fb9b5-7cfc-44ce-977b-ab5602c4295a)

![Screenshot from 2024-01-08 15-19-06](https://github.com/RedHatInsights/insights-inventory-frontend/assets/93318917/ff0c03f1-3f0f-425f-950f-d45037bfda2f)


*Tested locally that when a host has also the `public_dns` property, it is being presented in the UI alongside the `public_ipv4_addresses` property. 
Attached screenshots of the changes and the UI:*

*Added code that is needed to ensure that the necessary values are presented when received*

![Added code that is needed to ensure that the necessary values are presented when received](https://github.com/RedHatInsights/insights-inventory-frontend/assets/93318917/a4371863-aa0c-4ca5-afd8-4c22a18f2413)

*The passed values are presented in the UI*

![The passed values are presented in the UI](https://github.com/RedHatInsights/insights-inventory-frontend/assets/93318917/6a81baee-26e7-4008-8aae-61fe09520c05)

# Before the change

Host Details Page for a host that contains the `public_ipv4_addresses` property
Green - name of host so we can easily find it
Yellow - Infrastructure Card does not contain the mentioned properties

![Before: Host Details Page for a host that contains the public_ipv4_addresses property](https://github.com/RedHatInsights/insights-inventory-frontend/assets/93318917/fb672923-57c9-49f6-9c5a-2dd936cbcc84)

# After the change

Host Details Page for a host that contains the `public_ipv4_addresses` property
Green - name of host so we can easily find it (same host name)
Orange - New Public IP property that is showing on the Infrastructure Card because this host contains the necessary property
Yellow - New FQDN property is being presented on the card, but is showing Not Available for this host because it does not contain the necessary `public_dns` property

![After: Host Details Page for a host that contains the public_ipv4_addresses property](https://github.com/RedHatInsights/insights-inventory-frontend/assets/93318917/68765b8c-4845-4d1d-8082-5d8566ea13f9)


# Checklist

- [X] Check the property `public_ipv4_addresses`
- [X] Check the property `public_dns` -> Need to create a host containing this prop (blocked) but tested locally (explained in the Please Read section)
- [X] update appropriate snapshots
- [X] Add screenshots