### PR TITLE
fix(RHINENG-9248): fetch non-edge hosts

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -28,6 +28,8 @@ export const INVENTORY_FETCH_BOOTC_PARAMS =
 export const INVENTORY_FETCH_BOOTC = `${INVENTORY_FETCH_BOOTC_PARAMS}=not_nil`;
 export const INVENTORY_FETCH_NON_BOOTC = `${INVENTORY_FETCH_BOOTC_PARAMS}=nil`;
 export const INVENTORY_TOTAL_FETCH_BOOTC_PARAMS = `${INVENTORY_FETCH_BOOTC}&per_page=1`;
+export const INVENTORY_FILTER_NO_HOST_TYPE =
+  'filter[system_profile][host_type]=nil';
 export function subtractDate(days) {
   const date = new Date();
   date.setDate(date.getDate() - days);

--- a/src/routes/InventoryComponents/BifrostPage.js
+++ b/src/routes/InventoryComponents/BifrostPage.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import {
   INVENTORY_FETCH_BOOTC,
   INVENTORY_FETCH_NON_BOOTC,
+  INVENTORY_FILTER_NO_HOST_TYPE,
   INVENTORY_TOTAL_FETCH_URL_SERVER,
 } from '../../Utilities/constants';
 import BifrostTable from './BifrostTable';
@@ -19,7 +20,7 @@ const BifrostPage = () => {
       );
 
       const packageBasedSystems = await axios.get(
-        `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_FETCH_NON_BOOTC}&per_page=1`
+        `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_FETCH_NON_BOOTC}&${INVENTORY_FILTER_NO_HOST_TYPE}&per_page=1`
       );
 
       const booted = result.data.results.map(


### PR DESCRIPTION
For the new bootc image table, we request the non-image based system count to include at the bottom of the table. This PR modifies the api call to request to filter by non-edge based systems so we get a count of systems that matches the system table.