### PR TITLE
feat(OperatingSystem): enhance the filter to fetch custom endpoint

### DIFF
--- a/doc/props_table.md
+++ b/doc/props_table.md
@@ -17,6 +17,7 @@
   - [initialLoading](#initialloading)
   - [ignoreRefresh](#ignorerefresh)
   - [showTagModal](#showtagmodal)
+  - [fetchCustomOSes](#fetchCustomOSes)
 
 # Props
 
@@ -123,3 +124,28 @@ On the initial mount and when items/sortBy are changed, the inventoryTable ignor
 *boolean*
 
 Will enable TagModal even the filter or the column is not shown.
+
+## fetchCustomOSes
+
+*falsy | (apFilters) => array*
+
+Operating systems filter by default fetches the os versions from inventory API. However, there might be requirement to fetch from some other custom API endpoints. In this case, you can provide your custom operating system API fetch funtion as a prop. The returned result must be in the shape of:
+
+```
+  {
+      "total": Number,
+      "count": Number,
+      "page": Number,
+      "per_page": Number,
+      "results": [
+          {
+              "value": {
+                  "name": String,
+                  "major": Number,
+                  "minor": Number,
+              },
+              "count": Number
+          },
+      ]
+  }
+```

--- a/src/Utilities/hooks/useFetchOperatingSystems.js
+++ b/src/Utilities/hooks/useFetchOperatingSystems.js
@@ -26,7 +26,12 @@ const useFetchOperatingSystems = ({
 
       return await getOperatingSystems(...fetchArgs);
     }
-  }, [hasAccess, apiParams, showCentosVersions]);
+  }, [
+    hasAccess,
+    JSON.stringify(apiParams),
+    showCentosVersions,
+    typeof fetchCustomOSes !== 'undefined',
+  ]);
 
   useEffect(() => {
     (async () => {

--- a/src/Utilities/hooks/useFetchOperatingSystems.js
+++ b/src/Utilities/hooks/useFetchOperatingSystems.js
@@ -17,14 +17,16 @@ const useFetchOperatingSystems = ({
   const [data, setData] = useState(initialState);
 
   const fetchOperatingSystems = useCallback(async () => {
+    if (hasAccess === false) return;
+
+    const fetchFn = fetchCustomOSes || getOperatingSystems;
     const fetchArgs = [apiParams, showCentosVersions];
+    console.log(fetchFn, 'fetchFN');
 
-    if (typeof hasAccess === 'undefined' || hasAccess === true) {
-      if (fetchCustomOSes) {
-        return await fetchCustomOSes(...fetchArgs);
-      }
-
-      return await getOperatingSystems(...fetchArgs);
+    try {
+      return await fetchFn(...fetchArgs);
+    } catch (error) {
+      return { results: [] };
     }
   }, [
     hasAccess,
@@ -38,7 +40,7 @@ const useFetchOperatingSystems = ({
       const result = await fetchOperatingSystems();
       if (mounted.current) {
         setData({
-          operatingSystems: result.results,
+          operatingSystems: result?.results || [],
           operatingSystemsLoaded: true,
         });
       }

--- a/src/Utilities/hooks/useFetchOperatingSystems.js
+++ b/src/Utilities/hooks/useFetchOperatingSystems.js
@@ -25,13 +25,14 @@ const useFetchOperatingSystems = ({
     try {
       return await fetchFn(...fetchArgs);
     } catch (error) {
+      console.error(error);
       return { results: [] };
     }
   }, [
     hasAccess,
     JSON.stringify(apiParams),
     showCentosVersions,
-    typeof fetchCustomOSes !== 'undefined',
+    fetchCustomOSes,
   ]);
 
   useEffect(() => {

--- a/src/Utilities/hooks/useFetchOperatingSystems.js
+++ b/src/Utilities/hooks/useFetchOperatingSystems.js
@@ -1,23 +1,30 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getOperatingSystems } from '../../api';
 
+const initialState = {
+  operatingSystems: [],
+  operatingSystemsLoaded: false,
+};
+
 const useFetchOperatingSystems = ({
   apiParams = [],
   hasAccess,
   showCentosVersions,
+  fetchCustomOSes,
 }) => {
   const mounted = useRef(true);
-  const initialState = {
-    operatingSystems: [],
-    operatingSystemsLoaded: false,
-  };
+
   const [data, setData] = useState(initialState);
 
   const fetchOperatingSystems = useCallback(async () => {
-    if (typeof hasAccess === 'undefined') {
-      return await getOperatingSystems(apiParams, showCentosVersions);
-    } else if (typeof hasAccess !== 'undefined' && hasAccess === true) {
-      return await getOperatingSystems(apiParams, showCentosVersions);
+    const fetchArgs = [apiParams, showCentosVersions];
+
+    if (typeof hasAccess === 'undefined' || hasAccess === true) {
+      if (fetchCustomOSes) {
+        return await fetchCustomOSes(...fetchArgs);
+      }
+
+      return await getOperatingSystems(...fetchArgs);
     }
   }, [hasAccess, apiParams, showCentosVersions]);
 
@@ -36,7 +43,7 @@ const useFetchOperatingSystems = ({
       setData(initialState);
       mounted.current = false;
     };
-  }, []);
+  }, [fetchOperatingSystems]);
 
   return data;
 };

--- a/src/Utilities/hooks/useFetchOperatingSystems.js
+++ b/src/Utilities/hooks/useFetchOperatingSystems.js
@@ -21,7 +21,6 @@ const useFetchOperatingSystems = ({
 
     const fetchFn = fetchCustomOSes || getOperatingSystems;
     const fetchArgs = [apiParams, showCentosVersions];
-    console.log(fetchFn, 'fetchFN');
 
     try {
       return await fetchFn(...fetchArgs);

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -103,6 +103,7 @@ const EntityTableToolbar = ({
   showCentosVersions,
   showNoGroupOption,
   enableExport,
+  fetchCustomOSes,
   ...props
 }) => {
   const dispatch = useDispatch();
@@ -171,7 +172,13 @@ const EntityTableToolbar = ({
     setEndDate,
   ] = useLastSeenFilter(reducer);
   const [osFilterConfig, osFilterChips, osFilterValue, setOsFilterValue] =
-    useOperatingSystemFilter(reducer, [], hasAccess, showCentosVersions);
+    useOperatingSystemFilter(
+      reducer,
+      [],
+      hasAccess,
+      showCentosVersions,
+      fetchCustomOSes
+    );
   const [
     updateMethodConfig,
     updateMethodChips,
@@ -691,6 +698,7 @@ EntityTableToolbar.propTypes = {
   showSystemTypeFilter: PropTypes.bool,
   enableExport: PropTypes.bool,
   exportConfig: PropTypes.object,
+  fetchCustomOSes: PropTypes.func,
 };
 
 EntityTableToolbar.defaultProps = {

--- a/src/components/filters/useOperatingSystemFilter.js
+++ b/src/components/filters/useOperatingSystemFilter.js
@@ -16,7 +16,8 @@ export const useOperatingSystemFilter = (
   // TODO Get rid of all additional (unnecessary) parameters
   apiParams,
   hasAccess,
-  showCentosVersions
+  showCentosVersions,
+  fetchCustomOSes
 ) => {
   const [operatingSystemsStateValue, setStateValue] = useState({});
   const operatingSystemsValue = dispatch
@@ -28,6 +29,7 @@ export const useOperatingSystemFilter = (
       apiParams,
       hasAccess,
       showCentosVersions,
+      fetchCustomOSes,
     }
   );
 

--- a/src/components/filters/useOperatingSystemFilter.test.js
+++ b/src/components/filters/useOperatingSystemFilter.test.js
@@ -1,8 +1,7 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { mockSystemProfile } from '../../__mocks__/hostApi';
 import useFetchOperatingSystems from '../../Utilities/hooks/useFetchOperatingSystems';
 import { buildOperatingSystems } from '../../__factories__/operatingSystems';
-
 import { useOperatingSystemFilter } from './useOperatingSystemFilter';
 jest.mock('../../Utilities/hooks/useFetchOperatingSystems');
 
@@ -70,6 +69,27 @@ describe('useOperatingSystemFilter', () => {
         },
       });
       expect(chipsUpdated).toMatchSnapshot();
+    });
+  });
+
+  describe('with custom operating system fetch endpoint', () => {
+    it('Should use the provided custom fetch function', async () => {
+      const fetchCustomOSes = jest.fn(
+        Promise.resolve({
+          operatingSystems,
+          operatingSystemsLoaded: true,
+        })
+      );
+
+      renderHook(() =>
+        useOperatingSystemFilter(undefined, [], true, true, fetchCustomOSes)
+      );
+
+      await waitFor(() =>
+        expect(useFetchOperatingSystems).toHaveBeenCalledWith(
+          expect.objectContaining({ fetchCustomOSes })
+        )
+      );
     });
   });
 });


### PR DESCRIPTION
This allows the operating systems filter to fetch OS versions from a custom endpoint. This is yet a proposal and open for feedback.

To test:
1. run the PR linked with compliance PR https://github.com/RedHatInsights/compliance-frontend/pull/2192
2. make sure you have enabled REST api in compliance app
3. navigate to systems page
4. observe that now operating systems are fetched from compliance api and the filter versions are displayed
5. apply any os version
6. navigate to policy detail page
7. observe that now operating systems are fetched from compliance api with policy id provided.
8. play with the filter
9. now make sure that the operating system filter continues to function as before in all other apps. 
