### PR TITLE
fix(RHINENG-11371): Clear text input after reseting filters in InfoTable

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -86,7 +86,8 @@ export const generateFilters = (
         id: filter.id || `${activeLabel}-${activeKey}`,
         onChange: (_e, newFilter) =>
           onChange(activeKey, newFilter, activeLabel),
-        value: activeFilters[activeKey] && activeFilters[activeKey].value,
+        value:
+          (activeFilters[activeKey] && activeFilters[activeKey].value) || '',
         ...(filter.options && { items: filter.options }),
       },
     };


### PR DESCRIPTION
Table used in modals (Inventory > System's Details > CPU flags || SAP IDs) doesn't clear search input after removing filters. This PR should fix it.