### PR TITLE
fix(RHINENG-15978): Disable Compliance tab for image mode systems

### DIFF
--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -66,6 +66,7 @@ const appList = {
         <ApplicationTab appName="compliance" title="Compliance" {...props} />
       ),
       nonEdge: true,
+      nonImage: true,
     },
     {
       title: 'Patch',
@@ -131,10 +132,13 @@ const Inventory = () => {
         .replace(' ', '-')
         .toUpperCase() || 'RHEL';
 
+    let imageModeSystem = !!entity?.system_profile?.bootc_status;
     let newApps =
       entity &&
       appList[osSlug]?.map((app) => {
-        app.isDisabled = app.nonEdge && hostType === 'edge' ? true : false;
+        app.isDisabled =
+          (app.nonEdge && hostType === 'edge') ||
+          (app.nonImage && imageModeSystem === true);
         app['data-cy'] = `${app.name}-tab`;
 
         if (app.name === 'ros') {


### PR DESCRIPTION
Disable Compliance tab for Conventonal image mode systems as Compliance doesn't support these.

### How to test:
1. Navigate to inventory systems -> Conventional tab
2. Filter systems by system type "Image mode"
3. Open system details page
4. Observe that Compliance tab is disabled

<img width="1485" alt="Screenshot 2025-04-03 at 11 31 06" src="https://github.com/user-attachments/assets/f6149c3e-77e1-4d11-b2a9-5875b757bded" />
