### PR TITLE
fix(RHINENG-18732): broken selection on Workspaces page

### DIFF
--- a/src/components/GroupsTable/GroupsTable.js
+++ b/src/components/GroupsTable/GroupsTable.js
@@ -345,7 +345,7 @@ const GroupsTable = ({ onCreateGroupClick }) => {
 
   const containsUngrouped = (selectedIds) => {
     for (const id of selectedIds) {
-      ungrouped = groups.find(id)?.ungrouped;
+      const ungrouped = groups.find((group) => group.id === id)?.ungrouped;
       if (ungrouped) {
         return true;
       }


### PR DESCRIPTION
To repro:
- Inventory -> Workspaces
- Bulk select or single select any workspace

The page reloads the first time, and crashes on the second selection.

This PR fixes the selection in both instances.

## Summary by Sourcery

Fix broken workspace selection on the Workspaces page by correcting the group lookup logic to prevent crashes on subsequent selections.

Bug Fixes:
- Fix crash on second workspace selection by using the correct find predicate to identify ungrouped groups
- Ensure bulk and single workspace selections no longer reload or crash