### PR TITLE
feat(RHINENG-8881): Add bootc card host detail page

### DIFF
--- a/src/components/GeneralInfo/BootcImageCard/BootcImageCard.js
+++ b/src/components/GeneralInfo/BootcImageCard/BootcImageCard.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import LoadingCard from '../LoadingCard';
+import { bootcSelector } from '../selectors';
+import { extraShape } from '../../../constants';
+
+const BootcImageCardCore = ({ bootc, detailLoaded, handleClick, extra }) => (
+  <LoadingCard
+    title="BOOTC"
+    isLoading={!detailLoaded}
+    items={[
+      ...[{ title: 'Booted Image', value: bootc.bootedImage }],
+      ...[{ title: 'Booted Image Digest', value: bootc.bootedImageDigest }],
+      ...[{ title: 'Staged Image', value: bootc.stagedImage }],
+      ...[{ title: 'Staged Image Digest', value: bootc.stagedImageDigest }],
+      ...[{ title: 'Rollback Image', value: bootc.rollbackImage }],
+      ...[{ title: 'Rollback Image Digest', value: bootc.rollbackImageDigest }],
+      ...extra.map(({ onClick, ...item }) => ({
+        ...item,
+        ...(onClick && { onClick: (e) => onClick(e, handleClick) }),
+      })),
+    ]}
+  />
+);
+
+BootcImageCardCore.propTypes = {
+  detailLoaded: PropTypes.bool,
+  handleClick: PropTypes.func,
+  bootc: PropTypes.shape({
+    bootedImage: PropTypes.string,
+    bootedImageDigest: PropTypes.string,
+    stagedImage: PropTypes.string,
+    stagedImageDigest: PropTypes.string,
+    rollbackImage: PropTypes.string,
+    rollbackImageDigest: PropTypes.string,
+  }),
+  extra: PropTypes.arrayOf(extraShape),
+};
+BootcImageCardCore.defaultProps = {
+  detailLoaded: false,
+  handleClick: () => undefined,
+  extra: [],
+};
+
+export const BootcImageCard = connect(
+  ({ systemProfileStore: { systemProfile } }) => ({
+    detailLoaded: systemProfile && systemProfile.loaded,
+    bootc: bootcSelector(systemProfile),
+  })
+)(BootcImageCardCore);
+
+BootcImageCard.propTypes = BootcImageCardCore.propTypes;
+BootcImageCard.defaultProps = BootcImageCardCore.defaultProps;
+
+export default BootcImageCard;

--- a/src/components/GeneralInfo/BootcImageCard/BootcImageCard.js
+++ b/src/components/GeneralInfo/BootcImageCard/BootcImageCard.js
@@ -1,30 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import LoadingCard from '../LoadingCard';
 import { bootcSelector } from '../selectors';
 import { extraShape } from '../../../constants';
 
