### PR TITLE
fix(RHINENG-13293): Fix undefined values on staleness page while loading

### DIFF
--- a/src/components/InventoryHostStaleness/HostStalenessCard.js
+++ b/src/components/InventoryHostStaleness/HostStalenessCard.js
@@ -178,9 +178,9 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
   };
 
   const batchedApi = async () => {
-    edgeSystemCheck();
-    fetchApiStalenessData();
-    fetchDefaultValues();
+    await edgeSystemCheck();
+    await fetchApiStalenessData();
+    await fetchDefaultValues();
     setIsLoading(false);
   };
 

--- a/src/components/InventoryHostStaleness/__test__/InventoryHostStaleness.test.js
+++ b/src/components/InventoryHostStaleness/__test__/InventoryHostStaleness.test.js
@@ -23,36 +23,124 @@ describe('Table Renders', () => {
       immutable_time_to_delete: 15552000,
       id: 'system_default',
     });
-  });
-
-  it('renders table with two tabs', async () => {
-    render(
-      <TestWrapper store={getStore()}>
-        <HostStalenessCard canModifyHostStaleness={true} />
-      </TestWrapper>
-    );
-
-    await waitFor(() => {
-      screen.getByRole('tab', { name: 'Conventional (RPM-DNF)' });
-      screen.getByRole('tab', { name: 'Immutable (OSTree)' });
+    mock.onGet(`/api/inventory/v1/account/staleness/defaults`).reply(200, {
+      conventional_time_to_stale: 86400,
+      conventional_time_to_stale_warning: 604800,
+      conventional_time_to_delete: 1209600,
+      immutable_time_to_stale: 172800,
+      immutable_time_to_stale_warning: 1290600,
+      immutable_time_to_delete: 15552000,
+      id: 'system_default',
     });
   });
 
-  it('enables staleness options when edit is clicked', async () => {
-    render(
+  const renderHostStalenessCard = (canModifyHostStaleness = true) => {
+    return render(
       <TestWrapper store={getStore()}>
-        <HostStalenessCard canModifyHostStaleness={true} />
+        <HostStalenessCard canModifyHostStaleness={canModifyHostStaleness} />
       </TestWrapper>
     );
+  };
 
+  it('renders table with two tabs', async () => {
+    renderHostStalenessCard();
+
+    await screen.findByRole('tab', { name: 'Conventional (RPM-DNF)' });
+    await screen.findByRole('tab', { name: 'Immutable (OSTree)' });
+  });
+
+  it('editing is disabled when edit is not clicked', async () => {
+    renderHostStalenessCard();
+
+    // Wait for the component to finish loading
+    const menuToggleButtons = await waitFor(() =>
+      screen
+        .getAllByRole('button')
+        .filter((button) => button.classList.contains('pf-v5-c-menu-toggle'))
+    );
+
+    menuToggleButtons.forEach((button) => expect(button).toBeDisabled());
+  });
+
+  it('enables staleness editing when edit is clicked', async () => {
+    renderHostStalenessCard();
+
+    await screen.findByRole('button', { name: 'Edit' });
     await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    const menuToggleButtons = screen
-      .getAllByRole('button')
-      .filter((button) => button.classList.contains('pf-v5-c-menu-toggle'));
+
+    const menuToggleButtons = await waitFor(() =>
+      screen
+        .getAllByRole('button')
+        .filter((button) => button.classList.contains('pf-v5-c-menu-toggle'))
+    );
 
     menuToggleButtons.forEach((button) => expect(button).toBeEnabled());
 
-    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled()
+    );
+  });
+
+  it('System Staleness Dropdown cant match or be higher than staleness warning dropdown', async () => {
+    renderHostStalenessCard();
+
+    await screen.findByRole('button', { name: 'Edit' });
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const menuToggleButtons = await waitFor(() =>
+      screen
+        .getAllByRole('button')
+        .filter((button) => button.classList.contains('pf-v5-c-menu-toggle'))
+    );
+
+    menuToggleButtons.forEach((button) => expect(button).toBeEnabled());
+    await userEvent.click(menuToggleButtons[0]);
+    const option = screen.getByRole('option', {
+      name: /7 days/i,
+    });
+    await userEvent.click(option);
+    expect(
+      screen.getByText(/staleness must be before stale warning/i)
+    ).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled()
+    );
+  });
+
+  it('System Staleness Warning Dropdown cant match or be higher than staleness deleting dropdown', async () => {
+    renderHostStalenessCard();
+
+    await screen.findByRole('button', { name: 'Edit' });
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const menuToggleButtons = await waitFor(() =>
+      screen
+        .getAllByRole('button')
+        .filter((button) => button.classList.contains('pf-v5-c-menu-toggle'))
+    );
+
+    menuToggleButtons.forEach((button) => expect(button).toBeEnabled());
+    await userEvent.click(menuToggleButtons[1]);
+    const option = screen.getByRole('option', {
+      name: /21 days/i,
+    });
+    await userEvent.click(option);
+    expect(
+      screen.getByText(/stale warning must be before deletion/i)
+    ).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled()
+    );
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-13293
On page load, setIsLoading would fire BEFORE all of the calls were completed because these are all asychronous functions returning promises. They were starting and setIsLoading would fire without them being completed. 

Each call needs to be awaited to ensure the async functions are completed before firing off the setIsloading(false);
To test just navigate to staleness and deletion page and observe the drop downs on page load. They should only load in with data, and never display undefined.

Before: 
![Screenshot 2024-10-31 at 2 57 02 PM](https://github.com/user-attachments/assets/0c4548ce-41cf-4733-bcae-f70908d75e1a)

After: (just an example, data can be different depending on the account.
![Screenshot 2024-10-31 at 2 59 59 PM](https://github.com/user-attachments/assets/70214705-0d68-4d19-8397-fbbf0210afcd)
