### PR TITLE
fix(filters): Fix letter casing in filters

### DIFF
--- a/src/Utilities/OperatingSystemFilterHelpers.js
+++ b/src/Utilities/OperatingSystemFilterHelpers.js
@@ -111,7 +111,7 @@ export const buildOSFilterChip = (
   return minors?.length > 0
     ? [
         {
-          category: 'Operating System',
+          category: 'Operating system',
           type: OS_CHIP,
           chips,
         },

--- a/src/Utilities/__snapshots__/OperatingSystemFilterHelpers.test.js.snap
+++ b/src/Utilities/__snapshots__/OperatingSystemFilterHelpers.test.js.snap
@@ -3,7 +3,7 @@
 exports[`buildOSFilterChip returns five version chips 1`] = `
 [
   {
-    "category": "Operating System",
+    "category": "Operating system",
     "chips": [
       {
         "groupLabel": "RHEL 6",

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -32,8 +32,8 @@ const TABLE_HEADERS = [
 const AVAILABLE_FILTER_NAMES = [
   'Name',
   'Status',
-  'Operating System',
-  'Data Collector',
+  'Operating system',
+  'Data collector',
   'RHC status',
   'Last seen',
   'Group',

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -33,8 +33,8 @@ const expectDefaultFiltersVisible = async () => {
   const DEFAULT_FILTERS = [
     'Name',
     'Status',
-    'Operating System',
-    'Data Collector',
+    'Operating system',
+    'Data collector',
     'RHC status',
     'Last seen',
   ];

--- a/src/components/InventoryTable/InventoryTable.cy.js
+++ b/src/components/InventoryTable/InventoryTable.cy.js
@@ -60,8 +60,8 @@ const shorterGroupsFixtures = {
 const AVAILABLE_FILTER_NAMES = [
   'Name',
   'Status',
-  'Operating System',
-  'Data Collector',
+  'Operating system',
+  'Data collector',
   'RHC status',
   'Last seen',
   'Group',
@@ -271,7 +271,7 @@ describe('hiding filters', () => {
     mountTable({ hasAccess: true, hideFilters: { registeredWith: true } });
     waitForTable();
     cy.get(PT_CONDITIONAL_FILTER_TOGGLE).click();
-    cy.get(DROPDOWN_ITEM).should('not.contain', 'Data Collector');
+    cy.get(DROPDOWN_ITEM).should('not.contain', 'Data collector');
   });
 
   it('can hide rhcd filter', () => {
@@ -285,7 +285,7 @@ describe('hiding filters', () => {
     mountTable({ hasAccess: true, hideFilters: { operatingSystem: true } });
     waitForTable();
     cy.get(PT_CONDITIONAL_FILTER_TOGGLE).click();
-    cy.get(DROPDOWN_ITEM).should('not.contain', 'Operating System');
+    cy.get(DROPDOWN_ITEM).should('not.contain', 'Operating system');
   });
 
   it('can hide last seen filter', () => {

--- a/src/components/InventoryTable/InventoryTable.test.js
+++ b/src/components/InventoryTable/InventoryTable.test.js
@@ -32,8 +32,8 @@ const TABLE_HEADERS_SORTING_KEYS = [
 const DEFAULT_FILTER_NAMES = [
   'Name',
   'Status',
-  'Operating System',
-  'Data Collector',
+  'Operating system',
+  'Data collector',
   'RHC status',
   'Last seen',
   'Group',

--- a/src/components/filters/__snapshots__/useOperatingSystemFilter.test.js.snap
+++ b/src/components/filters/__snapshots__/useOperatingSystemFilter.test.js.snap
@@ -3,7 +3,7 @@
 exports[`useOperatingSystemFilter with operating systems loaded should return correct chips array, current value and value setter 1`] = `
 [
   {
-    "category": "Operating System",
+    "category": "Operating system",
     "chips": [
       {
         "groupKey": "RHEL-7",
@@ -36,7 +36,7 @@ exports[`useOperatingSystemFilter with operating systems yet not loaded should r
       "onChange": [Function],
       "selected": {},
     },
-    "label": "Operating System",
+    "label": "Operating system",
     "type": "group",
     "value": "operating-system-filter",
   },

--- a/src/components/filters/useOperatingSystemFilter.js
+++ b/src/components/filters/useOperatingSystemFilter.js
@@ -44,7 +44,7 @@ export const useOperatingSystemFilter = (
   );
 
   const filter = {
-    label: 'Operating System',
+    label: 'Operating system',
     value: 'operating-system-filter',
     type: 'group',
     filterValues: {
@@ -71,7 +71,7 @@ export const useOperatingSystemFilter = (
     Object.values(operatingSystemsValue).length > 0
       ? [
           {
-            category: 'Operating System',
+            category: 'Operating system',
             type: OS_CHIP,
             chips,
           },

--- a/src/components/filters/useOperatingSystemFilter.test.js
+++ b/src/components/filters/useOperatingSystemFilter.test.js
@@ -43,7 +43,7 @@ describe('useOperatingSystemFilter', () => {
       );
       const [config] = result.current;
       expect(config.filterValues.groups.length).toBe(5);
-      expect(config.label).toBe('Operating System'); // should be all caps
+      expect(config.label).toBe('Operating system'); // should be all caps
       expect(config.type).toBe('group');
     });
 

--- a/src/components/filters/useRegisteredWithFilter.js
+++ b/src/components/filters/useRegisteredWithFilter.js
@@ -22,7 +22,7 @@ export const useRegisteredWithFilter = (
     : setStateValue;
 
   const filter = {
-    label: 'Data Collector',
+    label: 'Data collector',
     value: 'data-collector-registered-with',
     type: 'checkbox',
     filterValues: {
@@ -35,7 +35,7 @@ export const useRegisteredWithFilter = (
     registeredWithValue?.length > 0
       ? [
           {
-            category: 'Data Collector',
+            category: 'Data collector',
             type: REGISTERED_CHIP,
             chips: registered
               .filter(({ value }) => registeredWithValue.includes(value))

--- a/src/components/filters/useRegisteredWithFilter.test.js
+++ b/src/components/filters/useRegisteredWithFilter.test.js
@@ -7,7 +7,7 @@ describe('useRegisteredWithFilter', () => {
     const [filter] = result.current;
 
     expect(filter).toMatchObject({
-      label: 'Data Collector',
+      label: 'Data collector',
       value: 'data-collector-registered-with',
       type: 'checkbox',
     });
@@ -32,7 +32,7 @@ describe('useRegisteredWithFilter', () => {
     expect(filter.filterValues.value.length).toBe(1);
     expect(chip).toMatchObject([
       {
-        category: 'Data Collector',
+        category: 'Data collector',
         chips: [{ name: 'insights-client', value: 'puptoo' }],
         type: 'registered_with',
       },

--- a/src/components/filters/useRhcdFilter.js
+++ b/src/components/filters/useRhcdFilter.js
@@ -24,6 +24,7 @@ export const useRhcdFilter = ([state, dispatch] = [rhcdFilterState]) => {
       value: rhcdValue,
       onChange: (_e, value) => setValue(value),
       items: rhcdOptions,
+      placeholder: 'Filter by RHC status',
     },
   };
   const chip =

--- a/src/modules/OsFilterHelpers.js
+++ b/src/modules/OsFilterHelpers.js
@@ -60,7 +60,7 @@ const groupOSVersions = (versions) => {
  */
 export const buildOSFilterConfig = (config = {}, operatingSystems = []) => ({
   ...config,
-  label: 'Operating System',
+  label: 'Operating system',
   value: 'os-filter',
   type: 'group',
   filterValues: {


### PR DESCRIPTION
Filter labels, placeholders and chips should use `Sentence case`, not `Title Case`
- Operating System --> Operating system
- Data Collector --> Data collector

Also fixed strict lower casing
- Filter by rhc status --> Filter by RHC status