### PR TITLE
fix(RHINENG-8372): Fix Group details not loading Edge devices

### DIFF
--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -109,7 +109,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
   );
 
   const getUpdateInfo = useGetInventoryGroupUpdateInfo();
-  const [deviceData, setDeviceData] = useState();
+  const [deviceData, setDeviceData] = useState(null);
   const [deviceImageSet, setDeviceImageSet] = useState();
   const [updateModal, setUpdateModal] = useState({
     isOpen: false,
@@ -271,7 +271,9 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
               {
                 title: (
                   <ActionDropdownItem
-                    isAriaDisabled={!deviceData.includes(row.id)}
+                    isAriaDisabled={
+                      deviceData === null || !deviceData.includes(row.id)
+                    }
                     requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                       groupId
                     )}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-8372.

The Immutable tab was playing up because of the deviceData being undefined or null which was not treated as a separate edge case.

## How to test

1. Have a group with both conventional and immutable systems
2. Navigate to this group
3. Make sure you can switch between both immutable and conventional systems tabs without crash (which is reproducible on stage)