### PR TITLE
fix(RHINENG-9239): Create separate state for system tables

### DIFF
--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -214,7 +214,7 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
       )}
 
       <InventoryTable
-        isolateStore={true}
+        isolateStore
         columns={(columns) => mergeColumns(prepareColumns(columns))}
         hideFilters={{ hostGroupFilter: true }}
         getEntities={customGetEntities}

--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -212,112 +212,112 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
           refreshTable={() => true}
         />
       )}
-      {!addToGroupModalOpen && (
-        <InventoryTable
-          columns={(columns) => mergeColumns(prepareColumns(columns))}
-          hideFilters={{ hostGroupFilter: true }}
-          getEntities={customGetEntities}
-          tableProps={{
-            isStickyHeader: true,
-            variant: TableVariant.compact,
-            canSelectAll: false,
-            actionResolver: (row) => [
-              {
-                title: (
-                  <ActionDropdownItem
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={noAccessTooltip}
-                    onClick={() => {
-                      setCurrentSystem([row]);
-                      setRemoveHostsFromGroupModalOpen(true);
-                    }}
-                  >
-                    {removeLabel}
-                  </ActionDropdownItem>
-                ),
-              },
-              {
-                title: (
-                  <ActionDropdownItem
-                    isAriaDisabled={
-                      deviceData === null || !deviceData.includes(row.id)
-                    }
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={noAccessTooltip}
-                    onClick={() => {
-                      setCurrentSystem([row]);
-                      navigate(`/insights/inventory/${row.id}/update`);
-                    }}
-                  >
-                    Update
-                  </ActionDropdownItem>
-                ),
-              },
+
+      <InventoryTable
+        isolateStore={true}
+        columns={(columns) => mergeColumns(prepareColumns(columns))}
+        hideFilters={{ hostGroupFilter: true }}
+        getEntities={customGetEntities}
+        tableProps={{
+          isStickyHeader: true,
+          variant: TableVariant.compact,
+          canSelectAll: false,
+          actionResolver: (row) => [
+            {
+              title: (
+                <ActionDropdownItem
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={NO_MODIFY_GROUP_TOOLTIP_MESSAGE}
+                  onClick={() => {
+                    setCurrentSystem([row]);
+                    setRemoveHostsFromGroupModalOpen(true);
+                  }}
+                >
+                  {removeLabel}
+                </ActionDropdownItem>
+              ),
+            },
+            {
+              title: (
+                <ActionDropdownItem
+                  isAriaDisabled={
+                    deviceData === null || !deviceData.includes(row.id)
+                  }
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={noAccessTooltip}
+                  onClick={() => {
+                    setCurrentSystem([row]);
+                    navigate(`/insights/inventory/${row.id}/update`);
+                  }}
+                >
+                  Update
+                </ActionDropdownItem>
+              ),
+            },
+          ],
+        }}
+        actionsConfig={{
+          actions: [
+            [
+              <div key="primary-actions" className="pf-v5-c-action-list">
+                <ActionButton
+                  key="add-systems-button"
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={noAccessTooltip}
+                  onClick={() => {
+                    dispatch(clearEntitiesAction());
+                    setAddToGroupModalOpen(true);
+                  }}
+                  ouiaId="add-systems-button"
+                >
+                  Add systems
+                </ActionButton>
+                <ActionButton
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={noAccessTooltip}
+                  key="update-systems-button"
+                  onClick={() => {
+                    setupdateDevice(true);
+                    handleUpdateSelected();
+                  }}
+                  ouiaId="update-systems-button"
+                  isAriaDisabled={!canUpdate}
+                >
+                  Update
+                </ActionButton>
+              </div>,
             ],
-          }}
-          actionsConfig={{
-            actions: [
-              [
-                <div key="primary-actions" className="pf-v5-c-action-list">
-                  <ActionButton
-                    key="add-systems-button"
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={noAccessTooltip}
-                    onClick={() => {
-                      dispatch(clearEntitiesAction());
-                      setAddToGroupModalOpen(true);
-                    }}
-                    ouiaId="add-systems-button"
-                  >
-                    Add systems
-                  </ActionButton>
-                  <ActionButton
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={noAccessTooltip}
-                    key="update-systems-button"
-                    onClick={() => {
-                      setupdateDevice(true);
-                      handleUpdateSelected();
-                    }}
-                    ouiaId="update-systems-button"
-                    isAriaDisabled={!canUpdate}
-                  >
-                    Update
-                  </ActionButton>
-                </div>,
-              ],
-              {
-                label: removeLabel,
-                props: {
-                  isAriaDisabled: !canModify || calculateSelected() === 0,
-                  ...(!canModify && {
-                    tooltipProps: {
-                      content: noAccessTooltip,
-                    },
-                  }),
-                },
-                onClick: () => {
-                  setCurrentSystem(Array.from(selected.values()));
-                  setRemoveHostsFromGroupModalOpen(true);
-                },
+            {
+              label: removeLabel,
+              props: {
+                isAriaDisabled: !canModify || calculateSelected() === 0,
+                ...(!canModify && {
+                  tooltipProps: {
+                    content: noAccessTooltip,
+                  },
+                }),
               },
-            ],
-          }}
-          bulkSelect={bulkSelectConfig}
-          showTags
-          ref={inventory}
-          showCentosVersions
-          {...props}
-        />
-      )}
+              onClick: () => {
+                setCurrentSystem(Array.from(selected.values()));
+                setRemoveHostsFromGroupModalOpen(true);
+              },
+            },
+          ],
+        }}
+        bulkSelect={bulkSelectConfig}
+        showTags
+        ref={inventory}
+        showCentosVersions
+        {...props}
+      />
     </div>
   );
 };

