### PR TITLE
fix(RHINENG-11788): Add reg assistant link to sys details

### DIFF
--- a/src/components/InventoryDetail/InsightsPrompt.js
+++ b/src/components/InventoryDetail/InsightsPrompt.js
@@ -15,6 +15,7 @@ import {
   TextListItem,
   TextVariants,
 } from '@patternfly/react-core';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 const InsightsPrompt = () => {
   return (
@@ -89,6 +90,11 @@ const InsightsPrompt = () => {
               </Card>
             </GridItem>
           </Grid>
+        </GridItem>
+        <GridItem style={{ paddingBottom: '8px' }}>
+          <InsightsLink to={'/'} app="registration">
+            How to register with insights-client?
+          </InsightsLink>
         </GridItem>
         <GridItem>
           <Button


### PR DESCRIPTION
The details page for a system not registered with Insights is not pointing to the main source of information for registering the system. We should include a link to 'Registration Assistant'.

To test, navigate to inventory and click on the name of a system that is not registered (yellow icon). A link to the registration assistant should be provided as this is the main location to find information on how to register your system. The banner at the top of the page should include "How to register with insights-client?", and it should link to Registration Assistant app.