### PR TITLE
fix(RHINENG-13776): Fix unnecessary toolbar items space

### DIFF
--- a/src/components/InventoryTable/InventoryList.scss
+++ b/src/components/InventoryTable/InventoryList.scss
@@ -9,9 +9,6 @@
 
 .ins-c-inventory__table--toolbar {
     &:not(.ins-c-inventory__table--toolbar-has-items) {
-        .pf-v5-c-toolbar__content {
-            .pf-v5-c-toolbar__item:last-child { min-width: 12.5rem; }
-        }
         .pf-v5-c-pagination__nav-page-select input {  min-width: 4.68755rem; }
     }
 


### PR DESCRIPTION
I have looked around inventory and it css piece I removed doesn't affect it at all. But this is going to make Compliance look better on Report details page. I also found out that Compliance had extra space on the right side from compact pagination, it's also fixed here

After: 
![image](https://github.com/user-attachments/assets/32510561-70db-46ce-b9f9-8451fb713c8f)
