### PR TITLE
fix(TagModal): RHINENG-11908 - Correctly create objects for selected items

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -165,14 +165,17 @@ export const arrayToSelection = (selected) =>
       ...acc,
       [namespace]: {
         ...acc[namespace?.title || namespace],
-        [key?.title || key]: {
+        [`${key?.title || key}=${value?.title || value}`]: {
           isSelected: true,
           group: {
             value: namespace?.title || namespace,
             label: namespace?.title || namespace,
           },
           item: {
-            value: key?.title || key,
+            tagKey: key?.title || key,
+            tagValue: value?.title || value,
+            value: `${key?.title || key}=${value?.title || value}`,
+            id: `${key?.title || key}-${value?.title || value}`,
             meta: {
               tag: { key: key?.title || key, value: value?.title || value },
             },

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -128,7 +128,6 @@ const InventoryTable = forwardRef(
       : props?.columns;
 
     const sortBy = useSelector(({ entities: { sortBy: invSortBy } }) => {
-      console.log('LMAO invsortby', invSortBy, 'propsSortBy', propsSortBy);
       const propsSortByOrFallback =
         propsSortBy?.key != null ? propsSortBy : invSortBy;
       const invSortByOrFallback =


### PR DESCRIPTION
This fixes the issue where the selection within the filter toolbar gets lost after applying tags from the TagModal. 

**How to test:**

1) Open the "Systems" page
2) Select a tag in the filter toolbar
3) Open the tag modal via the "Show more" link within the filter
4) Select a new tag in the modal and apply the tag(s)
5) Verify that the current selection is correct in the filter and chips displayed

## Summary by Sourcery

Fix lost filter toolbar selection after applying tags by correcting the structure of selection objects

Bug Fixes:
- Preserve current selection in the filter toolbar after applying tags

Enhancements:
- Generate selection entries with composite keys (`key=value`) and include `tagKey`, `tagValue`, `value`, and `id` fields

Chores:
- Remove stray debug `console.log` from `InventoryTable`