### PR TITLE
fix(RHINENG-11367): Fix dropdown spacing

### DIFF
--- a/src/components/InventoryHostStaleness/TabCard.js
+++ b/src/components/InventoryHostStaleness/TabCard.js
@@ -40,7 +40,7 @@ const TabCard = ({
     <React.Fragment>
       <Card isPlain className="pf-v5-u-mb-lg">
         <Flex
-          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          spaceItems={{ default: 'spaceItems2xl' }}
           style={{ minHeight: '110px' }}
         >
           {dropdownArray(activeTabKey).map((item) => (

--- a/src/components/InventoryHostStaleness/__test__/InventoryHostStaleness.test.js
+++ b/src/components/InventoryHostStaleness/__test__/InventoryHostStaleness.test.js
@@ -145,4 +145,57 @@ describe('Table Renders', () => {
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled(),
     );
   });
+
+  jest.setTimeout(10000);
+  it('Will reset to default', async () => {
+    renderHostStalenessCard();
+
+    await screen.findByRole('button', { name: 'Edit' });
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const menuToggleButtons = await waitFor(() =>
+      screen
+        .getAllByRole('button')
+        .filter((button) => button.classList.contains('pf-v5-c-menu-toggle')),
+    );
+
+    menuToggleButtons.forEach((button) => expect(button).toBeEnabled());
+    await userEvent.click(menuToggleButtons[0]);
+    const option1 = screen.getByRole('option', {
+      name: /2 days/i,
+    });
+    await userEvent.click(option1);
+
+    await userEvent.click(menuToggleButtons[1]);
+    const option2 = screen.getByRole('option', {
+      name: /6 days/i,
+    });
+    await userEvent.click(option2);
+
+    await userEvent.click(menuToggleButtons[2]);
+    const option3 = screen.getByRole('option', {
+      name: /21 days/i,
+    });
+    await userEvent.click(option3);
+
+    expect(
+      screen.queryByRole('button', { name: /7 days/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /2 days/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /6 days/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /21 days/i })).toBeVisible();
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /reset to default setting/i,
+      }),
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /6 days/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /1 day/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /7 days/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /14 days/i })).toBeVisible();
+  });
 });

--- a/src/components/InventoryTable/hooks/useColumns.test.js
+++ b/src/components/InventoryTable/hooks/useColumns.test.js
@@ -127,8 +127,6 @@ describe('useColumns', () => {
         ? { ...col, key: overrideKey, sortKey: overrideKey }
         : col,
     );
-    console.log('result', result.current);
-    console.log('updatedcolumns', updatedColumns);
     expect(result.current).toEqual(updatedColumns);
   });
 
@@ -150,8 +148,6 @@ describe('useColumns', () => {
         ? { ...col, key: overrideKey, sortKey: overrideKey }
         : col,
     );
-    console.log('result', result.current);
-    console.log('updatedcolumns', updatedColumns);
     expect(result.current).toEqual(updatedColumns);
   });
 
@@ -173,8 +169,6 @@ describe('useColumns', () => {
         ? { ...col, key: overrideKey, sortKey: overrideKey }
         : col,
     );
-    console.log('result', result.current);
-    console.log('updatedcolumns', updatedColumns);
     expect(result.current).toEqual(updatedColumns);
   });
 });


### PR DESCRIPTION
Staleness, Stale warning and Deletion configuration dropdown should align closer to show relationships. On large screen, the dropdowns are far from each other. 'Layout spacing is a little off and the relationship between the dropdowns are needed.' from SPUR review.

Steps to Reproduce
- Navigate to RHEL > Inventory > System Configuration > Staleness and Deletion
- Click Edit (you need the correct permissions)

## Summary by Sourcery

Align configuration dropdowns more closely and enhance related tests

Bug Fixes:
- Fix dropdown spacing in InventoryHostStaleness TabCard

Enhancements:
- Adjust Flex layout to use larger spaceItems spacing for dropdown alignment

Tests:
- Increase timeout and add reset-to-default behavior test for InventoryHostStaleness dropdowns
- Remove console.log statements from useColumns hook tests