### PR TITLE
fix(RHINENG-14652): Fix column titles, rename Ansible workload

### DIFF
--- a/src/components/GeneralInfo/SystemCard/SystemCard.test.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.test.js
@@ -503,7 +503,7 @@ describe('SystemCard', () => {
           name: /Workloads value/i,
         })
       ).toHaveTextContent(
-        /SAP|Ansible|CrowdStrike|RHEL AI|InterSystems|IBM Db2|Microsoft SQL|Oracle Database/
+        /SAP|Ansible Automation Platform|CrowdStrike|RHEL AI|InterSystems|IBM Db2|Microsoft SQL|Oracle Database/
       );
     });
   });

--- a/src/components/GeneralInfo/SystemCard/SystemCardConfigs.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCardConfigs.js
@@ -22,7 +22,7 @@ export const workloadConfigs = (handleClick, workloadsData) => [
     title: 'Ansible Automation Platform',
     onClick: () =>
       handleClick(
-        'Ansible',
+        'Ansible Automation Platform',
         workloadsDataMapper({
           data: [workloadsData.ansible],
           fieldKeys: [
@@ -30,6 +30,12 @@ export const workloadConfigs = (handleClick, workloadsData) => [
             'controller_version',
             'hub_version',
             'sso_version',
+          ],
+          columnTitles: [
+            'Catalog worker version',
+            'Controller version',
+            'Hub version',
+            'SSO version',
           ],
         })
       ),
@@ -56,6 +62,7 @@ export const workloadConfigs = (handleClick, workloadsData) => [
         workloadsDataMapper({
           data: [workloadsData.crowdstrike],
           fieldKeys: ['falcon_aid', 'falcon_backend', 'falcon_version'],
+          columnTitles: ['Falcon AID', 'Falcon backend', 'Falcon version'],
         })
       ),
     target: 'crowdstrike',
@@ -75,6 +82,13 @@ export const workloadConfigs = (handleClick, workloadsData) => [
             'rhel_ai_version_id',
             'variant',
           ],
+          columnTitles: [
+            'AMD GPU models',
+            'Intel Gaudi HPU models',
+            'Nvidia GPU models',
+            'RHEL AI version ID',
+            'Variant',
+          ],
         })
       ),
     target: 'rhel_ai',
@@ -88,6 +102,7 @@ export const workloadConfigs = (handleClick, workloadsData) => [
         workloadsDataMapper({
           data: workloadsData.intersystems.running_instances,
           fieldKeys: ['instance_name', 'product', 'version'],
+          columnTitles: ['Instance name', 'Product', 'Version'],
         })
       ),
     target: 'intersystems',

