### PR TITLE
fix(Workspaces page): Fix infinite quickstarts open

### DIFF
--- a/src/components/InventoryGroups/GetHelpExpandable.js
+++ b/src/components/InventoryGroups/GetHelpExpandable.js
@@ -21,7 +21,7 @@ const QuickstartButton = ({ quickStartId, children }) => {
       variant="link"
       className="ins-c-groups-help-expandable__link"
       size="lg"
-      onClick={quickStarts.activateQuickstart(quickStartId)}
+      onClick={() => quickStarts.activateQuickstart(quickStartId)}
     >
       {children} <ArrowRightIcon />
     </Button>


### PR DESCRIPTION
No jira.

The workspaces page had infinite quickstarts tab open also triggering new requests.