### PR TITLE
feat(RHINENG-14652): Add workloads field to the system props card

### DIFF
--- a/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/src/components/GeneralInfo/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -245,16 +245,16 @@ exports[`GeneralInformation should render correctly 1`] = `
                           Not available
                         </dd>
                         <dt
-                          aria-label="SAP title"
+                          aria-label="Workloads title"
                           class=""
-                          data-ouia-component-id="SAP title"
+                          data-ouia-component-id="Workloads title"
                         >
-                          SAP
+                          Workloads
                         </dt>
                         <dd
-                          aria-label="SAP value"
+                          aria-label="Workloads value"
                           class=""
-                          data-ouia-component-id="SAP value"
+                          data-ouia-component-id="Workloads value"
                         >
                           Not available
                         </dd>

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -34,7 +34,15 @@ const valueToText = (value, singular, plural) => {
   return value || 'Not available';
 };
 
-export const Clickable = ({ value, target, plural, singular, onClick }) => {
+export const Clickable = ({
+  value,
+  target,
+  plural,
+  singular,
+  onClick,
+  workload,
+  title,
+}) => {
   const { pathname } = useLocation();
   // const { modalId } = useParams(); is causing regression when using LoadingCard derived components in Federated mode
   const modalId = pathname.split('/').pop();
@@ -47,14 +55,14 @@ export const Clickable = ({ value, target, plural, singular, onClick }) => {
   if (target?.[0] === '/') {
     return (
       <InsightsLink to={target} app="inventory">
-        {valueToText(value, singular, plural)}
+        {workload ? title : valueToText(value, singular, plural)}
       </InsightsLink>
     );
   }
 
   return (
     <Link to={`${pathname}/${target}`}>
-      {valueToText(value, singular, plural)}
+      {workload ? title : valueToText(value, singular, plural)}
     </Link>
   );
 };
@@ -65,6 +73,8 @@ Clickable.propTypes = {
   onClick: PropTypes.func,
   plural: PropTypes.string,
   singular: PropTypes.string,
+  title: PropTypes.string,
+  workload: PropTypes.string,
 };
 
 const LoadingCard = ({
@@ -109,7 +119,6 @@ const LoadingCard = ({
                       typeof itemTitle === 'string'
                         ? itemTitle
                         : itemTitle?.props?.title;
-
                     return (
                       <Fragment key={key}>
                         <TextListItem

--- a/src/components/GeneralInfo/SystemCard/SystemCard.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.js
@@ -9,8 +9,8 @@ import TitleWithPopover from '../TitleWithPopover';
 import EditButton from '../EditButton';
 import { generalMapper } from '../dataMapper';
 import { extraShape } from '../../../constants';
-import { Clickable } from '../LoadingCard/LoadingCard';
-import { workloadConfigs, workloadsTypesKeys } from './SystemCardConfigs';
+import { workloadsTypesKeys } from './SystemCardConfigs';
+import WorkloadsSection from './Workloads';
 
 class SystemCardCore extends Component {
   state = {
@@ -82,33 +82,6 @@ class SystemCardCore extends Component {
     const workloadsTypes = checkWorkloadsKeys(
       workloadsData,
       workloadsTypesKeys
-    );
-
-    const renderedWorkloads = workloadConfigs(handleClick, workloadsData)
-      .filter(({ type }) => workloadsTypes.includes(type))
-      .map(({ type, title, onClick, target, customRender }) => {
-        if (typeof customRender === 'function') {
-          return <Fragment key={type}>{customRender()}</Fragment>;
-        }
-
-        return (
-          <Clickable
-            key={type}
-            onClick={onClick}
-            target={target}
-            workload={type}
-            title={title}
-          />
-        );
-      });
-
-    const interleavedWorkloads = renderedWorkloads.reduce(
-      (acc, curr, index) => {
-        if (index !== 0) acc.push(', ');
-        acc.push(curr);
-        return acc;
-      },
-      []
     );
 
     return (
@@ -198,7 +171,13 @@ class SystemCardCore extends Component {
                   {
                     title: 'Workloads',
                     size: 'md',
-                    value: <Fragment>{interleavedWorkloads}</Fragment>,
+                    value: (
+                      <WorkloadsSection
+                        handleClick={handleClick}
+                        workloadsData={workloadsData}
+                        workloadsTypes={workloadsTypes}
+                      />
+                    ),
                   },
                 ]
               : [

--- a/src/components/GeneralInfo/SystemCard/SystemCard.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.js
@@ -7,15 +7,10 @@ import { editAnsibleHost, editDisplayName } from '../../../store/actions';
 import TextInputModal from '../TextInputModal';
 import TitleWithPopover from '../TitleWithPopover';
 import EditButton from '../EditButton';
-import { generalMapper, workloadsDataMapper } from '../dataMapper';
+import { generalMapper } from '../dataMapper';
 import { extraShape } from '../../../constants';
 import { Clickable } from '../LoadingCard/LoadingCard';
-import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
-import { Icon, Tooltip } from '@patternfly/react-core';
+import { workloadConfigs, workloadsTypesKeys } from './SystemCardConfigs';
 
 class SystemCardCore extends Component {
   state = {
@@ -75,19 +70,10 @@ class SystemCardCore extends Component {
       hasCPUFlags,
       hasRAM,
       extra,
-      workloadsData,
+      workloadsData = {},
     } = this.props;
     const { isDisplayNameModalOpen, isAnsibleHostModalOpen } = this.state;
-    const workloadsTypesKeys = [
-      'ansible',
-      'crowdstrike',
-      'ibm_db2',
-      'intersystems',
-      'mssql',
-      'oracle_db',
-      'rhel_ai',
-      'sap',
-    ];
+
     function checkWorkloadsKeys(input = {}, referenceKeys) {
       return referenceKeys.filter(
         (key) => typeof input[key] === 'object' && input[key] !== null
@@ -98,135 +84,7 @@ class SystemCardCore extends Component {
       workloadsTypesKeys
     );
 
-    const workloadConfigs = [
-      {
-        type: 'sap',
-        title: 'SAP',
-        onClick: () =>
-          handleClick(
-            'SAP IDs (SID)',
-            generalMapper(workloadsData.sap.sids, 'SID')
-          ),
-        target: 'sap_sids',
-      },
-      {
-        type: 'ansible',
-        title: 'Ansible Automation Platform',
-        onClick: () =>
-          handleClick(
-            'Ansible',
-            workloadsDataMapper({
-              data: [workloadsData.ansible],
-              fieldKeys: [
-                'catalog_worker_version',
-                'controller_version',
-                'hub_version',
-                'sso_version',
-              ],
-            })
-          ),
-        target: 'ansible',
-      },
-      {
-        type: 'mssql',
-        title: 'Microsoft SQL',
-        onClick: () =>
-          handleClick(
-            'Microsoft SQL',
-            workloadsDataMapper({
-              data: [{ version: workloadsData.mssql.version }],
-            })
-          ),
-        target: 'mssql',
-      },
-      {
-        type: 'crowdstrike',
-        title: 'CrowdStrike',
-        onClick: () =>
-          handleClick(
-            'CrowdStrike',
-            workloadsDataMapper({
-              data: [workloadsData.crowdstrike],
-              fieldKeys: ['falcon_aid', 'falcon_backend', 'falcon_version'],
-            })
-          ),
-        target: 'crowdstrike',
-      },
-      {
-        type: 'rhel_ai',
-        title: 'RHEL AI',
-        onClick: () =>
-          handleClick(
-            'RHEL AI',
-            workloadsDataMapper({
-              data: [workloadsData.rhel_ai],
-              fieldKeys: [
-                'amd_gpu_models',
-                'intel_gaudi_hpu_models',
-                'nvidia_gpu_models',
-                'rhel_ai_version_id',
-                'variant',
-              ],
-            })
-          ),
-        target: 'rhel_ai',
-      },
-      {
-        type: 'intersystems',
-        title: 'InterSystems',
-        onClick: () =>
-          handleClick(
-            'InterSystems',
-            workloadsDataMapper({
-              data: workloadsData.intersystems.running_instances,
-              fieldKeys: ['instance_name', 'product', 'version'],
-            })
-          ),
-        target: 'intersystems',
-      },
-      {
-        type: 'ibm_db2',
-        customRender: () => {
-          const isRunning = workloadsData?.ibm_db2?.is_running;
-          return (
-            <>
-              <Icon status={isRunning ? 'success' : 'warning'}>
-                <Tooltip content={isRunning ? 'Running' : 'Failed'}>
-                  {isRunning ? (
-                    <CheckCircleIcon />
-                  ) : (
-                    <ExclamationTriangleIcon />
-                  )}
-                </Tooltip>
-              </Icon>{' '}
-              IBM Db2
-            </>
-          );
-        },
-      },
-      {
-        type: 'oracle_db',
-        customRender: () => {
-          const isRunning = workloadsData?.oracle_db?.is_running;
-          return (
-            <>
-              <Icon status={isRunning ? 'success' : 'warning'}>
-                <Tooltip content={isRunning ? 'Running' : 'Failed'}>
-                  {isRunning ? (
-                    <CheckCircleIcon />
-                  ) : (
-                    <ExclamationTriangleIcon />
-                  )}
-                </Tooltip>
-              </Icon>{' '}
-              Oracle Database
-            </>
-          );
-        },
-      },
-    ];
-
-    const renderedWorkloads = workloadConfigs
+    const renderedWorkloads = workloadConfigs(handleClick, workloadsData)
       .filter(({ type }) => workloadsTypes.includes(type))
       .map(({ type, title, onClick, target, customRender }) => {
         if (typeof customRender === 'function') {

--- a/src/components/GeneralInfo/SystemCard/SystemCard.test.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.test.js
@@ -10,13 +10,14 @@ import { rhsmFacts, testProperties } from '../../../__mocks__/selectors';
 import SystemCard from './SystemCard';
 import { TestWrapper } from '../../../Utilities/TestingUtilities';
 import { hostInventoryApi } from '../../../api/hostInventoryApi';
+import { mockWorkloadsData } from '../dataMapper/dataMapper.test';
 
 const fields = [
   'Host name',
   'Display name',
   'Ansible hostname',
   'Workspace',
-  'SAP',
+  'Workloads',
   'System purpose',
   'Number of CPUs',
   'Sockets',
@@ -47,7 +48,7 @@ describe('SystemCard', () => {
       .onGet('/api/inventory/v1/hosts/test-id/system_profile')
       .reply(200, mockedData);
     mock.onGet('/api/inventory/v1/hosts/test-id').reply(200, mockedData);
-        mock.onGet('/api/inventory/v1/hosts/test-id/system_profile?fields%5Bsystem_profile%5D%5B%5D=operating_system').reply(200, mockedData); // eslint-disable-line
+    mock.onGet('/api/inventory/v1/hosts/test-id/system_profile?fields%5Bsystem_profile%5D%5B%5D=operating_system').reply(200, mockedData); // eslint-disable-line
 
     location.pathname = 'localhost:3000/example/path';
 
@@ -151,31 +152,6 @@ describe('SystemCard', () => {
       'href',
       '//inventory/workspaces/your_favourite_uuid'
     );
-  });
-
-  it('should render correctly with SAP IDS', () => {
-    render(
-      <TestWrapper
-        store={mockStore({
-          ...initialState,
-          systemProfileStore: {
-            systemProfile: {
-              loaded: true,
-              ...testProperties,
-              sap_sids: ['AAA', 'BBB'],
-            },
-          },
-        })}
-      >
-        <SystemCard />
-      </TestWrapper>
-    );
-
-    expect(
-      screen.getByRole('definition', {
-        name: /sap value/i,
-      })
-    ).toHaveTextContent('2 identifiers');
   });
 
   it('should render correctly with rhsm facts', () => {
@@ -374,43 +350,6 @@ describe('SystemCard', () => {
       expect(store.getActions().length).toBe(0); // the button is disabled since the input hasn't been changed
     });
 
-    it('should handle click on SAP identifiers', async () => {
-      const handleClick = jest.fn();
-      render(
-        <TestWrapper
-          store={mockStore({
-            ...initialState,
-            systemProfileStore: {
-              systemProfile: {
-                loaded: true,
-                ...testProperties,
-                sap_sids: ['AAA', 'BBB'],
-              },
-            },
-          })}
-          routerProps={{ initialEntries: ['/example/sap_sids'] }}
-        >
-          <SystemCard handleClick={handleClick} />
-        </TestWrapper>
-      );
-
-      await userEvent.click(
-        screen.getByRole('link', {
-          name: /2 identifiers/i,
-        })
-      );
-      expect(handleClick).toHaveBeenCalledWith('SAP IDs (SID)', {
-        cells: [
-          {
-            title: 'SID',
-            transforms: expect.any(Array),
-          },
-        ],
-        filters: [{ type: 'text' }],
-        rows: [['AAA'], ['BBB']],
-      });
-    });
-
     it('should handle click on cpu flags identifiers', async () => {
       const handleClick = jest.fn();
       render(
@@ -449,29 +388,30 @@ describe('SystemCard', () => {
     });
   });
 
-  [
-    'hasHostName',
-    'hasDisplayName',
-    'hasAnsibleHostname',
-    'hasWorkspace',
-    'hasSAP',
-    'hasSystemPurpose',
-    'hasCPUs',
-    'hasSockets',
-    'hasCores',
-    'hasCPUFlags',
-    'hasRAM',
-  ].map((item, index) =>
-    it(`should not render ${item}`, () => {
+  const fieldsToTest = [
+    { prop: 'hasHostName', label: 'Host name' },
+    { prop: 'hasDisplayName', label: 'Display name' },
+    { prop: 'hasAnsibleHostname', label: 'Ansible hostname' },
+    { prop: 'hasWorkspace', label: 'Workspace' },
+    { prop: 'hasSystemPurpose', label: 'System purpose' },
+    { prop: 'hasCPUs', label: 'Number of CPUs' },
+    { prop: 'hasSockets', label: 'Sockets' },
+    { prop: 'hasCores', label: 'Cores per socket' },
+    { prop: 'hasCPUFlags', label: 'CPU flags' },
+    { prop: 'hasRAM', label: 'RAM' },
+  ];
+
+  fieldsToTest.forEach(({ prop, label }) => {
+    it(`should not render ${prop}`, () => {
       render(
         <TestWrapper store={mockStore(initialState)}>
-          <SystemCard {...{ [item]: false }} />
+          <SystemCard {...{ [prop]: false }} />
         </TestWrapper>
       );
 
-      expect(screen.queryByText(fields[index])).not.toBeInTheDocument();
-    })
-  );
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    });
+  });
 
   it('should render extra', () => {
     render(
@@ -507,5 +447,377 @@ describe('SystemCard', () => {
       'test',
       '1 tests',
     ]);
+  });
+
+  const workloadTestCases = [
+    {
+      name: 'SAP',
+      workloads: {
+        sap: {
+          instance_number:
+            'j2r1MRNe49og, df.lWNAV._m_2sbl, KAS1MYAqXXqGIirplJG',
+          sap_system: true,
+          sids: ['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A'],
+          version: 'ezU7Htkuo, GU_aiKHi52n7PFH, ONRu1Ku4_skoUXrR',
+        },
+      },
+      expectedText: 'SAP',
+    },
+    {
+      name: 'Ansible',
+      workloads: {
+        ansible: {
+          catalog_worker_version: '9.8.7, banana.42, 0.0.abc',
+          controller_version: 'x.1.2, foo.bar, 3.3.3',
+          hub_version: 'abc.def, 123.456, xyz.789',
+          sso_version: 'preview-1, glitch.9.9, zz-top.7',
+        },
+      },
+      expectedText: 'Ansible Automation Platform',
+    },
+    {
+      name: 'RHEL AI',
+      workloads: {
+        rhel_ai: {
+          amd_gpu_models: ['Quantum Spark GT, Mangoburst 900X'],
+          intel_gaudi_hpu_models: ['Turbo Flux HL-Ω1, Gaudi++ Phantom Edition'],
+          nvidia_gpu_models: ['RTX Hypernova 12X, GX-99π Phantom'],
+          rhel_ai_version_id: 'vX.Y.Z-beta',
+          variant: 'RHEL AI Galactic',
+        },
+      },
+      expectedText: 'RHEL AI',
+    },
+    {
+      name: 'InterSystems',
+      workloads: {
+        intersystems: {
+          is_intersystems: true,
+          running_instances: [
+            {
+              instance_name: 'NOVA-X, ENV-Δ42',
+              product: 'HyperIRIS',
+              version: '3021.∞, nebula.7',
+            },
+          ],
+        },
+      },
+      expectedText: 'InterSystems',
+    },
+    {
+      name: 'IBM Db2',
+      workloads: {
+        ibm_db2: {
+          is_running: true,
+        },
+      },
+      expectedText: 'IBM Db2',
+    },
+    {
+      name: 'IBM Db2',
+      workloads: {
+        ibm_db2: {
+          is_running: false,
+        },
+      },
+      expectedText: 'IBM Db2',
+    },
+    {
+      name: 'CrowdStrike',
+      workloads: {
+        crowdstrike: {
+          falcon_aid: 'xfoCshFVO6TwXdGHvy',
+          falcon_backend: 'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
+          falcon_version: 'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
+        },
+      },
+      expectedText: 'CrowdStrike',
+    },
+    {
+      name: 'Microsoft SQL',
+      workloads: {
+        mssql: {
+          version: 'nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL',
+        },
+      },
+      expectedText: 'Microsoft SQL',
+    },
+    {
+      name: 'Oracle DB',
+      workloads: {
+        oracle_db: {
+          is_running: true,
+        },
+      },
+      expectedText: 'Oracle Database',
+    },
+    {
+      name: 'Oracle DB',
+      workloads: {
+        oracle_db: {
+          is_running: false,
+        },
+      },
+      expectedText: 'Oracle Database',
+    },
+  ];
+
+  describe('SystemCard workload rendering', () => {
+    it.each(workloadTestCases)(
+      'should render correctly with $name workload',
+      ({ workloads, expectedText }) => {
+        render(
+          <TestWrapper
+            store={mockStore({
+              ...initialState,
+              systemProfileStore: {
+                systemProfile: {
+                  loaded: true,
+                  ...testProperties,
+                  workloads,
+                },
+              },
+            })}
+          >
+            <SystemCard />
+          </TestWrapper>
+        );
+
+        expect(
+          screen.getByRole('definition', {
+            name: /Workloads value/i,
+          })
+        ).toHaveTextContent(expectedText);
+      }
+    );
+
+    it('should render correctly with every workload', () => {
+      render(
+        <TestWrapper
+          store={mockStore({
+            ...initialState,
+            systemProfileStore: {
+              systemProfile: {
+                loaded: true,
+                ...testProperties,
+                workloads: mockWorkloadsData,
+              },
+            },
+          })}
+        >
+          <SystemCard />
+        </TestWrapper>
+      );
+
+      expect(
+        screen.getByRole('definition', {
+          name: /Workloads value/i,
+        })
+      ).toHaveTextContent(
+        /SAP|Ansible|CrowdStrike|RHEL AI|InterSystems|IBM Db2|Microsoft SQL|Oracle Database/
+      );
+    });
+  });
+
+  const workloadClickTestCases = [
+    {
+      name: 'SAP',
+      linkText: /SAP/i,
+      workloads: {
+        sap: {
+          instance_number:
+            'j2r1MRNe49og, df.lWNAV._m_2sbl, KAS1MYAqXXqGIirplJG',
+          sap_system: true,
+          sids: ['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A'],
+          version: 'ezU7Htkuo, GU_aiKHi52n7PFH, ONRu1Ku4_skoUXrR',
+        },
+      },
+      expectedClickTitle: 'SAP IDs (SID)',
+      expectedData: {
+        cells: [
+          {
+            title: 'SID',
+            transforms: expect.any(Array),
+          },
+        ],
+        filters: [{ type: 'text' }],
+        rows: [['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A']],
+      },
+    },
+    {
+      name: 'Ansible',
+      linkText: /Ansible Automation Platform/i,
+      workloads: {
+        ansible: {
+          catalog_worker_version: '9.8.7, banana.42, 0.0.abc',
+          controller_version: 'x.1.2, foo.bar, 3.3.3',
+          hub_version: 'abc.def, 123.456, xyz.789',
+          sso_version: 'preview-1, glitch.9.9, zz-top.7',
+        },
+      },
+      expectedClickTitle: 'Ansible',
+      expectedData: {
+        cells: [
+          { title: 'Catalog Worker Version' },
+          { title: 'Controller Version' },
+          { title: 'Hub Version' },
+          { title: 'Sso Version' },
+        ],
+        filters: [{ type: 'text' }],
+        rows: [
+          [
+            '9.8.7, banana.42, 0.0.abc',
+            'x.1.2, foo.bar, 3.3.3',
+            'abc.def, 123.456, xyz.789',
+            'preview-1, glitch.9.9, zz-top.7',
+          ],
+        ],
+      },
+    },
+    {
+      name: 'RHEL AI',
+      linkText: /RHEL AI/i,
+      workloads: {
+        rhel_ai: {
+          amd_gpu_models: ['Quantum Spark GT, Mangoburst 900X'],
+          intel_gaudi_hpu_models: ['Turbo Flux HL-Ω1, Gaudi++ Phantom Edition'],
+          nvidia_gpu_models: ['RTX Hypernova 12X, GX-99π Phantom'],
+          rhel_ai_version_id: 'vX.Y.Z-beta',
+          variant: 'RHEL AI Galactic',
+        },
+      },
+      expectedClickTitle: 'RHEL AI',
+      expectedData: {
+        cells: [
+          { title: 'Amd Gpu Models' },
+          { title: 'Intel Gaudi Hpu Models' },
+          { title: 'Nvidia Gpu Models' },
+          { title: 'Rhel Ai Version Id' },
+          { title: 'Variant' },
+        ],
+        filters: [{ type: 'text' }],
+        rows: [
+          [
+            'Quantum Spark GT, Mangoburst 900X',
+            'Turbo Flux HL-Ω1, Gaudi++ Phantom Edition',
+            'RTX Hypernova 12X, GX-99π Phantom',
+            'vX.Y.Z-beta',
+            'RHEL AI Galactic',
+          ],
+        ],
+      },
+    },
+    {
+      name: 'InterSystems',
+      linkText: /InterSystems/i,
+      workloads: {
+        intersystems: {
+          is_intersystems: true,
+          running_instances: [
+            {
+              instance_name: 'NOVA-X, ENV-Δ42',
+              product: 'HyperIRIS',
+              version: '3021.∞, nebula.7',
+            },
+          ],
+        },
+      },
+      expectedClickTitle: 'InterSystems',
+      expectedData: {
+        cells: [
+          { title: 'Instance Name' },
+          { title: 'Product' },
+          { title: 'Version' },
+        ],
+        filters: [{ type: 'text' }],
+        rows: [['NOVA-X, ENV-Δ42', 'HyperIRIS', '3021.∞, nebula.7']],
+      },
+    },
+    {
+      name: 'CrowdStrike',
+      linkText: /CrowdStrike/i,
+      workloads: {
+        crowdstrike: {
+          falcon_aid: 'xfoCshFVO6TwXdGHvy',
+          falcon_backend: 'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
+          falcon_version: 'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
+        },
+      },
+      expectedClickTitle: 'CrowdStrike',
+      expectedData: {
+        cells: [
+          { title: 'Falcon Aid' },
+          { title: 'Falcon Backend' },
+          { title: 'Falcon Version' },
+        ],
+        filters: [{ type: 'text' }],
+        rows: [
+          [
+            'xfoCshFVO6TwXdGHvy',
+            'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
+            'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
+          ],
+        ],
+      },
+    },
+    {
+      name: 'Microsoft SQL',
+      linkText: /Microsoft SQL/i,
+      workloads: {
+        mssql: {
+          version: 'nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL',
+        },
+      },
+      expectedClickTitle: 'Microsoft SQL',
+      expectedData: {
+        cells: [{ title: 'Value' }],
+        filters: [{ type: 'text' }],
+        rows: [['nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL']],
+      },
+    },
+  ];
+
+  describe('SystemCard workload clicks', () => {
+    it.each(workloadClickTestCases)(
+      'should handle click on %s Workloads',
+      async ({
+        name,
+        linkText,
+        workloads,
+        expectedClickTitle,
+        expectedData,
+      }) => {
+        const handleClick = jest.fn();
+
+        render(
+          <TestWrapper
+            store={mockStore({
+              ...initialState,
+              systemProfileStore: {
+                systemProfile: {
+                  loaded: true,
+                  ...testProperties,
+                  workloads,
+                },
+              },
+            })}
+            routerProps={{ initialEntries: [`/example/${name.toLowerCase()}`] }}
+          >
+            <SystemCard handleClick={handleClick} />
+          </TestWrapper>
+        );
+
+        await userEvent.click(
+          screen.getByRole('link', {
+            name: linkText,
+          })
+        );
+
+        expect(handleClick).toHaveBeenCalledWith(
+          expectedClickTitle,
+          expectedData
+        );
+      }
+    );
   });
 });

--- a/src/components/GeneralInfo/SystemCard/SystemCard.test.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.test.js
@@ -11,6 +11,10 @@ import SystemCard from './SystemCard';
 import { TestWrapper } from '../../../Utilities/TestingUtilities';
 import { hostInventoryApi } from '../../../api/hostInventoryApi';
 import { mockWorkloadsData } from '../dataMapper/dataMapper.test';
+import {
+  workloadClickTestCases,
+  workloadTestCases,
+} from './SystemCardTestsFixtures';
 
 const fields = [
   'Host name',
@@ -389,28 +393,26 @@ describe('SystemCard', () => {
   });
 
   const fieldsToTest = [
-    { prop: 'hasHostName', label: 'Host name' },
-    { prop: 'hasDisplayName', label: 'Display name' },
-    { prop: 'hasAnsibleHostname', label: 'Ansible hostname' },
-    { prop: 'hasWorkspace', label: 'Workspace' },
-    { prop: 'hasSystemPurpose', label: 'System purpose' },
-    { prop: 'hasCPUs', label: 'Number of CPUs' },
-    { prop: 'hasSockets', label: 'Sockets' },
-    { prop: 'hasCores', label: 'Cores per socket' },
-    { prop: 'hasCPUFlags', label: 'CPU flags' },
-    { prop: 'hasRAM', label: 'RAM' },
+    ['hasHostName', 'Host name'],
+    ['hasDisplayName', 'Display name'],
+    ['hasAnsibleHostname', 'Ansible hostname'],
+    ['hasWorkspace', 'Workspace'],
+    ['hasSystemPurpose', 'System purpose'],
+    ['hasCPUs', 'Number of CPUs'],
+    ['hasSockets', 'Sockets'],
+    ['hasCores', 'Cores per socket'],
+    ['hasCPUFlags', 'CPU flags'],
+    ['hasRAM', 'RAM'],
   ];
 
-  fieldsToTest.forEach(({ prop, label }) => {
-    it(`should not render ${prop}`, () => {
-      render(
-        <TestWrapper store={mockStore(initialState)}>
-          <SystemCard {...{ [prop]: false }} />
-        </TestWrapper>
-      );
+  it.each(fieldsToTest)('should not render %s when disabled', (prop, label) => {
+    render(
+      <TestWrapper store={mockStore(initialState)}>
+        <SystemCard {...{ [prop]: false }} />
+      </TestWrapper>
+    );
 
-      expect(screen.queryByText(label)).not.toBeInTheDocument();
-    });
+    expect(screen.queryByText(label)).not.toBeInTheDocument();
   });
 
   it('should render extra', () => {
@@ -448,119 +450,6 @@ describe('SystemCard', () => {
       '1 tests',
     ]);
   });
-
-  const workloadTestCases = [
-    {
-      name: 'SAP',
-      workloads: {
-        sap: {
-          instance_number:
-            'j2r1MRNe49og, df.lWNAV._m_2sbl, KAS1MYAqXXqGIirplJG',
-          sap_system: true,
-          sids: ['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A'],
-          version: 'ezU7Htkuo, GU_aiKHi52n7PFH, ONRu1Ku4_skoUXrR',
-        },
-      },
-      expectedText: 'SAP',
-    },
-    {
-      name: 'Ansible',
-      workloads: {
-        ansible: {
-          catalog_worker_version: '9.8.7, banana.42, 0.0.abc',
-          controller_version: 'x.1.2, foo.bar, 3.3.3',
-          hub_version: 'abc.def, 123.456, xyz.789',
-          sso_version: 'preview-1, glitch.9.9, zz-top.7',
-        },
-      },
-      expectedText: 'Ansible Automation Platform',
-    },
-    {
-      name: 'RHEL AI',
-      workloads: {
-        rhel_ai: {
-          amd_gpu_models: ['Quantum Spark GT, Mangoburst 900X'],
-          intel_gaudi_hpu_models: ['Turbo Flux HL-Ω1, Gaudi++ Phantom Edition'],
-          nvidia_gpu_models: ['RTX Hypernova 12X, GX-99π Phantom'],
-          rhel_ai_version_id: 'vX.Y.Z-beta',
-          variant: 'RHEL AI Galactic',
-        },
-      },
-      expectedText: 'RHEL AI',
-    },
-    {
-      name: 'InterSystems',
-      workloads: {
-        intersystems: {
-          is_intersystems: true,
-          running_instances: [
-            {
-              instance_name: 'NOVA-X, ENV-Δ42',
-              product: 'HyperIRIS',
-              version: '3021.∞, nebula.7',
-            },
-          ],
-        },
-      },
-      expectedText: 'InterSystems',
-    },
-    {
-      name: 'IBM Db2',
-      workloads: {
-        ibm_db2: {
-          is_running: true,
-        },
-      },
-      expectedText: 'IBM Db2',
-    },
-    {
-      name: 'IBM Db2',
-      workloads: {
-        ibm_db2: {
-          is_running: false,
-        },
-      },
-      expectedText: 'IBM Db2',
-    },
-    {
-      name: 'CrowdStrike',
-      workloads: {
-        crowdstrike: {
-          falcon_aid: 'xfoCshFVO6TwXdGHvy',
-          falcon_backend: 'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
-          falcon_version: 'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
-        },
-      },
-      expectedText: 'CrowdStrike',
-    },
-    {
-      name: 'Microsoft SQL',
-      workloads: {
-        mssql: {
-          version: 'nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL',
-        },
-      },
-      expectedText: 'Microsoft SQL',
-    },
-    {
-      name: 'Oracle DB',
-      workloads: {
-        oracle_db: {
-          is_running: true,
-        },
-      },
-      expectedText: 'Oracle Database',
-    },
-    {
-      name: 'Oracle DB',
-      workloads: {
-        oracle_db: {
-          is_running: false,
-        },
-      },
-      expectedText: 'Oracle Database',
-    },
-  ];
 
   describe('SystemCard workload rendering', () => {
     it.each(workloadTestCases)(
@@ -618,164 +507,6 @@ describe('SystemCard', () => {
       );
     });
   });
-
-  const workloadClickTestCases = [
-    {
-      name: 'SAP',
-      linkText: /SAP/i,
-      workloads: {
-        sap: {
-          instance_number:
-            'j2r1MRNe49og, df.lWNAV._m_2sbl, KAS1MYAqXXqGIirplJG',
-          sap_system: true,
-          sids: ['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A'],
-          version: 'ezU7Htkuo, GU_aiKHi52n7PFH, ONRu1Ku4_skoUXrR',
-        },
-      },
-      expectedClickTitle: 'SAP IDs (SID)',
-      expectedData: {
-        cells: [
-          {
-            title: 'SID',
-            transforms: expect.any(Array),
-          },
-        ],
-        filters: [{ type: 'text' }],
-        rows: [['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A']],
-      },
-    },
-    {
-      name: 'Ansible',
-      linkText: /Ansible Automation Platform/i,
-      workloads: {
-        ansible: {
-          catalog_worker_version: '9.8.7, banana.42, 0.0.abc',
-          controller_version: 'x.1.2, foo.bar, 3.3.3',
-          hub_version: 'abc.def, 123.456, xyz.789',
-          sso_version: 'preview-1, glitch.9.9, zz-top.7',
-        },
-      },
-      expectedClickTitle: 'Ansible',
-      expectedData: {
-        cells: [
-          { title: 'Catalog Worker Version' },
-          { title: 'Controller Version' },
-          { title: 'Hub Version' },
-          { title: 'Sso Version' },
-        ],
-        filters: [{ type: 'text' }],
-        rows: [
-          [
-            '9.8.7, banana.42, 0.0.abc',
-            'x.1.2, foo.bar, 3.3.3',
-            'abc.def, 123.456, xyz.789',
-            'preview-1, glitch.9.9, zz-top.7',
-          ],
-        ],
-      },
-    },
-    {
-      name: 'RHEL AI',
-      linkText: /RHEL AI/i,
-      workloads: {
-        rhel_ai: {
-          amd_gpu_models: ['Quantum Spark GT, Mangoburst 900X'],
-          intel_gaudi_hpu_models: ['Turbo Flux HL-Ω1, Gaudi++ Phantom Edition'],
-          nvidia_gpu_models: ['RTX Hypernova 12X, GX-99π Phantom'],
-          rhel_ai_version_id: 'vX.Y.Z-beta',
-          variant: 'RHEL AI Galactic',
-        },
-      },
-      expectedClickTitle: 'RHEL AI',
-      expectedData: {
-        cells: [
-          { title: 'Amd Gpu Models' },
-          { title: 'Intel Gaudi Hpu Models' },
-          { title: 'Nvidia Gpu Models' },
-          { title: 'Rhel Ai Version Id' },
-          { title: 'Variant' },
-        ],
-        filters: [{ type: 'text' }],
-        rows: [
-          [
-            'Quantum Spark GT, Mangoburst 900X',
-            'Turbo Flux HL-Ω1, Gaudi++ Phantom Edition',
-            'RTX Hypernova 12X, GX-99π Phantom',
-            'vX.Y.Z-beta',
-            'RHEL AI Galactic',
-          ],
-        ],
-      },
-    },
-    {
-      name: 'InterSystems',
-      linkText: /InterSystems/i,
-      workloads: {
-        intersystems: {
-          is_intersystems: true,
-          running_instances: [
-            {
-              instance_name: 'NOVA-X, ENV-Δ42',
-              product: 'HyperIRIS',
-              version: '3021.∞, nebula.7',
-            },
-          ],
-        },
-      },
-      expectedClickTitle: 'InterSystems',
-      expectedData: {
-        cells: [
-          { title: 'Instance Name' },
-          { title: 'Product' },
-          { title: 'Version' },
-        ],
-        filters: [{ type: 'text' }],
-        rows: [['NOVA-X, ENV-Δ42', 'HyperIRIS', '3021.∞, nebula.7']],
-      },
-    },
-    {
-      name: 'CrowdStrike',
-      linkText: /CrowdStrike/i,
-      workloads: {
-        crowdstrike: {
-          falcon_aid: 'xfoCshFVO6TwXdGHvy',
-          falcon_backend: 'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
-          falcon_version: 'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
-        },
-      },
-      expectedClickTitle: 'CrowdStrike',
-      expectedData: {
-        cells: [
-          { title: 'Falcon Aid' },
-          { title: 'Falcon Backend' },
-          { title: 'Falcon Version' },
-        ],
-        filters: [{ type: 'text' }],
-        rows: [
-          [
-            'xfoCshFVO6TwXdGHvy',
-            'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
-            'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
-          ],
-        ],
-      },
-    },
-    {
-      name: 'Microsoft SQL',
-      linkText: /Microsoft SQL/i,
-      workloads: {
-        mssql: {
-          version: 'nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL',
-        },
-      },
-      expectedClickTitle: 'Microsoft SQL',
-      expectedData: {
-        cells: [{ title: 'Value' }],
-        filters: [{ type: 'text' }],
-        rows: [['nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL']],
-      },
-    },
-  ];
 
   describe('SystemCard workload clicks', () => {
     it.each(workloadClickTestCases)(

--- a/src/components/GeneralInfo/SystemCard/SystemCardConfigs.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCardConfigs.js
@@ -1,0 +1,138 @@
+import React from 'react';
+import { generalMapper, workloadsDataMapper } from '../dataMapper';
+import { Icon, Tooltip } from '@patternfly/react-core';
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+} from '@patternfly/react-icons';
+
+export const workloadConfigs = (handleClick, workloadsData) => [
+  {
+    type: 'sap',
+    title: 'SAP',
+    onClick: () =>
+      handleClick(
+        'SAP IDs (SID)',
+        generalMapper(workloadsData.sap.sids, 'SID')
+      ),
+    target: 'sap_sids',
+  },
+  {
+    type: 'ansible',
+    title: 'Ansible Automation Platform',
+    onClick: () =>
+      handleClick(
+        'Ansible',
+        workloadsDataMapper({
+          data: [workloadsData.ansible],
+          fieldKeys: [
+            'catalog_worker_version',
+            'controller_version',
+            'hub_version',
+            'sso_version',
+          ],
+        })
+      ),
+    target: 'ansible',
+  },
+  {
+    type: 'mssql',
+    title: 'Microsoft SQL',
+    onClick: () =>
+      handleClick(
+        'Microsoft SQL',
+        workloadsDataMapper({
+          data: [{ version: workloadsData.mssql.version }],
+        })
+      ),
+    target: 'mssql',
+  },
+  {
+    type: 'crowdstrike',
+    title: 'CrowdStrike',
+    onClick: () =>
+      handleClick(
+        'CrowdStrike',
+        workloadsDataMapper({
+          data: [workloadsData.crowdstrike],
+          fieldKeys: ['falcon_aid', 'falcon_backend', 'falcon_version'],
+        })
+      ),
+    target: 'crowdstrike',
+  },
+  {
+    type: 'rhel_ai',
+    title: 'RHEL AI',
+    onClick: () =>
+      handleClick(
+        'RHEL AI',
+        workloadsDataMapper({
+          data: [workloadsData.rhel_ai],
+          fieldKeys: [
+            'amd_gpu_models',
+            'intel_gaudi_hpu_models',
+            'nvidia_gpu_models',
+            'rhel_ai_version_id',
+            'variant',
+          ],
+        })
+      ),
+    target: 'rhel_ai',
+  },
+  {
+    type: 'intersystems',
+    title: 'InterSystems',
+    onClick: () =>
+      handleClick(
+        'InterSystems',
+        workloadsDataMapper({
+          data: workloadsData.intersystems.running_instances,
+          fieldKeys: ['instance_name', 'product', 'version'],
+        })
+      ),
+    target: 'intersystems',
+  },
+  {
+    type: 'ibm_db2',
+    customRender: () => {
+      const isRunning = workloadsData?.ibm_db2?.is_running;
+      return (
+        <>
+          <Icon status={isRunning ? 'success' : 'warning'}>
+            <Tooltip content={isRunning ? 'Running' : 'Failed'}>
+              {isRunning ? <CheckCircleIcon /> : <ExclamationTriangleIcon />}
+            </Tooltip>
+          </Icon>{' '}
+          IBM Db2
+        </>
+      );
+    },
+  },
+  {
+    type: 'oracle_db',
+    customRender: () => {
+      const isRunning = workloadsData?.oracle_db?.is_running;
+      return (
+        <>
+          <Icon status={isRunning ? 'success' : 'warning'}>
+            <Tooltip content={isRunning ? 'Running' : 'Failed'}>
+              {isRunning ? <CheckCircleIcon /> : <ExclamationTriangleIcon />}
+            </Tooltip>
+          </Icon>{' '}
+          Oracle Database
+        </>
+      );
+    },
+  },
+];
+
+export const workloadsTypesKeys = [
+  'ansible',
+  'crowdstrike',
+  'ibm_db2',
+  'intersystems',
+  'mssql',
+  'oracle_db',
+  'rhel_ai',
+  'sap',
+];

--- a/src/components/GeneralInfo/SystemCard/SystemCardTestsFixtures.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCardTestsFixtures.js
@@ -1,0 +1,268 @@
+export const workloadClickTestCases = [
+  {
+    name: 'SAP',
+    linkText: /SAP/i,
+    workloads: {
+      sap: {
+        instance_number: 'j2r1MRNe49og, df.lWNAV._m_2sbl, KAS1MYAqXXqGIirplJG',
+        sap_system: true,
+        sids: ['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A'],
+        version: 'ezU7Htkuo, GU_aiKHi52n7PFH, ONRu1Ku4_skoUXrR',
+      },
+    },
+    expectedClickTitle: 'SAP IDs (SID)',
+    expectedData: {
+      cells: [
+        {
+          title: 'SID',
+          transforms: expect.any(Array),
+        },
+      ],
+      filters: [{ type: 'text' }],
+      rows: [['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A']],
+    },
+  },
+  {
+    name: 'Ansible',
+    linkText: /Ansible Automation Platform/i,
+    workloads: {
+      ansible: {
+        catalog_worker_version: '9.8.7, banana.42, 0.0.abc',
+        controller_version: 'x.1.2, foo.bar, 3.3.3',
+        hub_version: 'abc.def, 123.456, xyz.789',
+        sso_version: 'preview-1, glitch.9.9, zz-top.7',
+      },
+    },
+    expectedClickTitle: 'Ansible',
+    expectedData: {
+      cells: [
+        { title: 'Catalog Worker Version' },
+        { title: 'Controller Version' },
+        { title: 'Hub Version' },
+        { title: 'Sso Version' },
+      ],
+      filters: [{ type: 'text' }],
+      rows: [
+        [
+          '9.8.7, banana.42, 0.0.abc',
+          'x.1.2, foo.bar, 3.3.3',
+          'abc.def, 123.456, xyz.789',
+          'preview-1, glitch.9.9, zz-top.7',
+        ],
+      ],
+    },
+  },
+  {
+    name: 'RHEL AI',
+    linkText: /RHEL AI/i,
+    workloads: {
+      rhel_ai: {
+        amd_gpu_models: ['Quantum Spark GT, Mangoburst 900X'],
+        intel_gaudi_hpu_models: ['Turbo Flux HL-Ω1, Gaudi++ Phantom Edition'],
+        nvidia_gpu_models: ['RTX Hypernova 12X, GX-99π Phantom'],
+        rhel_ai_version_id: 'vX.Y.Z-beta',
+        variant: 'RHEL AI Galactic',
+      },
+    },
+    expectedClickTitle: 'RHEL AI',
+    expectedData: {
+      cells: [
+        { title: 'Amd Gpu Models' },
+        { title: 'Intel Gaudi Hpu Models' },
+        { title: 'Nvidia Gpu Models' },
+        { title: 'Rhel Ai Version Id' },
+        { title: 'Variant' },
+      ],
+      filters: [{ type: 'text' }],
+      rows: [
+        [
+          'Quantum Spark GT, Mangoburst 900X',
+          'Turbo Flux HL-Ω1, Gaudi++ Phantom Edition',
+          'RTX Hypernova 12X, GX-99π Phantom',
+          'vX.Y.Z-beta',
+          'RHEL AI Galactic',
+        ],
+      ],
+    },
+  },
+  {
+    name: 'InterSystems',
+    linkText: /InterSystems/i,
+    workloads: {
+      intersystems: {
+        is_intersystems: true,
+        running_instances: [
+          {
+            instance_name: 'NOVA-X, ENV-Δ42',
+            product: 'HyperIRIS',
+            version: '3021.∞, nebula.7',
+          },
+        ],
+      },
+    },
+    expectedClickTitle: 'InterSystems',
+    expectedData: {
+      cells: [
+        { title: 'Instance Name' },
+        { title: 'Product' },
+        { title: 'Version' },
+      ],
+      filters: [{ type: 'text' }],
+      rows: [['NOVA-X, ENV-Δ42', 'HyperIRIS', '3021.∞, nebula.7']],
+    },
+  },
+  {
+    name: 'CrowdStrike',
+    linkText: /CrowdStrike/i,
+    workloads: {
+      crowdstrike: {
+        falcon_aid: 'xfoCshFVO6TwXdGHvy',
+        falcon_backend: 'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
+        falcon_version: 'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
+      },
+    },
+    expectedClickTitle: 'CrowdStrike',
+    expectedData: {
+      cells: [
+        { title: 'Falcon Aid' },
+        { title: 'Falcon Backend' },
+        { title: 'Falcon Version' },
+      ],
+      filters: [{ type: 'text' }],
+      rows: [
+        [
+          'xfoCshFVO6TwXdGHvy',
+          'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
+          'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
+        ],
+      ],
+    },
+  },
+  {
+    name: 'Microsoft SQL',
+    linkText: /Microsoft SQL/i,
+    workloads: {
+      mssql: {
+        version: 'nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL',
+      },
+    },
+    expectedClickTitle: 'Microsoft SQL',
+    expectedData: {
+      cells: [{ title: 'Value' }],
+      filters: [{ type: 'text' }],
+      rows: [['nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL']],
+    },
+  },
+];
+
+export const workloadTestCases = [
+  {
+    name: 'SAP',
+    workloads: {
+      sap: {
+        instance_number: 'j2r1MRNe49og, df.lWNAV._m_2sbl, KAS1MYAqXXqGIirplJG',
+        sap_system: true,
+        sids: ['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A'],
+        version: 'ezU7Htkuo, GU_aiKHi52n7PFH, ONRu1Ku4_skoUXrR',
+      },
+    },
+    expectedText: 'SAP',
+  },
+  {
+    name: 'Ansible',
+    workloads: {
+      ansible: {
+        catalog_worker_version: '9.8.7, banana.42, 0.0.abc',
+        controller_version: 'x.1.2, foo.bar, 3.3.3',
+        hub_version: 'abc.def, 123.456, xyz.789',
+        sso_version: 'preview-1, glitch.9.9, zz-top.7',
+      },
+    },
+    expectedText: 'Ansible Automation Platform',
+  },
+  {
+    name: 'RHEL AI',
+    workloads: {
+      rhel_ai: {
+        amd_gpu_models: ['Quantum Spark GT, Mangoburst 900X'],
+        intel_gaudi_hpu_models: ['Turbo Flux HL-Ω1, Gaudi++ Phantom Edition'],
+        nvidia_gpu_models: ['RTX Hypernova 12X, GX-99π Phantom'],
+        rhel_ai_version_id: 'vX.Y.Z-beta',
+        variant: 'RHEL AI Galactic',
+      },
+    },
+    expectedText: 'RHEL AI',
+  },
+  {
+    name: 'InterSystems',
+    workloads: {
+      intersystems: {
+        is_intersystems: true,
+        running_instances: [
+          {
+            instance_name: 'NOVA-X, ENV-Δ42',
+            product: 'HyperIRIS',
+            version: '3021.∞, nebula.7',
+          },
+        ],
+      },
+    },
+    expectedText: 'InterSystems',
+  },
+  {
+    name: 'IBM Db2',
+    workloads: {
+      ibm_db2: {
+        is_running: true,
+      },
+    },
+    expectedText: 'IBM Db2',
+  },
+  {
+    name: 'IBM Db2',
+    workloads: {
+      ibm_db2: {
+        is_running: false,
+      },
+    },
+    expectedText: 'IBM Db2',
+  },
+  {
+    name: 'CrowdStrike',
+    workloads: {
+      crowdstrike: {
+        falcon_aid: 'xfoCshFVO6TwXdGHvy',
+        falcon_backend: 'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
+        falcon_version: 'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
+      },
+    },
+    expectedText: 'CrowdStrike',
+  },
+  {
+    name: 'Microsoft SQL',
+    workloads: {
+      mssql: {
+        version: 'nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL',
+      },
+    },
+    expectedText: 'Microsoft SQL',
+  },
+  {
+    name: 'Oracle DB',
+    workloads: {
+      oracle_db: {
+        is_running: true,
+      },
+    },
+    expectedText: 'Oracle Database',
+  },
+  {
+    name: 'Oracle DB',
+    workloads: {
+      oracle_db: {
+        is_running: false,
+      },
+    },
+    expectedText: 'Oracle Database',
+  },
+];

--- a/src/components/GeneralInfo/SystemCard/Workloads.js
+++ b/src/components/GeneralInfo/SystemCard/Workloads.js
@@ -10,33 +10,30 @@ const WorkloadsSection = ({ handleClick, workloadsData, workloadsTypes }) => {
     );
   }, [handleClick, workloadsData, workloadsTypes]);
 
-  const interleaved = useMemo(() => {
-    const rendered = filteredConfigs.map(
-      ({ type, title, onClick, target, customRender }) => {
-        if (typeof customRender === 'function') {
-          return <Fragment key={type}>{customRender()}</Fragment>;
-        }
-
+  return filteredConfigs.map(
+    ({ type, title, onClick, target, customRender }, index) => {
+      if (typeof customRender === 'function') {
         return (
+          <Fragment key={type}>
+            {index > 0 && ', '}
+            {customRender()}
+          </Fragment>
+        );
+      }
+
+      return (
+        <Fragment key={type}>
+          {index > 0 && ', '}
           <Clickable
-            key={type}
             onClick={onClick}
             target={target}
             workload={type}
             title={title}
           />
-        );
-      }
-    );
-
-    return rendered.reduce((acc, curr, index) => {
-      if (index !== 0) acc.push(', ');
-      acc.push(curr);
-      return acc;
-    }, []);
-  }, [filteredConfigs]);
-
-  return <Fragment>{interleaved}</Fragment>;
+        </Fragment>
+      );
+    }
+  );
 };
 
 WorkloadsSection.propTypes = {

--- a/src/components/GeneralInfo/SystemCard/Workloads.js
+++ b/src/components/GeneralInfo/SystemCard/Workloads.js
@@ -1,0 +1,48 @@
+import React, { Fragment, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { workloadConfigs } from './SystemCardConfigs';
+import { Clickable } from '../LoadingCard/LoadingCard';
+
+const WorkloadsSection = ({ handleClick, workloadsData, workloadsTypes }) => {
+  const filteredConfigs = useMemo(() => {
+    return workloadConfigs(handleClick, workloadsData).filter(({ type }) =>
+      workloadsTypes.includes(type)
+    );
+  }, [handleClick, workloadsData, workloadsTypes]);
+
+  const interleaved = useMemo(() => {
+    const rendered = filteredConfigs.map(
+      ({ type, title, onClick, target, customRender }) => {
+        if (typeof customRender === 'function') {
+          return <Fragment key={type}>{customRender()}</Fragment>;
+        }
+
+        return (
+          <Clickable
+            key={type}
+            onClick={onClick}
+            target={target}
+            workload={type}
+            title={title}
+          />
+        );
+      }
+    );
+
+    return rendered.reduce((acc, curr, index) => {
+      if (index !== 0) acc.push(', ');
+      acc.push(curr);
+      return acc;
+    }, []);
+  }, [filteredConfigs]);
+
+  return <Fragment>{interleaved}</Fragment>;
+};
+
+WorkloadsSection.propTypes = {
+  handleClick: PropTypes.func.isRequired,
+  workloadsData: PropTypes.object.isRequired,
+  workloadsTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default React.memo(WorkloadsSection);

--- a/src/components/GeneralInfo/SystemCard/__snapshots__/SystemCard.test.js.snap
+++ b/src/components/GeneralInfo/SystemCard/__snapshots__/SystemCard.test.js.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should return DOWN 1`] = `
+<DocumentFragment>
+  <div
+    style="display: contents;"
+  >
+    <svg
+      aria-hidden="true"
+      class="pf-v5-svg ins-c-inventory__detail--down"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      viewBox="0 0 512 512"
+      width="1em"
+    >
+      <path
+        d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm-32-316v116h-67c-10.7 0-16 12.9-8.5 20.5l99 99c4.7 4.7 12.3 4.7 17 0l99-99c7.6-7.6 2.2-20.5-8.5-20.5h-67V140c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12z"
+      />
+    </svg>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`should return UP 1`] = `
+<DocumentFragment>
+  <div
+    style="display: contents;"
+  >
+    <svg
+      aria-hidden="true"
+      class="pf-v5-svg ins-c-inventory__detail--up"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      viewBox="0 0 512 512"
+      width="1em"
+    >
+      <path
+        d="M256 504c137 0 248-111 248-248S393 8 256 8 8 119 8 256s111 248 248 248zm0-448c110.5 0 200 89.5 200 200s-89.5 200-200 200S56 366.5 56 256 145.5 56 256 56zm20 328h-40c-6.6 0-12-5.4-12-12V256h-67c-10.7 0-16-12.9-8.5-20.5l99-99c4.7-4.7 12.3-4.7 17 0l99 99c7.6 7.6 2.2 20.5-8.5 20.5h-67v116c0 6.6-5.4 12-12 12z"
+      />
+    </svg>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`should return false 1`] = `
+<DocumentFragment>
+  <div
+    style="display: contents;"
+  >
+    <svg
+      aria-hidden="true"
+      class="pf-v5-svg ins-c-inventory__detail--disabled"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      viewBox="0 0 352 512"
+      width="1em"
+    >
+      <path
+        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+      />
+    </svg>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`should return true 1`] = `
+<DocumentFragment>
+  <div
+    style="display: contents;"
+  >
+    <svg
+      aria-hidden="true"
+      class="pf-v5-svg ins-c-inventory__detail--enabled"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      viewBox="0 0 512 512"
+      width="1em"
+    >
+      <path
+        d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+      />
+    </svg>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/GeneralInfo/dataMapper/dataMapper.js
+++ b/src/components/GeneralInfo/dataMapper/dataMapper.js
@@ -194,3 +194,38 @@ export const generalMapper = (data = [], title = '') => ({
   rows: data.map((item) => [item]),
   filters: [{ type: 'text' }],
 });
