### PR TITLE
fix(RHINENG-11167): Fix pagination in Tags Modal

### DIFF
--- a/src/Utilities/TagsModal.js
+++ b/src/Utilities/TagsModal.js
@@ -6,9 +6,9 @@ import { TagModal } from '@redhat-cloud-services/frontend-components/TagModal';
 import { cellWidth } from '@patternfly/react-table';
 import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
+import { PAGINATION_DEFAULT } from '../constants';
 
 const TagsModal = ({ filterTagsBy, onToggleModal, onApply, getTags }) => {
-  const PAGINATION_DEFAULT = { perPage: 10, page: 1 };
   const dispatch = useDispatch();
   const [filterBy, setFilterBy] = useState('');
   const [selected, setSelected] = useState([]);

--- a/src/Utilities/TagsModal.js
+++ b/src/Utilities/TagsModal.js
@@ -8,13 +8,11 @@ import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
 
 const TagsModal = ({ filterTagsBy, onToggleModal, onApply, getTags }) => {
+  const PAGINATION_DEFAULT = { perPage: 10, page: 1 };
   const dispatch = useDispatch();
   const [filterBy, setFilterBy] = useState('');
   const [selected, setSelected] = useState([]);
-  const [statePagination, setStatePagination] = useState({
-    perPage: 10,
-    page: 1,
-  });
+  const [statePagination, setStatePagination] = useState(PAGINATION_DEFAULT);
 
   const showTagDialog = useSelector(
     ({ entities, entityDetails }) => (entities || entityDetails)?.showTagDialog
@@ -114,6 +112,7 @@ const TagsModal = ({ filterTagsBy, onToggleModal, onApply, getTags }) => {
         setSelected([]);
         setFilterBy('');
         onToggleModal();
+        setStatePagination(PAGINATION_DEFAULT);
         dispatch(toggleTagModal(false));
       }}
       filters={[

--- a/src/constants.js
+++ b/src/constants.js
@@ -269,6 +269,7 @@ export const GROUPS_ADMINISTRATOR_PERMISSIONS = [
 export const GENERAL_HOSTS_READ_PERMISSIONS = 'inventory:hosts:read';
 export const GENERAL_HOSTS_WRITE_PERMISSIONS = 'inventory:hosts:write';
 export const USER_ACCESS_ADMIN_PERMISSIONS = ['rbac:*:*'];
+export const PAGINATION_DEFAULT = { perPage: 10, page: 1 };
 
 export const TAB_REQUIRED_PERMISSIONS = {
   /**


### PR DESCRIPTION
To test:
- Go to inventory
- Find a system with tags (preferrably one with more than 10 tags)
- Click the tags icon to open the Tags Modal
- Change the pagination details in any way
- Close the Tags Modal

If you click on the tags icon of another system, you will see that the pagination details persist. This PR resets the pagination defaults on closing the modal.