### PR TITLE
fix(RHINENG-10975): remove unused items variable in customGetEntities

### DIFF
--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -100,7 +100,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
   ) => {
     const enhancedConfig = enhancedEdgeConfig(groupName.toString(), config);
     const defaultData = await defaultGetEntities(
-      items,
+      null,
       enhancedConfig,
       showTags
     );
@@ -109,13 +109,11 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
     setDeviceData(updateInfo?.update_devices_uuids || []);
     setDeviceImageSet(updateInfo?.device_image_set_info);
     const rowInfo = [];
-    let items = [];
     if (defaultData.total > 0) {
       const customResult = await edgeImageDataResult(mapDeviceIds.mapDeviceIds);
       customResult?.data?.devices.forEach((row) => {
         rowInfo.push({ ...row, id: row.DeviceUUID });
       });
-      items = rowInfo.map(({ id }) => id);
 
       return {
         results: mergeArraysByKey([defaultData.results, rowInfo]),
@@ -123,7 +121,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
       };
     } else {
       return {
-        results: mergeArraysByKey([defaultData.results]),
+        results: mergeArraysByKey([]),
         total: 0,
       };
     }
@@ -218,7 +216,6 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
         <InventoryTable
           columns={(columns) => mergeColumns(prepareColumns(columns))}
           hideFilters={{ hostGroupFilter: true }}
-          // getEntities={entities}
           getEntities={customGetEntities}
           tableProps={{
             isStickyHeader: true,

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -102,7 +102,7 @@ export const loadEntities = (
       }))
       .catch((error) => {
         //Somehow this catch block hides prior JS errors. Log is intended to be aware of them
-        console.log(error);
+        console.error(error);
         throw { ...error, type: 'LOAD_ENTITIES' };
       }),
     meta: {

--- a/src/store/inventory-actions.js
+++ b/src/store/inventory-actions.js
@@ -101,6 +101,8 @@ export const loadEntities = (
         hideFilters: config.hideFilters,
       }))
       .catch((error) => {
+        //Somehow this catch block hides prior JS errors. Log is intended to be aware of them
+        console.log(error);
         throw { ...error, type: 'LOAD_ENTITIES' };
       }),
     meta: {


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHINENG-10975

Please test this thoroughly as I found it hard to reproduce locally.

To test:
1. Navigate to /workspaces list page
2. On stage environment find some workspace with immutable systems added
3. Navigate to its detail page
4. Switch to immutable tab
5. Observe that the page functions as expected and you only see those added immutable systems in the table