### PR TITLE
fix(RHINENG-15664): modal links support trailing slash

### DIFF
--- a/src/Utilities/sharedFunctions.js
+++ b/src/Utilities/sharedFunctions.js
@@ -68,3 +68,5 @@ export const loadSystems = (options, showTags, getEntities) => {
 
   return loadEntities(limitedItems, config, { showTags }, getEntities);
 };
+
+export const removeTrailingSlash = (path) => path.replace(/\/$/, '');

--- a/src/Utilities/sharedFunctions.test.js
+++ b/src/Utilities/sharedFunctions.test.js
@@ -1,6 +1,10 @@
 /* eslint-disable no-constant-condition */
 import { REPORTER_PUPTOO } from './constants';
-import { subtractWeeks, verifyCulledReporter } from './sharedFunctions';
+import {
+  removeTrailingSlash,
+  subtractWeeks,
+  verifyCulledReporter,
+} from './sharedFunctions';
 
 describe('sharedFunctions', () => {
   describe('verfiyDisconnectedSystem', () => {
@@ -37,6 +41,19 @@ describe('sharedFunctions', () => {
       const testDate = new Date('2022-07-20T10:07:08.313Z');
       const result = subtractWeeks(1, testDate);
       expect(result.getDate()).toEqual(13);
+    });
+  });
+  describe('removeTrailingSlash', () => {
+    it('Should remove the last slash', () => {
+      const url = 'https://console.redhat.com/';
+      const result = removeTrailingSlash(url);
+      expect(result).toEqual('https://console.redhat.com');
+    });
+
+    it('Should not modify the url if there is not a slash at the end', () => {
+      const url = 'https://console.redhat.com';
+      const result = removeTrailingSlash(url);
+      expect(result).toEqual('https://console.redhat.com');
     });
   });
 });

--- a/src/components/GeneralInfo/BiosCard/__snapshots__/BiosCard.test.js.snap
+++ b/src/components/GeneralInfo/BiosCard/__snapshots__/BiosCard.test.js.snap
@@ -639,7 +639,7 @@ exports[`BiosCard should render extra 1`] = `
               >
                 <div>
                   <a
-                    href="//undefined"
+                    href="/undefined"
                   >
                     1 tests
                   </a>

--- a/src/components/GeneralInfo/CollectionCard/__snapshots__/CollectionCard.test.js.snap
+++ b/src/components/GeneralInfo/CollectionCard/__snapshots__/CollectionCard.test.js.snap
@@ -421,7 +421,7 @@ exports[`CollectionCard should render extra 1`] = `
               >
                 <div>
                   <a
-                    href="//undefined"
+                    href="/undefined"
                   >
                     1 tests
                   </a>

--- a/src/components/GeneralInfo/InfrastructureCard/InfrastructureCard.test.js
+++ b/src/components/GeneralInfo/InfrastructureCard/InfrastructureCard.test.js
@@ -59,6 +59,17 @@ describe('InfrastructureCard', () => {
     expect(view.asFragment()).toMatchSnapshot();
   });
 
