### PR TITLE
fix: WIP update API calls after HBI client update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@redhat-cloud-services/frontend-components": "^5.2.12",
         "@redhat-cloud-services/frontend-components-notifications": "^4.1.23",
         "@redhat-cloud-services/frontend-components-utilities": "^5.0.13",
-        "@redhat-cloud-services/host-inventory-client": "^4.0.1",
+        "@redhat-cloud-services/host-inventory-client": "^4.0.2",
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.0",
         "@sentry/webpack-plugin": "^2.22.5",
         "@unleash/proxy-client-react": "^3.5.0",
@@ -4315,9 +4315,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/host-inventory-client": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-4.0.1.tgz",
-      "integrity": "sha512-QElYimdJUUQTzwkL59+ymq2g6tE3zDb1ZFmjTH/iwXLwVnG1o+wXloEtoNBkJoLdxFrgAsGNVhjGjBiZx0lsTg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-4.0.2.tgz",
+      "integrity": "sha512-+b+Rsss2XCo2DIV+I/WSQiMN4QOYNTuLjj7Iw1hZFSmonGXlrPHhNWSGrpIKiCvdJral4IZF0v5t2fUIUHLCIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@redhat-cloud-services/frontend-components": "^5.2.12",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.23",
     "@redhat-cloud-services/frontend-components-utilities": "^5.0.13",
-    "@redhat-cloud-services/host-inventory-client": "^4.0.1",
+    "@redhat-cloud-services/host-inventory-client": "^4.0.2",
     "@redhat-cloud-services/javascript-clients-shared": "^2.0.0",
     "@sentry/webpack-plugin": "^2.22.5",
     "@unleash/proxy-client-react": "^3.5.0",

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -12,10 +12,7 @@ import {
   UPDATE_METHOD_KEY,
   allStaleFilters,
 } from '../Utilities/constants';
-import {
-  ApiTagGetTagsOrderByEnum,
-  ApiTagGetTagsOrderHowEnum,
-} from '@redhat-cloud-services/host-inventory-client/ApiTagGetTags';
+import { ApiTagGetTagsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiTagGetTags';
 import {
   createStaleness as apiCreateStaleness,
   getDefaultStaleness as apiGetDefaultStaleness,
@@ -360,7 +357,7 @@ export function getAllTags(search, pagination = {}) {
   return apiGetTags({
     tags: [],
     orderBy: ApiTagGetTagsOrderByEnum.Tag,
-    orderHow: ApiTagGetTagsOrderHowEnum.Asc,
+    orderHow: 'ASC',
     perPage: pagination.perPage || 10,
     page: pagination.page || 1,
     staleness: allStaleFilters,


### PR DESCRIPTION
This PR relates to [RHINENG-18587](https://issues.redhat.com/browse/RHINENG-18587)
After the upgrade to host-inventory-client 4.0.2, several API parameters have changed (4 months worth of changes).

******This PR has to be merged before the fix for the systems page [PR 2486](https://github.com/RedHatInsights/insights-inventory-frontend/pull/2486)

## Summary by Sourcery

Bug Fixes:
- Replace ApiTagGetTagsOrderHowEnum.Asc with raw string 'ASC' in getAllTags API call