### PR TITLE
chore: cleanup unused parameter

### DIFF
--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -137,7 +137,6 @@ const GroupsTable = ({ onCreateGroupClick }) => {
           fetchGroups(
             {
               ...search,
-              ...(isKesselEnabled && { type: 'all' }),
               order_by,
               order_how,
             },


### PR DESCRIPTION
This parameter was renamed to `group_type` and we don't need it anymore.