### PR TITLE
fix(GroupSystems): RHINENG-16584 - Copy array to not mutate columns

### DIFF
--- a/src/components/GroupSystems/helpers.js
+++ b/src/components/GroupSystems/helpers.js
@@ -10,7 +10,7 @@ export const prepareColumnsCoventional = (
   // hides the "groups" column
   const columns = hideGroupColumn
     ? initialColumns.filter(({ key }) => key !== 'groups')
-    : initialColumns;
+    : [...initialColumns];
 
   // additionally insert the "update method" column
   columns.splice(columns.length - 2 /* must be the 3rd col from the end */, 0, {
@@ -62,7 +62,7 @@ export const prepareColumnsImmutable = (
   // hides the "groups" column
   const columns = hideGroupColumn
     ? initialColumns.filter(({ key }) => key !== 'groups')
-    : initialColumns;
+    : [...initialColumns];
   columns[columns.findIndex(({ key }) => key === 'display_name')].renderFunc = (
     value,
     hostId


### PR DESCRIPTION
Fixes duplicate and unnecessary "update_method" columns in SytemsTable.

How to test:

1) Open the Inventory Systems page
2) Navigate to the Workspaces and to a workspace details page (with systems)
3) You should see the "Update method" column
4) Open the "add systems" modal and add systems to the workspace and save.
5) Navigate to the Inventory Systems page
6) You should *not& see any "Update method" columns