### PR TITLE
fix(RHINENG-5932): Fix found visual regressions after PF5 migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@patternfly/react-core": "^5.1.2",
         "@patternfly/react-icons": "^5.1.2",
         "@patternfly/react-table": "^5.1.2",
-        "@redhat-cloud-services/frontend-components": "^4.2.3",
+        "@redhat-cloud-services/frontend-components": "^4.2.4",
         "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
         "@redhat-cloud-services/host-inventory-client": "1.2.13",
@@ -5502,9 +5502,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.3.tgz",
-      "integrity": "sha512-mc1HNFupS4EQY1ipZa8Tw/lR8L1J4NEtcSVbvMeKwvfFLlrUIG8isTnEHE+e8bjIcMhnCOO37b0K089uSzJHOw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.4.tgz",
+      "integrity": "sha512-5xne/DD1/+txtN50YOrKPeJKpSgENkGz4o4oqYMRB+ElJwnupsaOasvyfMwImKggDcAZ/uWLXt8KNoE8ZXhVvA==",
       "dependencies": {
         "@patternfly/react-component-groups": "^5.0.0",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@patternfly/react-core": "^5.1.2",
     "@patternfly/react-icons": "^5.1.2",
     "@patternfly/react-table": "^5.1.2",
-    "@redhat-cloud-services/frontend-components": "^4.2.3",
+    "@redhat-cloud-services/frontend-components": "^4.2.4",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
     "@redhat-cloud-services/host-inventory-client": "1.2.13",

--- a/src/Utilities/DeleteModal.js
+++ b/src/Utilities/DeleteModal.js
@@ -47,7 +47,7 @@ const DeleteModal = ({
     >
       <Split hasGutter>
         <SplitItem>
-          <Icon size="xl" className="ins-m-alert">
+          <Icon size="xl" status="warning">
             <ExclamationTriangleIcon />
           </Icon>
         </SplitItem>

--- a/src/Utilities/__snapshots__/DeleteModal.test.js.snap
+++ b/src/Utilities/__snapshots__/DeleteModal.test.js.snap
@@ -77,10 +77,10 @@ exports[`DeleteModal DOM should render correctly with multiple systems 1`] = `
                 class="pf-v5-l-split__item"
               >
                 <span
-                  class="pf-v5-c-icon pf-m-xl ins-m-alert"
+                  class="pf-v5-c-icon pf-m-xl"
                 >
                   <span
-                    class="pf-v5-c-icon__content"
+                    class="pf-v5-c-icon__content pf-m-warning"
                   >
                     <svg
                       aria-hidden="true"
@@ -290,10 +290,10 @@ exports[`DeleteModal DOM should render correctly with one system 1`] = `
                 class="pf-v5-l-split__item"
               >
                 <span
-                  class="pf-v5-c-icon pf-m-xl ins-m-alert"
+                  class="pf-v5-c-icon pf-m-xl"
                 >
                   <span
-                    class="pf-v5-c-icon__content"
+                    class="pf-v5-c-icon__content pf-m-warning"
                   >
                     <svg
                       aria-hidden="true"

--- a/src/Utilities/hooks/useBulkSelectConfig.js
+++ b/src/Utilities/hooks/useBulkSelectConfig.js
@@ -92,7 +92,6 @@ export const useBulkSelectConfig = (
       onSelectRows(0, value);
     },
     toggleProps: {
-      'data-ouia-component-type': 'bulk-select-toggle-button',
       children: isBulkLoading ? (
         [
           <Fragment key="sd">

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -455,6 +455,7 @@ const GroupsTable = ({ onCreateGroupClick }) => {
               requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
               noAccessTooltip={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}
               onClick={onCreateGroupClick}
+              ouiaId="CreateGroupButton"
             >
               Create group
             </ActionButton>,

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -450,22 +450,14 @@ const GroupsTable = ({ onCreateGroupClick }) => {
         }}
         actionsConfig={{
           actions: [
-            {
-              label: (
-                <ActionButton
-                  requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
-                  noAccessTooltip={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}
-                  onClick={onCreateGroupClick}
-                >
-                  Create group
-                </ActionButton>
-              ),
-              props: {
-                style: {
-                  backgroundColor: 'transparent',
-                },
-              },
-            },
+            <ActionButton
+              key="create-group-btn"
+              requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
+              noAccessTooltip={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}
+              onClick={onCreateGroupClick}
+            >
+              Create group
+            </ActionButton>,
             {
               label: (
                 <ActionDropdownItem

--- a/src/components/InventoryGroups/Modals/DeleteGroupModal.js
+++ b/src/components/InventoryGroups/Modals/DeleteGroupModal.js
@@ -5,8 +5,6 @@ import componentTypes from '@data-driven-forms/react-form-renderer/component-typ
 import Modal from './Modal';
 import { deleteGroupsById, getGroupsByIds } from '../utils/api';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import warningColor from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
-import dangerColor from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
 import {
   Backdrop,
   Bullseye,
@@ -50,7 +48,7 @@ const generateSchema = (groups) => ({
 const generateContent = (groups = []) => ({
   title: groups.length > 1 ? 'Delete groups?' : 'Delete group?',
   titleIconVariant: () => (
-    <Icon color={warningColor.value}>
+    <Icon status="warning">
       <ExclamationTriangleIcon />
     </Icon>
   ),
@@ -133,7 +131,7 @@ const DeleteGroupModal = ({
           : 'Cannot delete group at this time'
       }
       titleIconVariant={() => (
-        <Icon color={dangerColor.value}>
+        <Icon status="danger">
           <ExclamationCircleIcon />
         </Icon>
       )}

--- a/src/components/InventoryHostStaleness/HostStalenessCard.js
+++ b/src/components/InventoryHostStaleness/HostStalenessCard.js
@@ -195,8 +195,8 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
           <CardHeader>
             <Title headingLevel="h4" size="xl" id="HostTitle">
               Organization level system staleness and deletion
+              <InventoryHostStalenessPopover hasEdgeSystems={hasEdgeSystems} />
             </Title>
-            <InventoryHostStalenessPopover hasEdgeSystems={hasEdgeSystems} />
           </CardHeader>
           <CardBody>
             <p>

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -31,7 +31,7 @@ const expectDefaultFiltersVisible = async () => {
 
   await userEvent.click(
     screen.getByRole('button', {
-      name: 'Conditional filter',
+      name: /conditional filter toggle/i,
     })
   );
   DEFAULT_FILTERS.forEach((filterName) =>

--- a/src/routes/inventory.scss
+++ b/src/routes/inventory.scss
@@ -19,10 +19,6 @@
     background: var(--pf-v5-global--BackgroundColor--100);
 }
 
-svg.ins-m-alert {
-    fill: var(--pf-v5-global--warning-color--100);
-}
-
 .ins-c-inventory__table--remove {
     .pf-v5-c-clipboard-copy {
         margin: 0 3rem;


### PR DESCRIPTION
Fixes some of the bugs described in https://issues.redhat.com/browse/RHINENG-5932 comments.

This:
- On the staleness page, aligns the card title and popover
- Fixes all the icons that missed colours (danger, warning)
- On the groups page, aligns horizontally the Create group button with the rest of the toolbar
- Adds missing OUIA IDs and extends the OUIA coverage for the bulk select, conditional filter and actions in PrimaryToolbar. 