### PR TITLE
feat(runtimes): add Runtimes Processes card to GeneralInformation

### DIFF
--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
@@ -194,7 +194,7 @@ class GeneralInformation extends Component {
                   </GridItem>
                 )}
 
-                {this.props.showRuntimesProcesses && (
+                {this.props.showRuntimesProcesses && entity.fqdn && (
                   <GridItem>
                     <AsyncComponent
                       appName="runtimes"

--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
@@ -193,6 +193,16 @@ class GeneralInformation extends Component {
                     />
                   </GridItem>
                 )}
+
+                {this.props.showRuntimesProcesses && (
+                  <GridItem>
+                    <AsyncComponent
+                      appName="runtimes"
+                      module="./RuntimesProcessesCard"
+                      hostname={entity.fqdn}
+                    />
+                  </GridItem>
+                )}
               </Grid>
             </GridItem>
             {children}
@@ -227,6 +237,7 @@ GeneralInformation.propTypes = {
         name: PropTypes.string,
       }),
     }),
+    fqdn: PropTypes.string,
   }),
   openedModal: PropTypes.string,
   loadSystemDetail: PropTypes.func,
@@ -271,6 +282,7 @@ GeneralInformation.propTypes = {
   systemProfilePrefetched: PropTypes.bool,
   showImageDetails: PropTypes.bool,
   isBootcHost: PropTypes.bool,
+  showRuntimesProcesses: PropTypes.bool,
 };
 GeneralInformation.defaultProps = {
   entity: {},
@@ -285,6 +297,7 @@ GeneralInformation.defaultProps = {
   CollectionCardWrapper: false,
   systemProfilePrefetched: false,
   showImageDetails: false,
+  showRuntimesProcesses: false,
 };
 
 const GeneralInformationComponent = (props) => {

--- a/src/components/SystemDetails/GeneralInfo.js
+++ b/src/components/SystemDetails/GeneralInfo.js
@@ -16,6 +16,9 @@ const GeneralInfoTab = (props) => {
   const enableEdgeInventoryListDetails = useFeatureFlag(
     'edgeParity.inventory-list'
   );
+  const enableRuntimesInventoryCard = useFeatureFlag(
+    'runtimes.inventory-card.enabled'
+  );
 
   return (
     <GeneralInformation
@@ -24,6 +27,7 @@ const GeneralInfoTab = (props) => {
       showImageDetails={
         enableEdgeImageDetails && enableEdgeInventoryListDetails && isEdgeHost
       }
+      showRuntimesProcesses={enableRuntimesInventoryCard}
     />
   );
 };


### PR DESCRIPTION
Hi! This PR adds a card to the General Information on the Inventory Systems page to display information from runtimes-inventory.

This "Application Services Proccesses" card resides in the [insights-runtimes-frontend](https://github.com/RedHatInsights/insights-runtimes-frontend) repository, and at the moment is only deployed in Stage (but will be looking to get into prod soon). The runtimes-inventory API returns application processes data given a hostname, so the card will need to be passed the `fqdn` from General Information. If no information exists or nothing is returned from the runtimes-inventory endpoint, the card will not display.

As for testing this functionality, there are two ways that I use at the moment:

1. Webpack custom proxy + locally hosted mock data

The insights-runtimes-frontend repo contains a /mock folder that holds a json file containing a test response from insights-runtimes-inventory that can be tested against, see: https://github.com/RedHatInsights/insights-runtimes-frontend/blob/master/mock/instances.json

You can run a mock json-server in insights-runtimes-frontend by running: `npm run mock-instances`, and this json will be served at localhost:3000.

Over in insights-inventory-frontend, you can add some extra custom proxy to the dev webpack (I'll add a diff below) to make it use that json-server for information, and run `npm run mock-server` && `npm run start:mock`.

```
diff --git a/config/dev.webpack.config.js b/config/dev.webpack.config.js
index 0add63c..75ea99d 100644
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -26,8 +26,8 @@ const { config: webpackConfig, plugins } = config({
   ...(process.env.MOCK && {
     customProxy: [
       {
-        context: ['/api/inventory/v1/groups'], // you can adjust the `context` value to redirect only specific endpoints
-        target: 'http://localhost:4010', // default prism port
+        context: ['/api/inventory/v1/groups', '/api/inventory/v1/hosts'], // you can adjust the `context` value to redirect only specific endpoints
+        target: 'http://127.0.0.1:4010', // default prism port
         secure: false,
         changeOrigin: true,
         pathRewrite: { '^/api/inventory/v1': '' },
@@ -35,6 +35,15 @@ const { config: webpackConfig, plugins } = config({
           proxyReq.setHeader('x-rh-identity', 'foobar'); // avoid 401 errors by providing neccessary security header
         },
       },
+      {
+        context: ['/api/runtimes-inventory-service/v1/instances'],
+        target: 'http://localhost:3000',
+        secure: false,
+        changeOrigin: true,
+        pathRewrite: {
+          '^/api/runtimes-inventory-service/v1/instances': 'instances',
+        },
+      },
     ],
   }),
 });
```

2. Uploading mock host + reports to stage

In insights-runtimes-inventory, I've added a folder containing a couple of scripts that can be used to create mock reports for sending to Ephemeral or Stage environments for testing the frontend, see: https://gitlab.cee.redhat.com/insights-runtimes/insights-runtimes-inventory/-/blob/main/mock/mock.md?ref_type=heads

Once these reports are in Stage, you can view them with a proxied insights-inventory-frontend with `npm run start:proxy`.

Example UI:
![inventory-frontend-pr-2](https://github.com/RedHatInsights/insights-inventory-frontend/assets/10425301/0bd7e93a-bd0a-406d-a7f8-7f1f40d3c80a)