-const BootcImageCardCore = ({ bootc, detailLoaded, handleClick, extra }) => (
-  <LoadingCard
-    title="BOOTC"
-    isLoading={!detailLoaded}
-    items={[
-      ...[{ title: 'Booted Image', value: bootc.bootedImage }],
-      ...[{ title: 'Booted Image Digest', value: bootc.bootedImageDigest }],
-      ...[{ title: 'Staged Image', value: bootc.stagedImage }],
-      ...[{ title: 'Staged Image Digest', value: bootc.stagedImageDigest }],
-      ...[{ title: 'Rollback Image', value: bootc.rollbackImage }],
-      ...[{ title: 'Rollback Image Digest', value: bootc.rollbackImageDigest }],
-      ...extra.map(({ onClick, ...item }) => ({
-        ...item,
-        ...(onClick && { onClick: (e) => onClick(e, handleClick) }),
-      })),
-    ]}
-  />
-);
+export const BootcImageCard = ({ handleClick, extra }) => {
+  const { detailLoaded, bootc } = useSelector(
+    ({ systemProfileStore: { systemProfile } }) => ({
+      detailLoaded: systemProfile && systemProfile.loaded,
+      bootc: bootcSelector(systemProfile),
+    })
+  );
 
-BootcImageCardCore.propTypes = {
+  return (
+    <LoadingCard
+      title="BOOTC"
+      isLoading={!detailLoaded}
+      items={[
+        ...[{ title: 'Booted Image', value: bootc.bootedImage }],
+        ...[{ title: 'Booted Image Digest', value: bootc.bootedImageDigest }],
+        ...[{ title: 'Staged Image', value: bootc.stagedImage }],
+        ...[{ title: 'Staged Image Digest', value: bootc.stagedImageDigest }],
+        ...[{ title: 'Rollback Image', value: bootc.rollbackImage }],
+        ...[
+          { title: 'Rollback Image Digest', value: bootc.rollbackImageDigest },
+        ],
+        ...extra.map(({ onClick, ...item }) => ({
+          ...item,
+          ...(onClick && { onClick: (e) => onClick(e, handleClick) }),
+        })),
+      ]}
+    />
+  );
+};
+
+BootcImageCard.propTypes = {
   detailLoaded: PropTypes.bool,
   handleClick: PropTypes.func,
   bootc: PropTypes.shape({
@@ -37,20 +48,8 @@ BootcImageCardCore.propTypes = {
   }),
   extra: PropTypes.arrayOf(extraShape),
 };
-BootcImageCardCore.defaultProps = {
+BootcImageCard.defaultProps = {
   detailLoaded: false,
   handleClick: () => undefined,
   extra: [],
 };
-
-export const BootcImageCard = connect(
-  ({ systemProfileStore: { systemProfile } }) => ({
-    detailLoaded: systemProfile && systemProfile.loaded,
-    bootc: bootcSelector(systemProfile),
-  })
-)(BootcImageCardCore);
-
-BootcImageCard.propTypes = BootcImageCardCore.propTypes;
-BootcImageCard.defaultProps = BootcImageCardCore.defaultProps;
-
-export default BootcImageCard;

--- a/src/components/GeneralInfo/BootcImageCard/index.js
+++ b/src/components/GeneralInfo/BootcImageCard/index.js
@@ -1,2 +1,1 @@
 export * from './BootcImageCard';
-export { default } from './BootcImageCard';

--- a/src/components/GeneralInfo/BootcImageCard/index.js
+++ b/src/components/GeneralInfo/BootcImageCard/index.js
@@ -1,0 +1,2 @@
+export * from './BootcImageCard';
+export { default } from './BootcImageCard';

--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
@@ -11,6 +11,7 @@ import InfoTable from '../InfoTable';
 import { OperatingSystemCard } from '../OperatingSystemCard';
 import { SystemCard } from '../SystemCard';
 import { BiosCard } from '../BiosCard';
+import { BootcImageCard } from '../BootcImageCard';
 import { InfrastructureCard } from '../InfrastructureCard';
 import { ConfigurationCard } from '../ConfigurationCard';
 import { SystemStatusCard } from '../SystemStatusCard';
@@ -92,6 +93,7 @@ class GeneralInformation extends Component {
       SystemCardWrapper,
       OperatingSystemCardWrapper,
       BiosCardWrapper,
+      BootcImageCardWrapper,
       InfrastructureCardWrapper,
       ConfigurationCardWrapper,
       SystemStatusCardWrapper,
@@ -101,7 +103,6 @@ class GeneralInformation extends Component {
       entity,
     } = this.props;
     const Wrapper = store ? Provider : Fragment;
-
     return (
       <Wrapper {...(store && { store })}>
         {entity?.system_profile?.operating_system?.name === 'CentOS Linux' && (
@@ -157,6 +158,14 @@ class GeneralInformation extends Component {
                 {BiosCardWrapper && (
                   <GridItem>
                     <BiosCardWrapper handleClick={this.handleModalToggle} />
+                  </GridItem>
+                )}
+
+                {this.props.isBootcHost && BootcImageCardWrapper && (
+                  <GridItem>
+                    <BootcImageCardWrapper
+                      handleClick={this.handleModalToggle}
+                    />
                   </GridItem>
                 )}
 
@@ -232,6 +241,10 @@ GeneralInformation.propTypes = {
     PropTypes.bool,
   ]),
   BiosCardWrapper: PropTypes.oneOfType([PropTypes.elementType, PropTypes.bool]),
+  BootcImageCardWrapper: PropTypes.oneOfType([
+    PropTypes.elementType,
+    PropTypes.bool,
+  ]),
   InfrastructureCardWrapper: PropTypes.oneOfType([
     PropTypes.elementType,
     PropTypes.bool,
@@ -257,12 +270,14 @@ GeneralInformation.propTypes = {
   inventoryId: PropTypes.string.isRequired,
   systemProfilePrefetched: PropTypes.bool,
   showImageDetails: PropTypes.bool,
+  isBootcHost: PropTypes.bool,
 };
 GeneralInformation.defaultProps = {
   entity: {},
   SystemCardWrapper: SystemCard,
   OperatingSystemCardWrapper: OperatingSystemCard,
   BiosCardWrapper: BiosCard,
+  BootcImageCardWrapper: BootcImageCard,
   InfrastructureCardWrapper: InfrastructureCard,
   ConfigurationCardWrapper: ConfigurationCard,
   SystemStatusCardWrapper: SystemStatusCard,

--- a/src/components/GeneralInfo/selectors/selectors.js
+++ b/src/components/GeneralInfo/selectors/selectors.js
@@ -74,6 +74,15 @@ export const biosSelector = ({
   releaseDate: bios_release_date,
 });
 
+export const bootcSelector = ({ bootc_status } = {}) => ({
+  bootedImage: bootc_status?.booted?.image,
+  bootedImageDigest: bootc_status?.booted?.image_digest,
+  stagedImage: bootc_status?.staged?.image,
+  stagedImageDigest: bootc_status?.staged?.image_digest,
+  rollbackImage: bootc_status?.rollback?.image,
+  rollbackImageDigest: bootc_status?.rollback?.image_digest,
+});
+
 export const infrastructureSelector = (
   {
     infrastructure_type,

--- a/src/components/SystemDetails/GeneralInfo.js
+++ b/src/components/SystemDetails/GeneralInfo.js
@@ -9,6 +9,7 @@ const GeneralInfoTab = (props) => {
     ({ systemProfileStore }) => systemProfileStore?.systemProfile
   );
   const isEdgeHost = systemProfile?.host_type === 'edge';
+  const isBootcHost = !!systemProfile.bootc_status;
   const enableEdgeImageDetails = useFeatureFlag(
     'edgeParity.inventory-system-detail'
   );
@@ -19,6 +20,7 @@ const GeneralInfoTab = (props) => {
   return (
     <GeneralInformation
       {...props}
+      isBootcHost={isBootcHost}
       showImageDetails={
         enableEdgeImageDetails && enableEdgeInventoryListDetails && isEdgeHost
       }


### PR DESCRIPTION
Adds a new card with bootc system information.  It is hidden when the system is not a bootc system.
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/9499094/04eeec01-4f9e-4591-b6ce-df77f31595d6)

Note to reviewers:  Feel free to make changes directly.  Close and reopen a new PR if needed.  While I do believe this works and can be merged, its purpose is to imply intent.
