### PR TITLE
fix(InventoryTable): Set activeFilter only when filter exist

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -345,8 +345,10 @@ const EntityTableToolbar = ({
     if (textualFilter) {
       textualFilter.filter = trimmedValue;
     } else {
-      // TODO This is sus
-      activeFilters?.push({ value: TEXT_FILTER, filter: trimmedValue });
+      if (trimmedValue) {
+        // TODO This is sus
+        activeFilters?.push({ value: TEXT_FILTER, filter: trimmedValue });
+      }
     }
 
     const refresh = debounced ? debouncedRefresh : updateData;

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -692,10 +692,7 @@ describe('EntityTableToolbar', () => {
           })
         );
         expect(onRefreshData).toHaveBeenCalledWith({
-          filters: [
-            { filter: '', value: 'hostname_or_id' },
-            { tagFilters: [] },
-          ],
+          filters: [{ tagFilters: [] }],
           page: 1,
           perPage: 50,
         });


### PR DESCRIPTION
While I was trying to find the root cause of https://github.com/RedHatInsights/compliance-frontend/pull/2239 , I found out that inventory has it's own thing.

Issue is super minor but it happens when you search by name on Inventory table and then you reset filters - but you can see that API requests will still contain `hostname_or_id: ` with empty value

To reproduce:

1. Navigate to Inventory systems table
2. Search by name
3. Open devtools network tab and observe it while clicking on reset filters

Request before:
`https://console.stage.redhat.com/api/inventory/v1/hosts?hostname_or_id=&per_page....`

Request after:
`https://stage.foo.redhat.com:1337/api/inventory/v1/hosts?per_page...`