### PR TITLE
fix(RHINENG-18834): Update options name for Systems type filter

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -123,11 +123,11 @@ export const updateMethodOptions = initUpdateMethodOptions;
 
 export const systemTypeOptions = [
   {
-    label: 'Package mode',
+    label: 'Package-based system',
     value: 'nil',
   },
   {
-    label: 'Image mode',
+    label: 'Image-based system',
     value: 'not_nil',
   },
 ];


### PR DESCRIPTION
 Update options name for Systems type filter. This PR is part of https://issues.redhat.com/browse/RHINENG-18834 ticket (queries will be updated in different PR when new parameters for filtering systems by system type are introduced, card is linked). 


Changes:
"Package mode" -> "Package-based system"
"Image mode" -> "Image-based system"