### PR TITLE
fix(RHINENG-2632): Separate Satellite and Discovery data collectors

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -102,7 +102,8 @@ export const registered = [
     idName: 'Subscription manager id',
     idValue: 'subscription_manager_id',
   },
-  { label: 'Satellite/Discovery', value: 'yupana' },
+  { label: 'Satellite', value: 'satellite' },
+  { label: 'Discovery', value: 'discovery' },
   { label: 'insights-client not connected', value: '!puptoo' },
 ];
 export const InventoryContext = createContext({});

--- a/src/components/GeneralInfo/DataCollectorsCard/__snapshots__/DataCollectorsCard.test.js.snap
+++ b/src/components/GeneralInfo/DataCollectorsCard/__snapshots__/DataCollectorsCard.test.js.snap
@@ -309,7 +309,44 @@ exports[`DataCollectorsCard should render correctly - no data 1`] = `
                   data-label="Name"
                   tabindex="-1"
                 >
-                  Satellite/Discovery
+                  Satellite
+                </td>
+                <td
+                  class="pf-v5-c-table__td"
+                  data-label="Status"
+                  tabindex="-1"
+                >
+                  N/A
+                </td>
+                <td
+                  class="pf-v5-c-table__td"
+                  data-label="Last upload"
+                  tabindex="-1"
+                >
+                  N/A
+                </td>
+              </tr>
+            </tbody>
+            <tbody
+              class="pf-v5-c-table__tbody"
+              role="rowgroup"
+            >
+              <tr
+                class="pf-v5-c-table__tr"
+                data-ouia-component-id="OUIA-Generated-TableRow-7"
+                data-ouia-component-type="PF5/TableRow"
+                data-ouia-safe="true"
+              >
+                <td
+                  class="pf-v5-c-table__td"
+                  tabindex="-1"
+                />
+                <td
+                  class="pf-v5-c-table__td"
+                  data-label="Name"
+                  tabindex="-1"
+                >
+                  Discovery
                 </td>
                 <td
                   class="pf-v5-c-table__td"
@@ -383,7 +420,7 @@ exports[`DataCollectorsCard should render correctly with data 1`] = `
             >
               <tr
                 class="pf-v5-c-table__tr ins-c__no-border"
-                data-ouia-component-id="OUIA-Generated-TableRow-7"
+                data-ouia-component-id="OUIA-Generated-TableRow-8"
                 data-ouia-component-type="PF5/TableRow"
                 data-ouia-safe="true"
               >
@@ -421,7 +458,7 @@ exports[`DataCollectorsCard should render correctly with data 1`] = `
             >
               <tr
                 class="pf-v5-c-table__tr"
-                data-ouia-component-id="OUIA-Generated-TableRow-8"
+                data-ouia-component-id="OUIA-Generated-TableRow-9"
                 data-ouia-component-type="PF5/TableRow"
                 data-ouia-safe="true"
               >
@@ -485,7 +522,7 @@ exports[`DataCollectorsCard should render correctly with data 1`] = `
               </tr>
               <tr
                 class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                data-ouia-component-id="OUIA-Generated-TableRow-9"
+                data-ouia-component-id="OUIA-Generated-TableRow-10"
                 data-ouia-component-type="PF5/TableRow"
                 data-ouia-safe="true"
                 hidden=""
@@ -526,7 +563,7 @@ exports[`DataCollectorsCard should render correctly with data 1`] = `
             >
               <tr
                 class="pf-v5-c-table__tr"
-                data-ouia-component-id="OUIA-Generated-TableRow-10"
+                data-ouia-component-id="OUIA-Generated-TableRow-11"
                 data-ouia-component-type="PF5/TableRow"
                 data-ouia-safe="true"
               >
@@ -590,7 +627,7 @@ exports[`DataCollectorsCard should render correctly with data 1`] = `
               </tr>
               <tr
                 class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                data-ouia-component-id="OUIA-Generated-TableRow-11"
+                data-ouia-component-id="OUIA-Generated-TableRow-12"
                 data-ouia-component-type="PF5/TableRow"
                 data-ouia-safe="true"
                 hidden=""
@@ -631,7 +668,7 @@ exports[`DataCollectorsCard should render correctly with data 1`] = `
             >
               <tr
                 class="pf-v5-c-table__tr"
-                data-ouia-component-id="OUIA-Generated-TableRow-12"
+                data-ouia-component-id="OUIA-Generated-TableRow-13"
                 data-ouia-component-type="PF5/TableRow"
                 data-ouia-safe="true"
               >
@@ -644,7 +681,44 @@ exports[`DataCollectorsCard should render correctly with data 1`] = `
                   data-label="Name"
                   tabindex="-1"
                 >
-                  Satellite/Discovery
+                  Satellite
+                </td>
+                <td
+                  class="pf-v5-c-table__td"
+                  data-label="Status"
+                  tabindex="-1"
+                >
+                  N/A
+                </td>
+                <td
+                  class="pf-v5-c-table__td"
+                  data-label="Last upload"
+                  tabindex="-1"
+                >
+                  N/A
+                </td>
+              </tr>
+            </tbody>
+            <tbody
+              class="pf-v5-c-table__tbody"
+              role="rowgroup"
+            >
+              <tr
+                class="pf-v5-c-table__tr"
+                data-ouia-component-id="OUIA-Generated-TableRow-14"
+                data-ouia-component-type="PF5/TableRow"
+                data-ouia-safe="true"
+              >
+                <td
+                  class="pf-v5-c-table__td"
+                  tabindex="-1"
+                />
+                <td
+                  class="pf-v5-c-table__td"
+                  data-label="Name"
+                  tabindex="-1"
+                >
+                  Discovery
                 </td>
                 <td
                   class="pf-v5-c-table__td"
