### PR TITLE
chore: update npm version in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit_hash || 'refs/heads/master' }}
-
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'npm'
       - run: npm ci
       - run: npm run lint
       - name: Validate current commit (last commit) with commitlint


### PR DESCRIPTION
In https://github.com/RedHatInsights/insights-inventory-frontend/pull/2491 we've forgot to bump the version in CI as it was not very obvious.

## Summary by Sourcery

Update CI workflows to upgrade actions/checkout to v4 and configure Node.js 22 via actions/setup-node@v4

CI:
- Bump actions/checkout from v3 to v4 in main workflow
- Add actions/setup-node@v4 with Node.js v22 to both main and test workflows