### PR TITLE
fix(RHINENG-10413): Fix no entities found

### DIFF
--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -258,7 +258,7 @@ const GroupsTable = ({ onCreateGroupClick }) => {
               {
                 title: (
                   <NoEntitiesFound
-                    entities="groups"
+                    entities={isWorkspaceEnabled ? 'workspaces' : 'groups'}
                     onClearAll={onResetFilters}
                   />
                 ),


### PR DESCRIPTION
On groups table, when you enter a filter that returns no groups, even if workspaces is enabled, it shows groups instead. This passes the correct "entities" to the NoEntitiesFound component depending on if the workspaces feature flag is enabled.