### PR TITLE
feat(RHINENG-10513): Replace groups with workspaces

### DIFF
--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -291,6 +291,40 @@ export const featureFlagsInterceptors = {
       },
     }).as('getEdgeFeatureFlag');
   },
+  workspacesSuccessful: () => {
+    cy.intercept('GET', '/feature_flags*', {
+      statusCode: 200,
+      body: {
+        toggles: [
+          {
+            name: 'platform.rbac.groups-to-workspaces-rename',
+            enabled: true,
+            variant: {
+              name: 'disabled',
+              enabled: true,
+            },
+          },
+        ],
+      },
+    }).as('getWorkspacesFeatureFlag');
+  },
+  workspacesDisabled: () => {
+    cy.intercept('GET', '/feature_flags*', {
+      statusCode: 200,
+      body: {
+        toggles: [
+          {
+            name: 'platform.rbac.groups-to-workspaces-rename',
+            enabled: false,
+            variant: {
+              name: 'disabled',
+              enabled: false,
+            },
+          },
+        ],
+      },
+    }).as('getWorkspacesFeatureFlag');
+  },
 };
 
 export const edgeInterceptors = {

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -41,6 +41,8 @@ export const routes = {
   update: '/:inventoryId/update',
   edgeInventory: '/manage-edge-inventory',
   staleness: '/staleness-and-deletion',
+  workspace: '/workspace',
+  workspaceDetail: '/workspace/:groupId',
 };
 
 export const AccountStatContext = createContext({
@@ -102,6 +104,14 @@ export const Routes = () => {
     },
     {
       path: '/groups/:groupId',
+      element: <InventoryOrEdgeGroupDetailsView />,
+    },
+    {
+      path: '/workspace',
+      element: <InventoryOrEdgeView />,
+    },
+    {
+      path: '/workspace/:groupId',
       element: <InventoryOrEdgeGroupDetailsView />,
     },
     {

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -151,7 +151,11 @@ export const Routes = () => {
     </Suspense>
   ) : (
     <AccountStatContext.Provider
-      value={{ hasConventionalSystems, hasEdgeDevices, hasBootcImages }}
+      value={{
+        hasConventionalSystems,
+        hasEdgeDevices,
+        hasBootcImages,
+      }}
     >
       {element}
     </AccountStatContext.Provider>

--- a/src/Utilities/hooks/useWorkspaceFeatureFlag.js
+++ b/src/Utilities/hooks/useWorkspaceFeatureFlag.js
@@ -1,0 +1,6 @@
+import useFeatureFlag from '../useFeatureFlag';
+
+const useWorkspaceFeatureFlag = () =>
+  useFeatureFlag('platform.rbac.groups-to-workspaces-rename');
+
+export default useWorkspaceFeatureFlag;

--- a/src/Utilities/useFeatureFlag.js
+++ b/src/Utilities/useFeatureFlag.js
@@ -3,5 +3,5 @@ import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 export default (flag) => {
   const { flagsReady } = useFlagsStatus();
   const isFlagEnabled = useFlag(flag);
-  return flagsReady ? isFlagEnabled : false;
+  return flagsReady ? isFlagEnabled : undefined;
 };

--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -9,6 +9,7 @@ import RemoveHostsFromGroupModal from '../InventoryGroups/Modals/RemoveHostsFrom
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import {
   NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
 } from '../../constants';
 import {
@@ -30,6 +31,7 @@ import {
 import { edgeColumns } from '../ImmutableDevices/columns';
 import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { hybridInventoryTabKeys } from '../../Utilities/constants';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 export const prepareColumns = (
   initialColumns,
   hideGroupColumn,
@@ -53,7 +55,7 @@ export const prepareColumns = (
     </div>
   );
 
-  // map columns to the speicifc order
+  // map columns to the specific order
   return [
     'display_name',
     'groups',
@@ -70,6 +72,13 @@ export const prepareColumns = (
 
 const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
   const dispatch = useDispatch();
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
+  const noAccessTooltip = isWorkspaceEnabled
+    ? NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE
+    : NO_MODIFY_GROUP_TOOLTIP_MESSAGE;
+  const removeLabel = isWorkspaceEnabled
+    ? 'Remove from workspace'
+    : 'Remove from group';
   const mergeColumns = (inventoryColumns) => {
     const filteredColumns = inventoryColumns.filter(
       (column) => column.key !== 'groups'
@@ -258,13 +267,13 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
                     requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                       groupId
                     )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                    noAccessTooltip={noAccessTooltip}
                     onClick={() => {
                       setCurrentSystem([row]);
                       setRemoveHostsFromGroupModalOpen(true);
                     }}
                   >
-                    Remove from group
+                    {removeLabel}
                   </ActionDropdownItem>
                 ),
               },
@@ -277,7 +286,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
                     requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                       groupId
                     )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                    noAccessTooltip={noAccessTooltip}
                     onClick={() => {
                       setCurrentSystem([row]);
                       navigate(`/insights/inventory/${row.id}/update`);
@@ -298,7 +307,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
                     requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                       groupId
                     )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                    noAccessTooltip={noAccessTooltip}
                     onClick={() => {
                       dispatch(clearEntitiesAction());
                       setAddToGroupModalOpen(true);
@@ -311,7 +320,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
                     requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                       groupId
                     )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                    noAccessTooltip={noAccessTooltip}
                     key="update-systems-button"
                     onClick={() => {
                       setupdateDevice(true);
@@ -325,12 +334,12 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
                 </div>,
               ],
               {
-                label: 'Remove from group',
+                label: removeLabel,
                 props: {
                   isAriaDisabled: !canModify || calculateSelected() === 0,
                   ...(!canModify && {
                     tooltipProps: {
-                      content: NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+                      content: noAccessTooltip,
                     },
                   }),
                 },

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -9,6 +9,7 @@ import RemoveHostsFromGroupModal from '../InventoryGroups/Modals/RemoveHostsFrom
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import {
   NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
   getSearchParams,
 } from '../../constants';
@@ -24,6 +25,7 @@ import useGlobalFilter from '../filters/useGlobalFilter';
 import { hybridInventoryTabKeys } from '../../Utilities/constants';
 import useOnRefresh from '../filters/useOnRefresh';
 import { generateFilter } from '../../Utilities/constants';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 export const prepareColumns = (
   initialColumns,
@@ -101,6 +103,13 @@ const GroupSystems = ({ groupName, groupId }) => {
   );
 
   const [searchParams] = useSearchParams();
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
+  const noAccessTooltip = isWorkspaceEnabled
+    ? NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE
+    : NO_MODIFY_GROUP_TOOLTIP_MESSAGE;
+  const removeLabel = isWorkspaceEnabled
+    ? 'Remove from workspace'
+    : 'Remove from group';
 
   useEffect(() => {
     const { page, perPage } = getSearchParams(searchParams);
@@ -205,13 +214,13 @@ const GroupSystems = ({ groupName, groupId }) => {
                     requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                       groupId
                     )}
-                    noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                    noAccessTooltip={noAccessTooltip}
                     onClick={() => {
                       setCurrentSystem([row]);
                       setRemoveHostsFromGroupModalOpen(true);
                     }}
                   >
-                    Remove from group
+                    {removeLabel}
                   </ActionDropdownItem>
                 ),
               },
@@ -224,7 +233,7 @@ const GroupSystems = ({ groupName, groupId }) => {
                 requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                   groupId
                 )}
-                noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                noAccessTooltip={noAccessTooltip}
                 onClick={() => {
                   dispatch(clearEntitiesAction());
                   setAddToGroupModalOpen(true);
@@ -234,12 +243,12 @@ const GroupSystems = ({ groupName, groupId }) => {
                 Add systems
               </ActionButton>,
               {
-                label: 'Remove from group',
+                label: removeLabel,
                 props: {
                   isAriaDisabled: !canModify || calculateSelected() === 0,
                   ...(!canModify && {
                     tooltipProps: {
-                      content: NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+                      content: noAccessTooltip,
                     },
                   }),
                 },

--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -25,12 +25,15 @@ import { Link } from 'react-router-dom';
 import {
   GENERAL_GROUPS_WRITE_PERMISSION,
   NO_MODIFY_GROUPS_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE,
   NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
   TABLE_DEFAULT_PAGINATION,
 } from '../../constants';
 import { fetchGroups } from '../../store/inventory-actions';
 import useFetchBatched from '../../Utilities/hooks/useFetchBatched';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 import DeleteGroupModal from '../InventoryGroups/Modals/DeleteGroupModal';
 import RenameGroupModal from '../InventoryGroups/Modals/RenameGroupModal';
 import { getGroups } from '../InventoryGroups/utils/api';
@@ -122,6 +125,7 @@ const GroupsTable = ({ onCreateGroupClick }) => {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const groups = useMemo(() => data?.results || [], [data]);
   const { fetchBatched } = useFetchBatched();
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
   const loadingState = uninitialized || loading;
 
   const fetchData = useCallback(
@@ -321,7 +325,11 @@ const GroupsTable = ({ onCreateGroupClick }) => {
           requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
             rowData?.groupId
           )}
-          noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+          noAccessTooltip={
+            isWorkspaceEnabled
+              ? NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE
+              : NO_MODIFY_GROUP_TOOLTIP_MESSAGE
+          }
           onClick={() => {
             setSelectedGroup({
               id: rowData?.groupId,
@@ -330,7 +338,7 @@ const GroupsTable = ({ onCreateGroupClick }) => {
             setRenameModalOpen(true);
           }}
         >
-          Rename group
+          {isWorkspaceEnabled ? 'Rename workspace' : 'Rename group'}
         </ActionDropdownItem>
       ),
     },
@@ -340,7 +348,11 @@ const GroupsTable = ({ onCreateGroupClick }) => {
           requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
             rowData?.groupId
           )}
-          noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+          noAccessTooltip={
+            isWorkspaceEnabled
+              ? NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE
+              : NO_MODIFY_GROUP_TOOLTIP_MESSAGE
+          }
           onClick={() => {
             setSelectedGroup({
               id: rowData?.groupId,
@@ -349,7 +361,7 @@ const GroupsTable = ({ onCreateGroupClick }) => {
             setDeleteModalOpen(true);
           }}
         >
-          Delete group
+          {isWorkspaceEnabled ? 'Delete workspace' : 'Delete group'}
         </ActionDropdownItem>
       ),
     },
@@ -456,11 +468,15 @@ const GroupsTable = ({ onCreateGroupClick }) => {
             <ActionButton
               key="create-group-btn"
               requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
-              noAccessTooltip={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}
+              noAccessTooltip={
+                isWorkspaceEnabled
+                  ? NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE
+                  : NO_MODIFY_GROUPS_TOOLTIP_MESSAGE
+              }
               onClick={onCreateGroupClick}
               ouiaId="CreateGroupButton"
             >
-              Create group
+              {isWorkspaceEnabled ? 'Create workspace' : 'Create group'}
             </ActionButton>,
             {
               label: (
@@ -468,12 +484,22 @@ const GroupsTable = ({ onCreateGroupClick }) => {
                   requiredPermissions={selectedIds.flatMap((id) =>
                     REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(id)
                   )}
-                  noAccessTooltip={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}
+                  noAccessTooltip={
+                    isWorkspaceEnabled
+                      ? NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE
+                      : NO_MODIFY_GROUPS_TOOLTIP_MESSAGE
+                  }
                   onClick={() => setDeleteModalOpen(true)}
                   isAriaDisabled={selectedIds.length === 0}
                   checkAll
                 >
-                  {selectedIds.length > 1 ? 'Delete groups' : 'Delete group'}
+                  {selectedIds.length > 1
+                    ? isWorkspaceEnabled
+                      ? 'Delete workspaces'
+                      : 'Delete groups'
+                    : isWorkspaceEnabled
+                    ? 'Delete workspace'
+                    : 'Delete group'}
                 </ActionDropdownItem>
               ),
             },

--- a/src/components/InventoryGroupDetail/EmptyStateNoAccess.js
+++ b/src/components/InventoryGroupDetail/EmptyStateNoAccess.js
@@ -1,51 +1,80 @@
 import React from 'react';
 import AccessDenied from '../../Utilities/AccessDenied';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
-const EmptyStateNoAccessToSystems = () => (
-  <AccessDenied
-    title="Access needed for systems in this group"
-    showReturnButton={false}
-    description={
-      <div>
-        You do not have the necessary inventory host permissions to see the
-        systems in this group. Contact your organization administrator for
-        access.
-      </div>
-    }
-    variant="large" // overrides the default "full" value
-    requiredPermission="inventory:hosts:read"
-  />
-);
+const EmptyStateNoAccessToSystems = () => {
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
-const EmptyStateNoAccessToGroup = () => (
-  <AccessDenied
-    title="Inventory group access permissions needed"
-    showReturnButton={false}
-    description={
-      <div>
-        You do not have the necessary inventory group permissions to see this
-        inventory group. Contact your organization administrator for access.
-      </div>
-    }
-    variant="large" // overrides the default "full" value
-    requiredPermission="inventory:groups:read"
-  />
-);
+  return (
+    <AccessDenied
+      title={`Access needed for systems in this ${
+        isWorkspaceEnabled ? 'workspace' : 'group'
+      }`}
+      showReturnButton={false}
+      description={
+        <div>
+          {`You do not have the necessary inventory host permissions to see the
+        systems in this ${
+          isWorkspaceEnabled ? 'workspace' : 'group'
+        }. Contact your organization administrator for
+        access.`}
+        </div>
+      }
+      variant="large" // overrides the default "full" value
+      requiredPermission="inventory:hosts:read"
+    />
+  );
+};
 
-const EmptyStateNoAccessToGroups = () => (
-  <AccessDenied
-    title="Inventory group access permissions needed"
-    showReturnButton={false}
-    description={
-      <div>
-        You do not have the necessary inventory group permissions to see
-        inventory groups. Contact your organization administrator for access.
-      </div>
-    }
-    variant="large" // overrides the default "full" value
-    requiredPermission="inventory:groups:read"
-  />
-);
+const EmptyStateNoAccessToGroup = () => {
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
+
+  return (
+    <AccessDenied
+      title={`${
+        isWorkspaceEnabled ? 'Workspace' : 'Inventory group'
+      } access permissions needed`}
+      showReturnButton={false}
+      description={
+        <div>
+          {`You do not have the necessary ${
+            isWorkspaceEnabled ? 'workspace' : 'inventory group'
+          } permissions to see this
+        ${
+          isWorkspaceEnabled ? 'workspace' : 'inventory group'
+        }. Contact your organization administrator for access.`}
+        </div>
+      }
+      variant="large" // overrides the default "full" value
+      requiredPermission="inventory:groups:read"
+    />
+  );
+};
+
+const EmptyStateNoAccessToGroups = () => {
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
+
+  return (
+    <AccessDenied
+      title={`${
+        isWorkspaceEnabled ? 'Workspace' : 'Inventory group'
+      } access permissions needed`}
+      showReturnButton={false}
+      description={
+        <div>
+          {`You do not have the necessary ${
+            isWorkspaceEnabled ? 'workspace' : 'inventory group'
+          } permissions to see
+        ${
+          isWorkspaceEnabled ? 'workspaces' : 'inventory groups'
+        }. Contact your organization administrator for access.`}
+        </div>
+      }
+      variant="large" // overrides the default "full" value
+      requiredPermission="inventory:groups:read"
+    />
+  );
+};
 
 export {
   EmptyStateNoAccessToGroup,

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -30,6 +30,7 @@ import useInsightsNavigate from '@redhat-cloud-services/frontend-components-util
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
 import EdgeUpdateDeviceModal from './EdgeUpdateDeviceModal';
 import { getInventoryGroupDevicesUpdateInfo } from '../../api/edge/updates';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const GroupDetailHeader = ({ groupId }) => {
   const dispatch = useDispatch();
@@ -59,6 +60,8 @@ const GroupDetailHeader = ({ groupId }) => {
     'edgeParity.inventory-groups-enabled'
   );
 
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
+
   useEffect(() => {
     if (isEdgeParityGroupsEnabled) {
       (async () => {
@@ -79,7 +82,14 @@ const GroupDetailHeader = ({ groupId }) => {
     if (canRead) {
       if (uninitialized || loading) {
         return (
-          <Skeleton width="250px" screenreaderText="Loading group details" />
+          <Skeleton
+            width="250px"
+            screenreaderText={
+              isWorkspaceEnabled
+                ? 'Loading workspace details'
+                : 'Loading group details'
+            }
+          />
         );
       } else {
         return name || groupId; // in case of error, render just id from URL
@@ -119,7 +129,9 @@ const GroupDetailHeader = ({ groupId }) => {
       )}
       <Breadcrumb>
         <BreadcrumbItem>
-          <Link to="../groups">Groups</Link>
+          <Link to="../groups">
+            {isWorkspaceEnabled ? 'Workspaces' : 'Groups'}
+          </Link>
         </BreadcrumbItem>
         <BreadcrumbItem isActive>{getTitle()}</BreadcrumbItem>
       </Breadcrumb>
@@ -146,7 +158,7 @@ const GroupDetailHeader = ({ groupId }) => {
                 isDisabled={!canModify || uninitialized || loading}
                 ouiaId="group-actions-dropdown-toggle"
               >
-                Group actions
+                {isWorkspaceEnabled ? 'Workspace actions' : 'Group actions'}
               </MenuToggle>
             )}
           >

--- a/src/components/InventoryGroupDetail/GroupDetailInfo.js
+++ b/src/components/InventoryGroupDetail/GroupDetailInfo.js
@@ -54,7 +54,7 @@ const GroupDetailInfo = ({ chrome }) => {
           </span>
         ) : (
           <span>
-            Manage your ${isWorkspaceEnabled ? 'workspace' : 'inventory group'}{' '}
+            Manage your {isWorkspaceEnabled ? 'workspace' : 'inventory group'}{' '}
             user access configuration under Identity & Access Management {'>'}{' '}
             User Access.
           </span>

--- a/src/components/InventoryGroupDetail/GroupDetailInfo.js
+++ b/src/components/InventoryGroupDetail/GroupDetailInfo.js
@@ -48,7 +48,7 @@ const GroupDetailInfo = ({ chrome }) => {
       <CardBody>
         {isUserAccessAdministrator ? (
           <span>
-             Manage your {isWorkspaceEnabled ? 'workspace' : 'inventory group'}{' '}
+            Manage your {isWorkspaceEnabled ? 'workspace' : 'inventory group'}{' '}
             user access configuration under{' '}
             <a href={path}>Identity & Access Management {'>'} User Access</a>.
           </span>

--- a/src/components/InventoryGroupDetail/GroupDetailInfo.js
+++ b/src/components/InventoryGroupDetail/GroupDetailInfo.js
@@ -8,6 +8,7 @@ import {
 } from '../../constants';
 import { ActionButton } from '../InventoryTable/ActionWithRBAC';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const GroupDetailInfo = ({ chrome }) => {
   const path = `${chrome.isBeta() ? '/preview' : ''}/iam/user-access`;
@@ -15,6 +16,7 @@ const GroupDetailInfo = ({ chrome }) => {
     'rbac',
     USER_ACCESS_ADMIN_PERMISSIONS
   );
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   return (
     <Card>
@@ -46,13 +48,15 @@ const GroupDetailInfo = ({ chrome }) => {
       <CardBody>
         {isUserAccessAdministrator ? (
           <span>
-            Manage your inventory group user access configuration under{' '}
+            Manage your ${isWorkspaceEnabled ? 'workspace' : 'inventory group'}{' '}
+            user access configuration under{' '}
             <a href={path}>Identity & Access Management {'>'} User Access</a>.
           </span>
         ) : (
           <span>
-            Manage your inventory group user access configuration under Identity
-            & Access Management {'>'} User Access.
+            Manage your ${isWorkspaceEnabled ? 'workspace' : 'inventory group'}{' '}
+            user access configuration under Identity & Access Management {'>'}{' '}
+            User Access.
           </span>
         )}
       </CardBody>

--- a/src/components/InventoryGroupDetail/GroupDetailInfo.js
+++ b/src/components/InventoryGroupDetail/GroupDetailInfo.js
@@ -48,7 +48,7 @@ const GroupDetailInfo = ({ chrome }) => {
       <CardBody>
         {isUserAccessAdministrator ? (
           <span>
-            Manage your ${isWorkspaceEnabled ? 'workspace' : 'inventory group'}{' '}
+             Manage your {isWorkspaceEnabled ? 'workspace' : 'inventory group'}{' '}
             user access configuration under{' '}
             <a href={path}>Identity & Access Management {'>'} User Access</a>.
           </span>

--- a/src/components/InventoryGroupDetail/GroupTabDetails.js
+++ b/src/components/InventoryGroupDetail/GroupTabDetails.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS } from '../../constants';
 import { EmptyStateNoAccessToSystems } from './EmptyStateNoAccess';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
 
@@ -28,6 +29,7 @@ const GroupTabDetailsWrapper = ({
   const { hasAccess: canViewHosts } = usePermissionsWithContext(
     REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId)
   );
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
   const conventionalSystemsContent = useMemo(
     () => (
       <GroupSystems
@@ -109,7 +111,11 @@ const GroupTabDetailsWrapper = ({
           )}
         </PageSection>
       </Tab>
-      <Tab eventKey={1} title="Group info" aria-label="Group info tab">
+      <Tab
+        eventKey={1}
+        title={isWorkspaceEnabled ? 'Workspace info' : 'Group info'}
+        aria-label="Group info tab"
+      >
         {activeTabKey === 1 && ( // helps to lazy load the component
           <PageSection>
             <Suspense

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -31,6 +31,7 @@ import {
   hybridInventoryTabKeys,
 } from '../../Utilities/constants';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
 const InventoryGroupDetail = ({ groupId }) => {
@@ -56,6 +57,8 @@ const InventoryGroupDetail = ({ groupId }) => {
     REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId)
   );
 
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
+
   useEffect(() => {
     if (canViewGroup === true) {
       dispatch(fetchGroupDetail(groupId));
@@ -68,7 +71,11 @@ const InventoryGroupDetail = ({ groupId }) => {
 
   useEffect(() => {
     // if available, change ID to the group's name in the window title
-    chrome?.updateDocumentTitle?.(`${groupName || groupId} - Inventory Groups`);
+    chrome?.updateDocumentTitle?.(
+      `${groupName || groupId} - ${
+        isWorkspaceEnabled ? 'Workspaces' : 'Inventory Groups'
+      }`
+    );
   }, [data]);
 
   // TODO: append search parameter to identify the active tab
@@ -153,7 +160,11 @@ const InventoryGroupDetail = ({ groupId }) => {
                 )}
               </PageSection>
             </Tab>
-            <Tab eventKey={1} title="Group info" aria-label="Group info tab">
+            <Tab
+              eventKey={1}
+              title={isWorkspaceEnabled ? 'Workspace info' : 'Group info'}
+              aria-label="Group info tab"
+            >
               {activeTabKey === 1 && ( // helps to lazy load the component
                 <PageSection>
                   <Suspense

--- a/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
+++ b/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
@@ -13,12 +13,15 @@ import AddSystemsToGroupModal from '../InventoryGroups/Modals/AddSystemsToGroupM
 import PropTypes from 'prop-types';
 import {
   NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
 } from '../../constants';
 import { ActionButton } from '../InventoryTable/ActionWithRBAC';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const NoSystemsEmptyState = ({ groupId, groupName }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   return (
     <EmptyState
@@ -44,12 +47,18 @@ const NoSystemsEmptyState = ({ groupId, groupName }) => {
         headingLevel="h4"
       />
       <EmptyStateBody>
-        To manage systems more effectively, add systems to the group.
+        {`To manage systems more effectively, add systems to the ${
+          isWorkspaceEnabled ? 'workspace' : 'group'
+        }.`}
       </EmptyStateBody>
       <EmptyStateFooter>
         <ActionButton
           requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(groupId)}
-          noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+          noAccessTooltip={
+            isWorkspaceEnabled
+              ? NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE
+              : NO_MODIFY_GROUP_TOOLTIP_MESSAGE
+          }
           variant="primary"
           onClick={() => setIsModalOpen(true)}
           ouiaId="add-systems-button"

--- a/src/components/InventoryGroups/GetHelpExpandable.js
+++ b/src/components/InventoryGroups/GetHelpExpandable.js
@@ -11,11 +11,13 @@ import React from 'react';
 import { USER_ACCESS_ADMIN_PERMISSIONS } from '../../constants';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const GetHelpExpandable = () => {
   const { hasAccess: isUserAccessAdministrator, isOrgAdmin } =
     usePermissionsWithContext(USER_ACCESS_ADMIN_PERMISSIONS);
   const { quickStarts } = useChrome();
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   return (
     <ExpandableSection
@@ -33,7 +35,10 @@ const GetHelpExpandable = () => {
               quickStarts.activateQuickstart('insights-inventory-groups')
             }
           >
-            Create an Inventory group <ArrowRightIcon />
+            {isWorkspaceEnabled
+              ? 'Create a workspace'
+              : 'Create an Inventory group'}{' '}
+            <ArrowRightIcon />
           </Button>
         </ListItem>
         {isUserAccessAdministrator || isOrgAdmin ? (
@@ -46,7 +51,10 @@ const GetHelpExpandable = () => {
                 quickStarts.activateQuickstart('insights-inventory-groups-rbac')
               }
             >
-              Configure User Access for your Inventory groups <ArrowRightIcon />
+              {isWorkspaceEnabled
+                ? 'Configure User Access for your workspaces'
+                : 'Configure User Access for your Inventory groups'}{' '}
+              <ArrowRightIcon />
             </Button>
           </ListItem>
         ) : (

--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
@@ -10,6 +10,7 @@ import { CreateGroupButton } from '../SmallComponents/CreateGroupButton';
 import { addHostSchema } from './ModalSchemas/schemes';
 import CreateGroupModal from './CreateGroupModal';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const AddSelectedHostsToGroupModal = ({
   isModalOpen,
@@ -20,6 +21,7 @@ const AddSelectedHostsToGroupModal = ({
   const dispatch = useDispatch();
   const chrome = useChrome();
   const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
   const handleAddDevices = (values) => {
     const group = JSON.parse(values.group); // parse is a workaround for https://github.com/data-driven-forms/react-forms/issues/1401
     const statusMessages = {
@@ -52,9 +54,9 @@ const AddSelectedHostsToGroupModal = ({
         <Modal
           isModalOpen={isModalOpen}
           closeModal={() => setIsModalOpen(false)}
-          title="Add to group"
+          title={isWorkspaceEnabled ? 'Add to workspace' : 'Add to group'}
           submitLabel="Add"
-          schema={addHostSchema(hosts, chrome)}
+          schema={addHostSchema(hosts, chrome, isWorkspaceEnabled)}
           additionalMappers={{
             'create-group-btn': {
               component: CreateGroupButton,

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -33,6 +33,7 @@ import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components/Page
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { AccountStatContext } from '../../../Routes';
 import { hybridInventoryTabKeys } from '../../../Utilities/constants';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const AddSystemsToGroupModal = ({
   isModalOpen,
@@ -63,6 +64,7 @@ const AddSystemsToGroupModal = ({
     true,
     pageSelected
   );
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   const alreadyHasGroup = [...selected].filter(
     // eslint-disable-next-line camelcase
@@ -222,7 +224,11 @@ const AddSystemsToGroupModal = ({
                   <Alert
                     variant="warning"
                     isInline
-                    title="One or more of the selected systems already belong to a group. Only ungrouped systems can be added. Unselect these systems to move forward."
+                    title={
+                      isWorkspaceEnabled
+                        ? 'One or more of the selected systems already belong to a workspace. Only systems not already belonging to a workspace can be added. Unselect these systems to move forward.'
+                        : 'One or more of the selected systems already belong to a group. Only ungrouped systems can be added. Unselect these systems to move forward.'
+                    }
                   />
                 </FlexItem>
               )}

--- a/src/components/InventoryGroups/Modals/ConfirmSystemsAddModal.js
+++ b/src/components/InventoryGroups/Modals/ConfirmSystemsAddModal.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from './Modal';
 import { confirmSystemsAddSchema } from './ModalSchemas/schemes';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const ConfirmSystemsAddModal = ({
   isModalOpen,
@@ -13,57 +14,65 @@ const ConfirmSystemsAddModal = ({
   onBack,
   onCancel,
   hostsNumber,
-}) => (
-  <Modal
-    isModalOpen={isModalOpen}
-    title={'Add all selected systems to group?'}
-    titleIconVariant={() => (
-      <Icon color={warningColor.value}>
-        <ExclamationTriangleIcon />
-      </Icon>
-    )}
-    closeModal={onCancel}
-    schema={confirmSystemsAddSchema(hostsNumber)}
-    reloadData={() => {}}
-    onSubmit={onSubmit}
-    customFormTemplate={({ formFields, schema }) => {
-      const { handleSubmit, getState } = useFormApi();
-      const { submitting, valid } = getState();
+}) => {
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
-      return (
-        <form onSubmit={handleSubmit}>
-          <Flex
-            direction={{ default: 'column' }}
-            spaceItems={{ default: 'spaceItemsLg' }}
-          >
-            {schema.title}
-            {formFields}
-            <FormSpy>
-              {() => (
-                <Flex>
-                  <Button
-                    isDisabled={submitting || !valid}
-                    type="submit"
-                    color="primary"
-                    variant="primary"
-                  >
-                    Yes, add all systems to group
-                  </Button>
-                  <Button variant="secondary" onClick={onBack}>
-                    Back
-                  </Button>
-                  <Button variant="link" onClick={onCancel}>
-                    Cancel
-                  </Button>
-                </Flex>
-              )}
-            </FormSpy>
-          </Flex>
-        </form>
-      );
-    }}
-  />
-);
+  return (
+    <Modal
+      isModalOpen={isModalOpen}
+      title={`Add all selected systems to ${
+        isWorkspaceEnabled ? 'workspace' : 'group'
+      }?`}
+      titleIconVariant={() => (
+        <Icon color={warningColor.value}>
+          <ExclamationTriangleIcon />
+        </Icon>
+      )}
+      closeModal={onCancel}
+      schema={confirmSystemsAddSchema(hostsNumber, isWorkspaceEnabled)}
+      reloadData={() => {}}
+      onSubmit={onSubmit}
+      customFormTemplate={({ formFields, schema }) => {
+        const { handleSubmit, getState } = useFormApi();
+        const { submitting, valid } = getState();
+
+        return (
+          <form onSubmit={handleSubmit}>
+            <Flex
+              direction={{ default: 'column' }}
+              spaceItems={{ default: 'spaceItemsLg' }}
+            >
+              {schema.title}
+              {formFields}
+              <FormSpy>
+                {() => (
+                  <Flex>
+                    <Button
+                      isDisabled={submitting || !valid}
+                      type="submit"
+                      color="primary"
+                      variant="primary"
+                    >
+                      {`Yes, add all systems to ${
+                        isWorkspaceEnabled ? 'workspace' : 'group'
+                      }`}
+                    </Button>
+                    <Button variant="secondary" onClick={onBack}>
+                      Back
+                    </Button>
+                    <Button variant="link" onClick={onCancel}>
+                      Cancel
+                    </Button>
+                  </Flex>
+                )}
+              </FormSpy>
+            </Flex>
+          </form>
+        );
+      }}
+    />
+  );
+};
 
 ConfirmSystemsAddModal.propTypes = {
   isModalOpen: PropTypes.bool,

--- a/src/components/InventoryGroups/Modals/CreateGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/CreateGroupModal.cy.js
@@ -7,6 +7,8 @@ import { TEXT_INPUT } from '@redhat-cloud-services/frontend-components-utilities
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { getStore } from '../../../store';
+import { featureFlagsInterceptors } from '../../../../cypress/support/interceptors';
+import FlagProvider from '@unleash/proxy-client-react';
 
 const mockResponse = [
   {
@@ -63,15 +65,25 @@ describe('Create Group Modal', () => {
       },
     }).as('validate');
 
+    featureFlagsInterceptors.successful();
+
     mount(
-      <MemoryRouter>
-        <Provider store={getStore()}>
-          <CreateGroupModal
-            isModalOpen={true}
-            reloadData={() => console.log('data reloaded')}
-          />
-        </Provider>
-      </MemoryRouter>
+      <FlagProvider
+        config={{
+          url: 'http://localhost:8002/feature_flags',
+          clientKey: 'abc',
+          appName: 'abc',
+        }}
+      >
+        <MemoryRouter>
+          <Provider store={getStore()}>
+            <CreateGroupModal
+              isModalOpen={true}
+              reloadData={() => console.log('data reloaded')}
+            />
+          </Provider>
+        </MemoryRouter>
+      </FlagProvider>
     );
   });
 

--- a/src/components/InventoryGroups/Modals/CreateGroupModal.js
+++ b/src/components/InventoryGroups/Modals/CreateGroupModal.js
@@ -6,15 +6,18 @@ import apiWithToast from '../utils/apiWithToast';
 import { createGroup, validateGroupName } from '../utils/api';
 import { useDispatch } from 'react-redux';
 import awesomeDebouncePromise from 'awesome-debounce-promise';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
-export const validate = async (value = '') => {
+export const validate = async (value = '', isWorkspaceEnabled) => {
   if (value.length === 0) {
     return undefined; // the input is empty
   }
 
   const results = await validateGroupName(value.trim());
   if (results === true) {
-    throw 'Group name already exists';
+    throw isWorkspaceEnabled
+      ? 'Workspace name already exists'
+      : 'Group name already exists';
   }
 
   return undefined;
@@ -28,6 +31,7 @@ const CreateGroupModal = ({
   setterOfModalBefore,
 }) => {
   const dispatch = useDispatch();
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   const handleCreateGroup = useCallback(
     (values) => {
@@ -36,19 +40,28 @@ const CreateGroupModal = ({
           title: 'Success',
           description: `${values.name} has been created successfully`,
         },
-        onError: { title: 'Error', description: 'Failed to create group' },
+        onError: {
+          title: 'Error',
+          description: isWorkspaceEnabled
+            ? 'Failed to create workspace'
+            : 'Failed to create group',
+        },
       };
       return apiWithToast(dispatch, () => createGroup(values), statusMessages);
     },
-    [isModalOpen]
+    [isModalOpen, isWorkspaceEnabled]
   );
 
   const schema = useMemo(() => {
-    const d = awesomeDebouncePromise(validate, 500, {
-      onlyResolvesLast: false,
-    });
-    return createGroupSchema(d);
-  }, []);
+    const d = awesomeDebouncePromise(
+      (value) => validate(value, isWorkspaceEnabled),
+      500,
+      {
+        onlyResolvesLast: false,
+      }
+    );
+    return createGroupSchema(d, isWorkspaceEnabled);
+  }, [isWorkspaceEnabled]);
 
   const onClose = () => {
     if (modalBefore) {
@@ -63,7 +76,7 @@ const CreateGroupModal = ({
     <Modal
       isModalOpen={isModalOpen}
       closeModal={onClose}
-      title="Create group"
+      title={isWorkspaceEnabled ? 'Create workspace' : 'Create group'}
       submitLabel="Create"
       schema={schema}
       reloadData={reloadData}

--- a/src/components/InventoryGroups/Modals/CreateGroupModal.test.js
+++ b/src/components/InventoryGroups/Modals/CreateGroupModal.test.js
@@ -4,9 +4,11 @@ import { validateGroupName } from '../utils/api';
 import CreateGroupModal, { validate } from './CreateGroupModal';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 jest.mock('../utils/api');
 jest.mock('react-redux');
+jest.mock('../../../Utilities/hooks/useWorkspaceFeatureFlag');
 
 describe('validate function', () => {
   afterEach(() => {
@@ -49,6 +51,10 @@ describe('validate function', () => {
 });
 
 describe('create group modal', () => {
+  beforeEach(() => {
+    useWorkspaceFeatureFlag.mockReturnValue(false);
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -6,12 +6,15 @@ import { Text } from '@patternfly/react-core';
 import awesomeDebouncePromise from 'awesome-debounce-promise';
 import { getWritableGroups } from '../../utils/api';
 
-export const createGroupSchema = (namePresenceValidator) => ({
+export const createGroupSchema = (
+  namePresenceValidator,
+  isWorkspaceEnabled
+) => ({
   fields: [
     {
       component: componentTypes.TEXT_FIELD,
       name: 'name',
-      label: 'Group name',
+      label: isWorkspaceEnabled ? 'Workspace name' : 'Group name',
       helperText:
         'Can only contain letters, numbers, spaces, hyphens ( - ), and underscores ( _ ).',
       isRequired: true,
@@ -27,13 +30,17 @@ export const createGroupSchema = (namePresenceValidator) => ({
   ],
 });
 
-export const confirmSystemsAddSchema = (hostsNumber) => ({
+export const confirmSystemsAddSchema = (hostsNumber, isWorkspaceEnabled) => ({
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,
       name: 'warning-message',
-      label: `${hostsNumber} of the systems you selected already belong to a group.
-             Moving them to a different group will impact their configuration.`,
+      label: `${hostsNumber} of the systems you selected already belong to a ${
+        isWorkspaceEnabled ? 'workspace' : 'group'
+      }.
+             Moving them to a different ${
+               isWorkspaceEnabled ? 'workspace' : 'group'
+             } will impact their configuration.`,
     },
     {
       component: componentTypes.CHECKBOX,
@@ -44,10 +51,10 @@ export const confirmSystemsAddSchema = (hostsNumber) => ({
   ],
 });
 
-const createDescription = (hosts) => {
+const createDescription = (hosts, isWorkspaceEnabled) => {
   return (
     <Text>
-      Select a group to add{' '}
+      {`Select a ${isWorkspaceEnabled ? 'workspace' : 'group'} to add`}{' '}
       <strong>
         {hosts.length > 1 ? `${hosts.length} systems` : hosts[0].display_name}
       </strong>{' '}
@@ -76,27 +83,33 @@ const loadOptions = awesomeDebouncePromise(
   { onlyResolvesLast: false }
 );
 
-export const addHostSchema = (hosts, chrome) => ({
+export const addHostSchema = (hosts, chrome, isWorkspaceEnabled) => ({
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,
       name: 'description',
-      label: createDescription(hosts),
+      label: createDescription(hosts, isWorkspaceEnabled),
     },
     {
       component: 'select',
-      name: 'group',
-      label: 'Select a group',
+      name: isWorkspaceEnabled ? 'workspace' : 'group',
+      label: isWorkspaceEnabled ? 'Select a workspace' : 'Select a group',
       simpleValue: true,
       isSearchable: true, // enables typeahead
       isRequired: true,
       isClearable: true,
-      placeholder: 'Type or click to select a group',
+      placeholder: isWorkspaceEnabled
+        ? 'Type or click to select a workspace'
+        : 'Type or click to select a group',
       loadOptions: (searchValue) => loadOptions(searchValue, chrome),
       options: [],
       validate: [{ type: validatorTypes.REQUIRED }],
-      updatingMessage: 'Loading groups...',
-      loadingMessage: 'Loading groups...',
+      updatingMessage: isWorkspaceEnabled
+        ? 'Loading workspaces...'
+        : 'Loading groups...',
+      loadingMessage: isWorkspaceEnabled
+        ? 'Loading workspaces...'
+        : 'Loading groups...',
     },
     {
       component: 'create-group-btn',

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -92,7 +92,7 @@ export const addHostSchema = (hosts, chrome, isWorkspaceEnabled) => ({
     },
     {
       component: 'select',
-      name: isWorkspaceEnabled ? 'workspace' : 'group',
+      name: 'group',
       label: isWorkspaceEnabled ? 'Select a workspace' : 'Select a group',
       simpleValue: true,
       isSearchable: true, // enables typeahead

--- a/src/components/InventoryGroups/Modals/RemoveHostsFromGroupModal.js
+++ b/src/components/InventoryGroups/Modals/RemoveHostsFromGroupModal.js
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux';
 import { removeHostsFromGroup } from '../utils/api';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import { AlertActionLink, Text } from '@patternfly/react-core';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const schema = (hosts) => {
   const hostsInGroup = hosts.filter(({ groups }) => groups.length > 0); // selection can contain ungroupped hosts
@@ -76,6 +77,7 @@ const RemoveHostsFromGroupModal = ({
   reloadTimeout,
 }) => {
   const dispatch = useDispatch();
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
   const groupId = hosts.find(({ groups }) => groups.length > 0).groups[0].id;
 
   const handleRemoveHosts = () =>
@@ -93,7 +95,7 @@ const RemoveHostsFromGroupModal = ({
     <Modal
       isModalOpen={isModalOpen}
       closeModal={() => setIsModalOpen(false)}
-      title="Remove from group"
+      title={isWorkspaceEnabled ? 'Remove from workspace' : 'Remove from group'}
       variant="danger"
       submitLabel="Remove"
       schema={schema(hosts)}

--- a/src/components/InventoryGroups/Modals/RenameGroupModal.js
+++ b/src/components/InventoryGroups/Modals/RenameGroupModal.js
@@ -8,6 +8,7 @@ import { updateGroupById, validateGroupName } from '../utils/api';
 import { nameValidator } from '../helpers/validate';
 import apiWithToast from '../utils/apiWithToast';
 import { useDispatch } from 'react-redux';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const renameGroupSchema = (namePresenceValidator) => ({
   fields: [
@@ -36,6 +37,7 @@ const RenameGroupModal = ({
 }) => {
   const { id, name } = modalState;
   const dispatch = useDispatch();
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   const handleRenameModal = (values) => {
     const statusMessages = {
@@ -43,7 +45,12 @@ const RenameGroupModal = ({
         title: 'Success',
         description: `${name} has been renamed to ${values.name} successfully`,
       },
-      onError: { title: 'Error', description: 'Failed to rename group' },
+      onError: {
+        title: 'Error',
+        description: isWorkspaceEnabled
+          ? 'Failed to rename workspace'
+          : 'Failed to rename group',
+      },
     };
     apiWithToast(
       dispatch,
@@ -56,7 +63,9 @@ const RenameGroupModal = ({
     const check = async (value) => {
       const results = await validateGroupName(value);
       if (results === true) {
-        throw 'Group name already exists';
+        throw isWorkspaceEnabled
+          ? 'Workspace name already exists'
+          : 'Group name already exists';
       }
 
       return undefined;
@@ -71,7 +80,7 @@ const RenameGroupModal = ({
     <Modal
       isModalOpen={isModalOpen}
       closeModal={() => setIsModalOpen(false)}
-      title="Rename group"
+      title={isWorkspaceEnabled ? 'Rename workspace' : 'Rename group'}
       submitLabel="Save"
       schema={schema}
       initialValues={modalState}

--- a/src/components/InventoryGroups/Modals/__tests__/CreateGroupModal.test.js
+++ b/src/components/InventoryGroups/Modals/__tests__/CreateGroupModal.test.js
@@ -4,10 +4,17 @@ import '@testing-library/jest-dom';
 import { getStore } from '../../../../store';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
+import useWorkspaceFeatureFlag from '../../../../Utilities/hooks/useWorkspaceFeatureFlag';
+
+jest.mock('../../../../Utilities/hooks/useWorkspaceFeatureFlag');
 
 import CreateGroupModal from '../CreateGroupModal';
 
 describe('CreateGroupModal', () => {
+  beforeEach(() => {
+    useWorkspaceFeatureFlag.mockReturnValue(false);
+  });
+
   it('renders correctly', () => {
     render(
       <MemoryRouter>

--- a/src/components/InventoryGroups/Modals/__tests__/RemoveHostsFromGroupModal.test.js
+++ b/src/components/InventoryGroups/Modals/__tests__/RemoveHostsFromGroupModal.test.js
@@ -4,12 +4,18 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { removeHostsFromGroup } from '../../utils/api';
 import RemoveHostsFromGroupModal from '../RemoveHostsFromGroupModal';
+import useWorkspaceFeatureFlag from '../../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 jest.mock('react-redux');
 jest.mock('../../utils/api');
+jest.mock('../../../../Utilities/hooks/useWorkspaceFeatureFlag');
 
 describe('RemoveHostsFromGroupModal', () => {
   const setIsModalOpen = jest.fn();
+
+  beforeEach(() => {
+    useWorkspaceFeatureFlag.mockReturnValue(false);
+  });
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/src/components/InventoryGroups/Modals/__tests__/RenameGroupModal.test.js
+++ b/src/components/InventoryGroups/Modals/__tests__/RenameGroupModal.test.js
@@ -4,10 +4,16 @@ import '@testing-library/jest-dom';
 import { getStore } from '../../../../store';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
-
+import useWorkspaceFeatureFlag from '../../../../Utilities/hooks/useWorkspaceFeatureFlag';
 import RenameGroupModal from '../RenameGroupModal';
 
+jest.mock('../../../../Utilities/hooks/useWorkspaceFeatureFlag');
+
 describe('CreateGroupModal', () => {
+  beforeEach(() => {
+    useWorkspaceFeatureFlag.mockReturnValue(false);
+  });
+
   it('renders correctly', () => {
     render(
       <MemoryRouter>

--- a/src/components/InventoryGroups/NoGroupsEmptyState.js
+++ b/src/components/InventoryGroups/NoGroupsEmptyState.js
@@ -14,12 +14,14 @@ import PropTypes from 'prop-types';
 import { global_palette_black_600 as globalPaletteBlack600 } from '@patternfly/react-tokens/dist/js/global_palette_black_600';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { GENERAL_GROUPS_WRITE_PERMISSION } from '../../constants';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const REQUIRED_PERMISSIONS = [GENERAL_GROUPS_WRITE_PERMISSION];
 
 const NoGroupsEmptyState = ({ onCreateGroupClick }) => {
   const { hasAccess: canModifyGroups } =
     usePermissionsWithContext(REQUIRED_PERMISSIONS);
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   return (
     <EmptyState
@@ -28,7 +30,7 @@ const NoGroupsEmptyState = ({ onCreateGroupClick }) => {
       data-ouia-safe={true}
     >
       <EmptyStateHeader
-        titleText="No inventory groups"
+        titleText={isWorkspaceEnabled ? 'No workspaces' : 'No inventory groups'}
         icon={
           <EmptyStateIcon
             icon={PlusCircleIcon}
@@ -39,7 +41,9 @@ const NoGroupsEmptyState = ({ onCreateGroupClick }) => {
         headingLevel="h4"
       />
       <EmptyStateBody>
-        Manage device operations efficiently by creating inventory groups.
+        {`Manage device operations efficiently by creating ${
+          isWorkspaceEnabled ? 'workspaces' : 'inventory groups.'
+        }`}
       </EmptyStateBody>
       <EmptyStateFooter>
         {canModifyGroups ? (
@@ -48,12 +52,16 @@ const NoGroupsEmptyState = ({ onCreateGroupClick }) => {
             onClick={onCreateGroupClick}
             ouiaId="CreateGroupButton"
           >
-            Create group
+            {isWorkspaceEnabled ? 'Create workspace' : 'Create group'}
           </Button>
         ) : (
-          <Tooltip content="You do not have the necessary permissions to modify groups. Contact your organization administrator.">
+          <Tooltip
+            content={`You do not have the necessary permissions to modify ${
+              isWorkspaceEnabled ? 'workspaces' : 'groups'
+            }. Contact your organization administrator.`}
+          >
             <Button variant="primary" isAriaDisabled ouiaId="CreateGroupButton">
-              Create group
+              {isWorkspaceEnabled ? 'Create workspace' : 'Create group'}
             </Button>
           </Tooltip>
         )}

--- a/src/components/InventoryGroups/SmallComponents/CreateGroupButton.js
+++ b/src/components/InventoryGroups/SmallComponents/CreateGroupButton.js
@@ -3,17 +3,19 @@ import { Button, Text } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { GENERAL_GROUPS_WRITE_PERMISSION } from '../../../constants';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 export const CreateGroupButton = ({ closeModal }) => {
   const { hasAccess: canModifyGroups } = usePermissionsWithContext([
     GENERAL_GROUPS_WRITE_PERMISSION,
   ]);
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   return canModifyGroups ? (
     <>
       <Text>Or</Text>
       <Button variant="secondary" className="pf-v5-u-w-50" onClick={closeModal}>
-        Create a new group
+        {isWorkspaceEnabled ? 'Create a new workspace' : 'Create a new group'}
       </Button>
     </>
   ) : (

--- a/src/components/InventoryGroups/SmallComponents/Popover.js
+++ b/src/components/InventoryGroups/SmallComponents/Popover.js
@@ -8,33 +8,46 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
-const InventoryGroupsPopover = () => (
-  <Popover
-    aria-label="Inventory Groups popover"
-    headerContent={<Title headingLevel="h4">Inventory groups</Title>}
-    position="right"
-    bodyContent={
-      <TextContent>
-        <Text component={TextVariants.p}>
-          Inventory groups allow you to select specific systems and group them
-          together to better organize your inventory.
-        </Text>
-        <Text component={TextVariants.p}>
-          You can also manage user access to specific inventory groups to
-          enhance security within your organization.
-        </Text>
-      </TextContent>
-    }
-  >
-    <Button
-      variant="plain"
-      aria-label="Open Inventory groups popover"
-      style={{ padding: 0 }}
+const InventoryGroupsPopover = () => {
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
+
+  return (
+    <Popover
+      aria-label="Inventory Groups popover"
+      headerContent={
+        <Title headingLevel="h4">
+          {isWorkspaceEnabled ? 'Workspaces' : 'Inventory groups'}
+        </Title>
+      }
+      position="right"
+      bodyContent={
+        <TextContent>
+          <Text component={TextVariants.p}>
+            {`${
+              isWorkspaceEnabled ? 'Workspaces' : 'Inventory groups'
+            } allow you to select specific systems and group them
+          together to better organize your inventory.`}
+          </Text>
+          <Text component={TextVariants.p}>
+            {`You can also manage user access to specific ${
+              isWorkspaceEnabled ? 'workspaces' : 'inventory groups'
+            } to
+          enhance security within your organization.`}
+          </Text>
+        </TextContent>
+      }
     >
-      <OutlinedQuestionCircleIcon />
-    </Button>
-  </Popover>
-);
+      <Button
+        variant="plain"
+        aria-label="Open Inventory groups popover"
+        style={{ padding: 0 }}
+      >
+        <OutlinedQuestionCircleIcon />
+      </Button>
+    </Popover>
+  );
+};
 
 export default InventoryGroupsPopover;

--- a/src/components/InventoryGroups/__tests__/NoGroupsEmptyState.test.js
+++ b/src/components/InventoryGroups/__tests__/NoGroupsEmptyState.test.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { TestWrapper } from '../../../Utilities/TestingUtilities';
 import { getStore } from '../../../store';
 import NoGroupsEmptyState from '../NoGroupsEmptyState';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 jest.mock(
   '@redhat-cloud-services/frontend-components-utilities/RBACHook',
@@ -13,7 +14,13 @@ jest.mock(
   })
 );
 
+jest.mock('../../../Utilities/hooks/useWorkspaceFeatureFlag');
+
 describe('NoGroupsEmptyState', () => {
+  beforeEach(() => {
+    useWorkspaceFeatureFlag.mockReturnValue(false);
+  });
+
   it('renders title and icon', () => {
     render(
       <TestWrapper store={getStore()}>

--- a/src/components/InventoryTable/hooks/useColumns.js
+++ b/src/components/InventoryTable/hooks/useColumns.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/helpers/helpers';
 import { defaultColumns } from '../../../store/entities';
 import isEqual from 'lodash/isEqual';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const isColumnEnabled = (key, disableColumns, showTags) =>
   (key === 'tags' && showTags) ||
@@ -16,6 +17,7 @@ const useColumns = (
   showTags,
   columnsCounter
 ) => {
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
   const columnsRedux = useSelector(
     ({ entities: { columns } }) => columns,
     isEqual
@@ -28,15 +30,15 @@ const useColumns = (
     () =>
       disableDefaultColumns === true
         ? []
-        : defaultColumns().filter(({ key }) =>
+        : defaultColumns(isWorkspaceEnabled).filter(({ key }) =>
             isColumnEnabled(key, disabledColumns, showTags)
           ),
-    [disabledColumns, disableDefaultColumns, showTags]
+    [disabledColumns, disableDefaultColumns, showTags, isWorkspaceEnabled]
   );
 
   return useMemo(() => {
     if (typeof columnsProp === 'function') {
-      return columnsProp(defaultColumns());
+      return columnsProp(defaultColumns(isWorkspaceEnabled));
     } else if (columnsProp) {
       return mergeArraysByKey([defaultColumnsFiltered, columnsProp], 'key');
     } else if (!columnsProp && columnsRedux) {
@@ -58,6 +60,7 @@ const useColumns = (
       ? columnsRedux.map(({ key }) => key).join()
       : columnsRedux,
     columnsCounter,
+    isWorkspaceEnabled,
   ]);
 };
 

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -20,6 +20,7 @@ import RemoveHostsFromGroupModal from '../../InventoryGroups/Modals/RemoveHostsF
 import {
   GENERAL_GROUPS_WRITE_PERMISSION,
   NO_MODIFY_GROUPS_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE,
   NO_MODIFY_HOSTS_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
   REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP,
@@ -34,6 +35,7 @@ import useGlobalFilter from '../../filters/useGlobalFilter';
 import useOnRefresh from '../../filters/useOnRefresh';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { AccountStatContext } from '../../../Routes';
+import useWorkspaceFeatureFlag from '../../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const BulkDeleteButton = ({ selectedSystems, ...props }) => {
   const requiredPermissions = selectedSystems.map(({ groups }) =>
@@ -108,6 +110,7 @@ const ConventionalSystemsTab = ({
     rows,
     loaded
   );
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   const onRefresh = useOnRefresh((options) => {
     onSetfilters(options?.filters);
@@ -163,7 +166,8 @@ const ConventionalSystemsTab = ({
     onEditOpen,
     handleModalToggle,
     setRemoveHostsFromGroupModalOpen,
-    setAddHostGroupModalOpen
+    setAddHostGroupModalOpen,
+    isWorkspaceEnabled
   );
 
   const isBootcEnabled = useFeatureFlag('hbi.ui.bifrost');
@@ -206,14 +210,18 @@ const ConventionalSystemsTab = ({
                   key="bulk-add-to-group"
                   requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
                   isAriaDisabled={!isBulkAddHostsToGroupsEnabled()}
-                  noAccessTooltip={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}
+                  noAccessTooltip={
+                    isWorkspaceEnabled
+                      ? NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE
+                      : NO_MODIFY_GROUPS_TOOLTIP_MESSAGE
+                  }
                   onClick={() => {
                     setCurrentSystem(Array.from(selected.values()));
                     setAddHostGroupModalOpen(true);
                   }}
                   ignoreResourceDefinitions
                 >
-                  Add to group
+                  {isWorkspaceEnabled ? 'Add to workspace' : 'Add to group'}
                 </ActionDropdownItem>
               ),
             },
@@ -235,7 +243,11 @@ const ConventionalSystemsTab = ({
                       : []
                   }
                   isAriaDisabled={!isBulkRemoveFromGroupsEnabled()}
-                  noAccessTooltip={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}
+                  noAccessTooltip={
+                    isWorkspaceEnabled
+                      ? NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE
+                      : NO_MODIFY_GROUPS_TOOLTIP_MESSAGE
+                  }
                   onClick={() => {
                     setCurrentSystem(Array.from(selected.values()));
                     setRemoveHostsFromGroupModalOpen(true);
@@ -245,7 +257,9 @@ const ConventionalSystemsTab = ({
                     : {})}
                   checkAll
                 >
-                  Remove from group
+                  {isWorkspaceEnabled
+                    ? 'Remove from workspace'
+                    : 'Remove from group'}
                 </ActionDropdownItem>
               ),
             },

--- a/src/components/InventoryTabs/ConventionalSystems/useTableActions.js
+++ b/src/components/InventoryTabs/ConventionalSystems/useTableActions.js
@@ -2,7 +2,9 @@ import React, { useCallback } from 'react';
 import {
   GENERAL_GROUPS_WRITE_PERMISSION,
   NO_MODIFY_GROUPS_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE,
   NO_MODIFY_GROUP_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
   NO_MODIFY_HOST_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
   REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP,
@@ -15,93 +17,107 @@ const useTableActions = (
   onEditOpen,
   handleModalToggle,
   setRemoveHostsFromGroupModalOpen,
-  setAddHostGroupModalOpen
+  setAddHostGroupModalOpen,
+  isWorkspaceEnabled
 ) => {
-  const tableActionsCallback = useCallback((row) => {
-    const hostActions = [
-      {
-        title: (
-          <ActionDropdownItem
-            key={`${row.id}-edit`}
-            onClick={() => {
-              setCurrentSystem(row);
-              onEditOpen(() => true);
-            }}
-            requiredPermissions={[
-              REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP(
-                row.groups?.[0]?.id ?? null
-              ),
-            ]}
-            noAccessTooltip={NO_MODIFY_HOST_TOOLTIP_MESSAGE}
-          >
-            Edit
-          </ActionDropdownItem>
-        ),
-      },
-      {
-        title: (
-          <ActionDropdownItem
-            key={`${row.id}-delete`}
-            onClick={() => {
-              setCurrentSystem(row);
-              handleModalToggle(() => true);
-            }}
-            requiredPermissions={[
-              REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP(
-                row.groups?.[0]?.id ?? null
-              ),
-            ]}
-            noAccessTooltip={NO_MODIFY_HOST_TOOLTIP_MESSAGE}
-          >
-            Delete
-          </ActionDropdownItem>
-        ),
-      },
-    ];
+  const tableActionsCallback = useCallback(
+    (row) => {
+      const hostActions = [
+        {
+          title: (
+            <ActionDropdownItem
+              key={`${row.id}-edit`}
+              onClick={() => {
+                setCurrentSystem(row);
+                onEditOpen(() => true);
+              }}
+              requiredPermissions={[
+                REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP(
+                  row.groups?.[0]?.id ?? null
+                ),
+              ]}
+              noAccessTooltip={NO_MODIFY_HOST_TOOLTIP_MESSAGE}
+            >
+              Edit
+            </ActionDropdownItem>
+          ),
+        },
+        {
+          title: (
+            <ActionDropdownItem
+              key={`${row.id}-delete`}
+              onClick={() => {
+                setCurrentSystem(row);
+                handleModalToggle(() => true);
+              }}
+              requiredPermissions={[
+                REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP(
+                  row.groups?.[0]?.id ?? null
+                ),
+              ]}
+              noAccessTooltip={NO_MODIFY_HOST_TOOLTIP_MESSAGE}
+            >
+              Delete
+            </ActionDropdownItem>
+          ),
+        },
+      ];
 
-    const groupActions = [
-      {
-        title: (
-          <ActionDropdownItem
-            key={`${row.id}-add-to-group`}
-            onClick={() => {
-              setCurrentSystem([row]);
-              setAddHostGroupModalOpen(true);
-            }}
-            requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
-            noAccessTooltip={NO_MODIFY_GROUPS_TOOLTIP_MESSAGE}
-            isAriaDisabled={row.groups.length > 0} // additional condition for enabling the button
-            ignoreResourceDefinitions // to check if there is any groups:write permission (disregarding RD)
-          >
-            Add to group
-          </ActionDropdownItem>
-        ),
-      },
-      {
-        title: (
-          <ActionDropdownItem
-            key={`${row.id}-remove-from-group`}
-            onClick={() => {
-              setCurrentSystem([row]);
-              setRemoveHostsFromGroupModalOpen(true);
-            }}
-            requiredPermissions={
-              row?.groups?.[0]?.id !== undefined
-                ? REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(row.groups[0].id)
-                : []
-            }
-            noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
-            isAriaDisabled={row.groups.length === 0}
-            override={row?.groups?.[0]?.id === undefined ? true : undefined} // has access if no group
-          >
-            Remove from group
-          </ActionDropdownItem>
-        ),
-      },
-    ];
+      const groupActions = [
+        {
+          title: (
+            <ActionDropdownItem
+              key={`${row.id}-add-to-group`}
+              onClick={() => {
+                setCurrentSystem([row]);
+                setAddHostGroupModalOpen(true);
+              }}
+              requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
+              noAccessTooltip={
+                isWorkspaceEnabled
+                  ? NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE
+                  : NO_MODIFY_GROUPS_TOOLTIP_MESSAGE
+              }
+              isAriaDisabled={row.groups.length > 0} // additional condition for enabling the button
+              ignoreResourceDefinitions // to check if there is any groups:write permission (disregarding RD)
+            >
+              {isWorkspaceEnabled ? 'Add to workspace' : 'Add to group'}
+            </ActionDropdownItem>
+          ),
+        },
+        {
+          title: (
+            <ActionDropdownItem
+              key={`${row.id}-remove-from-group`}
+              onClick={() => {
+                setCurrentSystem([row]);
+                setRemoveHostsFromGroupModalOpen(true);
+              }}
+              requiredPermissions={
+                row?.groups?.[0]?.id !== undefined
+                  ? REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(row.groups[0].id)
+                  : []
+              }
+              noAccessTooltip={
+                isWorkspaceEnabled
+                  ? NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE
+                  : NO_MODIFY_GROUP_TOOLTIP_MESSAGE
+              }
+              isAriaDisabled={row.groups.length === 0}
+              override={row?.groups?.[0]?.id === undefined ? true : undefined} // has access if no group
+            >
+              {isWorkspaceEnabled
+                ? 'Remove from workspace'
+                : 'Remove from group'}
+            </ActionDropdownItem>
+          ),
+        },
+      ];
 
-    return [...groupActions, ...hostActions];
-  }, []);
+      return [...groupActions, ...hostActions];
+    },
+    [isWorkspaceEnabled]
+  );
 
   return tableActionsCallback;
 };

--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -11,6 +11,7 @@ import {
 
 import xor from 'lodash/xor';
 import PropTypes from 'prop-types';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const SearchableGroupFilter = ({
   initialGroups,
@@ -18,13 +19,14 @@ const SearchableGroupFilter = ({
   setSelectedGroupNames,
   showNoGroupOption = false,
 }) => {
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
   const initialValues = useMemo(
     () => [
       ...(showNoGroupOption
         ? [
             {
               itemId: '',
-              children: 'No group',
+              children: isWorkspaceEnabled ? 'No workspace' : 'No group',
             },
           ]
         : []),
@@ -33,7 +35,7 @@ const SearchableGroupFilter = ({
         children: name,
       })),
     ],
-    [initialGroups]
+    [initialGroups, isWorkspaceEnabled]
   );
 
   const [isOpen, setIsOpen] = useState(false);
@@ -54,7 +56,14 @@ const SearchableGroupFilter = ({
 
       // when no options are found after filtering, display 'No groups found'
       if (!newSelectOptions.length) {
-        newSelectOptions = [{ isDisabled: true, children: 'No groups found' }];
+        newSelectOptions = [
+          {
+            isDisabled: true,
+            children: isWorkspaceEnabled
+              ? 'No workspace found'
+              : 'No groups found',
+          },
+        ];
       }
     }
 
@@ -153,7 +162,9 @@ const SearchableGroupFilter = ({
           onKeyDown={onInputKeyDown}
           id="multi-typeahead-select-input"
           autoComplete="off"
-          placeholder="Filter by group"
+          placeholder={
+            isWorkspaceEnabled ? 'Filter by workspace' : 'Filter by group'
+          }
         />
       </TextInputGroup>
     </MenuToggle>
@@ -175,7 +186,11 @@ const SearchableGroupFilter = ({
       >
         <SelectList isAriaMultiselectable>
           {selectOptions.length === 0 ? (
-            <SelectOption key="none">No groups available</SelectOption>
+            <SelectOption key="none">
+              {isWorkspaceEnabled
+                ? 'No workspaces available'
+                : 'No groups available'}
+            </SelectOption>
           ) : (
             selectOptions.map((option, index) => (
               <div key={option.itemId || option.children}>

--- a/src/components/filters/SearchableGroupFilter.test.js
+++ b/src/components/filters/SearchableGroupFilter.test.js
@@ -3,6 +3,10 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import SearchableGroupFilter from './SearchableGroupFilter';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
+
+jest.mock('../../Utilities/hooks/useWorkspaceFeatureFlag');
+useWorkspaceFeatureFlag.mockReturnValue(false);
 
 const setter = jest.fn();
 

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -6,6 +6,7 @@ import { getGroups } from '../InventoryGroups/utils/api';
 import SearchableGroupFilter from './SearchableGroupFilter';
 import { GENERAL_GROUPS_READ_PERMISSION } from '../../constants';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 export const groupFilterState = { hostGroupFilter: null };
 export const GROUP_FILTER = 'GROUP_FILTER';
@@ -15,11 +16,14 @@ export const groupFilterReducer = (_state, { type, payload }) => ({
   }),
 });
 
-export const buildHostGroupChips = (selectedGroups = []) => {
+export const buildHostGroupChips = (
+  selectedGroups = [],
+  isWorkspaceEnabled
+) => {
   const chips = [...selectedGroups]?.map((group) =>
     group === ''
       ? {
-          name: 'No group',
+          name: isWorkspaceEnabled ? 'No workspace' : 'No group',
           value: '',
         }
       : {
@@ -30,7 +34,7 @@ export const buildHostGroupChips = (selectedGroups = []) => {
   return chips?.length > 0
     ? [
         {
-          category: 'Group',
+          category: isWorkspaceEnabled ? 'Workspace' : 'Group',
           type: HOST_GROUP_CHIP,
           chips,
         },
@@ -50,6 +54,8 @@ const useGroupFilter = (showNoGroupOption = false) => {
     true,
     false
   );
+
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   useEffect(() => {
     const fetchOptions = async () => {
@@ -87,14 +93,14 @@ const useGroupFilter = (showNoGroupOption = false) => {
   }, [hasAccess]);
 
   const chips = useMemo(
-    () => buildHostGroupChips(selectedGroupNames),
+    () => buildHostGroupChips(selectedGroupNames, isWorkspaceEnabled),
     [selectedGroupNames]
   );
 
   // hostGroupConfig is used in EntityTableToolbar.js
   const hostGroupConfig = useMemo(
     () => ({
-      label: 'Group',
+      label: isWorkspaceEnabled ? 'Workspace' : 'Group',
       value: 'group-host-filter',
       type: 'custom',
       filterValues: {

--- a/src/components/filters/useGroupFilter.test.js
+++ b/src/components/filters/useGroupFilter.test.js
@@ -2,12 +2,14 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import useFetchBatched from '../../Utilities/hooks/useFetchBatched';
 import useGroupFilter from './useGroupFilter';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import useWorkspaceFeatureFlag from '../../Utilities/hooks/useWorkspaceFeatureFlag';
 
 jest.mock('../../Utilities/hooks/useFetchBatched');
 jest.mock('../../Utilities/useFeatureFlag', () => ({
   __esModule: true,
   default: () => true,
 }));
+jest.mock('../../Utilities/hooks/useWorkspaceFeatureFlag');
 jest.mock('../InventoryGroups/utils/api', () => ({
   __esModule: true,
   getGroups: () =>
@@ -61,6 +63,10 @@ describe('groups request not yet resolved', () => {
 });
 
 describe('with some groups available', () => {
+  beforeEach(() => {
+    useWorkspaceFeatureFlag.mockReturnValue(false);
+  });
+
   const pageOffsetfetchBatched = jest.fn(
     () =>
       new Promise((resolve) => resolve([{ results: [{ name: 'group-1' }] }]))

--- a/src/constants.js
+++ b/src/constants.js
@@ -243,8 +243,12 @@ export const REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS = (groupId) => [
 
 export const NO_MODIFY_GROUPS_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify groups. Contact your organization administrator.';
+export const NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE =
+  'You do not have the necessary permissions to modify workspaces. Contact your organization administrator.';
 export const NO_MODIFY_GROUP_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify this group. Contact your organization administrator.';
+export const NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE =
+  'You do not have the necessary permissions to modify this workspace. Contact your organization administrator.';
 export const NO_MODIFY_HOSTS_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify hosts. Contact your organization administrator.';
 export const NO_MODIFY_HOST_TOOLTIP_MESSAGE =

--- a/src/routes/InventoryGroups.js
+++ b/src/routes/InventoryGroups.js
@@ -7,20 +7,26 @@ import {
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { Flex } from '@patternfly/react-core';
 import InventoryGroupsPopover from '../components/InventoryGroups/SmallComponents/Popover';
+import useWorkspaceFeatureFlag from '../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const Groups = () => {
   const chrome = useChrome();
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   useEffect(() => {
     chrome?.hideGlobalFilter?.();
-    chrome?.updateDocumentTitle?.('Groups - Inventory');
+    chrome?.updateDocumentTitle?.(
+      `${isWorkspaceEnabled ? 'Workspaces' : 'Groups'} - Inventory`
+    );
   }, []);
 
   return (
     <React.Fragment>
       <PageHeader>
         <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-          <PageHeaderTitle title="Groups" />
+          <PageHeaderTitle
+            title={isWorkspaceEnabled ? 'Workspaces' : 'Groups'}
+          />
           <InventoryGroupsPopover />
         </Flex>
       </PageHeader>

--- a/src/routes/InventoryGroups.test.js
+++ b/src/routes/InventoryGroups.test.js
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import InventoryGroups from './InventoryGroups';
+import useWorkspaceFeatureFlag from '../Utilities/hooks/useWorkspaceFeatureFlag';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -17,8 +18,13 @@ jest.mock(
     usePermissionsWithContext: () => ({ hasAccess: true }),
   })
 );
+jest.mock('../Utilities/hooks/useWorkspaceFeatureFlag');
 
 describe('inventory groups route', () => {
+  beforeEach(() => {
+    useWorkspaceFeatureFlag.mockReturnValue(false);
+  });
+
   it('renders header and table wrapper', () => {
     render(<InventoryGroups />);
 

--- a/src/routes/SystemUpdate.js
+++ b/src/routes/SystemUpdate.js
@@ -5,14 +5,18 @@ import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComp
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { getNotificationProp } from '../Utilities/edge';
 import { useDispatch } from 'react-redux';
+import useWorkspaceFeatureFlag from '../Utilities/hooks/useWorkspaceFeatureFlag';
 
 const SystemUpdate = () => {
   const chrome = useChrome();
   const dispatch = useDispatch();
   const notificationProp = getNotificationProp(dispatch);
+  const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
   useEffect(() => {
-    chrome?.updateDocumentTitle?.('Groups - Inventory');
+    chrome?.updateDocumentTitle?.(
+      `${isWorkspaceEnabled ? 'Workspaces' : 'Groups'} - Inventory`
+    );
   }, [chrome]);
   const { inventoryId } = useParams();
 

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -38,7 +38,7 @@ export const defaultState = {
   },
 };
 
-export const defaultColumns = () => [
+export const defaultColumns = (isWorkspaceEnabled) => [
   {
     key: 'display_name',
     sortKey: 'display_name',
@@ -50,12 +50,14 @@ export const defaultColumns = () => [
   {
     key: 'groups',
     sortKey: 'group_name',
-    title: 'Group',
+    title: isWorkspaceEnabled ? 'Workspace' : 'Group',
     props: { width: 10 },
     // eslint-disable-next-line camelcase
     renderFunc: (groups) =>
       isEmpty(groups) ? (
-        <div className="pf-v5-u-disabled-color-200">No group</div>
+        <div className="pf-v5-u-disabled-color-200">{`No ${
+          isWorkspaceEnabled ? 'workspace' : 'group'
+        }`}</div>
       ) : (
         groups[0].name
       ), // currently, one group at maximum is supported


### PR DESCRIPTION
This PR implements the feature flag for workspaces. If the feature flag is on, then "Workspace" will show up in place of "Group".

This PR only implements this change in regards to customer-facing use of the word "Group".

To test the flag, either turn the flag on, or open src/Utilities/hooks/useWorkspaceFeatureFlag.js and set the value to true.