### PR TITLE
fix: Prop types, unused props, replaced deprecated Main component

### DIFF
--- a/src/components/InventoryDetail/ApplicationDetails.js
+++ b/src/components/InventoryDetail/ApplicationDetails.js
@@ -13,6 +13,7 @@ import {
   REPORTER_RHSM_CONDUIT,
   REPORTER_RHSM_PROFILE_BRIDGE,
 } from '../../Utilities/constants';
+import { PageSection } from '@patternfly/react-core';
 
 /**
  * Component that renders tabs for each application detail and handles clicking on each item.
@@ -120,7 +121,7 @@ const ApplicationDetails = ({
                 >
                   {item.name === currentApp && (
                     <Suspense fallback={Spinner}>
-                      <section className="pf-v5-c-page__main-section">
+                      <PageSection>
                         {isEmptyState(currentApp) ? (
                           <NotConnected />
                         ) : (
@@ -130,7 +131,7 @@ const ApplicationDetails = ({
                             {...item}
                           />
                         )}
-                      </section>
+                      </PageSection>
                     </Suspense>
                   )}
                 </TabContent>
@@ -154,7 +155,7 @@ ApplicationDetails.propTypes = {
     })
   ),
   onTabSelect: PropTypes.func,
-  activeApp: PropTypes.string.isRequired,
+  activeApp: PropTypes.string,
   inventoryId: PropTypes.string.isRequired,
   entity: PropTypes.object,
 };

--- a/src/components/InventoryDetail/DetailHeader.js
+++ b/src/components/InventoryDetail/DetailHeader.js
@@ -82,7 +82,7 @@ HeaderInfo.propTypes = {
   addNotification: PropTypes.func,
 };
 DetailHeader.propTypes = {
-  BreadcrumbWrapper: PropTypes.elementType,
+  BreadcrumbWrapper: PropTypes.node,
   shouldWrapAsPage: PropTypes.bool,
   additionalClasses: PropTypes.object,
 };

--- a/src/components/InventoryGroups/InventoryGroups.js
+++ b/src/components/InventoryGroups/InventoryGroups.js
@@ -8,6 +8,7 @@ import NoGroupsEmptyState from './NoGroupsEmptyState';
 import { EmptyStateNoAccessToGroups } from '../InventoryGroupDetail/EmptyStateNoAccess';
 import GetHelpExpandable from './GetHelpExpandable';
 import CreateGroupModal from './Modals/CreateGroupModal';
+import { PageSection } from '@patternfly/react-core';
 
 const InventoryGroups = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -51,8 +52,7 @@ const InventoryGroups = () => {
   }, []);
 
   return (
-    <section
-      className="pf-v5-l-page__main-section pf-v5-c-page__main-section"
+    <PageSection
       data-ouia-component-id="groups-table-wrapper"
       data-testid="groups-table-wrapper"
       style={{ height: '100%' }}
@@ -80,7 +80,7 @@ const InventoryGroups = () => {
       ) : (
         <NoGroupsEmptyState onCreateGroupClick={onCreateGroupClick} />
       )}
-    </section>
+    </PageSection>
   );
 };
 

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -94,6 +94,7 @@ const EntityTableToolbar = ({
   loaded,
   showTagModal,
   showCentosVersions,
+  showNoGroupOption,
   ...props
 }) => {
   const dispatch = useDispatch();
@@ -167,7 +168,7 @@ const EntityTableToolbar = ({
     setUpdateMethodValue,
   ] = useUpdateMethodFilter(reducer);
   const [hostGroupConfig, hostGroupChips, hostGroupValue, setHostGroupValue] =
-    useGroupFilter(props.showNoGroupOption);
+    useGroupFilter(showNoGroupOption);
 
   const isUpdateMethodEnabled = useFeatureFlag('hbi.ui.system-update-method');
   const {

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -338,12 +338,20 @@ ConventionalSystemsTab.propTypes = {
   ]),
   filterbyName: PropTypes.arrayOf(PropTypes.string),
   tagsFilter: PropTypes.any,
-  page: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-  ),
-  perPage: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-  ),
+  page: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    ),
+  ]),
+  perPage: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    ),
+  ]),
   initialLoading: PropTypes.bool,
   rhcdFilter: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),

--- a/src/routes/InventoryPage.js
+++ b/src/routes/InventoryPage.js
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import './inventory.scss';
-import Main from '@redhat-cloud-services/frontend-components/Main';
 import HybridInventory from './InventoryComponents/HybridInventory';
 import InventoryPageHeader from './InventoryComponents/InventoryPageHeader';
 import BifrostPage from './InventoryComponents/BifrostPage';
+import { PageSection } from '@patternfly/react-core';
 
 export const pageContents = {
   hybridInventory: {
@@ -27,9 +27,9 @@ const Inventory = (props) => {
         mainContent={mainContent}
         changeMainContent={setMainContent}
       />
-      <Main>
+      <PageSection>
         {React.createElement(pageContents[mainContent].component, { ...props })}
-      </Main>
+      </PageSection>
     </React.Fragment>
   );
 };


### PR DESCRIPTION
While working on inventory I was annoyed by the amount of prop type/other errors. Fixed some of them.

Some components don't use certain props so I excluded them from the spread.

`Main` component from `frontend-components` was deprecated for a while.

How to test:
Make sure the green section is the same like on stage
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/20592948/b11f36ce-50a7-46fb-87ee-d80c5b1feefb)
