### PR TITLE
fix(RHINENG-16066): Custom staleness menu displays undefined when selecting already selected value

### DIFF
--- a/src/components/InventoryHostStaleness/BaseDropDown.js
+++ b/src/components/InventoryHostStaleness/BaseDropDown.js
@@ -29,8 +29,7 @@ const BaseDropdown = ({
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState(currentItem);
   const onSelect = (event, value) => {
-    let select = dropdownItems.find((item) => item.value === value);
-    setSelected(select.name);
+    setSelected(value);
     setIsOpen(false);
   };
 


### PR DESCRIPTION
`onSelected()` method assigned selected item's `name` instead of the `value`, which caused that `getNameByValue(selected) `always returned `undefined`. However, the `undefined` text was visible only if user had selected item from menu, that had been already selected - that was the only case, when `useEffect()` reacting on `currentItem`'s change didn't override the `undefined` text.