### PR TITLE
fix(RHINENG-9239, RHINENG-9260): Keep filtering in Hybrid Inventory Tabs separate, filter reset when Add Systems modal closes

### DIFF
--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -241,113 +241,112 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
           refreshTable={() => true}
         />
       )}
-      {!addToGroupModalOpen && (
-        <InventoryTable
-          columns={(columns) => mergeColumns(prepareColumns(columns))}
-          hideFilters={{ hostGroupFilter: true }}
-          // getEntities={entities}
-          getEntities={customGetEntities}
-          tableProps={{
-            isStickyHeader: true,
-            variant: TableVariant.compact,
-            canSelectAll: false,
-            actionResolver: (row) => [
-              {
-                title: (
-                  <ActionDropdownItem
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
-                    onClick={() => {
-                      setCurrentSystem([row]);
-                      setRemoveHostsFromGroupModalOpen(true);
-                    }}
-                  >
-                    Remove from group
-                  </ActionDropdownItem>
-                ),
-              },
-              {
-                title: (
-                  <ActionDropdownItem
-                    isAriaDisabled={
-                      deviceData === null || !deviceData.includes(row.id)
-                    }
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
-                    onClick={() => {
-                      setCurrentSystem([row]);
-                      navigate(`/insights/inventory/${row.id}/update`);
-                    }}
-                  >
-                    Update
-                  </ActionDropdownItem>
-                ),
-              },
+      <InventoryTable
+        isolateStore={true}
+        columns={(columns) => mergeColumns(prepareColumns(columns))}
+        hideFilters={{ hostGroupFilter: true }}
+        // getEntities={entities}
+        getEntities={customGetEntities}
+        tableProps={{
+          isStickyHeader: true,
+          variant: TableVariant.compact,
+          canSelectAll: false,
+          actionResolver: (row) => [
+            {
+              title: (
+                <ActionDropdownItem
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                  onClick={() => {
+                    setCurrentSystem([row]);
+                    setRemoveHostsFromGroupModalOpen(true);
+                  }}
+                >
+                  Remove from group
+                </ActionDropdownItem>
+              ),
+            },
+            {
+              title: (
+                <ActionDropdownItem
+                  isAriaDisabled={
+                    deviceData === null || !deviceData.includes(row.id)
+                  }
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                  onClick={() => {
+                    setCurrentSystem([row]);
+                    navigate(`/insights/inventory/${row.id}/update`);
+                  }}
+                >
+                  Update
+                </ActionDropdownItem>
+              ),
+            },
+          ],
+        }}
+        actionsConfig={{
+          actions: [
+            [
+              <div key="primary-actions" className="pf-v5-c-action-list">
+                <ActionButton
+                  key="add-systems-button"
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                  onClick={() => {
+                    dispatch(clearEntitiesAction());
+                    setAddToGroupModalOpen(true);
+                  }}
+                  ouiaId="add-systems-button"
+                >
+                  Add systems
+                </ActionButton>
+                <ActionButton
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                  key="update-systems-button"
+                  onClick={() => {
+                    setupdateDevice(true);
+                    handleUpdateSelected();
+                  }}
+                  ouiaId="update-systems-button"
+                  isAriaDisabled={!canUpdate}
+                >
+                  Update
+                </ActionButton>
+              </div>,
             ],
-          }}
-          actionsConfig={{
-            actions: [
-              [
-                <div key="primary-actions" className="pf-v5-c-action-list">
-                  <ActionButton
-                    key="add-systems-button"
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
-                    onClick={() => {
-                      dispatch(clearEntitiesAction());
-                      setAddToGroupModalOpen(true);
-                    }}
-                    ouiaId="add-systems-button"
-                  >
-                    Add systems
-                  </ActionButton>
-                  <ActionButton
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
-                    key="update-systems-button"
-                    onClick={() => {
-                      setupdateDevice(true);
-                      handleUpdateSelected();
-                    }}
-                    ouiaId="update-systems-button"
-                    isAriaDisabled={!canUpdate}
-                  >
-                    Update
-                  </ActionButton>
-                </div>,
-              ],
-              {
-                label: 'Remove from group',
-                props: {
-                  isAriaDisabled: !canModify || calculateSelected() === 0,
-                  ...(!canModify && {
-                    tooltipProps: {
-                      content: NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
-                    },
-                  }),
-                },
-                onClick: () => {
-                  setCurrentSystem(Array.from(selected.values()));
-                  setRemoveHostsFromGroupModalOpen(true);
-                },
+            {
+              label: 'Remove from group',
+              props: {
+                isAriaDisabled: !canModify || calculateSelected() === 0,
+                ...(!canModify && {
+                  tooltipProps: {
+                    content: NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+                  },
+                }),
               },
-            ],
-          }}
-          bulkSelect={bulkSelectConfig}
-          showTags
-          ref={inventory}
-          showCentosVersions
-          {...props}
-        />
-      )}
+              onClick: () => {
+                setCurrentSystem(Array.from(selected.values()));
+                setRemoveHostsFromGroupModalOpen(true);
+              },
+            },
+          ],
+        }}
+        bulkSelect={bulkSelectConfig}
+        showTags
+        ref={inventory}
+        showCentosVersions
+        {...props}
+      />
     </div>
   );
 };

