### PR TITLE
fix(RHINENG-18216): show 'No workspace' option in Workspace filter

### DIFF
--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -223,6 +223,7 @@ const ConventionalSystemsTab = ({
         initialLoading={initialLoading}
         ref={inventory}
         disableDefaultColumns={isLastCheckInEnabled}
+        showNoGroupOption
         tableProps={{
           actionResolver: tableActions,
           canSelectAll: false,

--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -24,7 +24,7 @@ const SearchableGroupFilter = ({
         ? [
             {
               itemId: '',
-              children: 'No group',
+              children: 'No workspace',
             },
           ]
         : []),


### PR DESCRIPTION
[RHINENG-18216](https://issues.redhat.com/browse/RHINENG-18216)

When Kessel FF ("hbi.kessel-migration") is disabled, the workspace filter in Systems page should have first option "No workspace".
When it's enabled, "No workspace" should be hidden in the workspace filter.

## Summary by Sourcery

Show the “No workspace” option in the Systems page workspace filter and update its label

Bug Fixes:
- Rename filter option label from “No group” to “No workspace”
- Enable display of the “No workspace” option via the showNoGroupOption prop in the workspace filter