### PR TITLE
feat(RHINENG-358): Add subscription info to inv details

### DIFF
--- a/src/__mocks__/selectors.js
+++ b/src/__mocks__/selectors.js
@@ -68,3 +68,11 @@ export const collectInfoTest = {
   insights_client_version: 'test-client',
   insights_egg_version: 'test-egg',
 };
+
+export const subscriptionsTest = {
+  system_purpose: {
+    usage: 'Development',
+    sla: 'Self-Support',
+    role: 'Red Hat Enterprise Linux Server',
+  },
+};

--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.js
@@ -16,6 +16,7 @@ import { InfrastructureCard } from '../InfrastructureCard';
 import { ConfigurationCard } from '../ConfigurationCard';
 import { SystemStatusCard } from '../SystemStatusCard';
 import { DataCollectorsCard } from '../DataCollectorsCard/DataCollectorsCard';
+import { SubscriptionCard } from '../SubscriptionCard';
 import { Provider } from 'react-redux';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
 
@@ -99,6 +100,7 @@ class GeneralInformation extends Component {
       SystemStatusCardWrapper,
       DataCollectorsCardWrapper,
       CollectionCardWrapper,
+      SubscriptionCardWrapper,
       children,
       entity,
     } = this.props;
@@ -158,6 +160,12 @@ class GeneralInformation extends Component {
                 {BiosCardWrapper && (
                   <GridItem>
                     <BiosCardWrapper handleClick={this.handleModalToggle} />
+                  </GridItem>
+                )}
+
+                {SubscriptionCardWrapper && (
+                  <GridItem>
+                    <SubscriptionCardWrapper />
                   </GridItem>
                 )}
 
@@ -276,6 +284,10 @@ GeneralInformation.propTypes = {
     PropTypes.elementType,
     PropTypes.bool,
   ]),
+  SubscriptionCardWrapper: PropTypes.oneOfType([
+    PropTypes.elementType,
+    PropTypes.bool,
+  ]),
   children: PropTypes.node,
   navigate: PropTypes.any,
   inventoryId: PropTypes.string.isRequired,
