### PR TITLE
fix(RHINENG-16451): Add access for Advisor read-only roles

### DIFF
--- a/src/ApplicationTab.js
+++ b/src/ApplicationTab.js
@@ -28,10 +28,7 @@ const ApplicationTab = ({ appName, title, ...props }) => {
 
   const Tab = tabs[appName];
 
-  return hasAccess ||
-    (isOrgAdmin &&
-      appName !==
-        'advisor') /** TODO: remove the advisor exception once the rbac-config is updated */ ? (
+  return hasAccess || isOrgAdmin ? (
     <Tab {...props} />
   ) : (
     <AccessDenied

--- a/src/constants.js
+++ b/src/constants.js
@@ -300,7 +300,7 @@ export const TAB_REQUIRED_PERMISSIONS = {
    * https://github.com/RedHatInsights/rbac-config/tree/master/configs/stage/roles
    * viewer roles.
    */
-  advisor: ['advisor:*:*'], // corresponds to the Advisor administrator - an only available - RBAC role
+  advisor: ['advisor:*:read'],
   vulnerability: [
     'vulnerability:vulnerability_results:read',
     'vulnerability:system.opt_out:read',


### PR DESCRIPTION
Before changes, a user with read-only access to Advisor can't access the data under the Advisor tab:
![Screenshot from 2025-06-10 13-54-16](https://github.com/user-attachments/assets/6a5ad8ed-8d70-4049-85af-a643f795189a)

After the changes, the same user can correctly see recommendations under the Advisor tab:
![Screenshot from 2025-06-10 13-56-52](https://github.com/user-attachments/assets/1bfcb047-39a2-4cda-b485-404ffef6dd8c)
