### PR TITLE
fix(ContentToggle): Fix tooltips missing for "View by" buttons

### DIFF
--- a/src/routes/InventoryComponents/InventoryPageHeader.js
+++ b/src/routes/InventoryComponents/InventoryPageHeader.js
@@ -1,4 +1,4 @@
-import React, { useContext, useRef } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   Split,
@@ -20,54 +20,43 @@ import { pageContents } from '../InventoryPage';
 import { AccountStatContext } from '../../Routes';
 import FontAwesomeImageIcon from '../../components/FontAwesomeImageIcon';
 
-const InventoryContentToggle = ({ changeMainContent, mainContent }) => {
-  const viewBySystemsToggle = useRef(null);
-  const viewByImagesToggle = useRef(null);
-
-  return (
-    <Split hasGutter>
-      <SplitItem>
-        <TextContent>
-          <Text style={{ paddingTop: '5px' }} component={TextVariants.h4}>
-            View by
-          </Text>
-        </TextContent>
-      </SplitItem>
-      <SplitItem>
-        <ToggleGroup aria-label="Inventory content toggle">
-          <Tooltip
-            content="View by systems"
-            position="top-end"
-            triggerRef={viewBySystemsToggle}
-          >
-            <ToggleGroupItem
-              ref={viewBySystemsToggle}
-              icon={<DesktopIcon />}
-              aria-label="Hybrid inventory"
-              isSelected={mainContent === pageContents.hybridInventory.key}
-              onChange={() =>
-                changeMainContent(pageContents.hybridInventory.key)
-              }
-            />
-          </Tooltip>
-          <Tooltip
-            content="View by images"
-            position="top-end"
-            triggerRef={viewByImagesToggle}
-          >
-            <ToggleGroupItem
-              ref={viewByImagesToggle}
-              icon={<FontAwesomeImageIcon />}
-              aria-label="Bifrost"
-              isSelected={mainContent === pageContents.bifrost.key}
-              onChange={() => changeMainContent(pageContents.bifrost.key)}
-            />
-          </Tooltip>
-        </ToggleGroup>
-      </SplitItem>
-    </Split>
-  );
-};
+const InventoryContentToggle = ({ changeMainContent, mainContent }) => (
+  <Split hasGutter>
+    <SplitItem>
+      <TextContent>
+        <Text style={{ paddingTop: '5px' }} component={TextVariants.h4}>
+          View by
+        </Text>
+      </TextContent>
+    </SplitItem>
+    <SplitItem>
+      <ToggleGroup aria-label="Inventory content toggle">
+        <Tooltip
+          content="View by systems"
+          triggerRef={() => document.getElementById('view-by-systems-toggle')}
+        />
+        <ToggleGroupItem
+          id="view-by-systems-toggle"
+          icon={<DesktopIcon />}
+          aria-label="View by systems"
+          isSelected={mainContent === pageContents.hybridInventory.key}
+          onChange={() => changeMainContent(pageContents.hybridInventory.key)}
+        />
+        <Tooltip
+          content="View by images"
+          triggerRef={() => document.getElementById('view-by-images-toggle')}
+        />
+        <ToggleGroupItem
+          id="view-by-images-toggle"
+          icon={<FontAwesomeImageIcon />}
+          aria-label="View by images"
+          isSelected={mainContent === pageContents.bifrost.key}
+          onChange={() => changeMainContent(pageContents.bifrost.key)}
+        />
+      </ToggleGroup>
+    </SplitItem>
+  </Split>
+);
 
 const InventoryPageHeader = (toggleProps) => {
   const isBifrostEnabled = useFeatureFlag('hbi.ui.bifrost');

--- a/src/routes/InventoryComponents/InventoryPageHeader.test.js
+++ b/src/routes/InventoryComponents/InventoryPageHeader.test.js
@@ -39,9 +39,9 @@ describe('InventoryContentToggle', () => {
     useFeatureFlag.mockReturnValue(true);
 
     mountWithContext();
-    expect(screen.getByLabelText('Hybrid inventory')).toBeVisible();
-    expect(screen.getByLabelText('Bifrost')).toBeVisible();
-    expect(screen.getByLabelText('Bifrost')).toHaveAttribute(
+    expect(screen.getByLabelText('View by systems')).toBeVisible();
+    expect(screen.getByLabelText('View by images')).toBeVisible();
+    expect(screen.getByLabelText('View by images')).toHaveAttribute(
       'aria-pressed',
       'true'
     );
@@ -54,15 +54,15 @@ describe('InventoryContentToggle', () => {
       ...defaultContextValues,
       hasBootcImages: false,
     });
-    expect(screen.queryByLabelText('Hybrid inventory')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Bifrost')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('View by systems')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('View by images')).not.toBeInTheDocument();
     expect(screen.getByText('Systems')).toBeVisible();
   });
 
   test('calls changeMainContent with correct content key when Bifrost is clicked', async () => {
     mountWithContext();
 
-    await user.click(screen.getByLabelText('Bifrost'));
+    await user.click(screen.getByLabelText('View by images'));
 
     expect(defaultProps.changeMainContent).toHaveBeenCalledWith('bifrost');
     expect(defaultProps.changeMainContent).toHaveBeenCalledTimes(1);
@@ -71,7 +71,7 @@ describe('InventoryContentToggle', () => {
   test('calls changeMainContent with correct content key when Hybrid inventory is clicked', async () => {
     mountWithContext();
 
-    await user.click(screen.getByLabelText('Hybrid inventory'));
+    await user.click(screen.getByLabelText('View by systems'));
 
     expect(defaultProps.changeMainContent).toHaveBeenCalledWith(
       'hybridInventory'

--- a/src/routes/InventoryPage.test.js
+++ b/src/routes/InventoryPage.test.js
@@ -35,7 +35,7 @@ describe('Inventory', () => {
 
   test('changes main content when toggle is clicked', async () => {
     mountWithContext();
-    const bifrostToggle = screen.getByLabelText('Bifrost');
+    const bifrostToggle = screen.getByLabelText('View by images');
 
     await userEvent.click(bifrostToggle);
 


### PR DESCRIPTION
No jira.

This returns the tooltip that should show up once users hover over "View by" buttons: view by systems, view by images.

## How to test

Check on /inventory that the toggle has tooltips on hover.

<img width="647" alt="Screenshot 2024-06-04 at 16 19 13" src="https://github.com/RedHatInsights/insights-inventory-frontend/assets/31385370/b0fb5d2c-3577-45f1-9fba-6a463592c596">
