### PR TITLE
chore(RHINENG-16241): Add help tooltip to RHC status

### DIFF
--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -71,7 +71,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                               aria-disabled="false"
                               aria-label="Action for Host name"
                               class="pf-v5-c-button pf-m-plain ins-active-general_information__popover-icon"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-7"
                               data-ouia-component-type="PF5/Button"
                               data-ouia-safe="true"
                               type="button"
@@ -114,7 +114,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                               aria-disabled="false"
                               aria-label="Action for Display name"
                               class="pf-v5-c-button pf-m-plain ins-active-general_information__popover-icon"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-8"
                               data-ouia-component-type="PF5/Button"
                               data-ouia-safe="true"
                               type="button"
@@ -179,7 +179,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                               aria-disabled="false"
                               aria-label="Action for Ansible hostname"
                               class="pf-v5-c-button pf-m-plain ins-active-general_information__popover-icon"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-9"
                               data-ouia-component-type="PF5/Button"
                               data-ouia-safe="true"
                               type="button"
@@ -617,7 +617,36 @@ exports[`GeneralInformation should render correctly 1`] = `
                           class=""
                           data-ouia-component-id="RHC title"
                         >
-                          RHC
+                          <span>
+                            RHC
+                          </span>
+                          <div
+                            style="display: contents;"
+                          >
+                            <button
+                              aria-disabled="false"
+                              aria-label="Action for RHC"
+                              class="pf-v5-c-button pf-m-plain ins-active-general_information__popover-icon"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                              data-ouia-component-type="PF5/Button"
+                              data-ouia-safe="true"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v5-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
                         </dt>
                         <dd
                           aria-label="RHC value"
@@ -735,7 +764,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                               aria-label="Details"
                               aria-labelledby="simple-node0 expand-toggle0"
                               class="pf-v5-c-button pf-m-plain"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-11"
                               data-ouia-component-type="PF5/Button"
                               data-ouia-safe="true"
                               id="expand-toggle0"
@@ -840,7 +869,7 @@ exports[`GeneralInformation should render correctly 1`] = `
                               aria-label="Details"
                               aria-labelledby="simple-node1 expand-toggle1"
                               class="pf-v5-c-button pf-m-plain"
-                              data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-12"
                               data-ouia-component-type="PF5/Button"
                               data-ouia-safe="true"
                               id="expand-toggle1"

--- a/src/components/GeneralInfo/SystemCard/SystemCard.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.js
@@ -2,32 +2,13 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import LoadingCard from '../LoadingCard';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { propertiesSelector } from '../selectors';
 import { editAnsibleHost, editDisplayName } from '../../../store/actions';
 import TextInputModal from '../TextInputModal';
-import { Button, Popover } from '@patternfly/react-core';
+import TitleWithPopover from '../TitleWithPopover';
 import EditButton from '../EditButton';
 import { generalMapper } from '../dataMapper';
 import { extraShape } from '../../../constants';
