### PR TITLE
fix: Ungrouped for kessel v2

### DIFF
--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -17,14 +17,15 @@ const SearchableGroupFilter = ({
   selectedGroupNames,
   setSelectedGroupNames,
   showNoGroupOption,
+  isKesselEnabled = false, // default to false for backward compatibility
 }) => {
   const initialValues = useMemo(
     () => [
-      ...(showNoGroupOption
+      ...(showNoGroupOption || isKesselEnabled
         ? [
             {
               itemId: '',
-              children: 'No workspace',
+              children: isKesselEnabled ? 'Ungrouped' : 'No workspace',
             },
           ]
         : []),
@@ -33,7 +34,7 @@ const SearchableGroupFilter = ({
         children: name,
       })),
     ],
-    [initialGroups, showNoGroupOption],
+    [initialGroups, showNoGroupOption, isKesselEnabled],
   );
 
   const [isOpen, setIsOpen] = useState(false);
@@ -214,6 +215,7 @@ SearchableGroupFilter.propTypes = {
   selectedGroupNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   setSelectedGroupNames: PropTypes.func.isRequired,
   showNoGroupOption: PropTypes.bool,
+  isKesselEnabled: PropTypes.bool, // default to false for backward compatibility
 };
 
 export default SearchableGroupFilter;

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -54,10 +54,8 @@ const useGroupFilter = (showNoGroupOption = false, isKesselEnabled = false) => {
     const fetchOptions = async () => {
       if (!hasAccess) return;
 
-      const search = isKesselEnabled ? { type: 'all' } : undefined;
-
       const firstRequest = !ignore
-        ? await getGroups(search, { page: 1, per_page: 50 })
+        ? await getGroups(undefined, { page: 1, per_page: 50 })
         : { total: 0 };
 
       const groups =
@@ -103,7 +101,8 @@ const useGroupFilter = (showNoGroupOption = false, isKesselEnabled = false) => {
             initialGroups={fetchedGroups}
             selectedGroupNames={selectedGroupNames}
             setSelectedGroupNames={setSelectedGroupNames}
-            showNoGroupOption={showNoGroupOption && !isKesselEnabled}
+            showNoGroupOption={showNoGroupOption}
+            isKesselEnabled={isKesselEnabled}
           />
         ),
       },


### PR DESCRIPTION
## Summary by Sourcery

Enable Kessel v2 support by adding an `isKesselEnabled` toggle to group filters, updating the no-group option to “Ungrouped” when active, and simplifying the fetch logic accordingly.

Enhancements:
- Introduce `isKesselEnabled` flag to toggle Kessel v2 grouping behavior
- Adjust the no-group option label to display “Ungrouped” when Kessel v2 is enabled
- Always include ungrouped option when `isKesselEnabled` is true and adjust its default children text
- Remove the legacy Kessel-specific search parameter from the group-fetching logic
- Propagate the new `isKesselEnabled` prop through `useGroupFilter` and `SearchableGroupFilter`