### PR TITLE
Create Sentry workflow for source maps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+name: sentryConfig
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_hash:
+        description: 'The commit hash (or branch/tag) to build'
+        required: true
+        default: 'master'
+
+jobs:
+  createSentryRelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.commit_hash }}
+
+      - name: Install dependencies
+        env:
+          SENTRY_RELEASE: inventory-${{ github.event.inputs.commit_hash }}
+        run: npm ci
+
+      - name: Build
+        env:
+          SENTRY_RELEASE: inventory-${{ github.event.inputs.commit_hash }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: npm run build --if-present
+
+      - name: Create a Sentry.io release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          tagName: ${{ github.event.inputs.commit_hash }}
+          releaseNamePrefix: advisor
+          environment: master
+          sourcemaps: 'dist/sourcemaps'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,6 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
           tagName: ${{ github.event.inputs.commit_hash }}
-          releaseNamePrefix: advisor
+          releaseNamePrefix: inventory
           environment: master
           sourcemaps: 'dist/sourcemaps'


### PR DESCRIPTION
This adds a sentry hook, to work more as a button. A manual job with an input, being the commit hash, that will upload source maps with that specific build