### PR TITLE
fix(RHINENG-12953): strip whitespace edit display and ansible hostname

### DIFF
--- a/src/components/GeneralInfo/TextInputModal/TextInputModal.js
+++ b/src/components/GeneralInfo/TextInputModal/TextInputModal.js
@@ -1,7 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, Modal, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Modal,
+  TextInput,
+  ValidatedOptions,
+} from '@patternfly/react-core';
 
 export default class TextInputModal extends Component {
   constructor(props) {
@@ -51,9 +59,12 @@ export default class TextInputModal extends Component {
             key="confirm"
             data-action="confirm"
             variant="primary"
-            onClick={() => onSubmit(this.state.value)}
+            onClick={() => onSubmit(this.state.value?.trim())}
             ouiaId={confirmOuiaId}
-            isDisabled={this.props.value === this.state.value}
+            isDisabled={
+              this.props.value === this.state.value ||
+              this.state.value?.trim().length === 0
+            }
           >
             Save
           </Button>,
@@ -74,7 +85,17 @@ export default class TextInputModal extends Component {
           ouiaId={inputOuiaId}
           onChange={(_event, value) => this.setState({ value })}
           aria-label={ariaLabel}
+          validated={value?.trim().length === 0 && ValidatedOptions.error}
         />
+        <FormHelperText>
+          <HelperText id="helper-text2" aria-live="polite">
+            {value?.trim().length === 0 && (
+              <HelperTextItem variant="error">
+                Name cannot be blank
+              </HelperTextItem>
+            )}
+          </HelperText>
+        </FormHelperText>
       </Modal>
     );
   }

--- a/src/components/GeneralInfo/TextInputModal/TextInputModal.test.js
+++ b/src/components/GeneralInfo/TextInputModal/TextInputModal.test.js
@@ -99,16 +99,53 @@ describe('TextInputModal', () => {
       expect(onCancel).toBeCalled();
     });
 
-    it('onSubmit should be called', async () => {
+    it('onSubmit should be called with trimmed string', async () => {
       const onSubmit = jest.fn();
       render(<TextInputModal isOpen onSubmit={onSubmit} />);
 
-      await userEvent.click(
-        screen.getByRole('button', {
-          name: /save/i,
-        })
+      await userEvent.type(
+        screen.getByRole('textbox', {
+          name: /input text/i,
+        }),
+        'some '
       );
-      expect(onSubmit).toBeCalled();
+
+      const submitButton = screen.getByRole('button', {
+        name: /save/i,
+      });
+
+      await userEvent.click(submitButton);
+      expect(onSubmit).toBeCalledWith('some');
+
+      await userEvent.type(
+        screen.getByRole('textbox', {
+          name: /input text/i,
+        }),
+        ' some'
+      );
+      expect(onSubmit).toBeCalledWith('some');
+    });
+
+    it('submitButton should be disabled', async () => {
+      const onSubmit = jest.fn();
+      render(<TextInputModal isOpen onSubmit={onSubmit} />);
+
+      const submitButton = screen.getByRole('button', {
+        name: /save/i,
+      });
+
+      /*eslint-disable jest-dom/prefer-enabled-disabled*/
+      expect(submitButton).toHaveProperty('disabled');
+
+      await userEvent.type(
+        screen.getByRole('textbox', {
+          name: /input text/i,
+        }),
+        '  '
+      );
+
+      expect(submitButton).toHaveProperty('disabled');
+      /*eslint-enable jest-dom/prefer-enabled-disabled*/
     });
 
     it('X button should call onClose', async () => {

--- a/src/components/GeneralInfo/TextInputModal/__snapshots__/TextInputModal.test.js.snap
+++ b/src/components/GeneralInfo/TextInputModal/__snapshots__/TextInputModal.test.js.snap
@@ -58,10 +58,10 @@ exports[`TextInputModal render should render aria label 1`] = `
             id="pf-modal-part-5"
           >
             <span
-              class="pf-v5-c-form-control"
+              class="pf-v5-c-form-control pf-m-error"
             >
               <input
-                aria-invalid="false"
+                aria-invalid="true"
                 aria-label="Some aria label"
                 data-ouia-component-id="OUIA-Generated-TextInputBase-3"
                 data-ouia-component-type="PF5/TextInput"
@@ -69,18 +69,59 @@ exports[`TextInputModal render should render aria label 1`] = `
                 type="text"
                 value=""
               />
+              <span
+                class="pf-v5-c-form-control__utilities"
+              >
+                <span
+                  class="pf-v5-c-form-control__icon pf-m-status"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                    />
+                  </svg>
+                </span>
+              </span>
             </span>
+            <div
+              class="pf-v5-c-form__helper-text"
+            >
+              <div
+                aria-live="polite"
+                class="pf-v5-c-helper-text"
+                id="helper-text2"
+              >
+                <div
+                  class="pf-v5-c-helper-text__item pf-m-error"
+                >
+                  <span
+                    class="pf-v5-c-helper-text__item-text"
+                  >
+                    Name cannot be blank
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
           <footer
             class="pf-v5-c-modal-box__footer"
           >
             <button
-              aria-disabled="false"
-              class="pf-v5-c-button pf-m-primary"
+              aria-disabled="true"
+              class="pf-v5-c-button pf-m-primary pf-m-disabled"
               data-action="confirm"
               data-ouia-component-id="OUIA-Generated-Button-primary-3"
               data-ouia-component-type="PF5/Button"
               data-ouia-safe="true"
+              disabled=""
               type="button"
             >
               Save
@@ -162,10 +203,10 @@ exports[`TextInputModal render should render open 1`] = `
             id="pf-modal-part-3"
           >
             <span
-              class="pf-v5-c-form-control"
+              class="pf-v5-c-form-control pf-m-error"
             >
               <input
-                aria-invalid="false"
+                aria-invalid="true"
                 aria-label="input text"
                 data-ouia-component-id="OUIA-Generated-TextInputBase-1"
                 data-ouia-component-type="PF5/TextInput"
@@ -173,18 +214,59 @@ exports[`TextInputModal render should render open 1`] = `
                 type="text"
                 value=""
               />
+              <span
+                class="pf-v5-c-form-control__utilities"
+              >
+                <span
+                  class="pf-v5-c-form-control__icon pf-m-status"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                    />
+                  </svg>
+                </span>
+              </span>
             </span>
+            <div
+              class="pf-v5-c-form__helper-text"
+            >
+              <div
+                aria-live="polite"
+                class="pf-v5-c-helper-text"
+                id="helper-text2"
+              >
+                <div
+                  class="pf-v5-c-helper-text__item pf-m-error"
+                >
+                  <span
+                    class="pf-v5-c-helper-text__item-text"
+                  >
+                    Name cannot be blank
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
           <footer
             class="pf-v5-c-modal-box__footer"
           >
             <button
-              aria-disabled="false"
-              class="pf-v5-c-button pf-m-primary"
+              aria-disabled="true"
+              class="pf-v5-c-button pf-m-primary pf-m-disabled"
               data-action="confirm"
               data-ouia-component-id="OUIA-Generated-Button-primary-1"
               data-ouia-component-type="PF5/Button"
               data-ouia-safe="true"
+              disabled=""
               type="button"
             >
               Save
@@ -280,10 +362,10 @@ exports[`TextInputModal render should render title 1`] = `
             id="pf-modal-part-4"
           >
             <span
-              class="pf-v5-c-form-control"
+              class="pf-v5-c-form-control pf-m-error"
             >
               <input
-                aria-invalid="false"
+                aria-invalid="true"
                 aria-label="input text"
                 data-ouia-component-id="OUIA-Generated-TextInputBase-2"
                 data-ouia-component-type="PF5/TextInput"
@@ -291,18 +373,59 @@ exports[`TextInputModal render should render title 1`] = `
                 type="text"
                 value=""
               />
+              <span
+                class="pf-v5-c-form-control__utilities"
+              >
+                <span
+                  class="pf-v5-c-form-control__icon pf-m-status"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                    />
+                  </svg>
+                </span>
+              </span>
             </span>
+            <div
+              class="pf-v5-c-form__helper-text"
+            >
+              <div
+                aria-live="polite"
+                class="pf-v5-c-helper-text"
+                id="helper-text2"
+              >
+                <div
+                  class="pf-v5-c-helper-text__item pf-m-error"
+                >
+                  <span
+                    class="pf-v5-c-helper-text__item-text"
+                  >
+                    Name cannot be blank
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
           <footer
             class="pf-v5-c-modal-box__footer"
           >
             <button
-              aria-disabled="false"
-              class="pf-v5-c-button pf-m-primary"
+              aria-disabled="true"
+              class="pf-v5-c-button pf-m-primary pf-m-disabled"
               data-action="confirm"
               data-ouia-component-id="OUIA-Generated-Button-primary-2"
               data-ouia-component-type="PF5/Button"
               data-ouia-safe="true"
+              disabled=""
               type="button"
             >
               Save


### PR DESCRIPTION
It is possible to set both Display name and Ansible hostname to a space character, ' '. Not only this makes the UI confusing, it makes you unable to click the host in the Systems page: you have to click Edit, change the name and only then you can open the host details.

Trailing whitespace is cleaned on some places, but not consistently; display name "test   " is stored as such.

To test, find a system and click the system to view its details. Edit the display name and ansible hostname values.

This PR disables the Save button if the name hasn't changed, or is empty, including only whitespaces. Also, if you add whitespace before or after the string, it will trim the whitespace on both sides.