### PR TITLE
fix(THEEDGE-3793): Fix update option showed when all system are updated in a group

### DIFF
--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -131,7 +131,6 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
       enhancedConfig,
       showTags
     );
-
     const mapDeviceIds = mapDefaultData(defaultData.results);
     const updateInfo = await getUpdateInfo(groupId);
     setDeviceData(updateInfo?.update_devices_uuids);
@@ -206,6 +205,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
       setCanUpdate(false);
     }
   }, [deviceData, selected, deviceImageSet]);
+
   return (
     <div id="group-systems-table">
       {addToGroupModalOpen && (
@@ -275,7 +275,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
                 title: (
                   <ActionDropdownItem
                     isAriaDisabled={
-                      deviceData && !deviceData.find((obj) => obj === row.id)
+                      deviceData ? !deviceData.includes(row.id) : true
                     }
                     requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                       groupId

--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -133,7 +133,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
     );
     const mapDeviceIds = mapDefaultData(defaultData.results);
     const updateInfo = await getUpdateInfo(groupId);
-    setDeviceData(updateInfo?.update_devices_uuids);
+    setDeviceData(updateInfo?.update_devices_uuids || []);
     setDeviceImageSet(updateInfo?.device_image_set_info);
     const rowInfo = [];
     let items = [];
@@ -274,9 +274,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
               {
                 title: (
                   <ActionDropdownItem
-                    isAriaDisabled={
-                      deviceData ? !deviceData.includes(row.id) : true
-                    }
+                    isAriaDisabled={!deviceData.includes(row.id)}
                     requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                       groupId
                     )}


### PR DESCRIPTION
According the ticket THEEDGE-3793, when we have a group with all the system "updated", we show on kebab menu the optiont o update as active. This is solved once a system with update pendent is added to the group.

The reason for this error is the deviceList been empty and it generate a false positive on the previous condition. This PR will fix the issue. 