@@ -295,6 +307,7 @@ GeneralInformation.defaultProps = {
   SystemStatusCardWrapper: SystemStatusCard,
   DataCollectorsCardWrapper: DataCollectorsCard,
   CollectionCardWrapper: false,
+  SubscriptionCardWrapper: SubscriptionCard,
   systemProfilePrefetched: false,
   showImageDetails: false,
   showRuntimesProcesses: false,

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -1189,6 +1189,97 @@ exports[`GeneralInformation should render correctly 1`] = `
                         data-ouia-safe="true"
                         data-pf-content="true"
                       >
+                        Subscriptions
+                      </h1>
+                    </div>
+                  </div>
+                  <div
+                    class="pf-v5-l-stack__item pf-m-fill"
+                  >
+                    <div
+                      class="pf-v5-c-content"
+                    >
+                      <dl
+                        class=""
+                      >
+                        <dt
+                          aria-label="Usage title"
+                          class=""
+                          data-ouia-component-id="Usage title"
+                        >
+                          Usage
+                        </dt>
+                        <dd
+                          aria-label="Usage value"
+                          class=""
+                          data-ouia-component-id="Usage value"
+                        >
+                          Production
+                        </dd>
+                        <dt
+                          aria-label="SLA title"
+                          class=""
+                          data-ouia-component-id="SLA title"
+                        >
+                          SLA
+                        </dt>
+                        <dd
+                          aria-label="SLA value"
+                          class=""
+                          data-ouia-component-id="SLA value"
+                        >
+                          Not available
+                        </dd>
+                        <dt
+                          aria-label="Role title"
+                          class=""
+                          data-ouia-component-id="Role title"
+                        >
+                          Role
+                        </dt>
+                        <dd
+                          aria-label="Role value"
+                          class=""
+                          data-ouia-component-id="Role value"
+                        >
+                          Not available
+                        </dd>
+                      </dl>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="pf-v5-l-grid__item"
+          >
+            <div
+              class="pf-v5-c-card"
+              data-ouia-component-id="system-properties-card"
+              data-ouia-component-type="PF5/Card"
+              data-ouia-safe="true"
+              id=""
+            >
+              <div
+                class="pf-v5-c-card__body"
+              >
+                <div
+                  class="pf-v5-l-stack pf-m-gutter"
+                >
+                  <div
+                    class="pf-v5-l-stack__item"
+                  >
+                    <div
+                      class="pf-v5-c-content"
+                    >
+                      <h1
+                        class=""
+                        data-ouia-component-id="SystemPropertiesCardTitle"
+                        data-ouia-component-type="PF5/Text"
+                        data-ouia-safe="true"
+                        data-pf-content="true"
+                      >
                         Configuration
                       </h1>
                     </div>

--- a/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.js
+++ b/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import LoadingCard from '../LoadingCard';
+import { subscriptionsSelector } from '../selectors';
+
+const SubscriptionCardCore = ({
+  systemPurpose,
+  detailLoaded,
+  hasUsage,
+  hasSLA,
+  hasRole,
+}) => {
+  return (
+    <LoadingCard
+      title="Subscriptions"
+      isLoading={!detailLoaded}
+      items={[
+        ...(hasUsage ? [{ title: 'Usage', value: systemPurpose.usage }] : []),
+        ...(hasSLA ? [{ title: 'SLA', value: systemPurpose.sla }] : []),
+        ...(hasRole ? [{ title: 'Role', value: systemPurpose.role }] : []),
+      ]}
+    />
+  );
+};
+
+SubscriptionCardCore.propTypes = {
+  detailLoaded: PropTypes.bool,
+  bios: PropTypes.shape({
+    usage: PropTypes.string,
+    sla: PropTypes.string,
+    role: PropTypes.string,
+  }),
+  hasUsage: PropTypes.bool,
+  hasSLA: PropTypes.bool,
+  hasRole: PropTypes.bool,
+};
+SubscriptionCardCore.defaultProps = {
+  detailLoaded: false,
+  hasUsage: true,
+  hasSLA: true,
+  hasRole: true,
+};
+
+export const SubscriptionCard = connect(
+  ({ systemProfileStore: { systemProfile } }) => ({
+    systemPurpose: subscriptionsSelector(systemProfile),
+    detailLoaded: systemProfile && systemProfile.loaded,
+  })
+)(SubscriptionCardCore);
+
+SubscriptionCard.propTypes = SubscriptionCardCore.propTypes;
+SubscriptionCard.defaultProps = SubscriptionCardCore.defaultProps;
+
+export default SubscriptionCard;

--- a/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.test.js
+++ b/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.test.js
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import { TestWrapper } from '../../../Utilities/TestingUtilities';
+import { subscriptionsTest } from '../../../__mocks__/selectors';
+import SubscriptionCard from './SubscriptionCard';
+
+describe('SubscriptionCard', () => {
+  let initialState;
+  let mockStore;
+
+  beforeEach(() => {
+    mockStore = configureStore();
+    initialState = {
+      systemProfileStore: {
+        systemProfile: {
+          loaded: true,
+          ...subscriptionsTest,
+          cpu_flags: ['one'],
+        },
+      },
+    };
+  });
+
+  it('should render correctly - loading', () => {
+    const store = mockStore({ systemProfileStore: {} });
+    const view = render(
+      <TestWrapper store={store}>
+        <SubscriptionCard />
+      </TestWrapper>
+    );
+    expect(view.asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with data', () => {
+    const store = mockStore(initialState);
+    const view = render(
+      <TestWrapper store={store}>
+        <SubscriptionCard />
+      </TestWrapper>
+    );
+    expect(view.asFragment()).toMatchSnapshot();
+  });
+
+  ['hasUsage', 'hasSLA', 'hasRole'].map((item) =>
+    it(`should not render ${item}`, () => {
+      const store = mockStore(initialState);
+      const view = render(
+        <TestWrapper store={store}>
+          <SubscriptionCard {...{ [item]: false }} />
+        </TestWrapper>
+      );
+      expect(view.asFragment()).toMatchSnapshot();
+    })
+  );
+});

--- a/src/components/GeneralInfo/SubscriptionCard/__snapshots__/SubscriptionCard.test.js.snap
+++ b/src/components/GeneralInfo/SubscriptionCard/__snapshots__/SubscriptionCard.test.js.snap
@@ -1,0 +1,437 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SubscriptionCard should not render hasRole 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-card"
+    data-ouia-component-id="system-properties-card"
+    data-ouia-component-type="PF5/Card"
+    data-ouia-safe="true"
+    id=""
+  >
+    <div
+      class="pf-v5-c-card__body"
+    >
+      <div
+        class="pf-v5-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-v5-l-stack__item"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <h1
+              class=""
+              data-ouia-component-id="SystemPropertiesCardTitle"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Subscriptions
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-v5-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <dl
+              class=""
+            >
+              <dt
+                aria-label="Usage title"
+                class=""
+                data-ouia-component-id="Usage title"
+              >
+                Usage
+              </dt>
+              <dd
+                aria-label="Usage value"
+                class=""
+                data-ouia-component-id="Usage value"
+              >
+                Development
+              </dd>
+              <dt
+                aria-label="SLA title"
+                class=""
+                data-ouia-component-id="SLA title"
+              >
+                SLA
+              </dt>
+              <dd
+                aria-label="SLA value"
+                class=""
+                data-ouia-component-id="SLA value"
+              >
+                Self-Support
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SubscriptionCard should not render hasSLA 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-card"
+    data-ouia-component-id="system-properties-card"
+    data-ouia-component-type="PF5/Card"
+    data-ouia-safe="true"
+    id=""
+  >
+    <div
+      class="pf-v5-c-card__body"
+    >
+      <div
+        class="pf-v5-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-v5-l-stack__item"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <h1
+              class=""
+              data-ouia-component-id="SystemPropertiesCardTitle"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Subscriptions
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-v5-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <dl
+              class=""
+            >
+              <dt
+                aria-label="Usage title"
+                class=""
+                data-ouia-component-id="Usage title"
+              >
+                Usage
+              </dt>
+              <dd
+                aria-label="Usage value"
+                class=""
+                data-ouia-component-id="Usage value"
+              >
+                Development
+              </dd>
+              <dt
+                aria-label="Role title"
+                class=""
+                data-ouia-component-id="Role title"
+              >
+                Role
+              </dt>
+              <dd
+                aria-label="Role value"
+                class=""
+                data-ouia-component-id="Role value"
+              >
+                Red Hat Enterprise Linux Server
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SubscriptionCard should not render hasUsage 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-card"
+    data-ouia-component-id="system-properties-card"
+    data-ouia-component-type="PF5/Card"
+    data-ouia-safe="true"
+    id=""
+  >
+    <div
+      class="pf-v5-c-card__body"
+    >
+      <div
+        class="pf-v5-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-v5-l-stack__item"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <h1
+              class=""
+              data-ouia-component-id="SystemPropertiesCardTitle"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Subscriptions
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-v5-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <dl
+              class=""
+            >
+              <dt
+                aria-label="SLA title"
+                class=""
+                data-ouia-component-id="SLA title"
+              >
+                SLA
+              </dt>
+              <dd
+                aria-label="SLA value"
+                class=""
+                data-ouia-component-id="SLA value"
+              >
+                Self-Support
+              </dd>
+              <dt
+                aria-label="Role title"
+                class=""
+                data-ouia-component-id="Role title"
+              >
+                Role
+              </dt>
+              <dd
+                aria-label="Role value"
+                class=""
+                data-ouia-component-id="Role value"
+              >
+                Red Hat Enterprise Linux Server
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SubscriptionCard should render correctly - loading 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-card"
+    data-ouia-component-id="system-properties-card"
+    data-ouia-component-type="PF5/Card"
+    data-ouia-safe="true"
+    id=""
+  >
+    <div
+      class="pf-v5-c-card__body"
+    >
+      <div
+        class="pf-v5-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-v5-l-stack__item"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <h1
+              class=""
+              data-ouia-component-id="SystemPropertiesCardTitle"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Subscriptions
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-v5-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <dl
+              class=""
+            >
+              <dt
+                aria-label="Usage title"
+                class=""
+                data-ouia-component-id="Usage title"
+              >
+                Usage
+              </dt>
+              <dd
+                aria-label="Usage value"
+                class=""
+                data-ouia-component-id="Usage value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                aria-label="SLA title"
+                class=""
+                data-ouia-component-id="SLA title"
+              >
+                SLA
+              </dt>
+              <dd
+                aria-label="SLA value"
+                class=""
+                data-ouia-component-id="SLA value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+              <dt
+                aria-label="Role title"
+                class=""
+                data-ouia-component-id="Role title"
+              >
+                Role
+              </dt>
+              <dd
+                aria-label="Role value"
+                class=""
+                data-ouia-component-id="Role value"
+              >
+                <div
+                  class="pf-v5-c-skeleton ins-c-skeleton ins-c-skeleton__sm"
+                >
+                  <span
+                    class="pf-v5-screen-reader"
+                  />
+                </div>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SubscriptionCard should render correctly with data 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-card"
+    data-ouia-component-id="system-properties-card"
+    data-ouia-component-type="PF5/Card"
+    data-ouia-safe="true"
+    id=""
+  >
+    <div
+      class="pf-v5-c-card__body"
+    >
+      <div
+        class="pf-v5-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-v5-l-stack__item"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <h1
+              class=""
+              data-ouia-component-id="SystemPropertiesCardTitle"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Subscriptions
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-v5-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <dl
+              class=""
+            >
+              <dt
+                aria-label="Usage title"
+                class=""
+                data-ouia-component-id="Usage title"
+              >
+                Usage
+              </dt>
+              <dd
+                aria-label="Usage value"
+                class=""
+                data-ouia-component-id="Usage value"
+              >
+                Development
+              </dd>
+              <dt
+                aria-label="SLA title"
+                class=""
+                data-ouia-component-id="SLA title"
+              >
+                SLA
+              </dt>
+              <dd
+                aria-label="SLA value"
+                class=""
+                data-ouia-component-id="SLA value"
+              >
+                Self-Support
+              </dd>
+              <dt
+                aria-label="Role title"
+                class=""
+                data-ouia-component-id="Role title"
+              >
+                Role
+              </dt>
+              <dd
+                aria-label="Role value"
+                class=""
+                data-ouia-component-id="Role value"
+              >
+                Red Hat Enterprise Linux Server
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/GeneralInfo/SubscriptionCard/index.js
+++ b/src/components/GeneralInfo/SubscriptionCard/index.js
@@ -1,0 +1,2 @@
+export * from './SubscriptionCard';
+export { default } from './SubscriptionCard';

--- a/src/components/GeneralInfo/selectors/selectors.js
+++ b/src/components/GeneralInfo/selectors/selectors.js
@@ -9,6 +9,12 @@ function safeParser(toParse, key) {
   }
 }
 
+export const subscriptionsSelector = ({ system_purpose } = {}) => ({
+  usage: system_purpose?.usage,
+  sla: system_purpose?.sla,
+  role: system_purpose?.role,
+});
+
 export const propertiesSelector = (
   {
     number_of_cpus,


### PR DESCRIPTION
Description of problem: Unable to review what subscription information per host is uploaded to Insights

Steps to Reproduce:

1. Navigate to https://console.redhat.com/insights/inventory/
2. Click on any system from the list and view its information under 'General information' tab

Actual results: Unable to review the Subscription information of a system, the info page of a system is lacking subscription relevant information

Expected results: The system info page has also subscription information (service-level, purpose role, purpose usage, purpose addons)

Use case:

- Add system purpose Role and Usage to some of my servers
- Run the Inventory Sync from Satellite 6.9+
- Go to Insights Inventory to review if the Satellite uploaded the correct values