### PR TITLE
fix(RHINENG-16137): Fix wrong empty state when no hosts in group

### DIFF
--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -229,6 +229,37 @@ export const hostsInterceptors = {
       }
     );
   },
+  emptyHybridSystems: () => {
+    cy.intercept(
+      '/api/inventory/v1/hosts*',
+      { hostname: 'localhost' },
+      (req) => {
+        if (req.url.includes('filter[system_profile][host_type]=edge')) {
+          req.reply({
+            statusCode: 200,
+            body: {
+              count: 1,
+              page: 1,
+              per_page: DEFAULT_ROW_COUNT,
+              total: 0,
+              results: [],
+            },
+          });
+        } else {
+          req.reply({
+            statusCode: 200,
+            body: {
+              count: 0,
+              page: 1,
+              per_page: DEFAULT_ROW_COUNT,
+              total: 0,
+              results: [],
+            },
+          });
+        }
+      }
+    ).as('emptyHybridSystems');
+  },
 };
 
 export const systemProfileInterceptors = {

--- a/src/components/InventoryGroupDetail/GroupTabDetails.js
+++ b/src/components/InventoryGroupDetail/GroupTabDetails.js
@@ -57,7 +57,7 @@ const GroupTabDetailsWrapper = ({
                   groupName={groupName}
                   groupId={groupId}
                   hostType={hybridInventoryTabKeys.conventional.key}
-                />{' '}
+                />
               </Tab>
               <Tab
                 eventKey={hybridInventoryTabKeys.immutable.key}

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
@@ -1,6 +1,8 @@
 /* eslint-disable rulesdir/disallow-fec-relative-imports */
 import {
   BREADCRUMB,
+  EMPTY_STATE_ICON,
+  EMPTY_STATE_TITLE,
   MENU_ITEM,
   MENU_TOGGLE,
   MODAL_CONTENT,
@@ -9,8 +11,10 @@ import {
 } from '@redhat-cloud-services/frontend-components-utilities';
 import groupDetailFixtures from '../../../cypress/fixtures/groups/620f9ae75A8F6b83d78F3B55Af1c4b2C.json';
 import {
+  featureFlagsInterceptors,
   groupDetailInterceptors,
   groupsInterceptors,
+  hostsInterceptors,
 } from '../../../cypress/support/interceptors';
 import InventoryGroupDetail from './InventoryGroupDetail';
 
@@ -35,6 +39,21 @@ describe('test data', () => {
 });
 
 describe('group detail page', () => {
+  beforeEach(() => {
+    featureFlagsInterceptors.edgeParitySuccessful(); // enable edge parity in this describe block
+  });
+
+  it('renders empty state when no hosts', () => {
+    groupDetailInterceptors.successful();
+    hostsInterceptors.emptyHybridSystems();
+
+    mountPage();
+
+    cy.wait('@emptyHybridSystems');
+    cy.get(EMPTY_STATE_TITLE).contains('No systems added');
+    cy.get(EMPTY_STATE_ICON);
+  });
+
   it('name from server is rendered in header and breadcrumb', () => {
     groupDetailInterceptors.successful();
     mountPage();

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -86,7 +86,7 @@ const InventoryGroupDetail = ({ groupId }) => {
       }
     };
 
-    if (edgeParityEnabled) {
+    if (edgeParityEnabled && groupName) {
       setInitialTab();
     }
   }, [edgeParityEnabled, groupName]);


### PR DESCRIPTION
This is an extra PR to fix the group details page wrongly displaying empty state. The empty state was not showing "No systems added" when there were no hosts in such group. This adds "groupName" to one of the useEffect dependencies so that the request to hosts count is done correctly only when group name is available.

## How to test

Open an empty group, make sure the page shows "No groups added" message.