### PR TITLE
fix: Fix bugs with staleness and groups endpoints handlers

### DIFF
--- a/src/api/hostInventoryApi.ts
+++ b/src/api/hostInventoryApi.ts
@@ -19,6 +19,7 @@ import { ApiHostGroupAddHostListToGroupParams } from '@redhat-cloud-services/hos
 import { ApiHostGroupDeleteHostsFromGroupParams } from '@redhat-cloud-services/host-inventory-client/ApiHostGroupDeleteHostsFromGroup';
 import { ApiGroupGetGroupListParams } from '@redhat-cloud-services/host-inventory-client/ApiGroupGetGroupList';
 import { ApiSystemProfileGetOperatingSystemParams } from '@redhat-cloud-services/host-inventory-client/ApiSystemProfileGetOperatingSystem';
+import { ApiStalenessUpdateStalenessParams } from '@redhat-cloud-services/host-inventory-client/ApiStalenessUpdateStaleness';
 
 export const INVENTORY_API_BASE = '/api/inventory/v1';
 
@@ -183,16 +184,23 @@ const getTags = async ({
 const getDefaultStaleness = async ({
   options,
 }: ApiStalenessGetDefaultStalenessParams = {}) =>
-  await hostInventoryApi.apiStalenessGetDefaultStaleness(
-    // @ts-expect-error The types for the inline paramters are all wrongly marked as required while they can be optional
-    options
-  );
+  await hostInventoryApi.apiStalenessGetDefaultStaleness({ options });
 
 const createStaleness = async ({
   stalenessIn,
   options,
 }: ApiStalenessCreateStalenessParams) =>
   await hostInventoryApi.apiStalenessCreateStaleness(
+    // @ts-expect-error The types for the inline paramters are all wrongly marked as required while they can be optional
+    stalenessIn,
+    options
+  );
+
+const updateStaleness = async ({
+  stalenessIn,
+  options,
+}: ApiStalenessUpdateStalenessParams) =>
+  await hostInventoryApi.apiStalenessUpdateStaleness(
     // @ts-expect-error The types for the inline paramters are all wrongly marked as required while they can be optional
     stalenessIn,
     options
@@ -345,6 +353,7 @@ export {
   getTags,
   getDefaultStaleness,
   createStaleness,
+  updateStaleness,
   getStaleness,
   patchHostById,
   deleteHostById,

--- a/src/components/InventoryGroups/Modals/CreateGroupModal.js
+++ b/src/components/InventoryGroups/Modals/CreateGroupModal.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import { createGroupSchema } from './ModalSchemas/schemes';
 import Modal from './Modal';
 import apiWithToast from '../utils/apiWithToast';
-import { createGroup, validateGroupName } from '../utils/api';
+import { validateGroupName } from '../utils/api';
 import { useDispatch } from 'react-redux';
 import awesomeDebouncePromise from 'awesome-debounce-promise';
+import { createGroup } from '../../../api/hostInventoryApi';
 
 export const validate = async (value = '') => {
   if (value.length === 0) {
@@ -41,7 +42,11 @@ const CreateGroupModal = ({
           description: 'Failed to create workspace',
         },
       };
-      return apiWithToast(dispatch, () => createGroup(values), statusMessages);
+      return apiWithToast(
+        dispatch,
+        () => createGroup({ groupIn: values }),
+        statusMessages
+      );
     },
     [isModalOpen]
   );

--- a/src/components/InventoryGroups/utils/api.js
+++ b/src/components/InventoryGroups/utils/api.js
@@ -101,8 +101,6 @@ export const getWritableGroups = async (
 export const getGroupsByIds = (groupIds, search = {}) =>
   getGroupsById({ groupIdList: groupIds, ...search });
 
-export const createGroup = (payload) => createGroup(payload);
-
 // TODO: improve the function to check against all workspaces since now it checks only against first 50 workspaces
 export const validateGroupName = (name) =>
   getGroupList().then((response) =>

--- a/src/components/InventoryHostStaleness/HostStalenessCard.js
+++ b/src/components/InventoryHostStaleness/HostStalenessCard.js
@@ -30,12 +30,12 @@ import {
   fetchDefaultStalenessValues,
   fetchEdgeSystem,
   fetchStalenessData,
-  patchStalenessData,
   postStalenessData,
 } from '../../api';
 import { addNotification as addNotificationAction } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
+import { updateStaleness } from '../../api/hostInventoryApi';
 
 const HostStalenessCard = ({ canModifyHostStaleness }) => {
   const [filter, setFilter] = useState({});
@@ -111,7 +111,7 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
           );
         });
     } else {
-      patchStalenessData(apiData)
+      updateStaleness({ stalenessIn: apiData })
         .then(() => {
           dispatch(
             addNotificationAction({


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-16620, https://issues.redhat.com/browse/RHINENG-16578.

This adds missing endpoints handlers and also makes it pass params correctly. This fixes the group creation and resetting staleness settings to default values.

## How to test

You must be able to create a group. You must be able to reset staleness settings to default values.