--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -242,7 +242,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
         />
       )}
       <InventoryTable
-        isolateStore={true}
+        isolateStore
         columns={(columns) => mergeColumns(prepareColumns(columns))}
         hideFilters={{ hostGroupFilter: true }}
         // getEntities={entities}

--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -213,6 +213,8 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
           isModalOpen={addToGroupModalOpen}
           setIsModalOpen={(value) => {
             dispatch(clearEntitiesAction());
+            // ImmutableDevicesView, which uses Edge's DevicesView, systems table persists filters in the Session Storage
+            window.sessionStorage.removeItem('edge-devices-table-filters');
             setAddToGroupModalOpen(value);
           }}
           groupId={groupId}

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -160,6 +160,8 @@ const GroupSystems = ({ groupName, groupId }) => {
           isModalOpen={addToGroupModalOpen}
           setIsModalOpen={(value) => {
             dispatch(clearEntitiesAction());
+            // The systems table of ImmutableDevicesView, which uses Edge's DevicesView, persists filters in the Session Storage
+            window.sessionStorage.removeItem('edge-devices-table-filters');
             setAddToGroupModalOpen(value);
           }}
           groupId={groupId}

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -176,7 +176,7 @@ const GroupSystems = ({ groupName, groupId }) => {
         />
       )}
       <InventoryTable
-        isolateStore={true}
+        isolateStore
         columns={(columns) => prepareColumns(columns, true)}
         hideFilters={{ hostGroupFilter: true }}
         initialLoading

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -175,91 +175,90 @@ const GroupSystems = ({ groupName, groupId }) => {
           modalState={currentSystem}
         />
       )}
