### PR TITLE
fix(InventoryTable): RHINENG-11904 -  Preserve a passed exportConfig

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -603,7 +603,9 @@ const EntityTableToolbar = ({
             <Skeleton size={SkeletonSize.lg} />
           )
         }
-        exportConfig={enableExport && exportConfig}
+        exportConfig={
+          props.exportConfig ? props.exportConfig : enableExport && exportConfig
+        }
       >
         {lastSeenFilterValue?.mark === 'custom' && (
           <Split>
@@ -695,6 +697,7 @@ EntityTableToolbar.propTypes = {
   showNoGroupOption: PropTypes.bool,
   showSystemTypeFilter: PropTypes.bool,
   enableExport: PropTypes.bool,
+  exportConfig: PropTypes.object,
 };
 
 EntityTableToolbar.defaultProps = {


### PR DESCRIPTION
Some applications using the `InventoryTable` provide an export of systems, in these cases we should not override the passed export config for the toolbar.

**How to test:**

1) Ensure the `hbi.export-data` feature flag is enabled
2) Open an application that provides a custom export (Vulnerability, Compliance for example) on the "Systems" page
3) Verify that the CSV/JSON export is possible
4) Open the Inventory Systems page and verify that the export is still available there too.

