### PR TITLE
fix(sentry): Update sentrys workflow and always inject debugIDs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,12 @@ jobs:
 
       - name: Install dependencies
         env:
-          SENTRY_RELEASE: inventory-${{ github.event.inputs.commit_hash }}
+          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash }}
         run: npm ci
 
       - name: Build
         env:
-          SENTRY_RELEASE: inventory-${{ github.event.inputs.commit_hash }}
+          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,14 +30,3 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: npm run build --if-present
 
-      - name: Create a Sentry.io release
-        uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-        with:
-          tagName: ${{ github.event.inputs.commit_hash }}
-          releaseNamePrefix: inventory
-          environment: master
-          sourcemaps: 'dist/sourcemaps'

--- a/fec.config.js
+++ b/fec.config.js
@@ -23,15 +23,27 @@ module.exports = {
             authToken: process.env.SENTRY_AUTH_TOKEN,
             org: 'red-hat-it',
             project: 'inventory-rhel',
-            _experiments: {
-              moduleMetadata: ({ release }) => ({
-                dsn: 'https://f6f21a635c05b0f91875de6a557f8c34@o490301.ingest.us.sentry.io/4507454722211840',
-                release,
-              }),
-            },
+            moduleMetadata: ({ release }) => ({
+              dsn: 'https://f6f21a635c05b0f91875de6a557f8c34@o490301.ingest.us.sentry.io/4507454722211840',
+              release,
+              org: 'red-hat-it',
+              project: 'inventory-rhel',
+            }),
           }),
         ]
-      : []),
+      : [
+          // Justs injects the debug ids
+          sentryWebpackPlugin({
+            org: 'red-hat-it',
+            project: 'inventory-rhel',
+            moduleMetadata: ({ release }) => ({
+              dsn: 'https://f6f21a635c05b0f91875de6a557f8c34@o490301.ingest.us.sentry.io/4507454722211840',
+              release,
+              org: 'red-hat-it',
+              project: 'inventory-rhel',
+            }),
+          }),
+        ]),
   ],
   moduleFederation: {
     shared: [


### PR DESCRIPTION
Updates flow to always inject debugID, and update the workflow file to remove overriding of release in sentry, and map against debug IDs properly