### PR TITLE
fix(RHINENG-17963): respect edgeParity.inventory-list-filter

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -144,18 +144,22 @@ const buildOperatingSystemFilter = (osFilterState = {}) => {
     }, {});
 };
 
-export const calculateSystemProfile = ({
-  osFilter,
-  rhcdFilter,
-  updateMethodFilter,
-  hostTypeFilter,
-  system_profile,
-  systemTypeFilter,
-}) => {
+export const calculateSystemProfile = (
+  {
+    osFilter,
+    rhcdFilter,
+    updateMethodFilter,
+    hostTypeFilter,
+    system_profile,
+    systemTypeFilter,
+  },
+  filterImmutable = true,
+) => {
   const operating_system = buildOperatingSystemFilter(osFilter);
+  const defaultHostTypeFilter = filterImmutable ? { host_type: 'nil' } : {};
   const newSystemProfile = {
     ...system_profile,
-    ...(hostTypeFilter ? { host_type: hostTypeFilter } : { host_type: 'nil' }),
+    ...(hostTypeFilter ? { host_type: hostTypeFilter } : defaultHostTypeFilter),
     ...(updateMethodFilter
       ? {
           [UPDATE_METHOD_KEY]: {
@@ -225,6 +229,7 @@ export async function getEntities(
         /* needed for image based systems */ 'bootc_status',
       ],
     },
+    filterImmutableByDefault = true,
     ...options
   },
   showTags,
@@ -292,7 +297,9 @@ export async function getEntities(
 
     const filterQueryParams =
       Object.keys(combinedFilters).length &&
-      generateFilter(calculateSystemProfile(combinedFilters));
+      generateFilter(
+        calculateSystemProfile(combinedFilters, filterImmutableByDefault),
+      );
 
     const fieldsQueryParams =
       Object.keys(fields || {}).length && generateFilter(fields, 'fields');

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -19,6 +19,7 @@ import { clearErrors, entitiesLoading } from '../../store/actions';
 import cloneDeep from 'lodash/cloneDeep';
 import { useSearchParams } from 'react-router-dom';
 import { ACTION_TYPES } from '../../store/action-types';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 /**
  * A helper function to store props and to always return the latest state.
@@ -143,6 +144,10 @@ const InventoryTable = forwardRef(
 
     const controller = useRef(new AbortController());
 
+    const edgeParityFilterDeviceEnabled = useFeatureFlag(
+      'edgeParity.inventory-list-filter',
+    );
+
     /**
      * If initialLoading is set to true, then the component should be in loading state until
      * entities.loaded is false (and then we can use the redux loading state and forget this one)
@@ -234,7 +239,12 @@ const InventoryTable = forwardRef(
           onRefresh(newParams, (options) => {
             dispatch(
               loadSystems(
-                { ...newParams, ...options, controller: controller.current },
+                {
+                  ...newParams,
+                  ...options,
+                  controller: controller.current,
+                  filterImmutableByDefault: edgeParityFilterDeviceEnabled,
+                },
                 cachedProps.showTags,
                 cachedProps.getEntities,
               ),
@@ -243,7 +253,11 @@ const InventoryTable = forwardRef(
         } else {
           dispatch(
             loadSystems(
-              { ...newParams, controller: controller.current },
+              {
+                ...newParams,
+                controller: controller.current,
+                filterImmutableByDefault: edgeParityFilterDeviceEnabled,
+              },
               cachedProps.showTags,
               cachedProps.getEntities,
             ),


### PR DESCRIPTION
edgeParity.inventory-list-filter is supposed to filter edge (OSTree) systems from ConventionalTab.

The flag was turned on for so long we forgot to implement this conditional behaviour in API.

This fixes the issue and allows for the flag to be disabled.

## Summary by Sourcery

Respect the edgeParity.inventory-list-filter feature flag by adding a toggle for the default host_type filter in API calls and wiring the flag in InventoryTable to control OSTree system filtering.

Bug Fixes:
- Allow disabling of OSTree system filtering by respecting the edgeParity.inventory-list-filter flag.

Enhancements:
- Introduce a filterImmutableByDefault parameter in calculateSystemProfile and getEntities to toggle the default host_type filter.
- Retrieve the edgeParity.inventory-list-filter flag in InventoryTable and pass it to loadSystems to control edge system filtering.