--- a/src/components/GroupSystems/GroupImmutableSystems.js
+++ b/src/components/GroupSystems/GroupImmutableSystems.js
@@ -184,6 +184,8 @@ const GroupImmutableSystems = ({ groupName, groupId, ...props }) => {
           isModalOpen={addToGroupModalOpen}
           setIsModalOpen={(value) => {
             dispatch(clearEntitiesAction());
+            // ImmutableDevicesView, which uses Edge's DevicesView, systems table persists filters in the Session Storage
+            window.sessionStorage.removeItem('edge-devices-table-filters');
             setAddToGroupModalOpen(value);
           }}
           groupId={groupId}

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -118,6 +118,8 @@ const GroupSystems = ({ groupName, groupId }) => {
           isModalOpen={addToGroupModalOpen}
           setIsModalOpen={(value) => {
             dispatch(clearEntitiesAction());
+            // The systems table of ImmutableDevicesView, which uses Edge's DevicesView, persists filters in the Session Storage
+            window.sessionStorage.removeItem('edge-devices-table-filters');
             setAddToGroupModalOpen(value);
           }}
           groupId={groupId}

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -134,7 +134,7 @@ const GroupSystems = ({ groupName, groupId }) => {
         />
       )}
       <InventoryTable
-        isolateStore={true}
+        isolateStore
         columns={(columns) => prepareColumns(columns, true)}
         hideFilters={{ hostGroupFilter: true }}
         initialLoading

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -133,91 +133,90 @@ const GroupSystems = ({ groupName, groupId }) => {
           modalState={currentSystem}
         />
       )}
