### PR TITLE
fix(RHINENG-15627): Images table persistent loading

### DIFF
--- a/src/routes/InventoryComponents/BifrostPage.js
+++ b/src/routes/InventoryComponents/BifrostPage.js
@@ -25,7 +25,7 @@ const BifrostPage = () => {
         `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_FETCH_NON_BOOTC}&${INVENTORY_FILTER_NO_HOST_TYPE}&per_page=1`
       );
 
-      const booted = result.data.results.map(
+      const booted = result.results.map(
         (system) => system.system_profile.bootc_status.booted
       );
 
@@ -62,7 +62,7 @@ const BifrostPage = () => {
         })),
         {
           image: 'Package based systems',
-          systemCount: packageBasedSystems.data.total,
+          systemCount: packageBasedSystems.total,
           hashCommitCount: '-',
         },
       ];

--- a/src/routes/InventoryComponents/BifrostPage.test.js
+++ b/src/routes/InventoryComponents/BifrostPage.test.js
@@ -14,9 +14,7 @@ import {
 jest.mock('@redhat-cloud-services/frontend-components-utilities/interceptors');
 
 describe('BifrostPage', () => {
-  const axiosMock = jest.fn(async () => ({
-    data: mockedBootCStatusData,
-  }));
+  const axiosMock = jest.fn(async () => mockedBootCStatusData);
 
   beforeEach(() => {
     useAxiosWithPlatformInterceptors.mockImplementation(() => ({


### PR DESCRIPTION
A regression happened where when you load the images table, it would remain in a persistent loading state. This PR fixes that issue.

To test:
- go to `/inventory` and click the images button for "View by images"

See that the table constantly shows loading state, but the fetch happens.