+
+export const workloadsDataMapper = ({ data = [], fieldKeys = [] } = {}) => {
+  const toTitleCase = (str) =>
+    str
+      .replace(/_/g, ' ')
+      .replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1));
+
+  const isSingleColumn = fieldKeys.length === 0;
+
+  const getCells = () => {
+    if (isSingleColumn) {
+      return [{ title: 'Value' }];
+    }
+    return fieldKeys.map((key) => ({ title: toTitleCase(key) }));
+  };
+
+  const formatValue = (value) => {
+    if (Array.isArray(value)) return value.join(', ');
+    if (value === undefined || value === null) return '';
+    return value;
+  };
+
+  const getRows = () => {
+    if (isSingleColumn) {
+      return data.map((item) => [item.version]);
+    }
+    return data.map((item) => fieldKeys.map((key) => formatValue(item[key])));
+  };
+
+  return {
+    cells: getCells(),
+    rows: getRows(),
+    filters: [{ type: 'text' }],
+  };
+};

--- a/src/components/GeneralInfo/dataMapper/dataMapper.test.js
+++ b/src/components/GeneralInfo/dataMapper/dataMapper.test.js
@@ -7,7 +7,54 @@ import {
   productsMapper,
   repositoriesMapper,
   statusHelper,
+  workloadsDataMapper,
 } from './dataMapper';
