### PR TITLE
fix(RHINENG-18217): add Ungrouped option to group filter

### DIFF
--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -17,14 +17,15 @@ const SearchableGroupFilter = ({
   selectedGroupNames,
   setSelectedGroupNames,
   showNoGroupOption,
+  isKesselEnabled = false,
 }) => {
   const initialValues = useMemo(
     () => [
-      ...(showNoGroupOption
+      ...(showNoGroupOption || isKesselEnabled
         ? [
             {
               itemId: '',
-              children: 'No workspace',
+              children: isKesselEnabled ? 'Ungrouped hosts' : 'No workspace',
             },
           ]
         : []),
@@ -33,7 +34,7 @@ const SearchableGroupFilter = ({
         children: name,
       })),
     ],
-    [initialGroups, showNoGroupOption],
+    [initialGroups, showNoGroupOption, isKesselEnabled],
   );
 
   const [isOpen, setIsOpen] = useState(false);
@@ -214,6 +215,7 @@ SearchableGroupFilter.propTypes = {
   selectedGroupNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   setSelectedGroupNames: PropTypes.func.isRequired,
   showNoGroupOption: PropTypes.bool,
+  isKesselEnabled: PropTypes.bool,
 };
 
 export default SearchableGroupFilter;

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -54,7 +54,7 @@ const useGroupFilter = (showNoGroupOption = false, isKesselEnabled = false) => {
     const fetchOptions = async () => {
       if (!hasAccess) return;
 
-      const search = isKesselEnabled ? { type: 'all' } : undefined;
+      const search = isKesselEnabled ? { groupType: 'all' } : {};
 
       const firstRequest = !ignore
         ? await getGroups(search, { page: 1, per_page: 50 })
@@ -65,7 +65,7 @@ const useGroupFilter = (showNoGroupOption = false, isKesselEnabled = false) => {
           ? await pageOffsetfetchBatched(
               getGroups,
               firstRequest.total - 50,
-              {},
+              search,
               50,
               1,
             )

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -14,11 +14,14 @@ export const groupFilterReducer = (_state, { type, payload }) => ({
   }),
 });
 
-export const buildHostGroupChips = (selectedGroups = []) => {
+export const buildHostGroupChips = (
+  selectedGroups = [],
+  isKesselEnabled = false,
+) => {
   const chips = [...selectedGroups]?.map((group) =>
     group === ''
       ? {
-          name: 'No workspace',
+          name: isKesselEnabled ? 'Ungrouped hosts' : 'No workspace',
           value: '',
         }
       : {
@@ -54,10 +57,8 @@ const useGroupFilter = (showNoGroupOption = false, isKesselEnabled = false) => {
     const fetchOptions = async () => {
       if (!hasAccess) return;
 
-      const search = isKesselEnabled ? { groupType: 'all' } : {};
-
       const firstRequest = !ignore
-        ? await getGroups(search, { page: 1, per_page: 50 })
+        ? await getGroups(undefined, { page: 1, per_page: 50 })
         : { total: 0 };
 
       const groups =
@@ -65,7 +66,7 @@ const useGroupFilter = (showNoGroupOption = false, isKesselEnabled = false) => {
           ? await pageOffsetfetchBatched(
               getGroups,
               firstRequest.total - 50,
-              search,
+              {},
               50,
               1,
             )
@@ -88,8 +89,8 @@ const useGroupFilter = (showNoGroupOption = false, isKesselEnabled = false) => {
   }, [hasAccess, pageOffsetfetchBatched]);
 
   const chips = useMemo(
-    () => buildHostGroupChips(selectedGroupNames),
-    [selectedGroupNames],
+    () => buildHostGroupChips(selectedGroupNames, isKesselEnabled),
+    [selectedGroupNames, isKesselEnabled],
   );
 
   return [
@@ -103,7 +104,8 @@ const useGroupFilter = (showNoGroupOption = false, isKesselEnabled = false) => {
             initialGroups={fetchedGroups}
             selectedGroupNames={selectedGroupNames}
             setSelectedGroupNames={setSelectedGroupNames}
-            showNoGroupOption={showNoGroupOption && !isKesselEnabled}
+            showNoGroupOption={showNoGroupOption}
+            isKesselEnabled={isKesselEnabled}
           />
         ),
       },

--- a/src/components/filters/useGroupFilter.test.js
+++ b/src/components/filters/useGroupFilter.test.js
@@ -47,6 +47,7 @@ describe('groups request not yet resolved', () => {
       {
         "children": <SearchableGroupFilter
           initialGroups={[]}
+          isKesselEnabled={false}
           selectedGroupNames={[]}
           setSelectedGroupNames={[Function]}
           showNoGroupOption={false}
@@ -87,6 +88,7 @@ describe('with some groups available', () => {
               undefined,
             ]
           }
+          isKesselEnabled={false}
           selectedGroupNames={[]}
           setSelectedGroupNames={[Function]}
           showNoGroupOption={false}
@@ -140,6 +142,7 @@ describe('with some groups available', () => {
               undefined,
             ]
           }
+          isKesselEnabled={false}
           selectedGroupNames={[]}
           setSelectedGroupNames={[Function]}
           showNoGroupOption={true}
@@ -193,9 +196,10 @@ describe('with some groups available', () => {
               undefined,
             ]
           }
+          isKesselEnabled={true}
           selectedGroupNames={[]}
           setSelectedGroupNames={[Function]}
-          showNoGroupOption={false}
+          showNoGroupOption={true}
         />,
       }
     `);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Include the missing 'type' parameter in the getGroupList API call to correctly filter group lists