### PR TITLE
fix(RHINENG-3920): Handle Groups 403

### DIFF
--- a/src/Utilities/hooks/useFetchBatched.js
+++ b/src/Utilities/hooks/useFetchBatched.js
@@ -10,7 +10,6 @@ const useFetchBatched = () => {
 
       const results = resolve(
         [...new Array(pages)].map(
-          // eslint-disable-next-line camelcase
           (_, pageIdx) => () =>
             fetchFunction(filter, { page: pageIdx + 1, per_page: batchSize })
         )
@@ -27,6 +26,27 @@ const useFetchBatched = () => {
             fetchFunction(
               list.slice(batchSize * pageIdx, batchSize * (pageIdx + 1))
             )
+        )
+      );
+
+      return results;
+    },
+    pageOffsetfetchBatched: (
+      fetchFunction,
+      total,
+      filter,
+      batchSize = 50,
+      pageOffset = 0
+    ) => {
+      const pages = Math.ceil(total / batchSize) || 1;
+
+      const results = resolve(
+        [...new Array(pages)].map(
+          (_, pageIdx) => () =>
+            fetchFunction(filter, {
+              page: pageOffset + pageIdx + 1,
+              per_page: batchSize,
+            })
         )
       );
 

--- a/src/components/InventoryTable/InventoryTable.test.js
+++ b/src/components/InventoryTable/InventoryTable.test.js
@@ -62,6 +62,14 @@ const renderTable = (store, props) => {
 
 jest.mock('../../Utilities/useFeatureFlag');
 
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/RBACHook',
+  () => ({
+    esModule: true,
+    usePermissionsWithContext: () => ({ hasAccess: true }),
+  })
+);
+
 const expectMainComponents = () => {
   try {
     screen.getByTestId('inventory-table-top-toolbar');


### PR DESCRIPTION
[RHINENG-3920](https://issues.redhat.com/browse/RHINENG-3920)

Previously when the user didn't have `inventory:groups:read` permission he would get this error.
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/20592948/d671d9a7-13ee-4a26-9b1f-6b3da71e3f0a)

Now this request is only made when user has `inventory:groups:read` permission.

Test without sufficient permissions:
1. Make sure your account doesn't have `inventory:groups:read`. If you don't have such account, you can use `acelakov-groups-test` and the usual password
2. Go to Inventory > Systems
3. Check the groups filter, it should be empty and no request should be made to hosts.

Test with sufficient permissions:
1. User `acelakov-groups` has the correct permissions
2. Go to Inventory > Systems
3. Check the groups filter and it should be populated