### PR TITLE
feat(RHINENG-11178): add workspace to system detail card

### DIFF
--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -231,6 +231,20 @@ exports[`GeneralInformation should render correctly 1`] = `
                           </a>
                         </dd>
                         <dt
+                          aria-label="Workspace title"
+                          class=""
+                          data-ouia-component-id="Workspace title"
+                        >
+                          Workspace
+                        </dt>
+                        <dd
+                          aria-label="Workspace value"
+                          class="sentry-mask data-hj-suppress"
+                          data-ouia-component-id="Workspace value"
+                        >
+                          Not available
+                        </dd>
+                        <dt
                           aria-label="SAP title"
                           class=""
                           data-ouia-component-id="SAP title"

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -18,6 +18,7 @@ import {
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 import { Link, useLocation } from 'react-router-dom';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 const valueToText = (value, singular, plural) => {
   if ((value || value === 0) && singular) {
@@ -42,6 +43,14 @@ export const Clickable = ({ value, target, plural, singular, onClick }) => {
       onClick({ value, target });
     }
   }, [modalId, target]);
+
+  if (target?.[0] === '/') {
+    return (
+      <InsightsLink to={target} app="inventory">
+        {valueToText(value, singular, plural)}
+      </InsightsLink>
+    );
+  }
 
   return (
     <Link to={`${pathname}/${target}`}>
@@ -120,7 +129,7 @@ const LoadingCard = ({
                             <Skeleton size={size || SkeletonSize.sm} />
                           )}
                           {!isLoading &&
-                            (onClick && value ? (
+                            ((onClick || target?.[0] === '/') && value ? (
                               <div>
                                 <Clickable
                                   onClick={onClick}

--- a/src/components/GeneralInfo/SystemCard/SystemCard.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.js
@@ -79,6 +79,7 @@ class SystemCardCore extends Component {
       hasHostName,
       hasDisplayName,
       hasAnsibleHostname,
+      hasWorkspace,
       hasSAP,
       hasSystemPurpose,
       hasCPUs,
@@ -89,6 +90,7 @@ class SystemCardCore extends Component {
       extra,
     } = this.props;
     const { isDisplayNameModalOpen, isAnsibleHostModalOpen } = this.state;
+
     return (
       <Fragment>
         <LoadingCard
@@ -156,6 +158,18 @@ class SystemCardCore extends Component {
                     ),
                     size: 'md',
                     customClass: 'sentry-mask data-hj-suppress',
+                  },
+                ]
+              : []),
+            ...(hasWorkspace
+              ? [
+                  {
+                    title: 'Workspace',
+                    value:
+                      entity.groups?.length > 0 && entity.groups?.[0]?.name,
+                    size: 'md',
+                    customClass: 'sentry-mask data-hj-suppress',
+                    target: `/workspaces/${entity.groups?.[0]?.id}`,
                   },
                 ]
               : []),
@@ -302,6 +316,7 @@ SystemCardCore.defaultProps = {
   hasHostName: true,
   hasDisplayName: true,
   hasAnsibleHostname: true,
+  hasWorkspace: true,
   hasSAP: true,
   hasSystemPurpose: true,
   hasCPUs: true,

--- a/src/components/GeneralInfo/SystemCard/SystemCard.test.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.test.js
@@ -15,6 +15,7 @@ const fields = [
   'Host name',
   'Display name',
   'Ansible hostname',
+  'Workspace',
   'SAP',
   'System purpose',
   'Number of CPUs',
@@ -83,7 +84,7 @@ describe('SystemCard', () => {
     fields.forEach(screen.getByText);
     expect(
       screen.getAllByRole('definition').map((element) => element.textContent)
-    ).toEqual(['', '', '', '', '', '', '', '', '', '']);
+    ).toEqual(['', '', '', '', '', '', '', '', '', '', '']);
     screen.getByRole('button', {
       name: /action for host name/i,
     });
@@ -109,6 +110,7 @@ describe('SystemCard', () => {
       'test-display-name',
       'test-ansible-host',
       'Not available',
+      'Not available',
       'Production',
       '1',
       '1',
@@ -116,6 +118,37 @@ describe('SystemCard', () => {
       '0 flags',
       '5 MB',
     ]);
+  });
+
+  it('should render correctly with Workspace', () => {
+    render(
+      <TestWrapper
+        store={mockStore({
+          entityDetails: {
+            entity: {
+              ...initialState.entityDetails.entity,
+              groups: [
+                {
+                  id: 'your_favourite_uuid',
+                  name: 'workspace_name',
+                },
+              ],
+            },
+          },
+          systemProfileStore: {
+            ...initialState.systemProfileStore,
+          },
+        })}
+      >
+        <SystemCard />
+      </TestWrapper>
+    );
+
+    expect(screen.getByText('workspace_name')).toBeInTheDocument();
+    expect(screen.getByText('workspace_name')).toHaveAttribute(
+      'href',
+      '//inventory/workspaces/your_favourite_uuid'
+    );
   });
 
   it('should render correctly with SAP IDS', () => {
@@ -165,6 +198,7 @@ describe('SystemCard', () => {
       'Not available',
       'test-display-name',
       'test-ansible-host',
+      'Not available',
       'Not available',
       'Not available',
       '2',
@@ -417,6 +451,7 @@ describe('SystemCard', () => {
     'hasHostName',
     'hasDisplayName',
     'hasAnsibleHostname',
+    'hasWorkspace',
     'hasSAP',
     'hasSystemPurpose',
     'hasCPUs',
@@ -459,6 +494,7 @@ describe('SystemCard', () => {
       'Not available',
       'test-display-name',
       'test-ansible-host',
+      'Not available',
       'Not available',
       'Production',
       '1',


### PR DESCRIPTION
Added Workspace to SystemCard in System detail page

Steps to test:
1. Go to System detail page
2. Observe System properties card - Workspace field
    - Not available on a system not assigned to a workspace
![image](https://github.com/user-attachments/assets/b8ed2861-4c58-46db-9e97-6ae79ad1195b)
    - link to a workspace on a system assigned to a workspace 
![image](https://github.com/user-attachments/assets/372b87d3-08cf-43d0-b58c-ac9e1fe9a4e8)

Before: 
![image](https://github.com/user-attachments/assets/b4557553-e6e5-437c-a9a9-66c196b77a4b)
