### PR TITLE
fix(RHINENG-11366): disable edit button when editing staleness

### DIFF
--- a/src/components/InventoryHostStaleness/HostStalenessCard.js
+++ b/src/components/InventoryHostStaleness/HostStalenessCard.js
@@ -214,6 +214,7 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
                     setIsEditing(!isEditing);
                   }}
                   ouiaId="edit-staleness-setting"
+                  isDisabled={isEditing}
                 >
                   Edit
                 </Button>


### PR DESCRIPTION
Disable Edit button when editing staleness

## Summary by Sourcery

Bug Fixes:
- Prevent the ‘Edit’ button from being clickable during staleness edit mode