### PR TITLE
feat(RHINENG-8562): Show conversion alert for CentOS systems

### DIFF
--- a/src/components/GeneralInfo/GeneralInformation/ConversionAlert.js
+++ b/src/components/GeneralInfo/GeneralInformation/ConversionAlert.js
@@ -1,0 +1,45 @@
+import { Alert, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+import React from 'react';
+
+const ConversionAlert = (props) => {
+  const navigate = useInsightsNavigate('tasks');
+
+  return (
+    <Alert
+      variant="custom"
+      isInline
+      title="Convert this CentOS system to RHEL"
+      {...props}
+    >
+      <TextContent>
+        <Text component={TextVariants.p}>
+          On June 30, 2024, CentOS Linux 7 will reach End of Life (EOL). Convert
+          your system to RHEL using the Convert2RHEL tool to migrate your system
+          to a fully supported production-grade operating system while
+          maintaining existing OS customizations, configurations, and
+          preferences.
+        </Text>
+        <Text component={TextVariants.p}>
+          Red Hat can help migrate CentOS Linux 7 users to maintain continuity
+          in their environment after the EOL date, whether they’re on premise or
+          in the cloud.{' '}
+          <a
+            href="https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/centos-migration"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Learn more about CentOS Migration here.
+          </a>
+        </Text>
+        <Text component={TextVariants.p}>
+          <a onClick={() => navigate('/available#pre-conversion-analysis')}>
+            Run a Pre-conversion analysis of this system
+          </a>
+        </Text>
+      </TextContent>
+    </Alert>
+  );
+};
+
+export { ConversionAlert };

--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
@@ -19,6 +19,7 @@ import { Provider } from 'react-redux';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
 
 import './general-information.scss';
+import { ConversionAlert } from './ConversionAlert';
 
 class GeneralInformation extends Component {
   state = {
@@ -97,10 +98,17 @@ class GeneralInformation extends Component {
       DataCollectorsCardWrapper,
       CollectionCardWrapper,
       children,
+      entity,
     } = this.props;
     const Wrapper = store ? Provider : Fragment;
+
     return (
       <Wrapper {...(store && { store })}>
+        {entity?.system_profile?.operating_system?.name === 'CentOS Linux' && (
+          <ConversionAlert
+            style={{ marginBottom: 'var(--pf-v5-global--spacer--md)' }}
+          />
+        )}
         <div className="ins-c-general-information">
           <Grid hasGutter>
             <GridItem md={6} sm={12}>
@@ -172,9 +180,7 @@ class GeneralInformation extends Component {
                     <AsyncComponent
                       appName="edge"
                       module="./ImagesInformationCard"
-                      deviceIdProps={
-                        this.props.inventoryId || this.props.entity.id
-                      }
+                      deviceIdProps={this.props.inventoryId || entity.id}
                     />
                   </GridItem>
                 )}
@@ -207,6 +213,11 @@ class GeneralInformation extends Component {
 GeneralInformation.propTypes = {
   entity: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    system_profile: PropTypes.shape({
+      operating_system: PropTypes.shape({
+        name: PropTypes.string,
+      }),
+    }),
   }),
   openedModal: PropTypes.string,
   loadSystemDetail: PropTypes.func,


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-8562.

This adds a banner for CentOS system on the host details page in Inventory. The first link leads to a documentation article, the second redirects to the tasks application.

## How to test

1. Go to Inventory and find any CentOS system
2. Navigate to the system details page
3. Confirm you can see the alert

## Screenshots

![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/a4f2bd3f-5a17-44a1-a109-6f56b888300a)
