### PR TITLE
fix(vulnerability): Fix padding issue in vuln sysdetails page

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -5,7 +5,3 @@ table.ins-entity-table th {
     padding: 1rem;
     padding-left: 2rem;
 }
-
-.inventory {
-  height: 100%;
-}


### PR DESCRIPTION
Fixes the padding issue inside vulnerability sys details page:

To replicate the issue, just go to any sysdetails in vulnerability
before there is a massive gap inbetween the table and header: 
<img width="943" alt="Screenshot 2024-08-07 at 2 59 41 PM" src="https://github.com/user-attachments/assets/a97d40d2-1e12-4847-b927-68d781aad8d6">
