### PR TITLE
fix(RHINENG-358): update selectors

### DIFF
--- a/src/__mocks__/selectors.js
+++ b/src/__mocks__/selectors.js
@@ -70,9 +70,9 @@ export const collectInfoTest = {
 };
 
 export const subscriptionsTest = {
-  system_purpose: {
-    usage: 'Development',
-    sla: 'Self-Support',
-    role: 'Red Hat Enterprise Linux Server',
+  facts: {
+    SYSPURPOSE_USAGE: 'Development',
+    SYSPURPOSE_SLA: 'Self-Support',
+    SYSPURPOSE_ROLE: 'Red Hat Enterprise Linux Server',
   },
 };

--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.test.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.test.js
@@ -67,6 +67,11 @@ describe('GeneralInformation', () => {
         entity: {
           id: 'test-id',
           per_reporter_staleness: {},
+          facts: {
+            SYSPURPOSE_USAGE: 'Development',
+            SYSPURPOSE_SLA: 'Self-Support',
+            SYSPURPOSE_ROLE: 'Red Hat Enterprise Linux Server',
+          },
         },
       },
       systemProfileStore: {

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -1214,7 +1214,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                           class=""
                           data-ouia-component-id="Usage value"
                         >
-                          Production
+                          Development
                         </dd>
                         <dt
                           aria-label="SLA title"
@@ -1228,7 +1228,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                           class=""
                           data-ouia-component-id="SLA value"
                         >
-                          Not available
+                          Self-Support
                         </dd>
                         <dt
                           aria-label="Role title"
@@ -1242,7 +1242,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                           class=""
                           data-ouia-component-id="Role value"
                         >
-                          Not available
+                          Red Hat Enterprise Linux Server
                         </dd>
                       </dl>
                     </div>

--- a/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.js
+++ b/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.js
@@ -5,7 +5,7 @@ import LoadingCard from '../LoadingCard';
 import { subscriptionsSelector } from '../selectors';
 
 const SubscriptionCardCore = ({
-  systemPurpose,
+  subscriptionFacts,
   detailLoaded,
   hasUsage,
   hasSLA,
@@ -16,9 +16,11 @@ const SubscriptionCardCore = ({
       title="Subscriptions"
       isLoading={!detailLoaded}
       items={[
-        ...(hasUsage ? [{ title: 'Usage', value: systemPurpose.usage }] : []),
-        ...(hasSLA ? [{ title: 'SLA', value: systemPurpose.sla }] : []),
-        ...(hasRole ? [{ title: 'Role', value: systemPurpose.role }] : []),
+        ...(hasUsage
+          ? [{ title: 'Usage', value: subscriptionFacts.usage }]
+          : []),
+        ...(hasSLA ? [{ title: 'SLA', value: subscriptionFacts.sla }] : []),
+        ...(hasRole ? [{ title: 'Role', value: subscriptionFacts.role }] : []),
       ]}
     />
   );
@@ -26,7 +28,7 @@ const SubscriptionCardCore = ({
 
 SubscriptionCardCore.propTypes = {
   detailLoaded: PropTypes.bool,
-  bios: PropTypes.shape({
+  subscriptionFacts: PropTypes.shape({
     usage: PropTypes.string,
     sla: PropTypes.string,
     role: PropTypes.string,
@@ -43,8 +45,8 @@ SubscriptionCardCore.defaultProps = {
 };
 
 export const SubscriptionCard = connect(
-  ({ systemProfileStore: { systemProfile } }) => ({
-    systemPurpose: subscriptionsSelector(systemProfile),
+  ({ entityDetails: { entity }, systemProfileStore: { systemProfile } }) => ({
+    subscriptionFacts: subscriptionsSelector(entity),
     detailLoaded: systemProfile && systemProfile.loaded,
   })
 )(SubscriptionCardCore);

--- a/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.test.js
+++ b/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.test.js
@@ -15,15 +15,19 @@ describe('SubscriptionCard', () => {
       systemProfileStore: {
         systemProfile: {
           loaded: true,
-          ...subscriptionsTest,
           cpu_flags: ['one'],
+        },
+      },
+      entityDetails: {
+        entity: {
+          ...subscriptionsTest,
         },
       },
     };
   });
 
   it('should render correctly - loading', () => {
-    const store = mockStore({ systemProfileStore: {} });
+    const store = mockStore({ entityDetails: {}, systemProfileStore: {} });
     const view = render(
       <TestWrapper store={store}>
         <SubscriptionCard />

--- a/src/components/GeneralInfo/selectors/selectors.js
+++ b/src/components/GeneralInfo/selectors/selectors.js
@@ -9,10 +9,10 @@ function safeParser(toParse, key) {
   }
 }
 
-export const subscriptionsSelector = ({ system_purpose } = {}) => ({
-  usage: system_purpose?.usage,
-  sla: system_purpose?.sla,
-  role: system_purpose?.role,
+export const subscriptionsSelector = ({ facts } = {}) => ({
+  usage: facts?.SYSPURPOSE_USAGE,
+  sla: facts?.SYSPURPOSE_SLA,
+  role: facts?.SYSPURPOSE_ROLE,
 });
 
 export const propertiesSelector = (


### PR DESCRIPTION
In the [previous PR](https://github.com/RedHatInsights/insights-inventory-frontend/pull/2208), we checked for systemProfile.system_purpose to find subscription info. But, we should be checking entity.facts instead.