### PR TITLE
fix(RHINENG-8675): Remove 'items' on bottom pagination

### DIFF
--- a/src/components/InventoryTable/Pagination.js
+++ b/src/components/InventoryTable/Pagination.js
@@ -46,6 +46,7 @@ const FooterPagination = ({
       onSetPage={onSetPage}
       onPerPageSelect={onPerPageSelect}
       titles={{
+        items: '',
         optionsToggleAriaLabel: 'Items per page',
       }}
       {...paginationProps}

--- a/src/components/InventoryTable/__snapshots__/Pagination.test.js.snap
+++ b/src/components/InventoryTable/__snapshots__/Pagination.test.js.snap
@@ -22,7 +22,7 @@ exports[`Pagination render should render correctly - with no access 1`] = `
       <b>
         0
       </b>
-       items
+       
     </div>
     <div>
       <button
@@ -44,7 +44,7 @@ exports[`Pagination render should render correctly - with no access 1`] = `
           <b>
             0
           </b>
-           items
+           
         </span>
         <span
           class="pf-v5-c-menu-toggle__controls"
@@ -239,7 +239,7 @@ exports[`Pagination render should render correctly with data 1`] = `
       <b>
         0
       </b>
-       items
+       
     </div>
     <div>
       <button
@@ -260,7 +260,7 @@ exports[`Pagination render should render correctly with data 1`] = `
           <b>
             0
           </b>
-           items
+           
         </span>
         <span
           class="pf-v5-c-menu-toggle__controls"
@@ -464,7 +464,7 @@ exports[`Pagination render should render correctly with data and isFull 1`] = `
           <b>
             500
           </b>
-           items
+           
         </span>
         <span
           class="pf-v5-c-menu-toggle__controls"
@@ -656,7 +656,7 @@ exports[`Pagination render should render correctly with data and props 1`] = `
       <b>
         500
       </b>
-       items
+       
     </div>
     <div>
       <button
@@ -677,7 +677,7 @@ exports[`Pagination render should render correctly with data and props 1`] = `
           <b>
             500
           </b>
-           items
+           
         </span>
         <span
           class="pf-v5-c-menu-toggle__controls"


### PR DESCRIPTION
Currently bottom pagination contains `items` word. This started happening after PF5 migration and we don't want to see items there
![image](https://github.com/user-attachments/assets/aec7e012-2ead-453c-8478-13f0159464cd)
