### PR TITLE
fix(RHINENG-11336): Update text in delete systems modal

### DIFF
--- a/src/Utilities/DeleteModal.js
+++ b/src/Utilities/DeleteModal.js
@@ -17,19 +17,21 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 const DeleteModal = ({
   handleModalToggle,
   isModalOpen,
-  currentSytems,
+  currentSystems,
   onConfirm,
 }) => {
   let systemToRemove;
   let systemLabel = 'system';
-  if (Array.isArray(currentSytems)) {
+  let systemPronoun = 'this';
+  if (Array.isArray(currentSystems)) {
     systemToRemove =
-      currentSytems.length === 1
-        ? currentSytems[0].display_name
-        : `${currentSytems.length} systems`;
-    systemLabel = currentSytems.length === 1 ? systemLabel : 'systems';
+      currentSystems.length === 1
+        ? currentSystems[0].display_name
+        : `${currentSystems.length} systems`;
+    systemLabel = currentSystems.length === 1 ? systemLabel : 'systems';
+    systemPronoun = currentSystems.length === 1 ? systemPronoun : 'these';
   } else {
-    systemToRemove = currentSytems.display_name;
+    systemToRemove = currentSystems.display_name;
   }
 
   return (
@@ -58,8 +60,8 @@ const DeleteModal = ({
               {systemLabel} to add it back to your inventory.
             </StackItem>
             <StackItem>
-              To disable the daily upload for this {systemLabel}, use the
-              following command:
+              To disable the daily upload for {systemPronoun} {systemLabel}, use
+              the following command:
             </StackItem>
             <StackItem>
               <ClipboardCopy>insights-client --unregister</ClipboardCopy>
@@ -97,7 +99,7 @@ const ActiveSystemProp = PropTypes.shape({
 
 DeleteModal.propTypes = {
   isModalOpen: PropTypes.bool,
-  currentSytems: PropTypes.oneOfType([
+  currentSystems: PropTypes.oneOfType([
     ActiveSystemProp,
     PropTypes.arrayOf(ActiveSystemProp),
   ]),
@@ -107,7 +109,7 @@ DeleteModal.propTypes = {
 
 DeleteModal.defaultProps = {
   isModalOpen: false,
-  currentSytems: {},
+  currentSystems: {},
   handleModalToggle: () => undefined,
   onConfirm: () => undefined,
 };

--- a/src/Utilities/DeleteModal.test.js
+++ b/src/Utilities/DeleteModal.test.js
@@ -8,7 +8,7 @@ describe('DeleteModal', () => {
     it('should render correctly with one system', () => {
       const view = render(
         <DeleteModal
-          currentSytems={{ display_name: 'something' }}
+          currentSystems={{ display_name: 'something' }}
           isModalOpen
         />,
       );
@@ -22,7 +22,7 @@ describe('DeleteModal', () => {
     it('should render correctly with multiple systems', () => {
       const view = render(
         <DeleteModal
-          currentSytems={[
+          currentSystems={[
             { display_name: 'something' },
             { display_name: 'another' },
           ]}
@@ -46,7 +46,7 @@ describe('DeleteModal', () => {
       const onClose = jest.fn();
       render(
         <DeleteModal
-          currentSytems={[
+          currentSystems={[
             { display_name: 'something' },
             { display_name: 'another' },
           ]}
@@ -67,7 +67,7 @@ describe('DeleteModal', () => {
       const onClose = jest.fn();
       render(
         <DeleteModal
-          currentSytems={[
+          currentSystems={[
             { display_name: 'something' },
             { display_name: 'another' },
           ]}
@@ -88,7 +88,7 @@ describe('DeleteModal', () => {
       const onConfirm = jest.fn();
       render(
         <DeleteModal
-          currentSytems={[
+          currentSystems={[
             { display_name: 'something' },
             { display_name: 'another' },
           ]}

--- a/src/Utilities/__snapshots__/DeleteModal.test.js.snap
+++ b/src/Utilities/__snapshots__/DeleteModal.test.js.snap
@@ -119,7 +119,9 @@ exports[`DeleteModal DOM should render correctly with multiple systems 1`] = `
                 <div
                   class="pf-v5-l-stack__item"
                 >
-                  To disable the daily upload for this 
+                  To disable the daily upload for 
+                  these
+                   
                   systems
                   , use the following command:
                 </div>
@@ -332,7 +334,9 @@ exports[`DeleteModal DOM should render correctly with one system 1`] = `
                 <div
                   class="pf-v5-l-stack__item"
                 >
-                  To disable the daily upload for this 
+                  To disable the daily upload for 
+                  this
+                   
                   system
                   , use the following command:
                 </div>

--- a/src/components/InventoryDetail/TopBar.js
+++ b/src/components/InventoryDetail/TopBar.js
@@ -169,7 +169,7 @@ const TopBar = ({
           className="sentry-mask data-hj-suppress"
           handleModalToggle={() => setIsModalOpen(!isModalOpen)}
           isModalOpen={isModalOpen}
-          currentSytems={entity}
+          currentSystems={entity}
           onConfirm={() => {
             addNotification({
               id: 'remove-initiated',

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -303,7 +303,7 @@ const ConventionalSystemsTab = ({
         className="sentry-mask data-hj-suppress"
         handleModalToggle={handleModalToggle}
         isModalOpen={isModalOpen}
-        currentSytems={currentSystem}
+        currentSystems={currentSystem}
         onConfirm={() => {
           let displayName;
           let removeSystems;


### PR DESCRIPTION
Description of Problem
The second paragraph should be plurals. It says 'this systems' but it should be 'these systems'.

Steps to Reproduce
- Navigate to the Inventory
- Select multiple systems
- Click 'Delete'

Actual Behavior
The modal is pluralized but the second paragraph 'this systems'.

Expected Behavior
'these systems' should be plural.

## Summary by Sourcery

Fix pluralization in the delete modal by introducing correct pronoun logic and rename mistyped prop across code and tests

Bug Fixes:
- Use 'these' instead of 'this' when deleting multiple systems in the delete modal

Tests:
- Update DeleteModal unit tests and snapshots to reflect prop rename and pronoun change

Chores:
- Rename mistyped prop 'currentSytems' to 'currentSystems' across components, prop types, and tests