### PR TITLE
fix(RHINENG-16241): Update text in rhc popover

### DIFF
--- a/src/components/GeneralInfo/SystemStatusCard/SystemStatusCard.test.js
+++ b/src/components/GeneralInfo/SystemStatusCard/SystemStatusCard.test.js
@@ -87,7 +87,7 @@ describe('SystemStatusCard', () => {
 
     expect(
       screen.queryByText(
-        /the displayed rhc status indicates that the rhc client is installed and configured but may not reflect actual connectivity\. for further troubleshooting, please visit \./i
+        /the rhc client was installed and configured but may not reflect actual connectivity\. to view the remediation status of your system, got to and open a remediation that your system is associated with\. under the tab, you will find the \./i
       )
     ).not.toBeInTheDocument();
 
@@ -97,7 +97,7 @@ describe('SystemStatusCard', () => {
 
     expect(
       screen.getByText(
-        /the displayed rhc status indicates that the rhc client is installed and configured but may not reflect actual connectivity\. for further troubleshooting, please visit \./i
+        /the rhc client was installed and configured but may not reflect actual connectivity\. to view the remediation status of your system, got to and open a remediation that your system is associated with\. under the tab, you will find the \./i
       )
     ).toBeInTheDocument();
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -269,9 +269,13 @@ const REMEDIATIONS_LINK = (
 );
 export const RHC_TOOLTIP_MESSAGE = (
   <span>
-    The displayed RHC status indicates that the RHC client is installed and
-    configured but may not reflect actual connectivity. For further
-    troubleshooting, please visit {REMEDIATIONS_LINK}.
+    The RHC client was installed and configured but may not reflect actual
+    connectivity.
+    <br />
+    <br /> To view the remediation status of your system, got to{' '}
+    {REMEDIATIONS_LINK} and open a remediation that your system is associated
+    with. Under the <b>Systems</b> tab, you will find the{' '}
+    <b>Connection Status</b>.
   </span>
 );
 export const GENERAL_GROUPS_WRITE_PERMISSION = 'inventory:groups:write';


### PR DESCRIPTION
This PR updates popover text to the RHC status on the inventory details screen. To test, go to Inventory -> System Details and see the RHC property of the System status card. The property should now have an icon and the text should match:

```
The RHC client was installed and configured but may not reflect actual connectivity.

To view the remediation status of your system, got to Automation Toolkit
> Remediations and open a remediation that your system is associated
with. Under the Systems tab, you will find the Connection Status.
```