### PR TITLE
feat(RHINENG-9687): create system type filter

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -8,6 +8,7 @@ export const REGISTERED_CHIP = 'registered_with';
 export const OS_CHIP = 'operating_system';
 export const RHCD_FILTER_KEY = 'rhc_client_id';
 export const UPDATE_METHOD_KEY = 'system_update_method';
+export const SYSTEM_TYPE_KEY = 'system_type';
 export const LAST_SEEN_CHIP = 'last_seen';
 export const HOST_GROUP_CHIP = 'group_name'; // use the same naming as for the back end parameter
 //REPORTERS
@@ -103,6 +104,17 @@ const initUpdateMethodOptions = [
 ];
 
 export const updateMethodOptions = initUpdateMethodOptions;
+
+export const systemTypeOptions = [
+  {
+    label: 'Package mode',
+    value: 'nil',
+  },
+  {
+    label: 'Image mode',
+    value: 'not_nil',
+  },
+];
 
 export function filterToGroup(filter = [], valuesKey = 'values') {
   return filter.reduce(

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -110,6 +110,7 @@ export const calculateSystemProfile = ({
   rhcdFilter,
   updateMethodFilter,
   hostTypeFilter,
+  systemTypeFilter,
 }) => {
   let systemProfile = {};
   const osFilterValues = Array.isArray(osFilter)
@@ -166,6 +167,16 @@ export const calculateSystemProfile = ({
     systemProfile['host_type'] = 'nil';
   }
 
+  if (systemTypeFilter?.length) {
+    systemProfile.bootc_status = {
+      booted: {
+        image_digest: {
+          is: systemTypeFilter,
+        },
+      },
+    };
+  }
+
   return generateFilter({
     system_profile: systemProfile,
   });
@@ -188,6 +199,9 @@ export const filtersReducer = (acc, filter = {}) => ({
   }),
   ...('hostGroupFilter' in filter && {
     hostGroupFilter: filter.hostGroupFilter,
+  }),
+  ...('systemTypeFilter' in filter && {
+    systemTypeFilter: filter.systemTypeFilter,
   }),
 });
 

--- a/src/components/InventoryTable/TitleColumn.js
+++ b/src/components/InventoryTable/TitleColumn.js
@@ -60,6 +60,7 @@ const TitleColumn = ({ children, id, item, ...props }) => (
                 <FontAwesomeImageIcon
                   fill="var(--pf-v5-global--icon--Color--light)"
                   margin="0px"
+                  aria-label="Image mode icon"
                 />
               </Icon>
             </Popover>
@@ -78,7 +79,10 @@ const TitleColumn = ({ children, id, item, ...props }) => (
               }
             >
               <Icon style={{ marginRight: '8px' }}>
-                <BundleIcon color="var(--pf-v5-global--icon--Color--light)" />
+                <BundleIcon
+                  color="var(--pf-v5-global--icon--Color--light)"
+                  aria-label="Package mode icon"
+                />
               </Icon>
             </Popover>
           )}

--- a/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
@@ -38,6 +38,7 @@ exports[`TitleColumn should render correctly with NO data 1`] = `
             >
               <svg
                 aria-hidden="true"
+                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"
@@ -83,6 +84,7 @@ exports[`TitleColumn should render correctly with data 1`] = `
             >
               <svg
                 aria-hidden="true"
+                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"
@@ -131,6 +133,7 @@ exports[`TitleColumn should render correctly with href 1`] = `
             >
               <svg
                 aria-hidden="true"
+                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"
@@ -182,6 +185,7 @@ exports[`TitleColumn should render correctly with os_release 1`] = `
             >
               <svg
                 aria-hidden="true"
+                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"
@@ -230,6 +234,7 @@ exports[`TitleColumn should render correctly with to 1`] = `
             >
               <svg
                 aria-hidden="true"
+                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -1,4 +1,10 @@
-import React, { Fragment, useEffect, useRef, useState } from 'react';
+import React, {
+  Fragment,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import * as actions from '../../../store/actions';
@@ -26,6 +32,8 @@ import uniq from 'lodash/uniq';
 import useTableActions from './useTableActions';
 import useGlobalFilter from '../../filters/useGlobalFilter';
 import useOnRefresh from '../../filters/useOnRefresh';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
+import { AccountStatContext } from '../../../Routes';
 
 const BulkDeleteButton = ({ selectedSystems, ...props }) => {
   const requiredPermissions = selectedSystems.map(({ groups }) =>
@@ -158,10 +166,12 @@ const ConventionalSystemsTab = ({
     setAddHostGroupModalOpen
   );
 
+  const isBootcEnabled = useFeatureFlag('hbi.ui.bifrost');
+  const { hasBootcImages } = useContext(AccountStatContext);
   return (
     <Fragment>
       <InventoryTableCmp
-        showSystemTypeFilter
+        showSystemTypeFilter={isBootcEnabled && hasBootcImages}
         hasAccess={hasAccess}
         isRbacEnabled
         customFilters={{ filters, globalFilter }}

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -63,6 +63,7 @@ const ConventionalSystemsTab = ({
   initialLoading,
   hasAccess,
   hostGroupFilter,
+  systemTypeFilter,
 }) => {
   const chrome = useChrome();
   const inventory = useRef(null);
@@ -78,7 +79,8 @@ const ConventionalSystemsTab = ({
       rhcdFilter,
       updateMethodFilter,
       hostGroupFilter,
-      lastSeenFilter
+      lastSeenFilter,
+      systemTypeFilter
     )
   );
   const [ediOpen, onEditOpen] = useState(false);
@@ -159,6 +161,7 @@ const ConventionalSystemsTab = ({
   return (
     <Fragment>
       <InventoryTableCmp
+        showSystemTypeFilter
         hasAccess={hasAccess}
         isRbacEnabled
         customFilters={{ filters, globalFilter }}
@@ -359,6 +362,10 @@ ConventionalSystemsTab.propTypes = {
     PropTypes.string,
   ]),
   lastSeenFilter: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]),
+  systemTypeFilter: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,
   ]),

--- a/src/components/filters/index.js
+++ b/src/components/filters/index.js
@@ -7,6 +7,7 @@ export * from './useRhcdFilter';
 export * from './useUpdateMethodFilter';
 export * from './useLastSeenFilter';
 export * from './useGroupFilter';
+export * from './useSystemTypeFilter';
 export const filtersReducer = (reducersList) => (state, action) =>
   reducersList.reduce(
     (acc, curr) => ({

--- a/src/components/filters/useSystemTypeFilter.js
+++ b/src/components/filters/useSystemTypeFilter.js
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import {
+  SYSTEM_TYPE_KEY,
+  systemTypeOptions as defaultSystemTypeOptions,
+} from '../../Utilities/index';
+
+export const systemTypeFilterState = { systemTypeFilter: [] };
+export const SYSTEM_TYPE_FILTER = 'SYSTEM_TYPE_FILTER';
+export const systemTypeFilterReducer = (_state, { type, payload }) => ({
+  ...(type === SYSTEM_TYPE_FILTER && {
+    systemTypeFilter: payload,
+  }),
+});
+
+export const useSystemTypeFilter = (
+  [state, dispatch] = [systemTypeFilterState]
+) => {
+  let [filterStateValue, setStateValue] = useState([]);
+  const systemTypeValue = dispatch ? state.systemTypeFilter : filterStateValue;
+  const setValue = dispatch
+    ? (newValue) => dispatch({ type: SYSTEM_TYPE_FILTER, payload: newValue })
+    : setStateValue;
+
+  const filter = {
+    label: 'System type',
+    value: 'not_nil',
+    type: 'checkbox',
+    filterValues: {
+      value: systemTypeValue,
+      onChange: (_e, value) => {
+        setValue(value);
+      },
+      items: defaultSystemTypeOptions,
+    },
+  };
+
+  const chip =
+    systemTypeValue?.length > 0
+      ? [
+          {
+            category: 'System type',
+            type: SYSTEM_TYPE_KEY,
+            chips: defaultSystemTypeOptions
+              .filter(({ value }) => systemTypeValue.includes(value))
+              .map(({ label, ...props }) => ({ name: label, ...props })),
+          },
+        ]
+      : [];
+
+  return [filter, chip, systemTypeValue, setValue];
+};


### PR DESCRIPTION
Impements https://issues.redhat.com/browse/RHINENG-9687.

The new filter should only be visible to customers that have bootc images and when the feature is enabled. The filter should comply with the design in this mockup: https://www.figma.com/file/izOiimeI3i1a44dKEaFsUf/Systems-in-Bifrost?type=design&node-id=1016-41257&mode=design&t=ZYd83sqYOyalba6a-4

To test:
1. Run the PR
2. Navigate to the landing page in the Inventory page 
3. Observe that now there is a new 'System type' filter among others in the filters dropdown
4. Try filtering the table with package mode, observe that the request is made with `filter[system_profile][bootc_status][booted][image_digest]=nil`
5. Try filtering the table with image mode, and observe that the request is made with `filter[system_profile][bootc_status][booted][image_digest]=not_nil`
6. In general, play with it