### PR TITLE
feat(RHINENG-17963): Show edge systems in main tab in Add systems modal

### DIFF
--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -119,9 +119,28 @@ const AddSystemsToGroupModal = ({
   const edgeParityInventoryGroupsEnabled = useFeatureFlag(
     'edgeParity.inventory-groups-enabled',
   );
+  const edgeParityFilterDeviceEnabled = useFeatureFlag(
+    'edgeParity.inventory-list-filter',
+  );
   const edgeParityEnabled =
     edgeParityInventoryListEnabled && edgeParityInventoryGroupsEnabled;
 
+  const defaultInventorySystemsGetEntities = (
+    items,
+    config,
+    showTags,
+    defaultGetEntities,
+  ) =>
+    defaultGetEntities(
+      items,
+      {
+        ...config,
+        filters: {
+          ...config.filters,
+        },
+      },
+      showTags,
+    );
   const [selectedImmutableDevices, setSelectedImmutableDevices] = useState([]);
   const selectedImmutableKeys = selectedImmutableDevices.map(
     (immutableDevice) => immutableDevice.id,
@@ -163,7 +182,11 @@ const AddSystemsToGroupModal = ({
   const ConventionalInventoryTable = (
     <InventoryTable
       columns={(columns) => prepareColumns(columns, false, true)}
-      getEntities={defaultConventionalSystemsGetEntities}
+      getEntities={
+        edgeParityFilterDeviceEnabled
+          ? defaultConventionalSystemsGetEntities
+          : defaultInventorySystemsGetEntities
+      }
       variant={TableVariant.compact} // TODO: this doesn't affect the table variant
       tableProps={{
         isStickyHeader: false,


### PR DESCRIPTION
PR to display all type of hosts in `Add systems` modal (`nil` and `edge`) when `edgeParityFilterDeviceEnabled` feature flag is disabled. (This is part of Edge decommission work)

Steps to reproduce:
1. Navigate to workspace details
2. disable flag 'edgeParity.inventory-list-filter' in stage-unleash
3. open Add systesm modal and search for 'edge' system or check the total of systems in Add systems modal table and main Systems page table = should be the same

## Summary by Sourcery

Use the edgeParity.inventory-list-filter feature flag to toggle between filtered and unfiltered system lists in the Add systems modal, ensuring edge hosts appear when the flag is disabled

New Features:
- Show both conventional and edge hosts in the Add systems modal when the edgeParity.inventory-list-filter flag is disabled

Enhancements:
- Introduce defaultInventorySystemsGetEntities helper to fetch inventory systems without applying the edgeParity device filter
- Conditionally switch the getEntities prop in AddSystemsToGroupModal based on the edgeParity.inventory-list-filter feature flag