### PR TITLE
chore(RHINENG-10516): Remove staleness feature flag

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -2,7 +2,6 @@ import React, { Suspense, lazy, useEffect, useState } from 'react';
 import { Navigate, useRoutes } from 'react-router-dom';
 import RenderWrapper from './Utilities/Wrapper';
 import useFeatureFlag from './Utilities/useFeatureFlag';
-import LostPage from './components/LostPage';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 import {
@@ -52,7 +51,6 @@ export const Routes = () => {
     'edgeParity.inventory-list'
   );
 
-  const stalenessAndDeletionEnabled = useFeatureFlag('hbi.custom-staleness');
   const isBifrostEnabled = useFeatureFlag('hbi.ui.bifrost');
   const isWorkspaceEnabled = useWorkspaceFeatureFlag();
 
@@ -133,11 +131,7 @@ export const Routes = () => {
     },
     {
       path: '/staleness-and-deletion',
-      element: stalenessAndDeletionEnabled ? (
-        <InventoryHostStaleness />
-      ) : (
-        <LostPage />
-      ),
+      element: <InventoryHostStaleness />,
     },
   ]);
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-10516

This removes all occurrences of the "hbi.custom-staleness" feature flag. The flag is no longer planned to switch, and the feature is considered stable in production.