### PR TITLE
fix(RHINENG-15591): Fix OUIA ID passing for BaseDropdown component

### DIFF
--- a/src/components/InventoryHostStaleness/BaseDropDown.js
+++ b/src/components/InventoryHostStaleness/BaseDropDown.js
@@ -62,7 +62,7 @@ const BaseDropdown = ({
           width: '200px',
         }}
         status={!isFormValid && 'danger'}
-        data-ouia-component-id={ouiaId}
+        ouiaId={ouiaId}
       >
         {getNameByValue(selected)}
       </MenuToggle>
@@ -130,7 +130,6 @@ BaseDropdown.propTypes = {
   placeholder: PropTypes.string,
   title: PropTypes.string,
   currentItem: PropTypes.number,
-  filter: PropTypes.object,
   newFormValues: PropTypes.any,
   setNewFormValues: PropTypes.any,
   edit: PropTypes.bool,

--- a/src/components/InventoryHostStaleness/__test__/BaseDropdown.test.js
+++ b/src/components/InventoryHostStaleness/__test__/BaseDropdown.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import BaseDropdown from '../BaseDropDown';
+
+describe('BaseDropdown', () => {
+  it('renders OUIA ID attributes', () => {
+    render(
+      <BaseDropdown
+        ouiaId={`TestOuiaIdValue`}
+        dropdownItems={[
+          { name: 'test1', value: 'test1' },
+          { name: 'test2', value: 'test2' },
+        ]}
+        currentItem={'test1'}
+        disabled={false}
+        title={'test1'}
+        isEditing={false}
+        newFormValues={[]}
+        setNewFormValues={jest.fn()}
+        setIsFormValid={jest.fn()}
+        modalMessage={'Modal message'}
+        isFormValid={true}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /test1/i,
+      })
+    ).toHaveAttribute('data-ouia-component-id', 'TestOuiaIdValue');
+  });
+});


### PR DESCRIPTION
This makes BaseDropdown to properly pass the OUIA ID prop. This was broken due to PF upgrades and end of direct `data-ouia-component-id` support.

Fixes https://issues.redhat.com/browse/RHINENG-15591.