-      {!addToGroupModalOpen && (
-        <InventoryTable
-          columns={(columns) => prepareColumns(columns, true)}
-          hideFilters={{ hostGroupFilter: true }}
-          initialLoading
-          getEntities={async (items, config, showTags, defaultGetEntities) =>
-            await defaultGetEntities(
-              items,
-              // filter systems by the group name
-              {
-                ...config,
-                filters: {
-                  ...config.filters,
-                  hostGroupFilter: [groupName],
-                },
+      <InventoryTable
+        isolateStore={true}
+        columns={(columns) => prepareColumns(columns, true)}
+        hideFilters={{ hostGroupFilter: true }}
+        initialLoading
+        getEntities={async (items, config, showTags, defaultGetEntities) =>
+          await defaultGetEntities(
+            items,
+            // filter systems by the group name
+            {
+              ...config,
+              filters: {
+                ...config.filters,
+                hostGroupFilter: [groupName],
               },
-              showTags
-            )
-          }
-          tableProps={{
-            isStickyHeader: true,
-            variant: TableVariant.compact,
-            canSelectAll: false,
-            actionResolver: (row) => [
-              {
-                title: (
-                  <ActionDropdownItem
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
-                    onClick={() => {
-                      setCurrentSystem([row]);
-                      setRemoveHostsFromGroupModalOpen(true);
-                    }}
-                  >
-                    Remove from group
-                  </ActionDropdownItem>
-                ),
+            },
+            showTags
+          )
+        }
+        tableProps={{
+          isStickyHeader: true,
+          variant: TableVariant.compact,
+          canSelectAll: false,
+          actionResolver: (row) => [
+            {
+              title: (
+                <ActionDropdownItem
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                  onClick={() => {
+                    setCurrentSystem([row]);
+                    setRemoveHostsFromGroupModalOpen(true);
+                  }}
+                >
+                  Remove from group
+                </ActionDropdownItem>
+              ),
+            },
+          ],
+        }}
+        actionsConfig={{
+          actions: [
+            <ActionButton
+              key="add-systems-button"
+              requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                groupId
+              )}
+              noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+              onClick={() => {
+                dispatch(clearEntitiesAction());
+                setAddToGroupModalOpen(true);
+              }}
+              ouiaId="add-systems-button"
+            >
+              Add systems
+            </ActionButton>,
+            {
+              label: 'Remove from group',
+              props: {
+                isAriaDisabled: !canModify || calculateSelected() === 0,
+                ...(!canModify && {
+                  tooltipProps: {
+                    content: NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+                  },
+                }),
               },
-            ],
-          }}
-          actionsConfig={{
-            actions: [
-              <ActionButton
-                key="add-systems-button"
-                requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                  groupId
-                )}
-                noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
-                onClick={() => {
-                  dispatch(clearEntitiesAction());
-                  setAddToGroupModalOpen(true);
-                }}
-                ouiaId="add-systems-button"
-              >
-                Add systems
-              </ActionButton>,
-              {
-                label: 'Remove from group',
-                props: {
-                  isAriaDisabled: !canModify || calculateSelected() === 0,
-                  ...(!canModify && {
-                    tooltipProps: {
-                      content: NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
-                    },
-                  }),
-                },
-                onClick: () => {
-                  setCurrentSystem(Array.from(selected.values()));
-                  setRemoveHostsFromGroupModalOpen(true);
-                },
+              onClick: () => {
+                setCurrentSystem(Array.from(selected.values()));
+                setRemoveHostsFromGroupModalOpen(true);
               },
-            ],
-          }}
-          bulkSelect={bulkSelectConfig}
-          showTags
-          ref={inventory}
-          showCentosVersions
-          customFilters={{ filters: initialFilters, globalFilter }}
-          autoRefresh
-          onRefresh={onRefresh}
-          ignoreRefresh
-        />
-      )}
+            },
+          ],
+        }}
+        bulkSelect={bulkSelectConfig}
+        showTags
+        ref={inventory}
+        showCentosVersions
+        customFilters={{ filters: initialFilters, globalFilter }}
+        autoRefresh
+        onRefresh={onRefresh}
+        ignoreRefresh
+      />
     </div>
   );
 };

--- a/src/components/InventoryGroupDetail/GroupTabDetails.js
+++ b/src/components/InventoryGroupDetail/GroupTabDetails.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS } from '../../constants';
 import { EmptyStateNoAccessToSystems } from './EmptyStateNoAccess';
+import { groupTabKeys } from './constants';
 
 const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
 
