### PR TITLE
fix(RHINENG-18805): Add to workspace button disabled

### DIFF
--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -180,7 +180,7 @@ const ConventionalSystemsTab = ({
 
       if (isKesselEnabled) {
         return selectedHosts.every(
-          ({ groups }) => groups[0].ungrouped !== true,
+          ({ groups }) => groups[0]?.ungrouped === true,
         );
       }
 


### PR DESCRIPTION
This PR fixes an issue where we were returning the incorrect boolean value to determine if the "Add to workspace" button was disabled.

To repro:
- Inventory -> Systems
- Select 1 or more system checkboxes with "Ungrouped hosts" value in the Workspace column
- Click action kebab in the toolbar

You should see that the "Add to workspaces" menu item is disabled. This PR fixes that.

## Summary by Sourcery

Bug Fixes:
- Correct the condition to properly disable the 'Add to workspace' button for ungrouped hosts