--- a/src/components/GeneralInfo/SystemCard/SystemCardTestsFixtures.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCardTestsFixtures.js
@@ -23,7 +23,7 @@ export const workloadClickTestCases = [
     },
   },
   {
-    name: 'Ansible',
+    name: 'Ansible Automation Platform',
     linkText: /Ansible Automation Platform/i,
     workloads: {
       ansible: {
@@ -33,13 +33,13 @@ export const workloadClickTestCases = [
         sso_version: 'preview-1, glitch.9.9, zz-top.7',
       },
     },
-    expectedClickTitle: 'Ansible',
+    expectedClickTitle: 'Ansible Automation Platform',
     expectedData: {
       cells: [
-        { title: 'Catalog Worker Version' },
-        { title: 'Controller Version' },
-        { title: 'Hub Version' },
-        { title: 'Sso Version' },
+        { title: 'Catalog worker version' },
+        { title: 'Controller version' },
+        { title: 'Hub version' },
+        { title: 'SSO version' },
       ],
       filters: [{ type: 'text' }],
       rows: [
@@ -67,10 +67,10 @@ export const workloadClickTestCases = [
     expectedClickTitle: 'RHEL AI',
     expectedData: {
       cells: [
-        { title: 'Amd Gpu Models' },
-        { title: 'Intel Gaudi Hpu Models' },
-        { title: 'Nvidia Gpu Models' },
-        { title: 'Rhel Ai Version Id' },
+        { title: 'AMD GPU models' },
+        { title: 'Intel Gaudi HPU models' },
+        { title: 'Nvidia GPU models' },
+        { title: 'RHEL AI version ID' },
         { title: 'Variant' },
       ],
       filters: [{ type: 'text' }],
@@ -103,7 +103,7 @@ export const workloadClickTestCases = [
     expectedClickTitle: 'InterSystems',
     expectedData: {
       cells: [
-        { title: 'Instance Name' },
+        { title: 'Instance name' },
         { title: 'Product' },
         { title: 'Version' },
       ],
@@ -124,9 +124,9 @@ export const workloadClickTestCases = [
     expectedClickTitle: 'CrowdStrike',
     expectedData: {
       cells: [
-        { title: 'Falcon Aid' },
-        { title: 'Falcon Backend' },
-        { title: 'Falcon Version' },
+        { title: 'Falcon AID' },
+        { title: 'Falcon backend' },
+        { title: 'Falcon version' },
       ],
       filters: [{ type: 'text' }],
       rows: [

--- a/src/components/GeneralInfo/dataMapper/dataMapper.js
+++ b/src/components/GeneralInfo/dataMapper/dataMapper.js
@@ -208,15 +208,18 @@ export const workloadsDataMapper = ({
   const isSingleColumn = fieldKeys.length === 0;
 
   const getCells = () => {
+    if (
+      columnTitles !== undefined &&
+      columnTitles.length === fieldKeys.length
+    ) {
+      return columnTitles.map((title) => ({ title }));
+    }
+
     if (isSingleColumn) {
       return [{ title: 'Value' }];
     }
 
-    if (columnTitles === undefined || columnTitles.length === 0) {
-      return fieldKeys.map((key) => ({ title: toTitleCase(key) }));
-    }
-
-    return columnTitles.map((title) => ({ title }));
+    return fieldKeys.map((key) => ({ title: toTitleCase(key) }));
   };
 
   const formatValue = (value) => {

--- a/src/components/GeneralInfo/dataMapper/dataMapper.js
+++ b/src/components/GeneralInfo/dataMapper/dataMapper.js
@@ -195,7 +195,11 @@ export const generalMapper = (data = [], title = '') => ({
   filters: [{ type: 'text' }],
 });
 
-export const workloadsDataMapper = ({ data = [], fieldKeys = [] } = {}) => {
+export const workloadsDataMapper = ({
+  data = [],
+  fieldKeys = [],
+  columnTitles,
+} = {}) => {
   const toTitleCase = (str) =>
     str
       .replace(/_/g, ' ')
@@ -207,7 +211,12 @@ export const workloadsDataMapper = ({ data = [], fieldKeys = [] } = {}) => {
     if (isSingleColumn) {
       return [{ title: 'Value' }];
     }
-    return fieldKeys.map((key) => ({ title: toTitleCase(key) }));
+
+    if (columnTitles === undefined || columnTitles.length === 0) {
+      return fieldKeys.map((key) => ({ title: toTitleCase(key) }));
+    }
+
+    return columnTitles.map((title) => ({ title }));
   };
 
   const formatValue = (value) => {

--- a/src/components/GeneralInfo/dataMapper/dataMapper.test.js
+++ b/src/components/GeneralInfo/dataMapper/dataMapper.test.js
@@ -774,11 +774,12 @@ describe('workloadsDataMapper test', () => {
     const result = workloadsDataMapper({
       data: [mockWorkloadsData.ansible],
       fieldKeys: ['controller_version', 'hub_version'],
+      columnTitles: ['Controller version', 'Hub version'],
     });
 
     expect(result.cells).toEqual([
-      { title: 'Controller Version' },
-      { title: 'Hub Version' },
+      { title: 'Controller version' },
+      { title: 'Hub version' },
     ]);
     expect(result.rows).toEqual([
       ['x.1.2, foo.bar, 3.3.3', 'abc.def, 123.456, xyz.789'],
@@ -789,6 +790,7 @@ describe('workloadsDataMapper test', () => {
     const result = workloadsDataMapper({
       data: [mockWorkloadsData.rhel_ai],
       fieldKeys: ['amd_gpu_models', 'nvidia_gpu_models'],
+      columnTitles: ['AMD GPU models', 'Nvidia GPU models'],
     });
 
     expect(result.rows).toEqual([
@@ -803,10 +805,11 @@ describe('workloadsDataMapper test', () => {
     const result = workloadsDataMapper({
       data: mockWorkloadsData.intersystems.running_instances,
       fieldKeys: ['instance_name', 'product', 'version'],
+      columnTitles: ['Instance name', 'Product', 'Version'],
     });
 
     expect(result.cells).toEqual([
-      { title: 'Instance Name' },
+      { title: 'Instance name' },
       { title: 'Product' },
       { title: 'Version' },
     ]);


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-14652.

This renames Ansible to Ansible Automation Platform workload title. Also, the commit changes the way column titles are calculated for Inventory details page parameters tables.

## How to test

Go to any host's Inventory details page, click through statuses, interfaces, workloads and other parameters that have a table list. Make sure the column names are correct. Also, verify that we use Ansible Automation Platform instead of just Ansible for workloads.