### PR TITLE
fix(RHINENG-11334): filter descriptions to lower case

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -77,7 +77,8 @@ export const generateFilters = (
   filters.map((filter, key) => {
     const activeKey = filter.index || key;
     const activeLabel =
-      cells[activeKey] && (cells[activeKey].title || cells[activeKey]);
+      cells[activeKey] &&
+      (cells[activeKey].title?.toLowerCase() || cells[activeKey]);
     return {
       value: String(activeKey),
       label: activeLabel,

--- a/src/constants.test.js
+++ b/src/constants.test.js
@@ -234,14 +234,14 @@ describe('generateFilters', () => {
     });
     expect(filters[2]).toMatchObject({
       value: '2',
-      label: 'Third',
+      label: 'third',
       filterValues: {
         items: [{ label: 'ff' }],
       },
     });
     expect(filters[3]).toMatchObject({
       value: '2',
-      label: 'Third',
+      label: 'third',
       type: 'text',
     });
     expect(filters.length).toBe(4);


### PR DESCRIPTION
## Description of Problem
The following modals have filter description using capital letters:

- Kernel modules: 'Filter by module'
- Installed packages: 'Filter by package name'
- Running processes: 'Filter by process name'
- Repositories: 'Filter by name' and  'Filter by enabled'

### How reproducible
Always

### Steps to Reproduce
Navigate to a system details page from system inventory Open one of the modal mentioned
Set a filter

### Actual Behavior
The filter description will appear with capital letters.

### Expected Behavior
Filter description should not have capital letters.