### PR TITLE
fix(RHINENG-11653): Fix delete system toast alerts

### DIFF
--- a/src/components/InventoryDetail/TopBar.js
+++ b/src/components/InventoryDetail/TopBar.js
@@ -173,10 +173,10 @@ const TopBar = ({
           onConfirm={() => {
             addNotification({
               id: 'remove-initiated',
-              variant: 'warning',
+              variant: 'info',
               title: 'Delete operation initiated',
               description: `Removal of ${entity.display_name} started.`,
-              dismissable: false,
+              dismissable: true,
             });
             deleteEntity([entity.id], entity.display_name, () =>
               redirectToInventoryList(entity.id, onBackToListClick, navigate),

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -321,10 +321,10 @@ const ConventionalSystemsTab = ({
           dispatch(
             addNotificationAction({
               id: 'remove-initiated',
-              variant: 'warning',
+              variant: 'info',
               title: 'Delete operation initiated',
               description: `Removal of ${displayName} started.`,
-              dismissable: false,
+              dismissable: true,
             }),
           );
           dispatch(actions.deleteEntity(removeSystems, displayName));

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.test.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.test.js
@@ -203,10 +203,10 @@ describe('ConventionalSystemsTab', () => {
     shouldDispatch(store, {
       payload: {
         description: `Removal of ${system1.display_name} started.`,
-        dismissable: false,
+        dismissable: true,
         id: 'remove-initiated',
         title: 'Delete operation initiated',
-        variant: 'warning',
+        variant: 'info',
       },
       type: '@@INSIGHTS-CORE/NOTIFICATIONS/ADD_NOTIFICATION',
     });

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -24,6 +24,13 @@ export const deleteEntity = (systems, displayName) => ({
         description: `${displayName} has been successfully removed.`,
         dismissable: true,
       },
+      rejected: {
+        variant: 'danger',
+        title: 'System failed to be removed from Inventory',
+        description:
+          'There was an error processing the request. Please try again.',
+        dismissable: true,
+      },
     },
     systems,
   },


### PR DESCRIPTION
A couple of changes were identified on toast alerts triggered when deleting a system from inventory.

- Error header should be: ‘System failed to be removed from inventory’ instead of 'Error'
- A blue icon - info should be used for 'Delete operation initiated' rather than warning - yellow
- 'Delete operation initiated' toast should have a ‘x’ close button

Steps to Reproduce
- Navigate to Inventory
- Try to delete a system from inventory

You can force a failure by changing the `hostIdList` value to 'blah' for the `deleteSystemsById` function in the src/components/InventoryTable/utils/api.js file.

## Summary by Sourcery

Fix delete system toast notifications by updating the error header, using the appropriate info icon, and adding a close button to the initiation toast.

Bug Fixes:
- Change delete failure toast title to 'System failed to be removed from Inventory'
- Switch 'Delete operation initiated' toast to use the info variant instead of warning
- Make the 'Delete operation initiated' toast dismissable by adding a close button