### PR TITLE
feat(RHINENG-9709): Add available image to bootc card

### DIFF
--- a/src/components/GeneralInfo/BootcImageCard/BootcImageCard.js
+++ b/src/components/GeneralInfo/BootcImageCard/BootcImageCard.js
@@ -22,6 +22,13 @@ export const BootcImageCard = ({ handleClick, extra }) => {
         ...[{ title: 'Booted Image Digest', value: bootc.bootedImageDigest }],
         ...[{ title: 'Staged Image', value: bootc.stagedImage }],
         ...[{ title: 'Staged Image Digest', value: bootc.stagedImageDigest }],
+        ...[{ title: 'Available Image', value: bootc.availableImage }],
+        ...[
+          {
+            title: 'Available Image Digest',
+            value: bootc.availableImageDigest,
+          },
+        ],
         ...[{ title: 'Rollback Image', value: bootc.rollbackImage }],
         ...[
           { title: 'Rollback Image Digest', value: bootc.rollbackImageDigest },
@@ -43,6 +50,8 @@ BootcImageCard.propTypes = {
     bootedImageDigest: PropTypes.string,
     stagedImage: PropTypes.string,
     stagedImageDigest: PropTypes.string,
+    availableImage: PropTypes.string,
+    availableImageDigest: PropTypes.string,
     rollbackImage: PropTypes.string,
     rollbackImageDigest: PropTypes.string,
   }),

--- a/src/components/GeneralInfo/BootcImageCard/BootcImageCard.test.js
+++ b/src/components/GeneralInfo/BootcImageCard/BootcImageCard.test.js
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import { TestWrapper } from '../../../Utilities/TestingUtilities';
+import { BootcImageCard } from './BootcImageCard';
+
+describe('BootcImageCard', () => {
+  let initialState;
+  let mockStore;
+
+  beforeEach(() => {
+    mockStore = configureStore();
+    initialState = {
+      systemProfileStore: {
+        systemProfile: {
+          loaded: true,
+          bootc_status: {
+            booted: {
+              image: 'quay.io:5000/bootc-insights:latest',
+              image_digest:
+                'sha256:8fa5b818d1560c7d15d8744069651b671acd13ec5290c2bb55d1fae2492fcb5f',
+            },
+            rollback: {
+              image: 'quay.io:5000/bootc-insights:latest',
+              cached_image: 'quay.io:5000/bootc-insights:latest',
+              image_digest:
+                'sha256:99dec597bd1e95565d9df181cab9bf0278b15e79a613dbd0a357d60f295e9a72',
+              cached_image_digest:
+                'sha256:06462b5728c3b445df63327451c32874d946eb1f2071401680145d52e578137b',
+            },
+          },
+          cpu_flags: ['one'],
+        },
+      },
+    };
+  });
+
+  it('should render correctly - no data', () => {
+    const store = mockStore({ systemProfileStore: {} });
+    const view = render(
+      <TestWrapper store={store}>
+        <BootcImageCard />
+      </TestWrapper>
+    );
+    expect(view.asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with data', () => {
+    const store = mockStore(initialState);
+    const view = render(
+      <TestWrapper store={store}>
+        <BootcImageCard />
+      </TestWrapper>
+    );
+    expect(view.asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/GeneralInfo/BootcImageCard/__snapshots__/BootcImageCard.test.js.snap
+++ b/src/components/GeneralInfo/BootcImageCard/__snapshots__/BootcImageCard.test.js.snap
@@ -1,0 +1,373 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BootcImageCard should render correctly - no data 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-card"
+    data-ouia-component-id="system-properties-card"
+    data-ouia-component-type="PF5/Card"
+    data-ouia-safe="true"
+    id=""
+  >
+    <div
+      class="pf-v5-c-card__body"
+    >
+      <div
+        class="pf-v5-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-v5-l-stack__item"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <h1
+              class=""
+              data-ouia-component-id="SystemPropertiesCardTitle"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              BOOTC
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-v5-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <dl
+              class=""
+            >
+              <dt
+                aria-label="Booted Image title"
+                class=""
+                data-ouia-component-id="Booted Image title"
+              >
+                Booted Image
+              </dt>
+              <dd
+                aria-label="Booted Image value"
+                class=""
+                data-ouia-component-id="Booted Image value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                aria-label="Booted Image Digest title"
+                class=""
+                data-ouia-component-id="Booted Image Digest title"
+              >
+                Booted Image Digest
+              </dt>
+              <dd
+                aria-label="Booted Image Digest value"
+                class=""
+                data-ouia-component-id="Booted Image Digest value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                aria-label="Staged Image title"
+                class=""
+                data-ouia-component-id="Staged Image title"
+              >
+                Staged Image
+              </dt>
+              <dd
+                aria-label="Staged Image value"
+                class=""
+                data-ouia-component-id="Staged Image value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                aria-label="Staged Image Digest title"
+                class=""
+                data-ouia-component-id="Staged Image Digest title"
+              >
+                Staged Image Digest
+              </dt>
+              <dd
+                aria-label="Staged Image Digest value"
+                class=""
+                data-ouia-component-id="Staged Image Digest value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                aria-label="Available Image title"
+                class=""
+                data-ouia-component-id="Available Image title"
+              >
+                Available Image
+              </dt>
+              <dd
+                aria-label="Available Image value"
+                class=""
+                data-ouia-component-id="Available Image value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                aria-label="Available Image Digest title"
+                class=""
+                data-ouia-component-id="Available Image Digest title"
+              >
+                Available Image Digest
+              </dt>
+              <dd
+                aria-label="Available Image Digest value"
+                class=""
+                data-ouia-component-id="Available Image Digest value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                aria-label="Rollback Image title"
+                class=""
+                data-ouia-component-id="Rollback Image title"
+              >
+                Rollback Image
+              </dt>
+              <dd
+                aria-label="Rollback Image value"
+                class=""
+                data-ouia-component-id="Rollback Image value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                aria-label="Rollback Image Digest title"
+                class=""
+                data-ouia-component-id="Rollback Image Digest title"
+              >
+                Rollback Image Digest
+              </dt>
+              <dd
+                aria-label="Rollback Image Digest value"
+                class=""
+                data-ouia-component-id="Rollback Image Digest value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BootcImageCard should render correctly with data 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-card"
+    data-ouia-component-id="system-properties-card"
+    data-ouia-component-type="PF5/Card"
+    data-ouia-safe="true"
+    id=""
+  >
+    <div
+      class="pf-v5-c-card__body"
+    >
+      <div
+        class="pf-v5-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-v5-l-stack__item"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <h1
+              class=""
+              data-ouia-component-id="SystemPropertiesCardTitle"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              BOOTC
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-v5-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <dl
+              class=""
+            >
+              <dt
+                aria-label="Booted Image title"
+                class=""
+                data-ouia-component-id="Booted Image title"
+              >
+                Booted Image
+              </dt>
+              <dd
+                aria-label="Booted Image value"
+                class=""
+                data-ouia-component-id="Booted Image value"
+              >
+                quay.io:5000/bootc-insights:latest
+              </dd>
+              <dt
+                aria-label="Booted Image Digest title"
+                class=""
+                data-ouia-component-id="Booted Image Digest title"
+              >
+                Booted Image Digest
+              </dt>
+              <dd
+                aria-label="Booted Image Digest value"
+                class=""
+                data-ouia-component-id="Booted Image Digest value"
+              >
+                sha256:8fa5b818d1560c7d15d8744069651b671acd13ec5290c2bb55d1fae2492fcb5f
+              </dd>
+              <dt
+                aria-label="Staged Image title"
+                class=""
+                data-ouia-component-id="Staged Image title"
+              >
+                Staged Image
+              </dt>
+              <dd
+                aria-label="Staged Image value"
+                class=""
+                data-ouia-component-id="Staged Image value"
+              >
+                Not available
+              </dd>
+              <dt
+                aria-label="Staged Image Digest title"
+                class=""
+                data-ouia-component-id="Staged Image Digest title"
+              >
+                Staged Image Digest
+              </dt>
+              <dd
+                aria-label="Staged Image Digest value"
+                class=""
+                data-ouia-component-id="Staged Image Digest value"
+              >
+                Not available
+              </dd>
+              <dt
+                aria-label="Available Image title"
+                class=""
+                data-ouia-component-id="Available Image title"
+              >
+                Available Image
+              </dt>
+              <dd
+                aria-label="Available Image value"
+                class=""
+                data-ouia-component-id="Available Image value"
+              >
+                Not available
+              </dd>
+              <dt
+                aria-label="Available Image Digest title"
+                class=""
+                data-ouia-component-id="Available Image Digest title"
+              >
+                Available Image Digest
+              </dt>
+              <dd
+                aria-label="Available Image Digest value"
+                class=""
+                data-ouia-component-id="Available Image Digest value"
+              >
+                Not available
+              </dd>
+              <dt
+                aria-label="Rollback Image title"
+                class=""
+                data-ouia-component-id="Rollback Image title"
+              >
+                Rollback Image
+              </dt>
+              <dd
+                aria-label="Rollback Image value"
+                class=""
+                data-ouia-component-id="Rollback Image value"
+              >
+                quay.io:5000/bootc-insights:latest
+              </dd>
+              <dt
+                aria-label="Rollback Image Digest title"
+                class=""
+                data-ouia-component-id="Rollback Image Digest title"
+              >
+                Rollback Image Digest
+              </dt>
+              <dd
+                aria-label="Rollback Image Digest value"
+                class=""
+                data-ouia-component-id="Rollback Image Digest value"
+              >
+                sha256:99dec597bd1e95565d9df181cab9bf0278b15e79a613dbd0a357d60f295e9a72
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/GeneralInfo/selectors/selectors.js
+++ b/src/components/GeneralInfo/selectors/selectors.js
@@ -77,6 +77,11 @@ export const biosSelector = ({
 export const bootcSelector = ({ bootc_status } = {}) => ({
   bootedImage: bootc_status?.booted?.image,
   bootedImageDigest: bootc_status?.booted?.image_digest,
+  availableImage:
+    bootc_status?.staged?.cached_image || bootc_status?.booted?.cached_image,
+  availableImageDigest:
+    bootc_status?.staged?.cached_image_digest ||
+    bootc_status?.booted?.cached_image_digest,
   stagedImage: bootc_status?.staged?.image,
   stagedImageDigest: bootc_status?.staged?.image_digest,
   rollbackImage: bootc_status?.rollback?.image,


### PR DESCRIPTION
Adds available image and available image hash.
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/9499094/5ab93362-5bc0-43ca-b880-4f3197368861)