+
+export const mockWorkloadsData = {
+  ansible: {
+    catalog_worker_version: '9.8.7, banana.42, 0.0.abc',
+    controller_version: 'x.1.2, foo.bar, 3.3.3',
+    hub_version: 'abc.def, 123.456, xyz.789',
+    sso_version: 'preview-1, glitch.9.9, zz-top.7',
+  },
+  rhel_ai: {
+    amd_gpu_models: ['Quantum Spark GT, Mangoburst 900X'],
+    intel_gaudi_hpu_models: ['Turbo Flux HL-Ω1, Gaudi++ Phantom Edition'],
+    nvidia_gpu_models: ['RTX Hypernova 12X, GX-99π Phantom'],
+    rhel_ai_version_id: 'vX.Y.Z-beta',
+    variant: 'RHEL AI Galactic',
+  },
+  intersystems: {
+    is_intersystems: true,
+    running_instances: [
+      {
+        instance_name: 'NOVA-X, ENV-Δ42',
+        product: 'HyperIRIS',
+        version: '3021.∞, nebula.7',
+      },
+    ],
+  },
+  crowdstrike: {
+    falcon_aid: 'xfoCshFVO6TwXdGHvy',
+    falcon_backend: 'dOqLegz0W8159Q0X2, fNbEf-pmK, r1zrECSYr_FgUDMbIu2',
+    falcon_version: 'lsSRGjjnhpl2Cz-, -KPJKI_kSyHVP5khj',
+  },
+  ibm_db2: {
+    is_running: false,
+  },
+  mssql: {
+    version: 'nTQNi8yZSTEN, x_OkwFDlxq7dl, LkIh__hO0qTnYZoCwL',
+  },
+  oracle_db: {
+    is_running: false,
+  },
+  sap: {
+    instance_number: 'j2r1MRNe49og, df.lWNAV._m_2sbl, KAS1MYAqXXqGIirplJG',
+    sap_system: true,
+    sids: ['FudUaJbpiPfLVJkNUT.F, 2DSO9DmPKg30, Vx-jCe1ibHTHj01A'],
+    version: 'ezU7Htkuo, GU_aiKHi52n7PFH, ONRu1Ku4_skoUXrR',
+  },
+};
 
 Object.keys(statusHelper).map((oneStatus) => {
   it(`should return ${oneStatus}`, () => {
@@ -719,5 +766,87 @@ describe('repositoriesMapper', () => {
         "rows": [],
       }
     `);
+  });
+});
+
+describe('workloadsDataMapper test', () => {
+  it('maps Ansible data correctly with selected fieldKeys', () => {
+    const result = workloadsDataMapper({
+      data: [mockWorkloadsData.ansible],
+      fieldKeys: ['controller_version', 'hub_version'],
+    });
+
+    expect(result.cells).toEqual([
+      { title: 'Controller Version' },
+      { title: 'Hub Version' },
+    ]);
+    expect(result.rows).toEqual([
+      ['x.1.2, foo.bar, 3.3.3', 'abc.def, 123.456, xyz.789'],
+    ]);
+  });
+
+  it('flattens array values for RHEL AI correctly', () => {
+    const result = workloadsDataMapper({
+      data: [mockWorkloadsData.rhel_ai],
+      fieldKeys: ['amd_gpu_models', 'nvidia_gpu_models'],
+    });
+
+    expect(result.rows).toEqual([
+      [
+        'Quantum Spark GT, Mangoburst 900X',
+        'RTX Hypernova 12X, GX-99π Phantom',
+      ],
+    ]);
+  });
+
+  it('handles Intersystems running_instances array correctly', () => {
+    const result = workloadsDataMapper({
+      data: mockWorkloadsData.intersystems.running_instances,
+      fieldKeys: ['instance_name', 'product', 'version'],
+    });
+
+    expect(result.cells).toEqual([
+      { title: 'Instance Name' },
+      { title: 'Product' },
+      { title: 'Version' },
+    ]);
+
+    expect(result.rows).toEqual([
+      ['NOVA-X, ENV-Δ42', 'HyperIRIS', '3021.∞, nebula.7'],
+    ]);
+  });
+
+  it('returns single-column structure when no fieldKeys are provided', () => {
+    const result = workloadsDataMapper({
+      data: [{ version: '1.0.0' }],
+      fieldKeys: [],
+    });
+
+    expect(result.cells).toEqual([{ title: 'Value' }]);
+    expect(result.rows).toEqual([['1.0.0']]);
+  });
+
+  it('handles missing fields gracefully', () => {
+    const result = workloadsDataMapper({
+      data: [{ foo: 'bar' }],
+      fieldKeys: ['foo', 'missing_field'],
+    });
+
+    expect(result.rows).toEqual([['bar', '']]);
+  });
+
+  it('handles mixed types (boolean, string, array)', () => {
+    const result = workloadsDataMapper({
+      data: [
+        {
+          bool_field: true,
+          string_field: 'hello',
+          array_field: ['a', 'b', 'c'],
+        },
+      ],
+      fieldKeys: ['bool_field', 'string_field', 'array_field'],
+    });
+
+    expect(result.rows).toEqual([[true, 'hello', 'a, b, c']]);
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-14652

1) Added functions that read workloads data from system profile and collect all the workloads that are present
2) Added a new field for workloads to the SystemCard.js, if workoads is present in workloadTypes it will render a clickable link that opens a modal for this workload.
3) Added a new data mapper that consumes the workloads data and populates the table
4) Wrote new tests for the mapper

How to test:
1)Replace workloadsData in SystemCard.js to the content of mockWorkloadsData from dataMapper.test.js
2)Open inventory, open any system
3)Check that there is a new Workloads field in the System properties card
4)Check the content of the modals and try to open them.
Screenshots:
![image](https://github.com/user-attachments/assets/c5e831db-e263-48cd-a505-31a25e2f3740)
![image](https://github.com/user-attachments/assets/2f8d5164-8268-4e65-99d6-7d081ecbbcdc)


