### PR TITLE
fix(GroupDetails): THEEDGE-3782 - Fixes Group details edge Update button

### DIFF
--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -78,8 +78,14 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
   };
 
   const navigate = useNavigate();
-  const canUpdateSelectedDevices = (deviceIds, imageSets) =>
-    deviceIds?.length > 0 && imageSets?.length == 1 ? true : false;
+  const canUpdateSelectedDevices = (deviceIds, imageSets, updatableDeviceIds) =>
+    deviceIds?.length > 0 &&
+    imageSets?.length === 1 &&
+    updatableDeviceIds?.length > 0 &&
+    // all deviceIds must be in updatableDeviceIds
+    deviceIds.filter((s) => updatableDeviceIds.includes(s)).length ===
+      deviceIds.length;
+
   const [removeHostsFromGroupModalOpen, setRemoveHostsFromGroupModalOpen] =
     useState(false);
   const [currentSystem, setCurrentSystem] = useState([]);
@@ -172,9 +178,6 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
       isOpen: true,
     }));
   };
-
-  let imageSet = [];
-  let deviceIds = [];
   const bulkSelectConfig = useBulkSelectConfig(
     selected,
     null,
@@ -185,20 +188,22 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
     groupName
   );
 
-  //enable disable bulk update based on selection, must refactor
   useEffect(() => {
-    if (selected.size > 0 && deviceImageSet?.size > 0) {
-      return () => {
-        [...selected.keys()].map((s) => {
-          const img = deviceImageSet[s];
-          if (!imageSet.includes(img)) {
-            imageSet.push(img);
-          }
-          deviceIds.push(s);
-        });
-        setCanUpdate(canUpdateSelectedDevices(deviceIds, imageSet));
-        setUpdateImageSet(imageSet);
-      };
+    if (selected.size > 0 && Object.keys(deviceImageSet || {}).length > 0) {
+      let imageSet = [];
+      let deviceIds = [];
+      [...selected.keys()].map((s) => {
+        const img = deviceImageSet[s];
+
+        if (!imageSet.includes(img)) {
+          imageSet.push(img);
+        }
+        deviceIds.push(s);
+      });
+      setCanUpdate(canUpdateSelectedDevices(deviceIds, imageSet, deviceData));
+      setUpdateImageSet(imageSet);
+    } else {
+      setCanUpdate(false);
     }
   }, [deviceData, selected, deviceImageSet]);
   return (


### PR DESCRIPTION
When systems to update was selected the Update button was not updated as expected. 

Now the button is enabled when the selected systems are updatable and have the same image set, in all other cases the button is disabled. 

FIXES: https://issues.redhat.com/browse/THEEDGE-3782

[Screencast from 2024-01-10 13-24-37.webm](https://github.com/RedHatInsights/insights-inventory-frontend/assets/131553/6c3845c7-066d-4346-a1a0-703b3abc4e1d)
