### PR TITLE
fix(RHINENG-15545): Show tooltip depending on feature flag

### DIFF
--- a/src/Utilities/LastSeenColumnHeader.js
+++ b/src/Utilities/LastSeenColumnHeader.js
@@ -1,23 +1,31 @@
 import React from 'react';
 import { Icon, Tooltip } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import useFeatureFlag from './useFeatureFlag';
 
-export const LastSeenColumnHeader = () => (
-  <span>
-    Last seen
-    <Tooltip
-      content="Last seen represents the most recent time a system
+export const LastSeenColumnHeader = () => {
+  const isLastCheckInEnabled = useFeatureFlag(
+    'hbi.create_last_check_in_update_per_reporter_staleness'
+  );
+  return (
+    <span>
+      Last seen
+      {isLastCheckInEnabled && (
+        <Tooltip
+          content="Last seen represents the most recent time a system
           checked in and uploaded sufficient data for Insights analysis.
           The timestamps may vary between applications as they rely on
           different data collectors."
-    >
-      <Icon>
-        <OutlinedQuestionCircleIcon
-          className="pf-v5-u-ml-sm"
-          color="var(--pf-v5-global--secondary-color--100)"
-          style={{ verticalAlign: -2 }}
-        />
-      </Icon>
-    </Tooltip>
-  </span>
-);
+        >
+          <Icon>
+            <OutlinedQuestionCircleIcon
+              className="pf-v5-u-ml-sm"
+              color="var(--pf-v5-global--secondary-color--100)"
+              style={{ verticalAlign: -2 }}
+            />
+          </Icon>
+        </Tooltip>
+      )}
+    </span>
+  );
+};


### PR DESCRIPTION
Show last seen tooltip depending on feature flag.
Tested with and without FF. Works fine with Inventory and other apps (Compliance, Advisor, etc)

## Summary by Sourcery

Enable conditional display of the “Last seen” tooltip based on a feature flag

Bug Fixes:
- Only render the “Last seen” tooltip when the hbi.create_last_check_in_update_per_reporter_staleness feature flag is enabled

Enhancements:
- Import and apply the useFeatureFlag hook in LastSeenColumnHeader to gate tooltip rendering