### PR TITLE
fix(RHINENG-13857): Make tags aligned with table header

### DIFF
--- a/src/components/InventoryTable/InventoryList.scss
+++ b/src/components/InventoryTable/InventoryList.scss
@@ -94,6 +94,10 @@
 
     .ins-c-inventory__list-tags {
         display: inline-block;
+        
+        .pf-v5-c-button {
+            padding-left: 0;
+        }
     }
 
     .ins-composed-col div {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/e21823bc-0a8c-4fc3-a1a0-d45f6de5cd8f)

After:
![image](https://github.com/user-attachments/assets/183311b3-e653-499c-bff8-848b66d5f000)
