### PR TITLE
fix(InventoryTable): RHINENG-16584 - Add columnsProp to effect dependencies

### DIFF
--- a/src/components/InventoryTable/hooks/useColumns.js
+++ b/src/components/InventoryTable/hooks/useColumns.js
@@ -45,6 +45,7 @@ const useColumns = (
       return defaultColumnsFiltered;
     }
   }, [
+    columnsProp,
     showTags,
     Array.isArray(disableDefaultColumns)
       ? disableDefaultColumns.join()


### PR DESCRIPTION
We use `columnsProp`, so it needs to be a dependency. 

**How to test:**

1) Open the Inventory Systems page
2) Navigate to the Workspaces and to a workspace details page (**with systems**)
3) You should see the "Update method" column
4) Navigate to the Inventory Systems page
5) You should **not*& see the "Update method" column