### PR TITLE
fix(RHINENG-4792): Don't show filter chip for whitespace

### DIFF
--- a/src/components/filters/useTextFilter.js
+++ b/src/components/filters/useTextFilter.js
@@ -27,7 +27,7 @@ export const useTextFilter = ([state, dispatch] = [textFilterState]) => {
     },
   };
   const chip =
-    value?.length > 0
+    value?.trim().length > 0
       ? [
           {
             category: 'Display name',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-4792

Fixed the following bug:
1. Go to Systems page
2. Type " " (space) inside the search text field
3. Filter chip appears, but it shouldn't