### PR TITLE
fix(styles): RHINENG-11305 remove double scrollbar in Groups page

### DIFF
--- a/src/components/InventoryGroups/InventoryGroups.js
+++ b/src/components/InventoryGroups/InventoryGroups.js
@@ -55,7 +55,6 @@ const InventoryGroups = () => {
     <PageSection
       data-ouia-component-id="groups-table-wrapper"
       data-testid="groups-table-wrapper"
-      style={{ height: '100%' }}
     >
       {createModalOpen && (
         <CreateGroupModal


### PR DESCRIPTION
Remove double scrollbars in Inventory Workspaces page 
bug was present only in Chromium browsers