### PR TITLE
fix(RHINENG-8684): Icon locator for image mode systems is not visible in Inspect

### DIFF
--- a/src/components/InventoryTable/TitleColumn.js
+++ b/src/components/InventoryTable/TitleColumn.js
@@ -56,11 +56,10 @@ const TitleColumn = ({ children, id, item, ...props }) => (
                 </div>
               }
             >
-              <Icon style={{ marginRight: '8px' }}>
+              <Icon style={{ marginRight: '8px' }} aria-label="Image mode icon">
                 <FontAwesomeImageIcon
                   fill="var(--pf-v5-global--icon--Color--light)"
                   margin="0px"
-                  aria-label="Image mode icon"
                 />
               </Icon>
             </Popover>
@@ -77,11 +76,11 @@ const TitleColumn = ({ children, id, item, ...props }) => (
                 </div>
               }
             >
-              <Icon style={{ marginRight: '8px' }}>
-                <BundleIcon
-                  color="var(--pf-v5-global--icon--Color--light)"
-                  aria-label="Package mode icon"
-                />
+              <Icon
+                style={{ marginRight: '8px' }}
+                aria-label="Package mode icon"
+              >
+                <BundleIcon color="var(--pf-v5-global--icon--Color--light)" />
               </Icon>
             </Popover>
           )}

--- a/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/TitleColumn.test.js.snap
@@ -30,6 +30,7 @@ exports[`TitleColumn should render correctly with NO data 1`] = `
           style="display: contents;"
         >
           <span
+            aria-label="Package mode icon"
             class="pf-v5-c-icon"
             style="margin-right: 8px;"
           >
@@ -38,7 +39,6 @@ exports[`TitleColumn should render correctly with NO data 1`] = `
             >
               <svg
                 aria-hidden="true"
-                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"
@@ -76,6 +76,7 @@ exports[`TitleColumn should render correctly with data 1`] = `
           style="display: contents;"
         >
           <span
+            aria-label="Package mode icon"
             class="pf-v5-c-icon"
             style="margin-right: 8px;"
           >
@@ -84,7 +85,6 @@ exports[`TitleColumn should render correctly with data 1`] = `
             >
               <svg
                 aria-hidden="true"
-                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"
@@ -125,6 +125,7 @@ exports[`TitleColumn should render correctly with href 1`] = `
           style="display: contents;"
         >
           <span
+            aria-label="Package mode icon"
             class="pf-v5-c-icon"
             style="margin-right: 8px;"
           >
@@ -133,7 +134,6 @@ exports[`TitleColumn should render correctly with href 1`] = `
             >
               <svg
                 aria-hidden="true"
-                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"
@@ -177,6 +177,7 @@ exports[`TitleColumn should render correctly with os_release 1`] = `
           style="display: contents;"
         >
           <span
+            aria-label="Package mode icon"
             class="pf-v5-c-icon"
             style="margin-right: 8px;"
           >
@@ -185,7 +186,6 @@ exports[`TitleColumn should render correctly with os_release 1`] = `
             >
               <svg
                 aria-hidden="true"
-                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"
@@ -226,6 +226,7 @@ exports[`TitleColumn should render correctly with to 1`] = `
           style="display: contents;"
         >
           <span
+            aria-label="Package mode icon"
             class="pf-v5-c-icon"
             style="margin-right: 8px;"
           >
@@ -234,7 +235,6 @@ exports[`TitleColumn should render correctly with to 1`] = `
             >
               <svg
                 aria-hidden="true"
-                aria-label="Package mode icon"
                 class="pf-v5-svg"
                 color="var(--pf-v5-global--icon--Color--light)"
                 fill="currentColor"


### PR DESCRIPTION
Currently` aria-label` is not visible for image mode icon is not visible in Inspect
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/20332825/508c5b31-177e-4575-91c7-3760ec78fdae)

with this change 'aria-label` should be visible in Inspect 
![image](https://github.com/RedHatInsights/insights-inventory-frontend/assets/20332825/ad3270d4-5bb5-4e5a-bacf-37411530d977)
 
