### PR TITLE
fix(TagsModal): RHINENG-12940 - Set activeSystemTag more explicitly

### DIFF
--- a/src/Utilities/TagsModal.js
+++ b/src/Utilities/TagsModal.js
@@ -31,11 +31,16 @@ const TagsModal = ({ filterTagsBy, onToggleModal, onApply, getTags }) => {
       entities?.tagModalLoaded || entityDetails?.tagModalLoaded
   );
 
-  const activeSystemTag = useSelector(({ entities, entityDetails }) =>
-    entities?.activeSystemTag?.created
-      ? entities.activeSystemTag
-      : entityDetails?.entity
-  );
+  const activeSystemTag = useSelector(({ entities, entityDetails }) => {
+    if (entityDetails?.entity) {
+      return entityDetails?.entity;
+    }
+
+    if (entities?.activeSystemTag) {
+      return entities.activeSystemTag;
+    }
+  });
+
   const tags = useSelector(({ entities, entityDetails }) => {
     const activeTags =
       entities?.activeSystemTag?.tags || entityDetails?.entity?.tags;
@@ -72,17 +77,21 @@ const TagsModal = ({ filterTagsBy, onToggleModal, onApply, getTags }) => {
     setFilterBy(filterTagsBy);
   }, [filterTagsBy]);
 
-  const fetchTags = (pagination, filterBy) => {
-    if (!activeSystemTag) {
-      dispatch(fetchAllTags(filterBy, pagination, getTags));
-    } else {
-      setStatePagination(() => pagination);
-    }
-  };
+  const fetchTags = useCallback(
+    (pagination, filterBy) => {
+      if (!activeSystemTag) {
+        dispatch(fetchAllTags(filterBy, pagination, getTags));
+      } else {
+        setStatePagination(() => pagination);
+      }
+    },
+    [activeSystemTag, dispatch, getTags]
+  );
 
-  const debouncedFetch = useCallback(debounce(fetchTags, 800), [
-    activeSystemTag,
-  ]);
+  const debouncedFetch = useCallback(
+    () => debounce(fetchTags, 800),
+    [fetchTags]
+  );
 
   return (
     <TagModal
@@ -143,7 +152,9 @@ const TagsModal = ({ filterTagsBy, onToggleModal, onApply, getTags }) => {
       bulkSelect={{ id: 'bulk-select-tags' }}
       title={
         activeSystemTag
-          ? `${activeSystemTag.display_name} (${tagsCount})`
+          ? `${
+              activeSystemTag.display_name || activeSystemTag.name
+            } (${tagsCount})`
           : `All tags in inventory (${tagsCount})`
       }
     />

--- a/src/Utilities/TagsModal.test.js
+++ b/src/Utilities/TagsModal.test.js
@@ -92,13 +92,11 @@ describe('TagsModal', () => {
         })
       ).toBeVisible();
 
-      expect(screen.getAllByRole('cell')).toHaveLength(4);
+      expect(screen.getAllByRole('cell')).toHaveLength(3);
       screen
         .getAllByRole('cell')
         .forEach((cell, index) =>
-          expect(cell).toHaveTextContent(
-            ['', 'some', 'test', 'something'][index]
-          )
+          expect(cell).toHaveTextContent(['some', 'test', 'something'][index])
         );
     });
 

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -295,10 +295,22 @@ function selectFilter(
   };
 }
 
+const getActiveSystemTag = (state, meta) => {
+  if (state.rows) {
+    return state.rows.find(
+      ({ id, insightsId, insights_id }) =>
+        meta.systemId === insightsId || insights_id || id
+    );
+  }
+  if (state.entity) {
+    return state.entity;
+  }
+  return {};
+};
+
 export function showTags(state, { payload, meta }) {
-  const { tags, ...activeSystemTag } = state.rows
-    ? state.rows.find(({ id }) => meta.systemId === id)
-    : state.entity || {};
+  const activeSystemTag = getActiveSystemTag(state, meta);
+
   return {
     ...state,
     tagModalLoaded: true,
@@ -314,9 +326,8 @@ export function showTags(state, { payload, meta }) {
 }
 
 export function showTagsPending(state, { meta }) {
-  const { tags, ...activeSystemTag } = state.rows
-    ? state.rows.find(({ id }) => meta.systemId === id)
-    : state.entity || {};
+  const activeSystemTag = getActiveSystemTag(state, meta);
+
   return {
     ...state,
     tagModalLoaded: false,


### PR DESCRIPTION
This fixes issues in applications like Compliance and Tasks, where the TagsModal misbehaves. 

The reason for this is that these applications do not use the inventory/insights ID of the systems as the `id` prop for their rows in the `InventoryTable`.

Changing the issue in the applications for them to use the inventory ID as `id` property might cause issues as these might rely on the `id` prop being their app specific systems ID. 

This PR adds properties ( id, insightsId, insights_id) to the lookup of the entity to set as activeSystemTag.

It also makes the setting of activeSystemTag more explicit to ensure the correct data is used in the modal even if the other data set exists.


**How to test:**

1) Run the Inventory with this PR
2) Open the Systems page
2.1) Verify the "tags links" in the table correctly open a TagModal showing the systems tags and no selection or apply button
2.2) Verify the Tags filters "More link" opens a TagModal correctly showing **all** tags available in the inventory, and it shows selection boxes as well as a apply button
2.2.1) Verify selected tags are applied as filters when clicking "Apply"
3) Open the details of a system
3.1) Verify the "tags link" opens a TagModal showing the systems tags and no selection or apply button.
4) Open the Compliance Systems page
4.1) Verify the things as with the Systems page in the Inventory and make sure the filter and tags link in each row open the correct TagModal


