### PR TITLE
fix(RHINENG-4108): Filters are Being Reset When AddSystemsToGroupModal Closes

### DIFF
--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -141,7 +141,7 @@ const GroupSystems = ({ groupName, groupId }) => {
       hostGroupFilter,
       lastSeenFilter
     );
-  }, []);
+  }, [addToGroupModalOpen]);
 
   const bulkSelectConfig = useBulkSelectConfig(
     selected,

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -190,7 +190,7 @@ const AddSystemsToGroupModal = ({
             setConfirmationModalOpen(false);
             setSystemSelectModalOpen(true); // switch back to the systems table modal
           }}
-          onCancel={() => handleModalClose()}
+          onCancel={handleModalClose}
           hostsNumber={alreadyHasGroup.length}
         />
         {/** hosts selection modal */}
@@ -214,7 +214,7 @@ const AddSystemsToGroupModal = ({
             </Flex>
           }
           isOpen={systemsSelectModalOpen}
-          onClose={() => handleModalClose()}
+          onClose={handleModalClose}
           footer={
             <Flex direction={{ default: 'column' }} style={{ width: '100%' }}>
               {showWarning && (
@@ -244,11 +244,7 @@ const AddSystemsToGroupModal = ({
                 >
                   Add systems
                 </Button>
-                <Button
-                  key="cancel"
-                  variant="link"
-                  onClick={() => handleModalClose()}
-                >
+                <Button key="cancel" variant="link" onClick={handleModalClose}>
                   Cancel
                 </Button>
               </FlexItem>

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -104,10 +104,10 @@ const AddSystemsToGroupModal = ({
     [isModalOpen]
   );
 
-  const calculateSelected = () => (selected ? selected.size : 0);
+  const numOfSelectedSystems = selected ? selected.size : 0;
 
   const handleModalClose = () => {
-    if (calculateSelected() > 0) {
+    if (numOfSelectedSystems > 0) {
       dispatch(selectEntity(-1, false));
     }
     dispatch(clearFilters());

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -107,11 +107,11 @@ const AddSystemsToGroupModal = ({
   const calculateSelected = () => (selected ? selected.size : 0);
 
   const handleModalClose = () => {
-    setIsModalOpen(false);
     if (calculateSelected() > 0) {
       dispatch(selectEntity(-1, false));
     }
     dispatch(clearFilters());
+    setIsModalOpen(false);
   };
 
   const edgeParityInventoryListEnabled = useFeatureFlag(


### PR DESCRIPTION
# Description

This PR addresses issue [#RHINENG-4108](https://issues.redhat.com/browse/RHINENG-4108)

When a user opens "Add systems" modal, the systems table filters are sometimes being reset when closing the modal

# Steps to Reproduce:

1. Visit https://console.stage.redhat.com/preview/insights/inventory/groups
2. Open any Group
3. Apply any filter to the Group's systems table
4. Click "Add systems" button
5. Close "Add systems" modal

Expected Results:
Systems table has previously applied filters

Actual Results:
Systems table sometimes doesn't have any filter when the modal closes