### PR TITLE
fix(RHINENG-10825): Use correct slug to the conversion analysis

### DIFF
--- a/src/components/GeneralInfo/GeneralInformation/ConversionAlert.js
+++ b/src/components/GeneralInfo/GeneralInformation/ConversionAlert.js
@@ -33,7 +33,7 @@ const ConversionAlert = (props) => {
           </a>
         </Text>
         <Text component={TextVariants.p}>
-          <a onClick={() => navigate('/available/convert-to-rhel-preanalysis')}>
+          <a onClick={() => navigate('/available/convert-to-rhel-analysis')}>
             Run a Pre-conversion analysis of this system
           </a>
         </Text>

--- a/src/components/GeneralInfo/GeneralInformation/GeneralInformation.test.js
+++ b/src/components/GeneralInfo/GeneralInformation/GeneralInformation.test.js
@@ -300,9 +300,7 @@ describe('GeneralInformation', () => {
       );
 
       await waitFor(() => {
-        expect(navigate).toBeCalledWith(
-          '/available/convert-to-rhel-preanalysis'
-        );
+        expect(navigate).toBeCalledWith('/available/convert-to-rhel-analysis');
       });
     });
 

--- a/src/components/InventoryTable/ConversionPopover/ConversionPopover.js
+++ b/src/components/InventoryTable/ConversionPopover/ConversionPopover.js
@@ -40,7 +40,7 @@ const ConversionPopover = () => {
       footerContent={
         <Button
           variant="secondary"
-          onClick={() => navigate('/available/convert-to-rhel-preanalysis')}
+          onClick={() => navigate('/available/convert-to-rhel-analysis')}
         >
           Run a pre-conversion analysis of this system
         </Button>

--- a/src/components/InventoryTable/TitleColumn.test.js
+++ b/src/components/InventoryTable/TitleColumn.test.js
@@ -99,7 +99,7 @@ describe('TitleColumn', () => {
       })
     );
     await waitFor(() => {
-      expect(navigate).toBeCalledWith('/available/convert-to-rhel-preanalysis');
+      expect(navigate).toBeCalledWith('/available/convert-to-rhel-analysis');
     });
   });
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-10825.

Use correct (newly updated) slug for the conversion analysis task. The change covers the label and popover at /inventory and the host details page alert.

## How to test

1. Go to /inventory
2. Filter out CentOS Linux hosts and find the label next to the host display name
3. Click on the label and then on the button to get redirected to Tasks
4. The correct task modal must be open
5. Do the same for /inventory/:id page for some CentOS Linux host and the alert that should prompt the same action