### PR TITLE
chore(RHINENG-9248): use frontend owned feature flag hbi.ui.bifrost

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -60,7 +60,7 @@ export const Routes = () => {
   );
 
   const stalenessAndDeletionEnabled = useFeatureFlag('hbi.custom-staleness');
-  const isBifrostEnabled = useFeatureFlag('hbi.api.disable-xjoin');
+  const isBifrostEnabled = useFeatureFlag('hbi.ui.bifrost');
 
   useEffect(() => {
     // zero state check

--- a/src/routes/InventoryComponents/InventoryPageHeader.js
+++ b/src/routes/InventoryComponents/InventoryPageHeader.js
@@ -29,7 +29,7 @@ const InventoryContentToggle = ({ changeMainContent, mainContent }) => (
 );
 
 const InventoryPageHeader = (toggleProps) => {
-  const isBifrostEnabled = useFeatureFlag('hbi.api.disable-xjoin');
+  const isBifrostEnabled = useFeatureFlag('hbi.ui.bifrost');
   const { hasBootcImages } = useContext(AccountStatContext);
   return (
     <PageHeader className="pf-m-light">


### PR DESCRIPTION
This removes the obsolete backend-owned feature flag `hbi.api.disable-xjoin`, instead, introduces the frontend flag 'hbi.ui.bifrost'. 