@@ -718,7 +792,7 @@ exports[`DataCollectorsCard should render custom collectors 1`] = `
             >
               <tr
                 class="pf-v5-c-table__tr ins-c__no-border"
-                data-ouia-component-id="OUIA-Generated-TableRow-13"
+                data-ouia-component-id="OUIA-Generated-TableRow-15"
                 data-ouia-component-type="PF5/TableRow"
                 data-ouia-safe="true"
               >
@@ -756,7 +830,7 @@ exports[`DataCollectorsCard should render custom collectors 1`] = `
             >
               <tr
                 class="pf-v5-c-table__tr"
-                data-ouia-component-id="OUIA-Generated-TableRow-14"
+                data-ouia-component-id="OUIA-Generated-TableRow-16"
                 data-ouia-component-type="PF5/TableRow"
                 data-ouia-safe="true"
               >
@@ -818,7 +892,7 @@ exports[`DataCollectorsCard should render custom collectors 1`] = `
               </tr>
               <tr
                 class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                data-ouia-component-id="OUIA-Generated-TableRow-15"
+                data-ouia-component-id="OUIA-Generated-TableRow-17"
                 data-ouia-component-type="PF5/TableRow"
                 data-ouia-safe="true"
                 hidden=""

--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -654,7 +654,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <tr
                           class="pf-v5-c-table__tr ins-c__no-border"
-                          data-ouia-component-id="OUIA-Generated-TableRow-7"
+                          data-ouia-component-id="OUIA-Generated-TableRow-8"
                           data-ouia-component-type="PF5/TableRow"
                           data-ouia-safe="true"
                         >
@@ -692,7 +692,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <tr
                           class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-8"
+                          data-ouia-component-id="OUIA-Generated-TableRow-9"
                           data-ouia-component-type="PF5/TableRow"
                           data-ouia-safe="true"
                         >
@@ -756,7 +756,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                         </tr>
                         <tr
                           class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                          data-ouia-component-id="OUIA-Generated-TableRow-9"
+                          data-ouia-component-id="OUIA-Generated-TableRow-10"
                           data-ouia-component-type="PF5/TableRow"
                           data-ouia-safe="true"
                           hidden=""
@@ -797,7 +797,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <tr
                           class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-10"
+                          data-ouia-component-id="OUIA-Generated-TableRow-11"
                           data-ouia-component-type="PF5/TableRow"
                           data-ouia-safe="true"
                         >
@@ -861,7 +861,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                         </tr>
                         <tr
                           class="pf-v5-c-table__tr pf-v5-c-table__expandable-row"
-                          data-ouia-component-id="OUIA-Generated-TableRow-11"
+                          data-ouia-component-id="OUIA-Generated-TableRow-12"
                           data-ouia-component-type="PF5/TableRow"
                           data-ouia-safe="true"
                           hidden=""
@@ -902,7 +902,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                       >
                         <tr
                           class="pf-v5-c-table__tr"
-                          data-ouia-component-id="OUIA-Generated-TableRow-12"
+                          data-ouia-component-id="OUIA-Generated-TableRow-13"
                           data-ouia-component-type="PF5/TableRow"
                           data-ouia-safe="true"
                         >
@@ -915,7 +915,44 @@ exports[`GeneralInformation should render correctly 1`] = `
                             data-label="Name"
                             tabindex="-1"
                           >
-                            Satellite/Discovery
+                            Satellite
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-label="Status"
+                            tabindex="-1"
+                          >
+                            N/A
+                          </td>
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-label="Last upload"
+                            tabindex="-1"
+                          >
+                            N/A
+                          </td>
+                        </tr>
+                      </tbody>
+                      <tbody
+                        class="pf-v5-c-table__tbody"
+                        role="rowgroup"
+                      >
+                        <tr
+                          class="pf-v5-c-table__tr"
+                          data-ouia-component-id="OUIA-Generated-TableRow-14"
+                          data-ouia-component-type="PF5/TableRow"
+                          data-ouia-safe="true"
+                        >
+                          <td
+                            class="pf-v5-c-table__td"
+                            tabindex="-1"
+                          />
+                          <td
+                            class="pf-v5-c-table__td"
+                            data-label="Name"
+                            tabindex="-1"
+                          >
+                            Discovery
                           </td>
                           <td
                             class="pf-v5-c-table__td"

--- a/src/components/filters/useRegisteredWithFilter.test.js
+++ b/src/components/filters/useRegisteredWithFilter.test.js
@@ -15,7 +15,8 @@ describe('useRegisteredWithFilter', () => {
     expect(filter.filterValues.items).toMatchObject([
       { label: 'insights-client', value: 'puptoo' },
       { label: 'subscription-manager', value: 'rhsm-conduit' },
-      { label: 'Satellite/Discovery', value: 'yupana' },
+      { label: 'Satellite', value: 'satellite' },
+      { label: 'Discovery', value: 'discovery' },
       { label: 'insights-client not connected', value: '!puptoo' },
     ]);
   });


### PR DESCRIPTION
This PR addresses [RHINENG-2632](https://issues.redhat.com/browse/RHINENG-2632). It separates the Satellite and Discovery data collectors. This change is needed ASAP because incoming host payloads now use the "satellite" and "discovery" values rather than "yupana".