+  it('should render correctly with trailing slash', () => {
+    const store = mockStore(initialState);
+    location.pathname = 'localhost:3000/example/path/';
+    const view = render(
+      <TestWrapper store={store}>
+        <InfrastructureCard />
+      </TestWrapper>
+    );
+    expect(view.asFragment()).toMatchSnapshot();
+  });
+
   it('should render correctly with rhsm facts', () => {
     const store = mockStore({
       ...initialState,

--- a/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
+++ b/src/components/GeneralInfo/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
@@ -1246,6 +1246,172 @@ exports[`InfrastructureCard should render correctly with rhsm facts 1`] = `
 </DocumentFragment>
 `;
 
+exports[`InfrastructureCard should render correctly with trailing slash 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-card"
+    data-ouia-component-id="infrastructure-card"
+    data-ouia-component-type="PF5/Card"
+    data-ouia-safe="true"
+    id=""
+  >
+    <div
+      class="pf-v5-c-card__body"
+    >
+      <div
+        class="pf-v5-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-v5-l-stack__item"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <h1
+              class=""
+              data-ouia-component-id="SystemPropertiesCardTitle"
+              data-ouia-component-type="PF5/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-v5-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-v5-c-content"
+          >
+            <dl
+              class=""
+            >
+              <dt
+                aria-label="Type title"
+                class=""
+                data-ouia-component-id="Type title"
+              >
+                Type
+              </dt>
+              <dd
+                aria-label="Type value"
+                class=""
+                data-ouia-component-id="Type value"
+              >
+                test-type
+              </dd>
+              <dt
+                aria-label="Vendor title"
+                class=""
+                data-ouia-component-id="Vendor title"
+              >
+                Vendor
+              </dt>
+              <dd
+                aria-label="Vendor value"
+                class=""
+                data-ouia-component-id="Vendor value"
+              >
+                test-vendor
+              </dd>
+              <dt
+                aria-label="Public IP title"
+                class=""
+                data-ouia-component-id="Public IP title"
+              >
+                Public IP
+              </dt>
+              <dd
+                aria-label="Public IP value"
+                class=""
+                data-ouia-component-id="Public IP value"
+              >
+                Not available
+              </dd>
+              <dt
+                aria-label="IPv4 addresses title"
+                class=""
+                data-ouia-component-id="IPv4 addresses title"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                aria-label="IPv4 addresses value"
+                class=""
+                data-ouia-component-id="IPv4 addresses value"
+              >
+                <div>
+                  <a
+                    href="localhost:3000/example/path/ipv4"
+                  >
+                    1 address
+                  </a>
+                </div>
+              </dd>
+              <dt
+                aria-label="IPv6 addresses title"
+                class=""
+                data-ouia-component-id="IPv6 addresses title"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                aria-label="IPv6 addresses value"
+                class=""
+                data-ouia-component-id="IPv6 addresses value"
+              >
+                <div>
+                  <a
+                    href="localhost:3000/example/path/ipv6"
+                  >
+                    1 address
+                  </a>
+                </div>
+              </dd>
+              <dt
+                aria-label="FQDN title"
+                class=""
+                data-ouia-component-id="FQDN title"
+              >
+                FQDN
+              </dt>
+              <dd
+                aria-label="FQDN value"
+                class=""
+                data-ouia-component-id="FQDN value"
+              >
+                Not available
+              </dd>
+              <dt
+                aria-label="Interfaces/NICs title"
+                class=""
+                data-ouia-component-id="Interfaces/NICs title"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                aria-label="Interfaces/NICs value"
+                class=""
+                data-ouia-component-id="Interfaces/NICs value"
+              >
+                <div>
+                  <a
+                    href="localhost:3000/example/path/interfaces"
+                  >
+                    1 NIC
+                  </a>
+                </div>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`InfrastructureCard should render enabled/disabled 1`] = `
 <DocumentFragment>
   <div

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -18,6 +18,7 @@ import {
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 import { Link, useLocation } from 'react-router-dom';
+import { removeTrailingSlash } from '../../../Utilities/sharedFunctions';
 
 const valueToText = (value, singular, plural) => {
   if ((value || value === 0) && singular) {
@@ -36,7 +37,8 @@ const valueToText = (value, singular, plural) => {
 export const Clickable = ({ value, target, plural, singular, onClick }) => {
   const { pathname } = useLocation();
   // const { modalId } = useParams(); is causing regression when using LoadingCard derived components in Federated mode
-  const modalId = pathname.split('/').pop();
+  const path = removeTrailingSlash(pathname);
+  const modalId = path.split('/').pop();
   useEffect(() => {
     if (target === modalId) {
       onClick({ value, target });
@@ -44,9 +46,7 @@ export const Clickable = ({ value, target, plural, singular, onClick }) => {
   }, [modalId, target]);
 
   return (
-    <Link to={`${pathname}/${target}`}>
-      {valueToText(value, singular, plural)}
-    </Link>
+    <Link to={`${path}/${target}`}>{valueToText(value, singular, plural)}</Link>
   );
 };
 


### PR DESCRIPTION
[RHINENG-15664](https://issues.redhat.com/browse/RHINENG-15664)

Issue was we weren't expecting a trailing slash in the url.
Added some tests

How to test:
1. Go to Inventory Detail page > Infrastructure Card > IPv4 address link (Other cards could be checked as well, but they use the same component)
2. Make sure the modal opens
3. Now add a `/` to the end of the URL
4. Make sure the modal still works