### PR TITLE
feat: Add a custom ESLint rule for InventoryTable

### DIFF
--- a/eslint-plugin-inventory-custom/index.mjs
+++ b/eslint-plugin-inventory-custom/index.mjs
@@ -1,0 +1,9 @@
+import noDeprecatedInventoryTable from './rules/no-deprecated-inventory-table.mjs';
+
+const plugin = {
+  rules: {
+    'no-deprecated-inventory-table': noDeprecatedInventoryTable,
+  },
+};
+
+export default plugin;

--- a/eslint-plugin-inventory-custom/rules/no-deprecated-inventory-table.mjs
+++ b/eslint-plugin-inventory-custom/rules/no-deprecated-inventory-table.mjs
@@ -1,0 +1,24 @@
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem', // or 'warning'
+    docs: {
+      description:
+        'Disallow the use of the deprecated InventoryTable component',
+      recommended: true,
+    },
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        if (node.name.name === 'InventoryTable') {
+          context.report({
+            node,
+            message:
+              'The InventoryTable component is deprecated and should not be used. Consider the SystemsTable alternative.',
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import testingLibrary from 'eslint-plugin-testing-library';
 import { defineConfig, globalIgnores } from 'eslint/config';
 import tseslint from 'typescript-eslint';
+import inventoryCustomPlugin from './eslint-plugin-inventory-custom/index.mjs';
 
 const flatPlugins = [
   fecPlugin,
@@ -58,6 +59,14 @@ export default defineConfig([
         },
       ],
       // Add other non-TypeScript specific rules here
+    },
+  },
+  {
+    plugins: {
+      'inventory-custom': inventoryCustomPlugin,
+    },
+    rules: {
+      'inventory-custom/no-deprecated-inventory-table': 'warn',
     },
   },
 ]);


### PR DESCRIPTION
## Summary by Sourcery

Add a custom ESLint plugin and rule to flag and warn against using the deprecated InventoryTable component, guiding developers to use the SystemsTable alternative.

New Features:
- Add custom ESLint rule 'no-deprecated-inventory-table' to disallow use of the deprecated InventoryTable component

Enhancements:
- Integrate the inventory-custom plugin into the ESLint configuration with a warning for deprecated InventoryTable usage