### PR TITLE
feat(RHINENG-19424): Upgrade sentry sourcemap actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,3 +34,39 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: npm run build --if-present
+
+      - name: Install Sentry CLI
+        if: ${{ github.event.inputs.commit_hash != '' }}
+        run: npm install -g @sentry/cli
+      - name: Upload sourcemaps to Sentry
+        if: ${{ github.event.inputs.commit_hash != '' }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          COMMIT=${{ github.event.inputs.commit_hash || github.sha }}
+
+          PROJECTS=(
+            advisor-rhel
+            vulnerability-rhel
+            compliance-rhel
+            remediations-rhel
+            dashboard-rhel
+            malware-rhel
+            ocp-advisor
+            ocp-vulnerability
+            patchman-rhel
+            registration-assistant-rhel
+            sed-frontend-rhc
+            tasks-rhel
+            policies-rhel
+          )
+          for PROJECT in "${PROJECTS[@]}"; do
+            echo "Uploading sourcemaps to $PROJECT..."
+            sentry-cli releases files "$COMMIT" upload-sourcemaps ./dist/js \
+              --org red-hat-it \
+              --project "$PROJECT" \
+              --release "$COMMIT" \
+              --dist "$COMMIT" \
+              --url-prefix '~/insights/inventory/js' \
+              --validate
+          done


### PR DESCRIPTION
Uploads inventory actions to multiple applications

## Summary by Sourcery

Enhance the CI workflow to install Sentry CLI and upload JavaScript sourcemaps for multiple applications using a commit hash

New Features:
- Add CI support for uploading sourcemaps to multiple Sentry projects

CI:
- Install @sentry/cli when a commit_hash is provided
- Loop through a predefined list of projects in main.yml and upload sourcemaps with sentry-cli using the commit hash for release and distribution