### PR TITLE
fix(RHINENG-16137): Use host type filter 'nil' when adding hosts

### DIFF
--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -25,7 +25,7 @@ import {
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
 import { hybridInventoryTabKeys } from '../../Utilities/constants';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
-import { getHostList } from '../../api/hostInventoryApi';
+import { getHostsCount } from './helpers/getHostsCount';
 
 const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
 
@@ -74,36 +74,20 @@ const InventoryGroupDetail = ({ groupId }) => {
 
   useEffect(() => {
     // determines the active tab opened by default
-    const lookUpAvailableSystems = async () => {
-      const conventionalSystems = await getHostList({
-        groupName,
-        perPage: 1,
-        page: 1,
-        filter: { system_profile: { host_type: 'edge' } },
-      });
+    const setInitialTab = async () => {
+      const hostsCount = await getHostsCount({ groupName });
 
-      const immutableSystems = await getHostList({
-        groupName,
-        perPage: 1,
-        page: 1,
-        filter: { system_profile: { host_type: 'nil' } },
-      });
-
-      if (immutableSystems.data.total > 0) {
+      if (hostsCount.immutableHostsCount > 0) {
         setHasEdgeImages(true);
 
-        if (conventionalSystems.data.total === 0) {
+        if (hostsCount.conventionalHostsCount === 0) {
           setActiveTab(hybridInventoryTabKeys.immutable.key);
         }
       }
     };
 
     if (edgeParityEnabled) {
-      try {
-        lookUpAvailableSystems();
-      } catch (error) {
-        console.error(error);
-      }
+      setInitialTab();
     }
   }, [edgeParityEnabled, groupName]);
 

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -23,16 +23,12 @@ import {
   EmptyStateNoAccessToSystems,
 } from './EmptyStateNoAccess';
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
-import axios from 'axios';
-import {
-  INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS,
-  INVENTORY_TOTAL_FETCH_EDGE_PARAMS,
-  INVENTORY_TOTAL_FETCH_URL_SERVER,
-  hybridInventoryTabKeys,
-} from '../../Utilities/constants';
+import { hybridInventoryTabKeys } from '../../Utilities/constants';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+import { getHostList } from '../../api/hostInventoryApi';
 
 const GroupDetailInfo = lazy(() => import('./GroupDetailInfo'));
+
 const InventoryGroupDetail = ({ groupId }) => {
   const [activeTabKey, setActiveTabKey] = useState(0);
 
@@ -64,48 +60,52 @@ const InventoryGroupDetail = ({ groupId }) => {
     return () => {
       dispatch({ type: 'GROUP_DETAIL_RESET' });
     };
-  }, [canViewGroup]);
+  }, [canViewGroup, groupId, dispatch]);
 
   useEffect(() => {
     // if available, change ID to the group's name in the window title
     chrome?.updateDocumentTitle?.(`${groupName || groupId} - Workspaces`);
-  }, [data]);
+  }, [groupName, groupId, chrome]);
 
   // TODO: append search parameter to identify the active tab
 
   const [hasEdgeImages, setHasEdgeImages] = useState(false);
-  const EdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
+  const edgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
 
   useEffect(() => {
-    if (EdgeParityEnabled) {
+    // determines the active tab opened by default
+    const lookUpAvailableSystems = async () => {
+      const conventionalSystems = await getHostList({
+        groupName,
+        perPage: 1,
+        page: 1,
+        filter: { system_profile: { host_type: 'edge' } },
+      });
+
+      const immutableSystems = await getHostList({
+        groupName,
+        perPage: 1,
+        page: 1,
+        filter: { system_profile: { host_type: 'nil' } },
+      });
+
+      if (immutableSystems.data.total > 0) {
+        setHasEdgeImages(true);
+
+        if (conventionalSystems.data.total === 0) {
+          setActiveTab(hybridInventoryTabKeys.immutable.key);
+        }
+      }
+    };
+
+    if (edgeParityEnabled) {
       try {
-        axios
-          .get(
-            `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_EDGE_PARAMS}&group_name=${groupName}`
-          )
-          .then((result) => {
-            const accountHasEdgeImages = result?.data?.total > 0;
-            setHasEdgeImages(accountHasEdgeImages);
-            axios
-              .get(
-                `${INVENTORY_TOTAL_FETCH_URL_SERVER}${INVENTORY_TOTAL_FETCH_CONVENTIONAL_PARAMS}&group_name=${groupName}&filter[system_profile][host_type]=nil`
-              )
-              .then((conventionalImages) => {
-                const accountHasConventionalImages =
-                  conventionalImages?.data?.total > 0;
-                if (accountHasEdgeImages && !accountHasConventionalImages) {
-                  setActiveTab(hybridInventoryTabKeys.immutable.key);
-                } else {
-                  setActiveTab(hybridInventoryTabKeys.conventional.key);
-                }
-              });
-          });
-      } catch (e) {
-        setHasEdgeImages(false);
-        setActiveTab(hybridInventoryTabKeys.conventional.key);
+        lookUpAvailableSystems();
+      } catch (error) {
+        console.error(error);
       }
     }
-  }, [data]);
+  }, [edgeParityEnabled, groupName]);
 
   if (
     (fulfilled && data.total === 0) || // group does not exist
@@ -114,7 +114,7 @@ const InventoryGroupDetail = ({ groupId }) => {
     navigate('/groups');
   }
 
-  return hasEdgeImages && canViewGroup && EdgeParityEnabled ? (
+  return hasEdgeImages && canViewGroup && edgeParityEnabled ? (
     <React.Fragment>
       <GroupDetailHeader groupId={groupId} />
       {canViewGroup ? (
@@ -140,7 +140,7 @@ const InventoryGroupDetail = ({ groupId }) => {
         <PageSection variant="light" type="tabs">
           <Tabs
             activeKey={activeTabKey}
-            onSelect={(event, value) => setActiveTabKey(value)}
+            onSelect={(_event, value) => setActiveTabKey(value)}
             aria-label="Group tabs"
             role="region"
             inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
@@ -186,7 +186,6 @@ const InventoryGroupDetail = ({ groupId }) => {
 
 InventoryGroupDetail.propTypes = {
   groupId: PropTypes.string.isRequired,
-  groupName: PropTypes.string,
 };
 
 export default InventoryGroupDetail;

--- a/src/components/InventoryGroupDetail/helpers/getHostsCount.js
+++ b/src/components/InventoryGroupDetail/helpers/getHostsCount.js
@@ -5,7 +5,16 @@ export const getConventionalHostsCount = (params) =>
     perPage: 1,
     page: 1,
     ...params,
-    filter: { system_profile: { host_type: 'edge' }, ...params.filter },
+    options: {
+      params: {
+        filter: {
+          system_profile: {
+            host_type: 'nil',
+          },
+        },
+      },
+      ...params?.options,
+    },
   });
 
 export const getImmutableHostsCount = (params) =>
@@ -13,18 +22,26 @@ export const getImmutableHostsCount = (params) =>
     perPage: 1,
     page: 1,
     ...params,
-    filter: { system_profile: { host_type: 'nil' }, ...params.filter },
+    options: {
+      params: {
+        filter: {
+          system_profile: {
+            host_type: 'edge',
+          },
+        },
+      },
+      ...params?.options,
+    },
   });
 
 export const getHostsCount = async (params) => {
   try {
-    const conventionalHostsCount = await getConventionalHostsCount(params).data
-      .total;
-    const immutableHostsCount = await getImmutableHostsCount(params).data.total;
+    const conventionalHosts = await getConventionalHostsCount(params);
+    const immutableHosts = await getImmutableHostsCount(params);
 
     return {
-      conventionalHostsCount,
-      immutableHostsCount,
+      conventionalHostsCount: conventionalHosts.total,
+      immutableHostsCount: immutableHosts.total,
     };
   } catch (error) {
     console.error(error);

--- a/src/components/InventoryGroupDetail/helpers/getHostsCount.js
+++ b/src/components/InventoryGroupDetail/helpers/getHostsCount.js
@@ -1,0 +1,37 @@
+import { getHostList } from '../../../api/hostInventoryApi';
+
+export const getConventionalHostsCount = (params) =>
+  getHostList({
+    perPage: 1,
+    page: 1,
+    ...params,
+    filter: { system_profile: { host_type: 'edge' }, ...params.filter },
+  });
+
+export const getImmutableHostsCount = (params) =>
+  getHostList({
+    perPage: 1,
+    page: 1,
+    ...params,
+    filter: { system_profile: { host_type: 'nil' }, ...params.filter },
+  });
+
+export const getHostsCount = async (params) => {
+  try {
+    const conventionalHostsCount = await getConventionalHostsCount(params).data
+      .total;
+    const immutableHostsCount = await getImmutableHostsCount(params).data.total;
+
+    return {
+      conventionalHostsCount,
+      immutableHostsCount,
+    };
+  } catch (error) {
+    console.error(error);
+
+    return {
+      conventionalHostsCount: 0,
+      immutableHostsCount: 0,
+    };
+  }
+};

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -39,7 +39,6 @@ const AddSystemsToGroupModal = ({
   setIsModalOpen,
   groupId,
   groupName,
-  edgeParityIsAllowed,
   activeTab,
 }) => {
   const dispatch = useDispatch();
@@ -121,9 +120,7 @@ const AddSystemsToGroupModal = ({
     'edgeParity.inventory-groups-enabled'
   );
   const edgeParityEnabled =
-    edgeParityIsAllowed &&
-    edgeParityInventoryListEnabled &&
-    edgeParityInventoryGroupsEnabled;
+    edgeParityInventoryListEnabled && edgeParityInventoryGroupsEnabled;
 
   const [selectedImmutableDevices, setSelectedImmutableDevices] = useState([]);
   const selectedImmutableKeys = selectedImmutableDevices.map(
@@ -307,7 +304,6 @@ AddSystemsToGroupModal.propTypes = {
   reloadData: PropTypes.func,
   groupId: PropTypes.string,
   groupName: PropTypes.string,
-  edgeParityIsAllowed: PropTypes.bool,
   activeTab: PropTypes.string,
 };
 

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -33,6 +33,7 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 import { hybridInventoryTabKeys } from '../../../Utilities/constants';
 import { AccountStatContext } from '../../../Contexts';
 import { prepareColumnsCoventional as prepareColumns } from '../../GroupSystems/helpers';
+import { defaultConventionalSystemsGetEntities } from '../helpers/defaultConventionalSystemsGetEntities';
 
 const AddSystemsToGroupModal = ({
   isModalOpen,
@@ -160,19 +161,7 @@ const AddSystemsToGroupModal = ({
   const ConventionalInventoryTable = (
     <InventoryTable
       columns={(columns) => prepareColumns(columns, false, true)}
-      getEntities={async (items, config, showTags, defaultGetEntities) =>
-        await defaultGetEntities(
-          items,
-          {
-            ...config,
-            filters: {
-              ...config.filters,
-              hostTypeFilter: 'nil', // request only conventional systems
-            },
-          },
-          showTags
-        )
-      }
+      getEntities={defaultConventionalSystemsGetEntities}
       variant={TableVariant.compact} // TODO: this doesn't affect the table variant
       tableProps={{
         isStickyHeader: false,

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -163,6 +163,19 @@ const AddSystemsToGroupModal = ({
   const ConventionalInventoryTable = (
     <InventoryTable
       columns={(columns) => prepareColumns(columns, false, true)}
+      getEntities={async (items, config, showTags, defaultGetEntities) =>
+        await defaultGetEntities(
+          items,
+          {
+            ...config,
+            filters: {
+              ...config.filters,
+              hostTypeFilter: 'nil', // request only conventional systems
+            },
+          },
+          showTags
+        )
+      }
       variant={TableVariant.compact} // TODO: this doesn't affect the table variant
       tableProps={{
         isStickyHeader: false,

--- a/src/components/InventoryGroups/helpers/defaultConventionalSystemsGetEntities.js
+++ b/src/components/InventoryGroups/helpers/defaultConventionalSystemsGetEntities.js
@@ -1,0 +1,17 @@
+export const defaultConventionalSystemsGetEntities = async (
+  items,
+  config,
+  showTags,
+  defaultGetEntities
+) =>
+  await defaultGetEntities(
+    items,
+    {
+      ...config,
+      filters: {
+        ...config.filters,
+        hostTypeFilter: 'nil', // request only conventional systems
+      },
+    },
+    showTags
+  );

--- a/src/components/InventoryGroups/helpers/defaultImmutableSystemsGetEntities.js
+++ b/src/components/InventoryGroups/helpers/defaultImmutableSystemsGetEntities.js
@@ -1,0 +1,17 @@
+export const defaultImmutableSystemsGetEntities = async (
+  items,
+  config,
+  showTags,
+  defaultGetEntities
+) =>
+  await defaultGetEntities(
+    items,
+    {
+      ...config,
+      filters: {
+        ...config.filters,
+        hostTypeFilter: 'edge', // request only edge systems
+      },
+    },
+    showTags
+  );


### PR DESCRIPTION
This fixes https://issues.redhat.com/browse/RHINENG-16137. When adding new hosts to workspace, in the Conventional tab, only conventional systems must be listed.