### PR TITLE
fix: Fix tooltip next to "Last seen" header not showing

### DIFF
--- a/src/store/constants.js
+++ b/src/store/constants.js
@@ -10,6 +10,7 @@ import { Tooltip } from '@patternfly/react-core';
 import { verifyCulledReporter } from '../Utilities/sharedFunctions';
 import { fitContent } from '@patternfly/react-table';
 import isEmpty from 'lodash/isEmpty';
+import { LastSeenColumnHeader } from '../Utilities/LastSeenColumnHeader';
 
 export const INVENTORY_COLUMNS = [
   {
@@ -63,7 +64,8 @@ export const INVENTORY_COLUMNS = [
   {
     key: 'last_check_in',
     sortKey: 'last_check_in',
-    title: 'Last seen',
+    dataLabel: 'Last seen',
+    title: <LastSeenColumnHeader />,
     // eslint-disable-next-line react/display-name
     renderFunc: (
       value,


### PR DESCRIPTION
Fix regression after adding the Last check in feature flag.

## Summary by Sourcery

Fix the tooltip for the "Last seen" column header by introducing a custom column header component

Bug Fixes:
- Resolved tooltip issue for the 'Last seen' column header after adding the Last check in feature flag

Enhancements:
- Updated the 'Last seen' column configuration to use a custom header component