### PR TITLE
test: Fix flaky HybridInventory.cy.js test

### DIFF
--- a/src/routes/InventoryComponents/HybridInventory.cy.js
+++ b/src/routes/InventoryComponents/HybridInventory.cy.js
@@ -41,11 +41,7 @@ const waitForTable = (waitNetwork = false) => {
   }
 
   // indicating the table is loaded
-  cy.get('table[aria-label="Host inventory"]').should(
-    'have.attr',
-    'data-ouia-safe',
-    'true'
-  );
+  cy.get('[data-label="Name"]').contains('dolor');
 };
 
 before(() => {


### PR DESCRIPTION
We don't pass `data-ouia-safe` to InventoryTable and it's set to true by default. Though, in the flaky test, for some reason, `data-ouia-safe` was missing completely, which makes this attribute somewhat unreliable to use: https://app.travis-ci.com/github/RedHatInsights/insights-inventory-frontend/jobs/625131895#L6568. HybridInventory.cy.test should use other way to indicate the table readiness.