### PR TITLE
feat(RHINENG-18834): Add image-based icon/label to immutable systems 

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -225,6 +225,7 @@ export async function getEntities(
     fields = {
       system_profile: [
         'operating_system',
+        /* needed by inventory groups */ 'host_type',
         /* needed by inventory groups */ 'system_update_method',
         /* needed for image based systems */ 'bootc_status',
       ],

--- a/src/components/InventoryDetail/FactsInfo.js
+++ b/src/components/InventoryDetail/FactsInfo.js
@@ -70,11 +70,11 @@ const FactsInfo = ({ entity, loaded, LastSeenWrapper, ...props }) => (
             )}
         </FlexItem>
         <FlexItem>
-          {loaded &&
-          entity?.system_profile?.system_update_method !== 'rpm-ostree' ? (
+          {loaded ? (
             <OsModeLabel
               osMode={
-                entity?.system_profile?.bootc_status?.booted?.image_digest
+                entity?.system_profile?.bootc_status?.booted?.image_digest ||
+                entity?.system_profile?.host_type === 'edge'
                   ? 'image'
                   : 'package'
               }

--- a/src/components/InventoryTable/TitleColumn.js
+++ b/src/components/InventoryTable/TitleColumn.js
@@ -41,7 +41,7 @@ const TitleColumn = ({ children, id, item, ...props }) => {
   const edgeParityFilterDeviceEnabled = useFeatureFlag(
     'edgeParity.inventory-list-filter',
   );
-  // const featureKey = edgeParityFilterDeviceEnabled ? 'enabled' : 'disabled';
+
   return (
     <div className="ins-composed-col sentry-mask data-hj-suppress">
       {item?.os_release && <div key="os_release">{item?.os_release}</div>}
@@ -50,7 +50,8 @@ const TitleColumn = ({ children, id, item, ...props }) => {
           children
         ) : (
           <span>
-            {item?.system_profile?.bootc_status?.booted?.image_digest ? (
+            {item?.system_profile?.bootc_status?.booted?.image_digest ||
+            item?.system_profile?.host_type === 'edge' ? (
               <Popover
                 triggerAction="hover"
                 headerContent="Image-based system"


### PR DESCRIPTION
Add image-based icon/label to immutable systems (https://issues.redhat.com/browse/RHINENG-18834)

![image](https://github.com/user-attachments/assets/98c5e13c-8284-493a-ae97-0717d7b494f9)


Steps to reproduce:
1. Navigate to Systems page
2. Disable flag `edgeParity.inventory-list-filter` in stage-unleash to enable edge systems in main tab  (currently table doesn't display edge systems)
3. Navigate to immutable system details to see Image label

