### PR TITLE
fix(RHINENG-8385): Make tag filter search box size look correct

### DIFF
--- a/src/components/InventoryTable/InventoryList.scss
+++ b/src/components/InventoryTable/InventoryList.scss
@@ -18,6 +18,10 @@
     .ins-c-chip-filters .pf-v5-c-chip-group:not(:last-of-type) { margin-right: var(--pf-v5-global--spacer--xs); }
 
     .ins-c-tagfilter { width: initial; }
+
+    .ins-c-tagfilter.pf-v5-c-menu-toggle {
+        height: 36px;
+    }
 }
 
 .ins-c-table__empty {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/9bd752f0-c9e8-4eca-9f51-b13f5f00338a)

After:
![image](https://github.com/user-attachments/assets/9e8975e1-1084-478b-9daa-cd5afa3066d1)
