### PR TITLE
Render host or id if display_name not available in TagsModal

### DIFF
--- a/src/Utilities/TagsModal.js
+++ b/src/Utilities/TagsModal.js
@@ -33,9 +33,10 @@ const TagsModal = ({ filterTagsBy, onToggleModal, onApply, getTags }) => {
       entities?.tagModalLoaded || entityDetails?.tagModalLoaded
   );
 
-  const activeSystemTag = useSelector(
-    ({ entities, entityDetails }) =>
-      entities?.activeSystemTag || entityDetails?.entity
+  const activeSystemTag = useSelector(({ entities, entityDetails }) =>
+    entities?.activeSystemTag?.created
+      ? entities.activeSystemTag
+      : entityDetails?.entity
   );
   const tags = useSelector(({ entities, entityDetails }) => {
     const activeTags =


### PR DESCRIPTION
Hi! Just noticed that `TagsModal` renders undefined if I don't have `display_name` set for my connected system, figured I can help improve it, let me know if tests are also needed but it's fairly minor change (I looked up the other properties in `SystemCard` component).

This is the UI problem now:
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/19702477/57c139b1-1541-4713-8483-ac8bfb3f733f)