-
-const TitleWithPopover = ({ title, content }) => (
-  <React.Fragment>
-    <span>{title}</span>
-    <Popover
-      headerContent={<div>{title}</div>}
-      bodyContent={<div>{content}</div>}
-    >
-      <Button
-        variant="plain"
-        aria-label={`Action for ${title}`}
-        className="ins-active-general_information__popover-icon"
-      >
-        <OutlinedQuestionCircleIcon />
-      </Button>
-    </Popover>
-  </React.Fragment>
-);
 
 class SystemCardCore extends Component {
   state = {
@@ -325,11 +306,6 @@ SystemCardCore.defaultProps = {
   hasCPUFlags: true,
   hasRAM: true,
   extra: [],
-};
-
-TitleWithPopover.propTypes = {
-  title: PropTypes.string.isRequired,
-  content: PropTypes.string.isRequired,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/src/components/GeneralInfo/SystemStatusCard/SystemStatusCard.js
+++ b/src/components/GeneralInfo/SystemStatusCard/SystemStatusCard.js
@@ -3,8 +3,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import LoadingCard from '../LoadingCard';
+import TitleWithPopover from '../TitleWithPopover';
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import { systemStatus } from '../selectors';
+import { RHC_TOOLTIP_MESSAGE } from '../../../constants';
 
 const SystemStatusCardCore = ({
   detailLoaded,
@@ -77,7 +79,13 @@ const SystemStatusCardCore = ({
       ...(hasRHC
         ? [
             {
-              title: 'RHC',
+              title: (
+                <TitleWithPopover
+                  title="RHC"
+                  content={RHC_TOOLTIP_MESSAGE}
+                  headerContent="RHC (Remote host configuration)"
+                />
+              ),
               value: systemProfile?.rhc_client_id
                 ? 'Connected'
                 : 'Not available',

--- a/src/components/GeneralInfo/SystemStatusCard/SystemStatusCard.test.js
+++ b/src/components/GeneralInfo/SystemStatusCard/SystemStatusCard.test.js
@@ -3,6 +3,8 @@ import SystemStatusCard from './SystemStatusCard';
 import configureStore from 'redux-mock-store';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { TestWrapper } from '../../../Utilities/TestingUtilities';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -73,5 +75,36 @@ describe('SystemStatusCard', () => {
     expect(screen.getByLabelText('Last seen value')).toHaveTextContent(
       '06 Mar 2025 00:00 UTC'
     );
+  });
+
+  it('should render correctly with data', async () => {
+    const store = mockStore(initialState);
+    render(
+      <TestWrapper store={store}>
+        <SystemStatusCard />
+      </TestWrapper>
+    );
+
+    expect(
+      screen.queryByText(
+        /the displayed rhc status indicates that the rhc client is installed and configured but may not reflect actual connectivity\. for further troubleshooting, please visit \./i
+      )
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /action for rhc/i })
+    );
+
+    expect(
+      screen.getByText(
+        /the displayed rhc status indicates that the rhc client is installed and configured but may not reflect actual connectivity\. for further troubleshooting, please visit \./i
+      )
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: /rhc-remediations-link/i,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/GeneralInfo/SystemStatusCard/__snapshots__/SystemStatusCard.test.js.snap
+++ b/src/components/GeneralInfo/SystemStatusCard/__snapshots__/SystemStatusCard.test.js.snap
@@ -88,7 +88,36 @@ exports[`SystemStatusCard should not render hasLastCheckIn 1`] = `
                 class=""
                 data-ouia-component-id="RHC title"
               >
-                RHC
+                <span>
+                  RHC
+                </span>
+                <div
+                  style="display: contents;"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="Action for RHC"
+                    class="pf-v5-c-button pf-m-plain ins-active-general_information__popover-icon"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                      />
+                    </svg>
+                  </button>
+                </div>
               </dt>
               <dd
                 aria-label="RHC value"
@@ -300,7 +329,36 @@ exports[`SystemStatusCard should not render hasRegistered 1`] = `
                 class=""
                 data-ouia-component-id="RHC title"
               >
-                RHC
+                <span>
+                  RHC
+                </span>
+                <div
+                  style="display: contents;"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="Action for RHC"
+                    class="pf-v5-c-button pf-m-plain ins-active-general_information__popover-icon"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                      />
+                    </svg>
+                  </button>
+                </div>
               </dt>
               <dd
                 aria-label="RHC value"
@@ -406,7 +464,36 @@ exports[`SystemStatusCard should not render hasState 1`] = `
                 class=""
                 data-ouia-component-id="RHC title"
               >
-                RHC
+                <span>
+                  RHC
+                </span>
+                <div
+                  style="display: contents;"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="Action for RHC"
+                    class="pf-v5-c-button pf-m-plain ins-active-general_information__popover-icon"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                      />
+                    </svg>
+                  </button>
+                </div>
               </dt>
               <dd
                 aria-label="RHC value"
@@ -550,7 +637,36 @@ exports[`SystemStatusCard should render correctly - no data 1`] = `
                 class=""
                 data-ouia-component-id="RHC title"
               >
-                RHC
+                <span>
+                  RHC
+                </span>
+                <div
+                  style="display: contents;"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="Action for RHC"
+                    class="pf-v5-c-button pf-m-plain ins-active-general_information__popover-icon"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                      />
+                    </svg>
+                  </button>
+                </div>
               </dt>
               <dd
                 aria-label="RHC value"
@@ -676,7 +792,36 @@ exports[`SystemStatusCard should render correctly with data 1`] = `
                 class=""
                 data-ouia-component-id="RHC title"
               >
-                RHC
+                <span>
+                  RHC
+                </span>
+                <div
+                  style="display: contents;"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="Action for RHC"
+                    class="pf-v5-c-button pf-m-plain ins-active-general_information__popover-icon"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                      />
+                    </svg>
+                  </button>
+                </div>
               </dt>
               <dd
                 aria-label="RHC value"

--- a/src/components/GeneralInfo/TitleWithPopover.js
+++ b/src/components/GeneralInfo/TitleWithPopover.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Button, Popover } from '@patternfly/react-core';
+
+const TitleWithPopover = ({ title, content, headerContent }) => (
+  <React.Fragment>
+    <span>{title}</span>
+    <Popover
+      headerContent={<div>{headerContent || title}</div>}
+      bodyContent={<div>{content}</div>}
+    >
+      <Button
+        variant="plain"
+        aria-label={`Action for ${title}`}
+        className="ins-active-general_information__popover-icon"
+      >
+        <OutlinedQuestionCircleIcon />
+      </Button>
+    </Popover>
+  </React.Fragment>
+);
+
+TitleWithPopover.propTypes = {
+  title: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  headerContent: PropTypes.string,
+};
+
+export default TitleWithPopover;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,11 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   HOST_GROUP_CHIP,
   RHCD_FILTER_KEY,
   UPDATE_METHOD_KEY,
 } from './Utilities/constants';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 export const tagsMapper = (acc, curr) => {
   let [namespace, keyValue] = curr.split('/');
@@ -259,6 +261,19 @@ export const NO_MODIFY_HOST_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify this host. Contact your organization administrator.';
 export const NO_MANAGE_USER_ACCESS_TOOLTIP_MESSAGE =
   'You must be an organization administrator to modify User Access configuration.';
+const REMEDIATIONS_DISPLAY = 'Automation Toolkit > Remediations';
+const REMEDIATIONS_LINK = (
+  <InsightsLink aria-label="rhc-remediations-link" to={'/'} app="remediations">
+    {REMEDIATIONS_DISPLAY}
+  </InsightsLink>
+);
+export const RHC_TOOLTIP_MESSAGE = (
+  <span>
+    The displayed RHC status indicates that the RHC client is installed and
+    configured but may not reflect actual connectivity. For further
+    troubleshooting, please visit {REMEDIATIONS_LINK}.
+  </span>
+);
 export const GENERAL_GROUPS_WRITE_PERMISSION = 'inventory:groups:write';
 export const GROUPS_WILDCARD = 'inventory:groups:*';
 export const INVENTORY_WILDCARD = 'inventory:*:*';


### PR DESCRIPTION
This PR adds a tooltip to the RHC status on the inventory details screen. To test, go to Inventory -> System Details and see the RHC property of the System status card. The property should now have an icon and the text should match:

"The displayed RHC status indicates that the RHC client is installed and configured but may not reflect actual connectivity. For further troubleshooting, please visit Automation Toolkit > Remediations."