-      {!addToGroupModalOpen && (
-        <InventoryTable
-          columns={(columns) => prepareColumns(columns, true)}
-          hideFilters={{ hostGroupFilter: true }}
-          initialLoading
-          getEntities={async (items, config, showTags, defaultGetEntities) =>
-            await defaultGetEntities(
-              items,
-              // filter systems by the group name
-              {
-                ...config,
-                filters: {
-                  ...config.filters,
-                  hostGroupFilter: [groupName],
-                },
+      <InventoryTable
+        isolateStore={true}
+        columns={(columns) => prepareColumns(columns, true)}
+        hideFilters={{ hostGroupFilter: true }}
+        initialLoading
+        getEntities={async (items, config, showTags, defaultGetEntities) =>
+          await defaultGetEntities(
+            items,
+            // filter systems by the group name
+            {
+              ...config,
+              filters: {
+                ...config.filters,
+                hostGroupFilter: [groupName],
               },
-              showTags
-            )
-          }
-          tableProps={{
-            isStickyHeader: true,
-            variant: TableVariant.compact,
-            canSelectAll: false,
-            actionResolver: (row) => [
-              {
-                title: (
-                  <ActionDropdownItem
-                    requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                      groupId
-                    )}
-                    noAccessTooltip={noAccessTooltip}
-                    onClick={() => {
-                      setCurrentSystem([row]);
-                      setRemoveHostsFromGroupModalOpen(true);
-                    }}
-                  >
-                    {removeLabel}
-                  </ActionDropdownItem>
-                ),
+            },
+            showTags
+          )
+        }
+        tableProps={{
+          isStickyHeader: true,
+          variant: TableVariant.compact,
+          canSelectAll: false,
+          actionResolver: (row) => [
+            {
+              title: (
+                <ActionDropdownItem
+                  requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                    groupId
+                  )}
+                  noAccessTooltip={noAccessTooltip}
+                  onClick={() => {
+                    setCurrentSystem([row]);
+                    setRemoveHostsFromGroupModalOpen(true);
+                  }}
+                >
+                  {removeLabel}
+                </ActionDropdownItem>
+              ),
+            },
+          ],
+        }}
+        actionsConfig={{
+          actions: [
+            <ActionButton
+              key="add-systems-button"
+              requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                groupId
+              )}
+              noAccessTooltip={noAccessTooltip}
+              onClick={() => {
+                dispatch(clearEntitiesAction());
+                setAddToGroupModalOpen(true);
+              }}
+              ouiaId="add-systems-button"
+            >
+              Add systems
+            </ActionButton>,
+            {
+              label: removeLabel,
+              props: {
+                isAriaDisabled: !canModify || calculateSelected() === 0,
+                ...(!canModify && {
+                  tooltipProps: {
+                    content: noAccessTooltip,
+                  },
+                }),
               },
-            ],
-          }}
-          actionsConfig={{
-            actions: [
-              <ActionButton
-                key="add-systems-button"
-                requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
-                  groupId
-                )}
-                noAccessTooltip={noAccessTooltip}
-                onClick={() => {
-                  dispatch(clearEntitiesAction());
-                  setAddToGroupModalOpen(true);
-                }}
-                ouiaId="add-systems-button"
-              >
-                Add systems
-              </ActionButton>,
-              {
-                label: removeLabel,
-                props: {
-                  isAriaDisabled: !canModify || calculateSelected() === 0,
-                  ...(!canModify && {
-                    tooltipProps: {
-                      content: noAccessTooltip,
-                    },
-                  }),
-                },
-                onClick: () => {
-                  setCurrentSystem(Array.from(selected.values()));
-                  setRemoveHostsFromGroupModalOpen(true);
-                },
+              onClick: () => {
+                setCurrentSystem(Array.from(selected.values()));
+                setRemoveHostsFromGroupModalOpen(true);
               },
-            ],
-          }}
-          bulkSelect={bulkSelectConfig}
-          showTags
-          ref={inventory}
-          showCentosVersions
-          customFilters={{ filters: initialFilters, globalFilter }}
-          autoRefresh
-          onRefresh={onRefresh}
-          ignoreRefresh
-        />
-      )}
+            },
+          ],
+        }}
+        bulkSelect={bulkSelectConfig}
+        showTags
+        ref={inventory}
+        showCentosVersions
+        customFilters={{ filters: initialFilters, globalFilter }}
+        autoRefresh
+        onRefresh={onRefresh}
+        ignoreRefresh
+      />
     </div>
   );
 };

--- a/src/components/InventoryGroupDetail/constants.js
+++ b/src/components/InventoryGroupDetail/constants.js
@@ -1,0 +1,5 @@
+// GroupTabDetails
+export const groupTabKeys = {
+  systems: 0,
+  groupInfo: 1,
+};

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -5,10 +5,18 @@ import React, {
   forwardRef,
   useEffect,
   useRef,
+  useMemo,
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux';
+import {
+  shallowEqual,
+  useDispatch,
+  useSelector,
+  useStore,
+  Provider,
+} from 'react-redux';
+import { getStore } from '../../store';
 import EntityTableToolbar from './EntityTableToolbar';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components/TableToolbar';
 import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
@@ -352,4 +360,24 @@ InventoryTable.propTypes = {
   enableExport: PropTypes.bool,
 };
 
-export default InventoryTable;
+const InventoryTableWrapper = forwardRef(
+  ({ isolateStore = false, ...props }, ref) => {
+    const store = useMemo(
+      () => (isolateStore ? getStore() : undefined),
+      [isolateStore]
+    );
+    const Wrapper = store ? Provider : React.Fragment;
+
+    return (
+      <Wrapper {...(store ? { store } : {})}>
+        <InventoryTable {...props} ref={ref} />
+      </Wrapper>
+    );
+  }
+);
+
+InventoryTableWrapper.propTypes = {
+  isolateStore: PropTypes.bool,
+};
+
+export default InventoryTableWrapper;

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -363,6 +363,7 @@ InventoryTable.propTypes = {
 const InventoryTableWrapper = forwardRef(
   ({ isolateStore = false, ...props }, ref) => {
     const store = useMemo(
+      // TODO: Create a partial store containing only relevant Slices & Reducers relevant to the InventoryTable
       () => (isolateStore ? getStore() : undefined),
       [isolateStore]
     );


### PR DESCRIPTION
Steps to reproduce:

1. visit https://console.stage.redhat.com/preview/insights/inventory/workspaces
2. click on any workspace to go to workspace details
3. apply any filter to Group's table with systems
4. click "Add systems" button
5. close "Add systems" modal

expected results:
5. Group's table with systems has applied filters

actual results:
5. Group's table with systems doesn't have any filter

This PR keeps the system tables stores separate. This includes the Conventional and Immutable tabs, as well as the Conventional and Immutable tabs in the Add systems modal.