### PR TITLE
fix(RHINENG-5953): Fix zero state not loading on no systems

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -54,17 +54,19 @@ export const Routes = () => {
   const stalenessAndDeletionEnabled = useFeatureFlag('hbi.custom-staleness');
 
   useEffect(() => {
+    // zero state check
     try {
       (async () => {
         const hasConventionalSystems = await inventoryHasConventionalSystems();
+        setHasConventionalSystems(hasConventionalSystems);
+
         if (edgeParityInventoryListEnabled) {
           const hasEdgeSystems = await inventoryHasEdgeSystems();
-          setHasConventionalSystems(hasConventionalSystems);
           setHasEdgeDevices(hasEdgeSystems);
         }
       })();
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
   }, []);
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-5953.

- The zero state component is now correctly rendered if there are no conventional nor immutable systems available for account. 
- This also adds isLoading flag to Routes to indicate the state when the component does not know yet about the number of systems available yet. It prevents Inventory from premature routes render.

## How to test

1. Use an account without any hosts available
2. Go to /inventory and make sure you see the zero state banner, the inventory shouldn't load any route content.
3. Also make sure there is no tables render before zero state appears. This PR sets the loading flag before all the hosts number requests are fulfilled.
