### PR TITLE
fix: Change condition for the IS_DEV flag

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -12,7 +12,7 @@ module.exports = {
   debug: true,
   plugins: [
     new webpack.DefinePlugin({
-      IS_DEV: process.env.NODE_ENV === 'development',
+      IS_DEV: process.env.NODE_ENV !== 'production',
     }),
   ],
   moduleFederation: {


### PR DESCRIPTION
No jira. This fixes the IS_DEV flag being always false. insights-chrome assigns "production" value if there is a production build or leaves it undefined in other cases (including the development build).