### PR TITLE
fix(THEEDGE-3790): fix conventional filter when no host typ informed

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -162,6 +162,8 @@ export const calculateSystemProfile = ({
 
   if (hostTypeFilter) {
     systemProfile['host_type'] = hostTypeFilter;
+  } else {
+    systemProfile['host_type'] = 'nil';
   }
 
   return generateFilter({


### PR DESCRIPTION
Add filter by host type as default to avoid list immutable and edge in the same list
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/5039367/1501384e-9d65-4240-bbf1-e8b5aac6067d)
