### PR TITLE
fix(TagModal): RHINENG-11908 - Fix applying tags to filter

### DIFF
--- a/src/Utilities/hooks/useFetchOperatingSystems.js
+++ b/src/Utilities/hooks/useFetchOperatingSystems.js
@@ -36,6 +36,7 @@ const useFetchOperatingSystems = ({
   ]);
 
   useEffect(() => {
+    mounted.current = true;
     (async () => {
       const result = await fetchOperatingSystems();
       if (mounted.current) {

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -196,7 +196,7 @@ const EntityTableToolbar = ({
     selectedTags,
     setSelectedTags,
     filterTagsBy,
-    seFilterTagsBy,
+    setFilterTagsBy,
   } = useTagsFilter(
     allTags,
     allTagsLoaded,
@@ -554,6 +554,30 @@ const EntityTableToolbar = ({
       : []),
     ...(filterConfig?.items || []),
   ];
+  const preselectedTags = Object.entries(selectedTags).reduce(
+    (sTags, [namespace, tag]) => {
+      const tags = Object.values(tag).map(
+        ({
+          item: {
+            meta: {
+              tag: { key, value },
+            },
+          },
+        }) => ({
+          id: `${namespace}/${key}=${value}`,
+          cells: [key, value, namespace],
+          item: {
+            meta: {
+              tag: { key, value },
+            },
+          },
+        })
+      );
+
+      return [...sTags, ...tags];
+    },
+    []
+  );
 
   return (
     <Fragment>
@@ -640,9 +664,9 @@ const EntityTableToolbar = ({
       </PrimaryToolbar>
       {(showTags || enabledFilters.tags || showTagModal) && (
         <TagsModal
+          selected={preselectedTags}
           filterTagsBy={filterTagsBy}
           onApply={(selected) => setSelectedTags(arrayToSelection(selected))}
-          onToggleModal={() => seFilterTagsBy('')}
           getTags={getTags}
         />
       )}

--- a/src/components/InventoryTable/helpers.js
+++ b/src/components/InventoryTable/helpers.js
@@ -96,14 +96,35 @@ export const onDeleteFilter = (deleted, currFilter = []) => {
   return currFilter.filter((item) => item !== deletedItem);
 };
 
-export const onDeleteTag = (deleted, selectedTags, onApplyTags) => {
-  const deletedItem = deleted?.chips?.[0];
-  if (selectedTags?.[deleted?.key]?.[deletedItem?.key] !== undefined) {
-    selectedTags[deleted?.key][deletedItem?.key] = false;
-  }
+const buildNewCategoryTags = (deleted, category, categoryTags) =>
+  Object.entries(categoryTags).reduce((newCategoryTags, [tagName, tag]) => {
+    const isDeleted =
+      deleted.category === category &&
+      deleted.chips[0].value === tag.item?.meta?.tag.value &&
+      deleted.chips[0].tagKey === tag.item?.meta?.tag.key;
+    return [...newCategoryTags, ...(isDeleted ? [] : [[tagName, tag]])];
+  }, []);
 
-  if (onApplyTags) onApplyTags(selectedTags, false);
-  return selectedTags;
+export const onDeleteTag = (deleted, selectedTags, onApplyTags) => {
+  const newSelectedTags = Object.fromEntries(
+    Object.entries(selectedTags).reduce((newTags, [category, categoryTags]) => {
+      const newCategoryTags = buildNewCategoryTags(
+        deleted,
+        category,
+        categoryTags
+      );
+
+      return [
+        ...newTags,
+        ...(newCategoryTags.length
+          ? [[category, Object.fromEntries(newCategoryTags)]]
+          : []),
+      ];
+    }, [])
+  );
+
+  if (onApplyTags) onApplyTags(newSelectedTags, false);
+  return newSelectedTags;
 };
 
 export const onDeleteGroupFilter = (deleted, currFilter) =>

--- a/src/components/InventoryTable/helpers.test.js
+++ b/src/components/InventoryTable/helpers.test.js
@@ -145,26 +145,53 @@ describe('onDeleteFilter', () => {
 
 describe('onDeleteTag', () => {
   const selectedTags = {
-    some: {
-      tag: true,
+    AAzfYuEy: {
+      'Eetzha=dbFigb': {
+        isSelected: true,
+        group: {
+          label: 'AAzfYuEy',
+          value: 'AAzfYuEy',
+          type: 'checkbox',
+        },
+        item: {
+          meta: {
+            tag: {
+              key: 'Eetzha',
+              value: 'dbFigb',
+            },
+          },
+        },
+      },
     },
   };
+
   it('should call onDeleteTag with updated value', () => {
     const onApplyTags = jest.fn();
     const data = onDeleteTag(
       {
+        type: 'tags',
+        key: 'AAzfYuEy',
+        category: 'AAzfYuEy',
         chips: [
           {
-            key: 'tag',
+            key: 'Eetzha=dbFigb',
+            tagKey: 'Eetzha',
+            value: 'dbFigb',
+            name: 'Eetzha=dbFigb',
+            group: {
+              value: 'AAzfYuEy',
+              label: 'AAzfYuEy',
+              type: 'checkbox',
+            },
           },
         ],
-        key: 'some',
       },
       selectedTags,
       onApplyTags
     );
+
     expect(onApplyTags).toHaveBeenCalled();
-    expect(data.some.tag).toBe(false);
+    expect(data['AAzfYuEy']?.['Eetzha=dbFigb']).toBe(undefined);
   });
 
   it('should call onDeleteTag without updated value', () => {

--- a/src/components/filters/useTagsFilter.js
+++ b/src/components/filters/useTagsFilter.js
@@ -14,6 +14,7 @@ export const useTagsFilter = (
     setValue,
     filterTagsBy,
     seFilterTagsBy,
+    setFilterTagsBy = seFilterTagsBy,
   } = tagsFilter(
     allTags,
     loaded,
@@ -37,6 +38,6 @@ export const useTagsFilter = (
     selectedTags,
     setSelectedTags: setValue,
     filterTagsBy,
-    seFilterTagsBy,
+    setFilterTagsBy,
   };
 };

--- a/src/components/filters/useTagsFilter.test.js
+++ b/src/components/filters/useTagsFilter.test.js
@@ -150,7 +150,7 @@ describe('useTagsFilter', () => {
     );
 
     act(() => {
-      result.current.seFilterTagsBy('test');
+      result.current.setFilterTagsBy('test');
     });
     expect(result.current.filterTagsBy).toBe('test');
   });


### PR DESCRIPTION
This should fix issues with the tags filter and the TagsModal component applying tags.

**How to test:**

1) Open the Inventory
2) Filter by a tag
3) Open the tag filter and open the Tags modal via the "load more" link
4) Verify the already selected tag is selected in the modal
5) Filter the tags and choose another to select
6) "Apply" the selected tags to filter the systems
7) Verify the tags selected in the modal are applied as filters
8) Test removing a tag from the filters
9) Test the modal and tags filter more.

## Summary by Sourcery

Fix issues with tag filtering and selection in the Inventory's TagsModal component

Bug Fixes:
- Improve tag selection and filtering logic in the TagsModal to correctly handle preselected tags and tag removal

Enhancements:
- Refactor tag selection and filtering mechanisms to provide more robust handling of tag states
- Update tag deletion logic to correctly remove selected tags