@@ -24,7 +25,7 @@ const GroupTabDetailsWrapper = ({
   hasEdgeImages,
 }) => {
   const [tab, setTab] = useState(0);
-  const [activeTabKey, setActiveTabKey] = useState(0);
+  const [groupTabKey, setGroupTabKey] = useState(groupTabKeys.systems);
 
   const { hasAccess: canViewHosts } = usePermissionsWithContext(
     REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId)
@@ -32,15 +33,19 @@ const GroupTabDetailsWrapper = ({
 
   return (
     <Tabs
-      activeKey={activeTabKey}
-      onSelect={(event, value) => setActiveTabKey(value)}
+      activeKey={groupTabKey}
+      onSelect={(event, value) => setGroupTabKey(value)}
       aria-label="Group tabs"
       role="region"
       inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
       mountOnEnter
       unmountOnExit
     >
-      <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
+      <Tab
+        eventKey={groupTabKeys.systems}
+        title="Systems"
+        aria-label="Group systems tab"
+      >
         <PageSection>
           {canViewHosts && hasEdgeImages ? (
             <Tabs
@@ -79,8 +84,12 @@ const GroupTabDetailsWrapper = ({
           )}
         </PageSection>
       </Tab>
-      <Tab eventKey={1} title="Group info" aria-label="Group info tab">
-        {activeTabKey === 1 && ( // helps to lazy load the component
+      <Tab
+        eventKey={groupTabKeys.groupInfo}
+        title="Group info"
+        aria-label="Group info tab"
+      >
+        {groupTabKey === groupTabKeys.groupInfo && ( // helps to lazy load the component
           <PageSection>
             <Suspense
               fallback={

--- a/src/components/InventoryGroupDetail/GroupTabDetails.js
+++ b/src/components/InventoryGroupDetail/GroupTabDetails.js
@@ -6,7 +6,7 @@ import {
   TabTitleText,
   Tabs,
 } from '@patternfly/react-core';
-import React, { Suspense, lazy, useEffect, useMemo, useState } from 'react';
+import React, { Suspense, lazy, useState } from 'react';
 import { hybridInventoryTabKeys } from '../../Utilities/constants';
 import GroupSystems from '../GroupSystems/GroupSystems';
 import GroupImmutableSystems from '../GroupSystems/GroupImmutableSystems';
@@ -24,51 +24,11 @@ const GroupTabDetailsWrapper = ({
   hasEdgeImages,
 }) => {
   const [tab, setTab] = useState(0);
+  const [activeTabKey, setActiveTabKey] = useState(0);
 
   const { hasAccess: canViewHosts } = usePermissionsWithContext(
     REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId)
   );
-  const conventionalSystemsContent = useMemo(
-    () => (
-      <GroupSystems
-        groupName={groupName}
-        groupId={groupId}
-        hostType={hybridInventoryTabKeys.conventional.key}
-      />
-    ),
-    [groupId, groupName]
-  );
-
-  const immutableSystemsContent = useMemo(
-    () => (
-      <GroupImmutableSystems
-        groupId={groupId}
-        groupName={groupName}
-        hostType={hybridInventoryTabKeys.immutable.key}
-      />
-    ),
-    [groupId, groupName]
-  );
-
-  const [component, setComponent] = useState(conventionalSystemsContent);
-
-  useEffect(() => {
-    if (activeTab === hybridInventoryTabKeys.conventional.key) {
-      setComponent(conventionalSystemsContent);
-    } else {
-      setComponent(immutableSystemsContent);
-    }
-  }, [activeTab]);
-  const handleTabClick = (_event, tabIndex) => {
-    setTab(tabIndex);
-    if (tabIndex === hybridInventoryTabKeys.conventional.key) {
-      setComponent(conventionalSystemsContent);
-    } else {
-      setComponent(immutableSystemsContent);
-    }
-  };
-
-  const [activeTabKey, setActiveTabKey] = useState(0);
 
   return (
     <Tabs
@@ -86,20 +46,30 @@ const GroupTabDetailsWrapper = ({
             <Tabs
               className="pf-m-light pf-v5-c-table"
               activeKey={activeTab && tab == 0 ? activeTab : tab}
-              onSelect={handleTabClick}
+              onSelect={(_event, tabIndex) => {
+                setTab(tabIndex);
+              }}
               aria-label="Hybrid inventory tabs"
             >
               <Tab
                 eventKey={hybridInventoryTabKeys.conventional.key}
                 title={<TabTitleText>Conventional (RPM-DNF)</TabTitleText>}
               >
-                {component}
+                <GroupSystems
+                  groupName={groupName}
+                  groupId={groupId}
+                  hostType={hybridInventoryTabKeys.conventional.key}
+                />
               </Tab>
               <Tab
                 eventKey={hybridInventoryTabKeys.immutable.key}
                 title={<TabTitleText>Immutable (OSTree)</TabTitleText>}
               >
-                {component}
+                <GroupImmutableSystems
+                  groupId={groupId}
+                  groupName={groupName}
+                  hostType={hybridInventoryTabKeys.immutable.key}
+                />
               </Tab>
             </Tabs>
           ) : canViewHosts ? (

--- a/src/components/InventoryGroupDetail/GroupTabDetails.js
+++ b/src/components/InventoryGroupDetail/GroupTabDetails.js
@@ -24,8 +24,10 @@ const GroupTabDetailsWrapper = ({
   activeTab,
   hasEdgeImages,
 }) => {
-  const [tab, setTab] = useState(0);
   const [groupTabKey, setGroupTabKey] = useState(groupTabKeys.systems);
+  const [hybridInventoryTabKey, setHybridInventoryTabKey] = useState(
+    hybridInventoryTabKeys.conventional.key
+  );
 
   const { hasAccess: canViewHosts } = usePermissionsWithContext(
     REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId)
@@ -50,9 +52,14 @@ const GroupTabDetailsWrapper = ({
           {canViewHosts && hasEdgeImages ? (
             <Tabs
               className="pf-m-light pf-v5-c-table"
-              activeKey={activeTab && tab == 0 ? activeTab : tab}
+              activeKey={
+                activeTab &&
+                hybridInventoryTabKey == hybridInventoryTabKeys.conventional.key
+                  ? activeTab
+                  : hybridInventoryTabKey
+              }
               onSelect={(_event, tabIndex) => {
-                setTab(tabIndex);
+                setHybridInventoryTabKey(tabIndex);
               }}
               aria-label="Hybrid inventory tabs"
             >

--- a/src/components/InventoryGroupDetail/constants.js
+++ b/src/components/InventoryGroupDetail/constants.js
@@ -1,0 +1,5 @@
+// GroupTabDetails
+export const groupTabKeys = {
+  systems: 0,
+  groupInfo: 1,
+};

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -5,10 +5,18 @@ import React, {
   forwardRef,
   useEffect,
   useRef,
+  useMemo,
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux';
+import {
+  shallowEqual,
+  useDispatch,
+  useSelector,
+  useStore,
+  Provider,
+} from 'react-redux';
+import { getStore } from '../../store';
 import EntityTableToolbar from './EntityTableToolbar';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components/TableToolbar';
 import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
@@ -349,4 +357,24 @@ InventoryTable.propTypes = {
   showNoGroupOption: PropTypes.bool, // group filter option
 };
 
-export default InventoryTable;
+const InventoryTableWrapper = forwardRef(
+  ({ isolateStore = false, ...props }, ref) => {
+    const store = useMemo(
+      () => (isolateStore ? getStore() : undefined),
+      [isolateStore]
+    );
+    const Wrapper = store ? Provider : React.Fragment;
+
+    return (
+      <Wrapper {...(store ? { store } : {})}>
+        <InventoryTable {...props} ref={ref} />
+      </Wrapper>
+    );
+  }
+);
+
+InventoryTableWrapper.propTypes = {
+  isolateStore: PropTypes.bool,
+};
+
+export default InventoryTableWrapper;

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -360,6 +360,7 @@ InventoryTable.propTypes = {
 const InventoryTableWrapper = forwardRef(
   ({ isolateStore = false, ...props }, ref) => {
     const store = useMemo(
+      // TODO: Create a partial store containing only relevant Slices & Reducers relevant to the InventoryTable
       () => (isolateStore ? getStore() : undefined),
       [isolateStore]
     );


### PR DESCRIPTION
## Description
This PR addresses issues: 
[#RHINENG-9239](https://issues.redhat.com/browse/RHINENG-9239)
[#RHINENG-9260](https://issues.redhat.com/browse/RHINENG-9260)

Inventory group's details page: Filtering of each tab should be kept separate and saved even when switching between tabs (Conventional and Immutable)
Also, this PR includes 2 commits that change state variable names (tab & activeTabKey) in GroupTabDetails component to improve code readability
4th commit - added Sebastian's suggestion 
5th commit - fixed an inconsistency between the different tabs on the "Add Systems" modal

This PR introduces a store instance for each tab, which holds it's own filters for it's InventoryTable. In order to create a new instance of the store for the InventoryTable, you need to provide InventoryTable component with the `isolateStore` prop to render it with a Provider Wrapper which holds a new store instance alongside with the InventoryTable.
I have removed the component state inside InventoryGroupDetail/GroupTabDetails.js and put the components inside the returned JSX of the component.
Regarding the Immutable tab inside the "Add Systems" Modal, the filters there were handled a bit differently, you can find small comments inside the 5th commit message which solves this inconsistency issue which was created in previous commits