### PR TITLE
chore: Fix typo in Vulnerability intl provider

### DIFF
--- a/src/components/SystemDetails/Vulnerability.js
+++ b/src/components/SystemDetails/Vulnerability.js
@@ -20,7 +20,7 @@ const VulnerabilityTab = () => {
       scope="vulnerability"
       module="./SystemDetail"
       getRegistry={getRegistry}
-      customItnlProvider
+      customIntlProvider
       entity={{ id: inventoryId }}
     />
   );


### PR DESCRIPTION
This change does not cause any issues, since Vulnerability accommodates both prop variants with and without a typo: https://github.com/RedHatInsights/vulnerability-ui/blob/a2eddb7ca2d811b32d718ee9fc1c0bd2229fd032/src/Components/SmartComponents/SystemCves/SystemCves.js#L287

