### PR TITLE
fix(RHINENG-11337): use default warning patternfly Modal icon

### DIFF
--- a/src/Utilities/DeleteModal.js
+++ b/src/Utilities/DeleteModal.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
   Button,
   ClipboardCopy,
-  Icon,
   Level,
   LevelItem,
   Modal,
@@ -12,7 +11,6 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 const DeleteModal = ({
   handleModalToggle,
@@ -38,6 +36,7 @@ const DeleteModal = ({
     <Modal
       variant="small"
       title="Delete from inventory"
+      titleIconVariant="warning"
       className="ins-c-inventory__table--remove sentry-mask data-hj-suppress"
       ouiaId="inventory-delete-modal"
       isOpen={isModalOpen}
@@ -47,11 +46,6 @@ const DeleteModal = ({
       }
     >
       <Split hasGutter>
-        <SplitItem>
-          <Icon size="xl" status="warning">
-            <ExclamationTriangleIcon />
-          </Icon>
-        </SplitItem>
         <SplitItem isFilled>
           <Stack hasGutter>
             <StackItem>

--- a/src/Utilities/__snapshots__/DeleteModal.test.js.snap
+++ b/src/Utilities/__snapshots__/DeleteModal.test.js.snap
@@ -18,7 +18,7 @@ exports[`DeleteModal DOM should render correctly with multiple systems 1`] = `
         aria-describedby="pf-modal-part-3"
         aria-labelledby="pf-modal-part-2"
         aria-modal="true"
-        class="pf-v5-c-modal-box ins-c-inventory__table--remove sentry-mask data-hj-suppress pf-m-sm"
+        class="pf-v5-c-modal-box ins-c-inventory__table--remove sentry-mask data-hj-suppress pf-m-warning pf-m-sm"
         data-ouia-component-id="inventory-delete-modal"
         data-ouia-component-type="PF5/ModalContent"
         data-ouia-safe="true"
@@ -56,9 +56,31 @@ exports[`DeleteModal DOM should render correctly with multiple systems 1`] = `
           class="pf-v5-c-modal-box__header"
         >
           <h1
-            class="pf-v5-c-modal-box__title"
+            class="pf-v5-c-modal-box__title pf-m-icon"
             id="pf-modal-part-2"
           >
+            <span
+              class="pf-v5-c-modal-box__title-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v5-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 576 512"
+                width="1em"
+              >
+                <path
+                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                />
+              </svg>
+            </span>
+            <span
+              class="pf-v5-screen-reader"
+            >
+              Warning alert:
+            </span>
             <span
               class="pf-v5-c-modal-box__title-text"
             >
@@ -73,31 +95,6 @@ exports[`DeleteModal DOM should render correctly with multiple systems 1`] = `
           <div
             class="pf-v5-l-split pf-m-gutter"
           >
-            <div
-              class="pf-v5-l-split__item"
-            >
-              <span
-                class="pf-v5-c-icon pf-m-xl"
-              >
-                <span
-                  class="pf-v5-c-icon__content pf-m-warning"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v5-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 576 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </div>
             <div
               class="pf-v5-l-split__item pf-m-fill"
             >
@@ -233,7 +230,7 @@ exports[`DeleteModal DOM should render correctly with one system 1`] = `
         aria-describedby="pf-modal-part-2"
         aria-labelledby="pf-modal-part-1"
         aria-modal="true"
-        class="pf-v5-c-modal-box ins-c-inventory__table--remove sentry-mask data-hj-suppress pf-m-sm"
+        class="pf-v5-c-modal-box ins-c-inventory__table--remove sentry-mask data-hj-suppress pf-m-warning pf-m-sm"
         data-ouia-component-id="inventory-delete-modal"
         data-ouia-component-type="PF5/ModalContent"
         data-ouia-safe="true"
@@ -271,9 +268,31 @@ exports[`DeleteModal DOM should render correctly with one system 1`] = `
           class="pf-v5-c-modal-box__header"
         >
           <h1
-            class="pf-v5-c-modal-box__title"
+            class="pf-v5-c-modal-box__title pf-m-icon"
             id="pf-modal-part-1"
           >
+            <span
+              class="pf-v5-c-modal-box__title-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v5-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 576 512"
+                width="1em"
+              >
+                <path
+                  d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                />
+              </svg>
+            </span>
+            <span
+              class="pf-v5-screen-reader"
+            >
+              Warning alert:
+            </span>
             <span
               class="pf-v5-c-modal-box__title-text"
             >
@@ -288,31 +307,6 @@ exports[`DeleteModal DOM should render correctly with one system 1`] = `
           <div
             class="pf-v5-l-split pf-m-gutter"
           >
-            <div
-              class="pf-v5-l-split__item"
-            >
-              <span
-                class="pf-v5-c-icon pf-m-xl"
-              >
-                <span
-                  class="pf-v5-c-icon__content pf-m-warning"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v5-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 576 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                    />
-                  </svg>
-                </span>
-              </span>
-            </div>
             <div
               class="pf-v5-l-split__item pf-m-fill"
             >


### PR DESCRIPTION
Implements RHINENG-11337

This PR makes DeleteModal component use default patternfly icon instead of custom one

# How to reproduce
1. navigate to HCC for RHEL
2. go to Inventory
3. go to Systems
4. select a system
5. click on DELETE button
