### PR TITLE
fix(RHINENG-7083): Temporarily ignore 403 when checking hosts count

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -58,8 +58,8 @@ export const Routes = () => {
 
   useEffect(() => {
     // zero state check
-    try {
-      (async () => {
+    (async () => {
+      try {
         const hasConventionalSystems = await inventoryHasConventionalSystems();
         setHasConventionalSystems(hasConventionalSystems);
 
@@ -69,10 +69,14 @@ export const Routes = () => {
         }
 
         setIsLoading(false);
-      })();
-    } catch (e) {
-      console.error(e);
-    }
+      } catch (error) {
+        console.error(error);
+
+        if (error.response.status === 403) {
+          setIsLoading(false);
+        }
+      }
+    })();
   }, []);
 
   let element = useRoutes([


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-7083.

This fixes the issue with users having no `inventory:hosts:read` permissions trying to access the /inventory page. Now, while checking for hosts count, if we get 403, we should proceed and set the loading flag to false. The permissions are further handled by the /inventory route again so it's safe.

⚠️ This is an intermediate (workaround) fix because of the time pressure (but the proper refactor PR will be open soon). 

## How to test

1. Have no 'inventory:hosts:read' permissions for your account
2. Navigate to /inventory
3. If you have at least one host (conventional/immutable), you should see the table rendered
4. If you don't have any hosts, you should see the "zero stage"