### PR TITLE
feat(RHINENG-8561): Mark CentOS systems and provide more details

### DIFF
--- a/src/components/InventoryDetail/FactsInfo.js
+++ b/src/components/InventoryDetail/FactsInfo.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Flex, FlexItem, Grid, GridItem } from '@patternfly/react-core';
+import { Flex, FlexItem, Grid, GridItem, Label } from '@patternfly/react-core';
 import {
   Skeleton,
   SkeletonSize,
@@ -63,6 +63,12 @@ const FactsInfo = ({
             ) && <InsightsDisconnected />}
         </FlexItem>
       </Flex>
+      {loaded &&
+        entity?.system_profile?.operating_system?.name === 'CentOS Linux' && (
+          <div>
+            <Label color="cyan">CentOS Linux system</Label>
+          </div>
+        )}
     </GridItem>
   </Grid>
 );

--- a/src/components/InventoryDetail/FactsInfo.test.js
+++ b/src/components/InventoryDetail/FactsInfo.test.js
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import FactsInfo from './FactsInfo';
+
+describe('FactsInfo', () => {
+  it('should render extra label for CentOS system', () => {
+    render(
+      <FactsInfo
+        loaded
+        entity={{
+          system_profile: {
+            operating_system: {
+              name: 'CentOS Linux',
+            },
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText(/centos linux system/i)).toBeVisible();
+  });
+});

--- a/src/components/InventoryDetail/InventoryDetail.scss
+++ b/src/components/InventoryDetail/InventoryDetail.scss
@@ -39,8 +39,6 @@
     div {
       @include rem('margin', 5px);
       margin-left: 0;
-
-      span:first-child { @include rem('margin-right', 5px); }
     }
   }
 

--- a/src/components/InventoryTable/ConversionPopover/ConversionPopover.js
+++ b/src/components/InventoryTable/ConversionPopover/ConversionPopover.js
@@ -1,0 +1,56 @@
+import {
+  Button,
+  Label,
+  Popover,
+  Text,
+  TextContent,
+} from '@patternfly/react-core';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+import React from 'react';
+
+const ConversionPopover = () => {
+  const navigate = useInsightsNavigate('tasks');
+
+  return (
+    <Popover
+      hasAutoWidth
+      aria-label="CentOS conversion alert popover"
+      headerContent={'Convert this system to RHEL'}
+      bodyContent={
+        <TextContent>
+          <Text style={{ maxWidth: '380px' }}>
+            On June 30, 2024, CentOS Linux 7 will reach End of Life (EOL).
+          </Text>
+          <Text style={{ maxWidth: '380px' }}>
+            Red Hat can help migrate CentOS Linux 7 users to maintain continuity
+            in their environment after the EOL date, whether they’re on premise
+            or in the cloud.
+          </Text>
+          <Text>
+            <a
+              href="https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/centos-migration"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Learn more about CentOS Migration
+            </a>
+          </Text>
+        </TextContent>
+      }
+      footerContent={
+        <Button
+          variant="secondary"
+          onClick={() => navigate('/available#pre-conversion-analysis')}
+        >
+          Run a pre-conversion analysis of this system
+        </Button>
+      }
+    >
+      <Label isCompact color="cyan">
+        Convert system to RHEL
+      </Label>
+    </Popover>
+  );
+};
+
+export { ConversionPopover };

--- a/src/components/InventoryTable/TitleColumn.js
+++ b/src/components/InventoryTable/TitleColumn.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { ConversionPopover } from './ConversionPopover/ConversionPopover';
 
 /**
  * Helper function to proprly calculate what to do when user clicks on first cell.
@@ -38,20 +39,27 @@ const TitleColumn = ({ children, id, item, ...props }) => (
       {props?.noDetail ? (
         children
       ) : (
-        <Link
-          to={item?.href || item?.to || id}
-          {...{
-            ...(props?.onRowClick
-              ? {
-                  onClick: (event) => {
-                    onRowClick(event, id, props);
-                  },
-                }
-              : {}),
-          }}
-        >
-          {children}
-        </Link>
+        <span>
+          <Link
+            to={item?.href || item?.to || id}
+            {...{
+              ...(props?.onRowClick
+                ? {
+                    onClick: (event) => {
+                      onRowClick(event, id, props);
+                    },
+                  }
+                : {}),
+            }}
+          >
+            {children}
+          </Link>
+          {item?.system_profile?.operating_system?.name === 'CentOS Linux' && (
+            <div>
+              <ConversionPopover />
+            </div>
+          )}
+        </span>
       )}
     </div>
   </div>

--- a/src/components/InventoryTable/TitleColumn.test.js
+++ b/src/components/InventoryTable/TitleColumn.test.js
@@ -1,8 +1,14 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import TitleColumn from './TitleColumn';
+import { TestWrapper } from '../../Utilities/TestingUtilities';
+import '@testing-library/jest-dom';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate'
+);
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   // eslint-disable-next-line react/prop-types
@@ -67,6 +73,34 @@ describe('TitleColumn', () => {
       </TitleColumn>
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render conversion label for CentOS system', async () => {
+    const navigate = jest.fn();
+    useInsightsNavigate.mockReturnValue(navigate);
+    render(
+      <TestWrapper>
+        <TitleColumn
+          id="testId"
+          item={{
+            system_profile: { operating_system: { name: 'CentOS Linux' } },
+          }}
+        >
+          something
+        </TitleColumn>
+      </TestWrapper>
+    );
+
+    expect(screen.getByText(/convert system to rhel/i)).toBeVisible();
+    await userEvent.click(screen.getByText(/convert system to rhel/i));
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /run a pre-conversion analysis of this system/i,
+      })
+    );
+    await waitFor(() => {
+      expect(navigate).toBeCalledWith('/available#pre-conversion-analysis');
+    });
   });
 
   describe('API', () => {

--- a/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
@@ -25,9 +25,11 @@ exports[`TitleColumn should render correctly with NO data 1`] = `
     <div
       class=""
     >
-      <a
-        class="fakeLink"
-      />
+      <span>
+        <a
+          class="fakeLink"
+        />
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -41,12 +43,14 @@ exports[`TitleColumn should render correctly with data 1`] = `
     <div
       class=""
     >
-      <a
-        class="fakeLink"
-        to="testId"
-      >
-        something
-      </a>
+      <span>
+        <a
+          class="fakeLink"
+          to="testId"
+        >
+          something
+        </a>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -60,12 +64,14 @@ exports[`TitleColumn should render correctly with href 1`] = `
     <div
       class=""
     >
-      <a
-        class="fakeLink"
-        to="/link/to/item"
-      >
-        something
-      </a>
+      <span>
+        <a
+          class="fakeLink"
+          to="/link/to/item"
+        >
+          something
+        </a>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -82,12 +88,14 @@ exports[`TitleColumn should render correctly with os_release 1`] = `
     <div
       class=""
     >
-      <a
-        class="fakeLink"
-        to="testId"
-      >
-        something
-      </a>
+      <span>
+        <a
+          class="fakeLink"
+          to="testId"
+        >
+          something
+        </a>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -101,12 +109,14 @@ exports[`TitleColumn should render correctly with to 1`] = `
     <div
       class=""
     >
-      <a
-        class="fakeLink"
-        to="[object Object]"
-      >
-        something
-      </a>
+      <span>
+        <a
+          class="fakeLink"
+          to="[object Object]"
+        >
+          something
+        </a>
+      </span>
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-8561.

This adds a CentOS label to the inventory details and inventory list page. The label should appear for systems that are of CentOS Linux operating system.

## How to test

1. Navigate to /inventory
2. Filter out CentOS systems and verify that you can see the label for each row
3. Click on any label and make sure more details are shown together with the button redirecting to Tasks
4. Click on any CentOS host and navigate to the host details page
5. Check that you can see a plain label after "Last seen"

## Screenshots

<img width="1195" alt="Screenshot 2024-03-08 at 10 49 49" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/59664e74-ea3c-4055-aa02-364629f54be1">
<img width="1305" alt="Screenshot 2024-03-08 at 10 13 33" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/c4bf66ca-0181-407c-af4e-da45c522b8d7">
