### PR TITLE
feat(RHINENG-19382): add iop inventory table

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -134,9 +134,13 @@ module.exports = {
         __dirname,
         '/src/modules/ImmutableDevices.js',
       ),
-      './IOPInventoryTable': resolve(
+      './IOPInventoryTableModule': resolve(
         __dirname,
-        '/src/modules/IOPInventoryTable.js',
+        '/src/modules/IOPInventoryTableModule.js',
+      ),
+      './IOPHybridInventory': resolve(
+        __dirname,
+        '/src/modules/IOPHybridInventory.js',
       ),
     },
   },

--- a/src/components/InventoryTable/IOPEntityTableToolbar.js
+++ b/src/components/InventoryTable/IOPEntityTableToolbar.js
@@ -1,0 +1,736 @@
+import './EntityTableToolbar.scss';
+import React, { Fragment, useEffect, useReducer } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@redhat-cloud-services/frontend-components/Skeleton';
+import {
+  mapGroups,
+  tagsFilterReducer,
+  tagsFilterState,
+} from '@redhat-cloud-services/frontend-components/FilterHooks';
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
+import {
+  clearFilters,
+  fetchAllTags,
+  setFilter,
+  toggleTagModal,
+} from '../../store/actions';
+import debounce from 'lodash/debounce';
+import {
+  HOST_GROUP_CHIP,
+  LAST_SEEN_CHIP,
+  OS_CHIP,
+  REGISTERED_CHIP,
+  RHCD_FILTER_KEY,
+  STALE_CHIP,
+  TAG_CHIP,
+  TEXTUAL_CHIP,
+  TEXT_FILTER,
+  TagsModal,
+  UPDATE_METHOD_KEY,
+  SYSTEM_TYPE_KEY,
+  arrayToSelection,
+  reduceFilters,
+} from '../../Utilities/index';
+import { onDeleteFilter, onDeleteGroupFilter, onDeleteTag } from './helpers';
+import {
+  filtersReducer,
+  groupFilterReducer,
+  groupFilterState,
+  lastSeenFilterReducer,
+  lastSeenFilterState,
+  operatingSystemFilterReducer,
+  operatingSystemFilterState,
+  registeredWithFilterReducer,
+  registeredWithFilterState,
+  rhcdFilterReducer,
+  rhcdFilterState,
+  stalenessFilterReducer,
+  stalenessFilterState,
+  textFilterReducer,
+  textFilterState,
+  updateMethodFilterReducer,
+  updateMethodFilterState,
+  useLastSeenFilter,
+  useOperatingSystemFilter,
+  useRegisteredWithFilter,
+  useRhcdFilter,
+  useStalenessFilter,
+  useTagsFilter,
+  useTextFilter,
+  useUpdateMethodFilter,
+  useSystemTypeFilter,
+  systemTypeFilterReducer,
+  systemTypeFilterState,
+} from '../filters';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
+import useGroupFilter from '../filters/useGroupFilter';
+import { DatePicker, Split, SplitItem } from '@patternfly/react-core';
+import { fromValidator, UNIX_EPOCH, toValidator } from '../filters/helpers';
+import useInventoryExport from './hooks/useInventoryExport/useInventoryExport';
+
+/**
+ * Table toolbar used at top of inventory table.
+ * It uses couple of filters and acces redux data along side all passed props.
+ *  @param {*} props used in this component.
+ */
+const IOPEntityTableToolbar = ({
+  total,
+  page,
+  perPage,
+  filterConfig,
+  hasItems,
+  children,
+  actionsConfig,
+  activeFiltersConfig,
+  showTags,
+  getTags,
+  items,
+  sortBy,
+  customFilters,
+  hasAccess,
+  bulkSelect,
+  hideFilters,
+  paginationProps,
+  onRefreshData,
+  loaded,
+  showTagModal,
+  showSystemTypeFilter,
+  showCentosVersions,
+  showNoGroupOption,
+  enableExport,
+  fetchCustomOSes,
+  ...props
+}) => {
+  const dispatch = useDispatch();
+  const reducer = useReducer(
+    filtersReducer([
+      textFilterReducer,
+      stalenessFilterReducer,
+      registeredWithFilterReducer,
+      tagsFilterReducer,
+      operatingSystemFilterReducer,
+      rhcdFilterReducer,
+      lastSeenFilterReducer,
+      updateMethodFilterReducer,
+      groupFilterReducer,
+      systemTypeFilterReducer,
+    ]),
+    {
+      ...textFilterState,
+      ...stalenessFilterState,
+      ...registeredWithFilterState,
+      ...tagsFilterState,
+      ...operatingSystemFilterState,
+      ...rhcdFilterState,
+      ...updateMethodFilterState,
+      ...lastSeenFilterState,
+      ...groupFilterState,
+      ...systemTypeFilterState,
+    },
+  );
+  const activeFilters = useSelector(
+    ({ entities: { activeFilters } }) => activeFilters,
+  );
+  const allTagsLoaded = useSelector(
+    ({ entities: { allTagsLoaded } }) => allTagsLoaded,
+  );
+  const allTags = useSelector(({ entities: { allTags } }) => allTags);
+  const additionalTagsCount = useSelector(
+    ({ entities: { additionalTagsCount } }) => additionalTagsCount,
+  );
+  const [nameFilter, nameChip, textFilter, setTextFilter] =
+    useTextFilter(reducer);
+  const [stalenessFilter, stalenessChip, staleFilter, setStaleFilter] =
+    useStalenessFilter(reducer);
+  const [
+    registeredFilter,
+    registeredChip,
+    registeredWithFilter,
+    setRegisteredWithFilter,
+  ] = useRegisteredWithFilter(reducer);
+  const [
+    rhcdFilterConfig,
+    rhcdFilterChips,
+    rhcdFilterValue,
+    setRhcdFilterValue,
+  ] = useRhcdFilter(reducer);
+  const [
+    lastSeenFilter,
+    lastSeenChip,
+    lastSeenFilterValue,
+    setLastSeenFilterValue,
+    onFromChange,
+    onToChange,
+    endDate,
+    startDate,
+    setStartDate,
+    setEndDate,
+  ] = useLastSeenFilter(reducer);
+  const [osFilterConfig, osFilterChips, osFilterValue, setOsFilterValue] =
+    useOperatingSystemFilter(
+      reducer,
+      [],
+      hasAccess,
+      showCentosVersions,
+      fetchCustomOSes,
+    );
+  const [
+    updateMethodConfig,
+    updateMethodChips,
+    updateMethodValue,
+    setUpdateMethodValue,
+  ] = useUpdateMethodFilter(reducer);
+
+  const isKesselEnabled = useFeatureFlag('hbi.kessel-migration');
+  const [hostGroupConfig, hostGroupChips, hostGroupValue, setHostGroupValue] =
+    useGroupFilter(showNoGroupOption, isKesselEnabled);
+
+  const isUpdateMethodEnabled = useFeatureFlag('hbi.ui.system-update-method');
+  const { tagsFilter, tagsChip, selectedTags, setSelectedTags, filterTagsBy } =
+    useTagsFilter(
+      allTags,
+      allTagsLoaded,
+      additionalTagsCount,
+      () => dispatch(toggleTagModal(true)),
+      reducer,
+    );
+
+  const [
+    systemTypeConfig,
+    systemTypeChips,
+    systemTypeValue,
+    setSystemTypeValue,
+  ] = useSystemTypeFilter(reducer);
+  /**
+   * Debounced function for fetching all tags.
+   */
+  const debounceGetAllTags = debounce((config, options) => {
+    if (showTags && !hasItems && hasAccess) {
+      dispatch(
+        fetchAllTags(
+          config,
+          {
+            ...options?.paginationhideFilters,
+          },
+          getTags,
+        ),
+      );
+    }
+  }, 800);
+
+  const enabledFilters = {
+    name: !(hideFilters.all && hideFilters.name !== false) && !hideFilters.name,
+    stale:
+      !(hideFilters.all && hideFilters.stale !== false) && !hideFilters.stale,
+    registeredWith:
+      !(hideFilters.all && hideFilters.registeredWith !== false) &&
+      !hideFilters.registeredWith,
+    operatingSystem:
+      !(hideFilters.all && hideFilters.operatingSystem !== false) &&
+      !hideFilters.operatingSystem,
+    tags: !(hideFilters.all && hideFilters.tags !== false) && !hideFilters.tags,
+    rhcdFilter:
+      !(hideFilters.all && hideFilters.rhcdFilter !== false) &&
+      !hideFilters.rhcdFilter,
+    lastSeenFilter:
+      !(hideFilters.all && hideFilters.lastSeen !== false) &&
+      !hideFilters.lastSeen,
+    //hides the filter untill API is ready. JIRA: RHIF-169
+    updateMethodFilter:
+      isUpdateMethodEnabled &&
+      !(hideFilters.all && hideFilters.updateMethodFilter !== false) &&
+      !hideFilters.updateMethodFilter,
+    hostGroupFilter:
+      !(hideFilters.all && hideFilters.hostGroupFilter !== false) &&
+      !hideFilters.hostGroupFilter,
+    systemTypeFilter:
+      !(hideFilters.all && hideFilters.systemTypeFilter !== false) &&
+      !hideFilters.systemTypeFilter,
+  };
+
+  const exportConfig = useInventoryExport({
+    filters: {
+      ...activeFilters,
+      ...customFilters,
+    },
+  });
+
+  /**
+   * Function to dispatch load systems and fetch all tags.
+   *  @param options
+   */
+  const onRefreshDataInner = (options) => {
+    if (hasAccess) {
+      onRefreshData(options);
+      if (showTags && !hasItems) {
+        dispatch(fetchAllTags(filterTagsBy, {}, getTags));
+      }
+    }
+  };
+
+  /**
+   * Function used to update data, it either calls `onRefresh` from props or dispatches `onRefreshData`.
+   * `onRefresh` function takes two parameters
+   * entire config with new changes.
+   * callback to update data.
+   *  @param {*} config new config to fetch data.
+   */
+  const updateData = (config) => {
+    if (hasAccess) {
+      onRefreshDataInner(config);
+    }
+  };
+
+  /**
+   * Debounced `updateData` function.
+   */
+  const debouncedRefresh = debounce((config) => updateData(config), 800);
+
+  /**
+   * Component did mount effect to calculate actual filters from redux.
+   */
+  useEffect(() => {
+    const {
+      textFilter,
+      tagFilters,
+      staleFilter,
+      registeredWithFilter,
+      osFilter,
+      rhcdFilter,
+      lastSeenFilter,
+      updateMethodFilter,
+      hostGroupFilter,
+      systemTypeFilter,
+    } = reduceFilters([
+      ...(activeFilters || []),
+      ...(customFilters?.filters || []),
+    ]);
+
+    debouncedRefresh();
+    enabledFilters.name && setTextFilter(textFilter);
+    enabledFilters.stale && setStaleFilter(staleFilter);
+    enabledFilters.registeredWith &&
+      setRegisteredWithFilter(registeredWithFilter);
+    enabledFilters.tags && setSelectedTags(tagFilters);
+    enabledFilters.operatingSystem && setOsFilterValue(osFilter);
+    enabledFilters.rhcdFilter && setRhcdFilterValue(rhcdFilter);
+    enabledFilters.updateMethodFilter &&
+      setUpdateMethodValue(updateMethodFilter);
+    enabledFilters.lastSeenFilter && setLastSeenFilterValue(lastSeenFilter);
+    enabledFilters.hostGroupFilter && setHostGroupValue(hostGroupFilter);
+    enabledFilters.systemTypeFilter && setSystemTypeValue(systemTypeFilter);
+  }, []);
+
+  /**
+   * Function used to change text filter.
+   *  @param {*} value     new value used for filtering.
+   *  @param {*} debounced if debounce function should be used.
+   */
+  const onSetTextFilter = (value, debounced = true) => {
+    const trimmedValue = value?.trim();
+
+    const textualFilter = activeFilters?.find(
+      (oneFilter) => oneFilter.value === TEXT_FILTER,
+    );
+    if (textualFilter) {
+      textualFilter.filter = trimmedValue;
+    } else {
+      if (trimmedValue) {
+        // TODO This is sus
+        activeFilters?.push({ value: TEXT_FILTER, filter: trimmedValue });
+      }
+    }
+
+    const refresh = debounced ? debouncedRefresh : updateData;
+    refresh({ page: 1, perPage, filters: activeFilters });
+  };
+
+  /**
+   * General function to apply filter (excluding tag and text).
+   *  @param {*} value     new value to be set of specified filter.
+   *  @param {*} filterKey which filter should be changed.
+   *  @param {*} refresh   refresh callback function.
+   */
+  const onSetFilter = (value, filterKey, refresh) => {
+    const newFilters = [
+      ...(activeFilters || []).filter(
+        (oneFilter) =>
+          !Object.prototype.hasOwnProperty.call(oneFilter, filterKey),
+      ),
+      { [filterKey]: value },
+    ];
+    refresh({ page: 1, perPage, filters: newFilters });
+  };
+
+  const shouldReload = page && perPage && activeFilters && (!hasItems || items);
+
+  useEffect(() => {
+    if (shouldReload && showTags && enabledFilters.tags) {
+      debounceGetAllTags(filterTagsBy);
+    }
+  }, [filterTagsBy, customFilters?.tags]);
+
+  useEffect(() => {
+    if (shouldReload && enabledFilters.name) {
+      onSetTextFilter(textFilter, true);
+    }
+  }, [textFilter]);
+
+  useEffect(() => {
+    if (shouldReload && enabledFilters.stale) {
+      onSetFilter(staleFilter, 'staleFilter', debouncedRefresh);
+    }
+  }, [staleFilter]);
+
+  useEffect(() => {
+    if (shouldReload && enabledFilters.registeredWith) {
+      onSetFilter(
+        registeredWithFilter,
+        'registeredWithFilter',
+        debouncedRefresh,
+      );
+    }
+  }, [registeredWithFilter]);
+
+  useEffect(() => {
+    if (shouldReload && showTags && enabledFilters.tags) {
+      onSetFilter(mapGroups(selectedTags), 'tagFilters', debouncedRefresh);
+    }
+  }, [selectedTags]);
+
+  useEffect(() => {
+    if (shouldReload && enabledFilters.operatingSystem) {
+      onSetFilter(osFilterValue, 'osFilter', debouncedRefresh);
+    }
+  }, [osFilterValue]);
+
+  useEffect(() => {
+    if (shouldReload && enabledFilters.rhcdFilter) {
+      onSetFilter(rhcdFilterValue, 'rhcdFilter', debouncedRefresh);
+    }
+  }, [rhcdFilterValue]);
+
+  useEffect(() => {
+    if (shouldReload && enabledFilters.lastSeenFilter) {
+      onSetFilter(lastSeenFilterValue, 'lastSeenFilter', debouncedRefresh);
+    }
+  }, [lastSeenFilterValue]);
+
+  useEffect(() => {
+    if (shouldReload && enabledFilters.updateMethodFilter) {
+      onSetFilter(updateMethodValue, 'updateMethodFilter', debouncedRefresh);
+    }
+  }, [updateMethodValue]);
+
+  useEffect(() => {
+    if (shouldReload && enabledFilters.hostGroupFilter) {
+      onSetFilter(hostGroupValue, 'hostGroupFilter', debouncedRefresh);
+    }
+  }, [hostGroupValue]);
+
+  useEffect(() => {
+    if (shouldReload && enabledFilters.systemTypeFilter) {
+      onSetFilter(systemTypeValue, 'systemTypeFilter', debouncedRefresh);
+    }
+  }, [systemTypeValue]);
+
+  /**
+   * Mapper to simplify removing of any filter.
+   */
+  const deleteMapper = {
+    [TEXTUAL_CHIP]: () => setTextFilter(''),
+    [TAG_CHIP]: (deleted) =>
+      setSelectedTags(
+        onDeleteTag(deleted, selectedTags, (selectedTags) =>
+          onSetFilter(mapGroups(selectedTags), 'tagFilters', updateData),
+        ),
+      ),
+    [STALE_CHIP]: (deleted) =>
+      setStaleFilter(onDeleteFilter(deleted, staleFilter)),
+    [REGISTERED_CHIP]: (deleted) =>
+      setRegisteredWithFilter(onDeleteFilter(deleted, registeredWithFilter)),
+    [OS_CHIP]: (deleted) =>
+      setOsFilterValue(onDeleteGroupFilter(deleted, osFilterValue)),
+    [RHCD_FILTER_KEY]: (deleted) =>
+      setRhcdFilterValue(onDeleteFilter(deleted, rhcdFilterValue)),
+    [LAST_SEEN_CHIP]: (deleted) => {
+      setLastSeenFilterValue(
+        onDeleteFilter(deleted, [lastSeenFilterValue.mark]),
+      );
+      setStartDate();
+      setEndDate();
+    },
+    [UPDATE_METHOD_KEY]: (deleted) =>
+      setUpdateMethodValue(onDeleteFilter(deleted, updateMethodValue)),
+    [HOST_GROUP_CHIP]: (deleted) =>
+      setHostGroupValue(onDeleteFilter(deleted, hostGroupValue)),
+    [SYSTEM_TYPE_KEY]: (deleted) =>
+      setSystemTypeValue(onDeleteFilter(deleted, systemTypeValue)),
+  };
+  /**
+   * Function to reset all filters with 'Reset Filter' is clicked
+   */
+  const resetFilters = () => {
+    enabledFilters.name && setTextFilter('');
+    enabledFilters.stale && setStaleFilter([]);
+    enabledFilters.registeredWith && setRegisteredWithFilter([]);
+    enabledFilters.tags && setSelectedTags({});
+    enabledFilters.operatingSystem && setOsFilterValue([]);
+    enabledFilters.rhcdFilter && setRhcdFilterValue([]);
+    enabledFilters.lastSeenFilter && setLastSeenFilterValue([]);
+    enabledFilters.updateMethodFilter && setUpdateMethodValue([]);
+    enabledFilters.hostGroupFilter && setHostGroupValue([]);
+    enabledFilters.systemTypeFilter && setSystemTypeValue([]);
+    setEndDate();
+    setStartDate(UNIX_EPOCH);
+    dispatch(setFilter([]));
+    updateData({ page: 1, filters: [] });
+  };
+
+  /**
+   * Function to create active filters chips.
+   */
+  const constructFilters = () => {
+    return {
+      ...(activeFiltersConfig || {}),
+      filters: [
+        ...(showTags && !hasItems && enabledFilters.tags ? tagsChip : []),
+        ...(!hasItems && enabledFilters.name ? nameChip : []),
+        ...(!hasItems && enabledFilters.stale ? stalenessChip : []),
+        ...(!hasItems && enabledFilters.registeredWith ? registeredChip : []),
+        ...(!hasItems && enabledFilters.operatingSystem ? osFilterChips : []),
+        ...(!hasItems && enabledFilters.rhcdFilter ? rhcdFilterChips : []),
+        ...(!hasItems && enabledFilters.updateMethodFilter
+          ? updateMethodChips
+          : []),
+        ...(!hasItems && enabledFilters.lastSeenFilter ? lastSeenChip : []),
+        ...(!hasItems && enabledFilters.hostGroupFilter ? hostGroupChips : []),
+        ...(showSystemTypeFilter && !hasItems && enabledFilters.systemTypeFilter
+          ? systemTypeChips
+          : []),
+        ...(activeFiltersConfig?.filters || []),
+      ],
+      onDelete: (e, [deleted, ...restDeleted], isAll) => {
+        if (isAll) {
+          dispatch(clearFilters());
+          resetFilters();
+        } else {
+          deleteMapper[deleted.type]?.(deleted);
+        }
+
+        activeFiltersConfig &&
+          activeFiltersConfig.onDelete &&
+          activeFiltersConfig.onDelete(e, [deleted, ...restDeleted], isAll);
+      },
+    };
+  };
+
+  const inventoryFilters = [
+    ...(!hasItems
+      ? [
+          ...(enabledFilters.name ? [nameFilter] : []),
+          ...(enabledFilters.stale ? [stalenessFilter] : []),
+          ...(enabledFilters.operatingSystem ? [osFilterConfig] : []),
+          ...(enabledFilters.registeredWith ? [registeredFilter] : []),
+          ...(enabledFilters.rhcdFilter ? [rhcdFilterConfig] : []),
+          ...(enabledFilters.updateMethodFilter ? [updateMethodConfig] : []),
+          ...(enabledFilters.lastSeenFilter ? [lastSeenFilter] : []),
+          ...(enabledFilters.hostGroupFilter ? [hostGroupConfig] : []),
+          ...(showSystemTypeFilter && enabledFilters.systemTypeFilter
+            ? [systemTypeConfig]
+            : []),
+          ...(showTags && enabledFilters.tags ? [tagsFilter] : []),
+        ]
+      : []),
+    ...(filterConfig?.items || []),
+  ];
+  const preselectedTags = Object.entries(selectedTags).reduce(
+    (sTags, [namespace, tag]) => {
+      const tags = Object.values(tag).map(
+        ({
+          item: {
+            meta: {
+              tag: { key, value },
+            },
+          },
+        }) => ({
+          id: `${namespace}/${key}=${value}`,
+          cells: [key, value, namespace],
+          item: {
+            meta: {
+              tag: { key, value },
+            },
+          },
+        }),
+      );
+
+      return [...sTags, ...tags];
+    },
+    [],
+  );
+
+  return (
+    <Fragment>
+      <PrimaryToolbar
+        {...props}
+        {...(bulkSelect && {
+          bulkSelect: {
+            ...bulkSelect,
+            isDisabled: bulkSelect?.isDisabled || !hasAccess,
+          },
+        })}
+        className={`ins-c-inventory__table--toolbar ${
+          hasItems || !inventoryFilters.length
+            ? 'ins-c-inventory__table--toolbar-has-items'
+            : ''
+        }`}
+        {...(inventoryFilters?.length > 0 && {
+          filterConfig: {
+            ...(filterConfig || {}),
+            isDisabled: !hasAccess,
+            items: inventoryFilters?.map((filter) => ({
+              ...filter,
+              filterValues: {
+                placeholder:
+                  filter?.filterValues?.placeholder ||
+                  `Filter by ${filter?.label?.toLowerCase()}`,
+                ...filter?.filterValues,
+                isDisabled: !hasAccess,
+              },
+            })),
+          },
+        })}
+        {...(hasAccess && { activeFiltersConfig: constructFilters() })}
+        actionsConfig={loaded ? actionsConfig : null}
+        pagination={
+          loaded ? (
+            {
+              page,
+              itemCount: !hasAccess ? 0 : total,
+              isDisabled: !hasAccess,
+              perPage,
+              onSetPage: (_e, newPage) => onRefreshData({ page: newPage }),
+              onPerPageSelect: (_e, newPerPage) =>
+                onRefreshData({ page: 1, per_page: newPerPage }),
+              titles: {
+                optionsToggleAriaLabel: 'Items per page',
+              },
+              ...paginationProps,
+            }
+          ) : (
+            <Skeleton size={SkeletonSize.lg} />
+          )
+        }
+        exportConfig={
+          props.exportConfig ? props.exportConfig : enableExport && exportConfig
+        }
+      >
+        {lastSeenFilterValue?.mark === 'custom' && (
+          <Split>
+            <SplitItem>
+              <DatePicker
+                onChange={onFromChange}
+                aria-label="Start date"
+                validators={[fromValidator(endDate)]}
+                placeholder="Start"
+              />
+            </SplitItem>
+            <SplitItem style={{ padding: '6px 12px 0 12px' }}>to</SplitItem>
+            <SplitItem>
+              <DatePicker
+                value={endDate}
+                onChange={onToChange}
+                rangeStart={
+                  startDate === UNIX_EPOCH ? new Date() : new Date(startDate)
+                }
+                validators={[toValidator(startDate)]}
+                aria-label="End date"
+                placeholder="End"
+              />
+            </SplitItem>
+          </Split>
+        )}
+        {children}
+      </PrimaryToolbar>
+      {(showTags || enabledFilters.tags || showTagModal) && (
+        <TagsModal
+          selected={preselectedTags}
+          filterTagsBy={filterTagsBy}
+          onApply={(selected) => setSelectedTags(arrayToSelection(selected))}
+          getTags={getTags}
+        />
+      )}
+    </Fragment>
+  );
+};
+
+IOPEntityTableToolbar.propTypes = {
+  showTags: PropTypes.bool,
+  getTags: PropTypes.func,
+  hasAccess: PropTypes.bool,
+  filterConfig: PropTypes.object,
+  total: PropTypes.number,
+  hasItems: PropTypes.bool,
+  page: PropTypes.number,
+  onClearFilters: PropTypes.func,
+  toggleTagModal: PropTypes.func,
+  perPage: PropTypes.number,
+  children: PropTypes.node,
+  pagination: PropTypes.shape({
+    page: PropTypes.number,
+    perPage: PropTypes.number,
+  }),
+  actionsConfig: PropTypes.object,
+  activeFiltersConfig: PropTypes.object,
+  onRefreshData: PropTypes.func,
+  customFilters: PropTypes.shape({
+    tags: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.arrayOf(PropTypes.string),
+    ]),
+    filters: PropTypes.array,
+  }),
+  hideFilters: PropTypes.shape({
+    tags: PropTypes.bool,
+    name: PropTypes.bool,
+    registeredWith: PropTypes.bool,
+    stale: PropTypes.bool,
+    operatingSystem: PropTypes.bool,
+    rhcdFilter: PropTypes.bool,
+    lastSeen: PropTypes.bool,
+    updateMethodFilter: PropTypes.bool,
+    hostGroupFilter: PropTypes.bool,
+    systemTypeFilter: PropTypes.bool,
+    all: PropTypes.bool,
+  }),
+  paginationProps: PropTypes.object,
+  loaded: PropTypes.bool,
+  onRefresh: PropTypes.func,
+  hasCheckbox: PropTypes.bool,
+  isLoaded: PropTypes.bool,
+  items: PropTypes.array,
+  sortBy: PropTypes.object,
+  bulkSelect: PropTypes.object,
+  showTagModal: PropTypes.bool,
+  disableDefaultColumns: PropTypes.any,
+  showCentosVersions: PropTypes.bool,
+  showSystemTypeFilter: PropTypes.bool,
+  showNoGroupOption: PropTypes.bool,
+  enableExport: PropTypes.bool,
+  exportConfig: PropTypes.object,
+  fetchCustomOSes: PropTypes.func,
+};
+
+IOPEntityTableToolbar.defaultProps = {
+  showTags: false,
+  hasAccess: true,
+  activeFiltersConfig: {},
+  hideFilters: {},
+  showNoGroupOption: false,
+};
+
+export default IOPEntityTableToolbar;

--- a/src/components/InventoryTable/IOPInventoryTable.js
+++ b/src/components/InventoryTable/IOPInventoryTable.js
@@ -1,0 +1,389 @@
+import React, {
+  Fragment,
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import PropTypes from 'prop-types';
+import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux';
+import { TableToolbar } from '@redhat-cloud-services/frontend-components/TableToolbar';
+import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
+import InventoryList from './InventoryList';
+import Pagination from './Pagination';
+import AccessDenied from '../../Utilities/AccessDenied';
+import { loadSystems } from '../../Utilities/sharedFunctions';
+import isEqual from 'lodash/isEqual';
+import { clearErrors, entitiesLoading } from '../../store/actions';
+import cloneDeep from 'lodash/cloneDeep';
+import { ACTION_TYPES } from '../../store/action-types';
+import IOPEntityTableToolbar from './IOPEntityTableToolbar';
+
+/**
+ * A helper function to store props and to always return the latest state.
+ * For example, EntityTableToolbar wraps OnRefreshData in a callback, so we need this
+ * to get the latest props and not the props at the time of when the function is
+ * being wrapped in callback.
+ */
+export const inventoryCache = () => {
+  let cache = {};
+
+  const updateProps = (props) => {
+    cache = cloneDeep({ ...cache, props });
+  };
+
+  const updateParams = (params) => {
+    cache = cloneDeep({ ...cache, params });
+  };
+
+  const getProps = () => cache.props;
+  const getParams = () => cache.params;
+
+  return { updateProps, updateParams, getProps, getParams };
+};
+
+/**
+ * This component is used to combine all essential components together:
+ * EntityTableToolbar - to control top toolbar.
+ * InventoryList - to allow consumers to change data from outside and contains actual inventory table.
+ * Pagination - bottom pagination.
+ * It also calculates pagination and sortBy from props or from store if consumer passed items or not.
+ */
+
+const IOPInventoryTable = forwardRef(
+  (
+    {
+      onRefresh,
+      children,
+      inventoryRef,
+      items,
+      total: propsTotal,
+      page: propsPage,
+      perPage: propsPerPage,
+      showTags,
+      sortBy: propsSortBy,
+      customFilters,
+      hasAccess = true,
+      isFullView = false,
+      getEntities,
+      getTags,
+      hideFilters,
+      paginationProps,
+      errorState = <ErrorState />,
+      autoRefresh,
+      isLoaded,
+      initialLoading,
+      ignoreRefresh,
+      showTagModal,
+      activeFiltersConfig,
+      tableProps,
+      isRbacEnabled,
+      hasCheckbox,
+      abortOnUnmount = true,
+      showCentosVersions = false,
+      enableExport,
+      lastSeenOverride,
+      ...props
+    },
+    ref,
+  ) => {
+    const hasItems = Boolean(items);
+    const error = useSelector(({ entities }) => entities?.error);
+    const page = useSelector(
+      ({ entities: { page: invPage } }) =>
+        hasItems ? propsPage : invPage || 1,
+      shallowEqual,
+    );
+    const perPage = useSelector(
+      ({ entities: { perPage: invPerPage } }) =>
+        hasItems ? propsPerPage : invPerPage || 50,
+      shallowEqual,
+    );
+    const total = useSelector(({ entities: { total: invTotal } }) => {
+      if (hasItems) {
+        return propsTotal !== undefined ? propsTotal : items?.length;
+      }
+
+      return invTotal;
+    }, shallowEqual);
+    const pagination = {
+      page,
+      perPage,
+      total,
+    };
+
+    const columns = lastSeenOverride
+      ? props?.columns?.map((col) =>
+          col.key === 'updated'
+            ? {
+                ...col,
+                key: lastSeenOverride,
+                sortKey: lastSeenOverride,
+              }
+            : col,
+        )
+      : props?.columns;
+
+    const sortBy = useSelector(({ entities: { sortBy: invSortBy } }) => {
+      const propsSortByOrFallback =
+        propsSortBy?.key != null ? propsSortBy : invSortBy;
+      const invSortByOrFallback =
+        invSortBy?.key != null ? invSortBy : propsSortBy;
+      return hasItems ? propsSortByOrFallback : invSortByOrFallback;
+    }, shallowEqual);
+
+    const reduxLoaded = useSelector(({ entities }) =>
+      hasItems && isLoaded !== undefined
+        ? isLoaded && entities?.loaded
+        : entities?.loaded,
+    );
+
+    const controller = useRef(new AbortController());
+
+    /**
+     * If initialLoading is set to true, then the component should be in loading state until
+     * entities.loaded is false (and then we can use the redux loading state and forget this one)
+     */
+    const [initialLoadingActive, disableInitialLoading] =
+      useState(initialLoading);
+    useEffect(() => {
+      if (!reduxLoaded) {
+        disableInitialLoading();
+      }
+    }, [reduxLoaded]);
+    const loaded = reduxLoaded && !initialLoadingActive;
+
+    const dispatch = useDispatch();
+    const store = useStore();
+
+    useEffect(() => {
+      return () => {
+        if (abortOnUnmount) controller.current.abort();
+      };
+    }, []);
+    const hasLoadEntitiesError =
+      error?.status === 404 &&
+      error?.type === ACTION_TYPES.LOAD_ENTITIES &&
+      parseInt(props.urlParams.page) !== 1;
+    useEffect(() => {
+      if (error) {
+        if (hasLoadEntitiesError) {
+          onRefreshData({ page: 1 });
+          dispatch(clearErrors());
+        }
+      }
+    }, [error]);
+
+    const cache = useRef(inventoryCache());
+    cache.current.updateProps({
+      page,
+      perPage,
+      items,
+      sortBy,
+      hideFilters,
+      showTags,
+      getEntities,
+      customFilters,
+      hasItems,
+      activeFiltersConfig,
+    });
+
+    /**
+     * If consumer wants to change data they can call this function via component ref.
+     *  @param {*} options          new options to be applied, like pagination, filters, etc.
+     *  @param     disableOnRefresh
+     *  @param     forceRefresh
+     */
+    const onRefreshData = (
+      options = {},
+      disableOnRefresh,
+      forceRefresh = false,
+    ) => {
+      const { activeFilters } = store.getState().entities;
+      const cachedProps = cache.current?.getProps() || {};
+
+      let sortBy = options?.sortBy || cachedProps.sortBy;
+      if (lastSeenOverride && sortBy?.key === 'updated') {
+        sortBy = { ...sortBy, key: lastSeenOverride };
+      }
+
+      const newParams = {
+        page: options?.page || cachedProps.page,
+        per_page: options?.per_page || options?.perPage || cachedProps.perPage,
+        items: cachedProps.items,
+        sortBy: sortBy,
+        hideFilters: cachedProps.hideFilters,
+        filters: activeFilters,
+        hasItems: cachedProps.hasItems,
+        //RHIF-246: Compliance app depends on activeFiltersConfig to apply its filters.
+        activeFiltersConfig: cachedProps.activeFiltersConfig,
+        ...customFilters,
+        ...options,
+        globalFilter: cachedProps?.customFilters?.globalFilter,
+      };
+
+      //Check for the rbac permissions
+      const cachedParams = cache.current.getParams();
+      if (hasAccess && (!isEqual(cachedParams, newParams) || forceRefresh)) {
+        cache.current.updateParams(newParams);
+        if (onRefresh && !disableOnRefresh) {
+          dispatch(entitiesLoading());
+          onRefresh(newParams, (options) => {
+            dispatch(
+              loadSystems(
+                {
+                  ...newParams,
+                  ...options,
+                  controller: controller.current,
+                  filterImmutableByDefault: false,
+                },
+                cachedProps.showTags,
+                cachedProps.getEntities,
+              ),
+            );
+          });
+        } else {
+          dispatch(
+            loadSystems(
+              {
+                ...newParams,
+                controller: controller.current,
+                filterImmutableByDefault: edgeParityFilterDeviceEnabled,
+              },
+              cachedProps.showTags,
+              cachedProps.getEntities,
+            ),
+          );
+        }
+      }
+    };
+
+    const prevFilters = useRef(customFilters);
+    useEffect(() => {
+      if (autoRefresh && !isEqual(prevFilters.current, customFilters)) {
+        onRefreshData();
+        prevFilters.current = customFilters;
+      }
+    });
+
+    return hasAccess === false && isFullView ? (
+      <AccessDenied
+        title="This application requires Inventory permissions"
+        description={
+          <div>
+            To view the content of this page, you must be granted a minimum of
+            inventory permissions from your Organization Administrator.
+          </div>
+        }
+      />
+    ) : !error || hasLoadEntitiesError ? (
+      <Fragment>
+        <IOPEntityTableToolbar
+          {...props}
+          columns={columns}
+          data-testid="inventory-table-top-toolbar"
+          customFilters={customFilters}
+          hasAccess={hasAccess}
+          items={items}
+          hasItems={hasItems}
+          total={pagination.total}
+          page={pagination.page}
+          perPage={pagination.perPage}
+          showTags={showTags}
+          getTags={getTags}
+          onRefreshData={onRefreshData}
+          sortBy={sortBy}
+          hideFilters={hideFilters}
+          paginationProps={paginationProps}
+          loaded={loaded}
+          showTagModal={showTagModal}
+          activeFiltersConfig={{
+            deleteTitle: 'Reset filters',
+            ...activeFiltersConfig,
+          }}
+          showCentosVersions={showCentosVersions}
+          enableExport={false}
+        >
+          {children}
+        </IOPEntityTableToolbar>
+        <InventoryList
+          {...props}
+          columns={columns}
+          hasCheckbox={hasCheckbox}
+          tableProps={tableProps}
+          customFilters={customFilters}
+          hasAccess={hasAccess}
+          ref={ref}
+          hasItems={hasItems}
+          items={items}
+          page={pagination.page}
+          sortBy={sortBy}
+          perPage={pagination.perPage}
+          showTags={showTags}
+          onRefreshData={onRefreshData}
+          loaded={loaded}
+          ignoreRefresh={ignoreRefresh}
+        />
+        <TableToolbar
+          isFooter
+          className="ins-c-inventory__table--toolbar"
+          data-testid="inventory-table-bottom-toolbar"
+        >
+          <Pagination
+            hasAccess={hasAccess}
+            isFull
+            total={pagination.total}
+            page={pagination.page}
+            perPage={pagination.perPage}
+            hasItems={hasItems}
+            onRefreshData={onRefreshData}
+            paginationProps={paginationProps}
+            loaded={loaded}
+            ouiaId={'bottom-pagination'}
+          />
+        </TableToolbar>
+      </Fragment>
+    ) : (
+      errorState
+    );
+  },
+);
+
+IOPInventoryTable.propTypes = {
+  autoRefresh: PropTypes.bool,
+  onRefresh: PropTypes.func,
+  children: PropTypes.node,
+  inventoryRef: PropTypes.object,
+  items: PropTypes.array,
+  total: PropTypes.number,
+  page: PropTypes.number,
+  perPage: PropTypes.number,
+  showTags: PropTypes.bool,
+  getTags: PropTypes.func,
+  sortBy: PropTypes.object,
+  customFilters: PropTypes.any,
+  hasAccess: PropTypes.bool,
+  isFullView: PropTypes.bool,
+  getEntities: PropTypes.func,
+  hideFilters: PropTypes.object,
+  paginationProps: PropTypes.object,
+  errorState: PropTypes.node,
+  isLoaded: PropTypes.bool,
+  initialLoading: PropTypes.bool,
+  ignoreRefresh: PropTypes.bool,
+  showTagModal: PropTypes.bool,
+  activeFiltersConfig: PropTypes.object,
+  tableProps: PropTypes.object,
+  isRbacEnabled: PropTypes.bool,
+  hasCheckbox: PropTypes.bool,
+  abortOnUnmount: PropTypes.bool,
+  showCentosVersions: PropTypes.bool,
+  enableExport: PropTypes.bool,
+  lastSeenOverride: PropTypes.string,
+  columns: PropTypes.array,
+  urlParams: PropTypes.string,
+};
+
+IOPInventoryTable.displayName = 'IOPInventoryTable';
+
+export default IOPInventoryTable;

--- a/src/components/InventoryTable/index.js
+++ b/src/components/InventoryTable/index.js
@@ -1,1 +1,2 @@
 export { default as InventoryTable } from './InventoryTable';
+export { default as IOPInventoryTable } from './IOPInventoryTable';

--- a/src/components/InventoryTabs/ConventionalSystems/IOPConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/IOPConventionalSystemsTab.js
@@ -1,0 +1,412 @@
+import React, {
+  Fragment,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import PropTypes from 'prop-types';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import * as actions from '../../../store/actions';
+import { addNotification as addNotificationAction } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import DeleteModal from '../../../Utilities/DeleteModal';
+import { TextInputModal } from '../../SystemDetails/GeneralInfo';
+import { generateFilter } from '../../../Utilities/constants';
+import { IOPInventoryTable as InventoryTableCmp } from '../../InventoryTable/IOPInventoryTable';
+import AddSelectedHostsToGroupModal from '../../InventoryGroups/Modals/AddSelectedHostsToGroupModal';
+import { useBulkSelectConfig } from '../../../Utilities/hooks/useBulkSelectConfig';
+import RemoveHostsFromGroupModal from '../../InventoryGroups/Modals/RemoveHostsFromGroupModal';
+import {
+  GENERAL_GROUPS_WRITE_PERMISSION,
+  NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE,
+  NO_MODIFY_HOSTS_TOOLTIP_MESSAGE,
+  REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
+  REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP,
+} from '../../../constants';
+import {
+  ActionButton,
+  ActionDropdownItem,
+} from '../../InventoryTable/ActionWithRBAC';
+import uniq from 'lodash/uniq';
+import useTableActions from './useTableActions';
+import useGlobalFilter from '../../filters/useGlobalFilter';
+import useOnRefresh from '../../filters/useOnRefresh';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
+import { AccountStatContext } from '../../../Contexts';
+import { INVENTORY_COLUMNS } from '../../../store/constants';
+import { DEFAULT_COLUMNS } from '../../../store/entities';
+
+const BulkDeleteButton = ({ selectedSystems, ...props }) => {
+  const requiredPermissions = selectedSystems.map(({ groups }) =>
+    REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP(groups?.[0]?.id ?? null),
+  );
+
+  return (
+    <ActionButton
+      requiredPermissions={requiredPermissions}
+      noAccessTooltip={NO_MODIFY_HOSTS_TOOLTIP_MESSAGE}
+      checkAll
+      ouiaId="bulk-delete-button"
+      {...props}
+    >
+      Delete
+    </ActionButton>
+  );
+};
+
+BulkDeleteButton.propTypes = {
+  selectedSystems: PropTypes.array,
+};
+
+const IOPConventionalSystemsTab = ({
+  status,
+  source,
+  filterbyName,
+  tagsFilter,
+  operatingSystem,
+  rhcdFilter,
+  updateMethodFilter,
+  lastSeenFilter,
+  page,
+  perPage,
+  initialLoading,
+  hasAccess,
+  hostGroupFilter,
+  systemTypeFilter,
+  sortBy,
+}) => {
+  const inventory = useRef(null);
+  const [isModalOpen, handleModalToggle] = useState(false);
+  const [currentSystem, setCurrentSystem] = useState({});
+  const [filters, onSetfilters] = useState(
+    generateFilter(
+      status,
+      source,
+      tagsFilter,
+      filterbyName,
+      operatingSystem,
+      rhcdFilter,
+      updateMethodFilter,
+      hostGroupFilter,
+      lastSeenFilter,
+      systemTypeFilter,
+    ),
+  );
+  const [ediOpen, onEditOpen] = useState(false);
+  const [addHostGroupModalOpen, setAddHostGroupModalOpen] = useState(false);
+  const [removeHostsFromGroupModalOpen, setRemoveHostsFromGroupModalOpen] =
+    useState(false);
+  const globalFilter = useGlobalFilter();
+  const rows = useSelector(({ entities }) => entities?.rows, shallowEqual);
+  const loaded = useSelector(({ entities }) => entities?.loaded);
+  const selected = useSelector(({ entities }) => entities?.selected);
+  const total = useSelector(({ entities }) => entities?.total);
+  const dispatch = useDispatch();
+  const bulkSelectConfig = useBulkSelectConfig(
+    selected,
+    globalFilter,
+    total,
+    rows,
+    loaded,
+  );
+
+  const onRefresh = useOnRefresh((options) => {
+    onSetfilters(options?.filters);
+  });
+
+  useEffect(() => {
+    dispatch(actions.clearNotifications());
+
+    if (sortBy && sortBy?.key != null) {
+      dispatch(actions.setSort(sortBy.key, sortBy.direction));
+    }
+
+    if (perPage || page) {
+      dispatch(
+        actions.setPagination(
+          Array.isArray(page) ? page[0] : page,
+          Array.isArray(perPage) ? perPage[0] : perPage,
+        ),
+      );
+    }
+
+    return () => {
+      dispatch(actions.clearEntitiesAction());
+    };
+  }, []);
+
+  const calculateSelected = () => (selected ? selected.size : 0);
+
+  const isBulkRemoveFromGroupsEnabled = () => {
+    return (
+      calculateSelected() > 0 &&
+      Array.from(selected.values()).some(({ groups }) => groups.length > 0) &&
+      uniq(
+        // can remove from at maximum one group at a time
+        Array.from(selected.values())
+          .filter(({ groups }) => groups.length > 0)
+          .map(({ groups }) => groups[0].name),
+      ).length === 1
+    );
+  };
+
+  const isBulkAddHostsToGroupsEnabled = () => {
+    if (calculateSelected() > 0) {
+      const selectedHosts = Array.from(selected.values());
+      return selectedHosts.every(({ groups }) => groups.length === 0);
+    }
+
+    return false;
+  };
+
+  const tableActions = useTableActions(
+    setCurrentSystem,
+    onEditOpen,
+    handleModalToggle,
+    setRemoveHostsFromGroupModalOpen,
+    setAddHostGroupModalOpen,
+    false,
+  );
+
+  const isBootcEnabled = useFeatureFlag('hbi.ui.bifrost');
+  const { hasBootcImages } = useContext(AccountStatContext);
+
+  const isLastCheckInEnabled = useFeatureFlag(
+    'hbi.create_last_check_in_update_per_reporter_staleness',
+  );
+
+  return (
+    <Fragment>
+      <InventoryTableCmp
+        showSystemTypeFilter={isBootcEnabled && hasBootcImages}
+        hasAccess={hasAccess}
+        isRbacEnabled
+        customFilters={{ filters, globalFilter }}
+        sortBy={sortBy}
+        isFullView
+        showTags
+        onRefresh={onRefresh}
+        hasCheckbox
+        autoRefresh
+        ignoreRefresh
+        initialLoading={initialLoading}
+        ref={inventory}
+        disableDefaultColumns={isLastCheckInEnabled}
+        showNoGroupOption
+        tableProps={{
+          actionResolver: tableActions,
+          canSelectAll: false,
+        }}
+        columns={isLastCheckInEnabled ? INVENTORY_COLUMNS : DEFAULT_COLUMNS}
+        lastSeenOverride={isLastCheckInEnabled ? 'last_check_in' : null}
+        actionsConfig={{
+          actions: [
+            <BulkDeleteButton
+              key="bulk-systems-delete"
+              selectedSystems={Array.from(selected?.values?.() || [])}
+              onClick={() => {
+                setCurrentSystem(Array.from(selected.values()));
+                handleModalToggle(true);
+              }}
+              variant="secondary"
+              isAriaDisabled={calculateSelected() === 0}
+            />,
+
+            {
+              label: (
+                <ActionDropdownItem
+                  key="bulk-add-to-group"
+                  requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
+                  isAriaDisabled={!isBulkAddHostsToGroupsEnabled()}
+                  noAccessTooltip={NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE}
+                  onClick={() => {
+                    setCurrentSystem(Array.from(selected.values()));
+                    setAddHostGroupModalOpen(true);
+                  }}
+                  ignoreResourceDefinitions
+                >
+                  Add to workspace
+                </ActionDropdownItem>
+              ),
+            },
+            {
+              label: (
+                <ActionDropdownItem
+                  key="bulk-remove-from-group"
+                  requiredPermissions={
+                    selected !== undefined
+                      ? Array.from(selected.values())
+                          .flatMap(({ groups }) =>
+                            groups?.[0]?.id !== undefined
+                              ? REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
+                                  groups[0].id,
+                                )
+                              : null,
+                          )
+                          .filter(Boolean) // don't check ungroupped hosts
+                      : []
+                  }
+                  isAriaDisabled={!isBulkRemoveFromGroupsEnabled()}
+                  noAccessTooltip={NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE}
+                  onClick={() => {
+                    setCurrentSystem(Array.from(selected.values()));
+                    setRemoveHostsFromGroupModalOpen(true);
+                  }}
+                  {...(selected === undefined // when nothing is selected, no access must be checked
+                    ? { override: true }
+                    : {})}
+                  checkAll
+                >
+                  Remove from workspace
+                </ActionDropdownItem>
+              ),
+            },
+          ],
+        }}
+        bulkSelect={bulkSelectConfig}
+        showCentosVersions
+        enableExport={false}
+      />
+
+      <DeleteModal
+        className="sentry-mask data-hj-suppress"
+        handleModalToggle={handleModalToggle}
+        isModalOpen={isModalOpen}
+        currentSystems={currentSystem}
+        onConfirm={() => {
+          let displayName;
+          let removeSystems;
+          if (Array.isArray(currentSystem)) {
+            removeSystems = currentSystem.map(({ id }) => id);
+            displayName =
+              currentSystem.length > 1
+                ? `${currentSystem.length} systems`
+                : currentSystem[0].display_name;
+          } else {
+            displayName = currentSystem.display_name;
+            removeSystems = [currentSystem.id];
+          }
+
+          dispatch(
+            addNotificationAction({
+              id: 'remove-initiated',
+              variant: 'info',
+              title: 'Delete operation initiated',
+              description: `Removal of ${displayName} started.`,
+              dismissable: true,
+            }),
+          );
+          dispatch(actions.deleteEntity(removeSystems, displayName));
+          handleModalToggle(false);
+        }}
+      />
+      <TextInputModal
+        title="Edit display name"
+        isOpen={ediOpen}
+        value={currentSystem.display_name}
+        onCancel={() => onEditOpen(false)}
+        onSubmit={(value) => {
+          dispatch(actions.editDisplayName(currentSystem.id, value));
+          onEditOpen(false);
+        }}
+      />
+      {addHostGroupModalOpen && (
+        <AddSelectedHostsToGroupModal
+          isModalOpen={addHostGroupModalOpen}
+          setIsModalOpen={setAddHostGroupModalOpen}
+          modalState={currentSystem}
+          reloadData={() => {
+            if (calculateSelected() > 0) {
+              dispatch(actions.selectEntity(-1, false));
+            }
+
+            setTimeout(
+              () => inventory.current.onRefreshData(filters, false, true),
+              500,
+            );
+          }}
+        />
+      )}
+      {removeHostsFromGroupModalOpen && (
+        <RemoveHostsFromGroupModal
+          isModalOpen={removeHostsFromGroupModalOpen}
+          setIsModalOpen={setRemoveHostsFromGroupModalOpen}
+          modalState={currentSystem}
+          reloadData={() => {
+            if (calculateSelected() > 0) {
+              dispatch(actions.selectEntity(-1, false));
+            }
+
+            setTimeout(
+              () => inventory.current.onRefreshData(filters, false, true),
+              500,
+            );
+          }}
+        />
+      )}
+    </Fragment>
+  );
+};
+
+IOPConventionalSystemsTab.propTypes = {
+  status: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]),
+  source: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]),
+  operatingSystem: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]),
+  filterbyName: PropTypes.arrayOf(PropTypes.string),
+  tagsFilter: PropTypes.any,
+  page: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    ),
+  ]),
+  perPage: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    ),
+  ]),
+  sortBy: PropTypes.shape({
+    key: PropTypes.string,
+    direction: PropTypes.string,
+  }),
+  initialLoading: PropTypes.bool,
+  rhcdFilter: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]),
+  updateMethodFilter: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]),
+  hasAccess: PropTypes.bool,
+  hostGroupFilter: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]),
+  lastSeenFilter: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]),
+  systemTypeFilter: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]),
+};
+
+IOPConventionalSystemsTab.defaultProps = {
+  initialLoading: true,
+};
+
+export default IOPConventionalSystemsTab;

--- a/src/modules/IOPHybridInventory.js
+++ b/src/modules/IOPHybridInventory.js
@@ -1,0 +1,45 @@
+import React, { Suspense, lazy, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import '../inventory.scss';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { getSearchParams } from '../constants';
+
+const IOPConventionalSystemsTab = lazy(
+  () =>
+    import(
+      '../components/InventoryTabs/ConventionalSystems/IOPConventionalSystemsTab'
+    ),
+);
+
+const SuspenseWrapper = ({ children }) => (
+  <Suspense
+    fallback={
+      <Bullseye>
+        <Spinner size="xl" />
+      </Bullseye>
+    }
+  >
+    {children}
+  </Suspense>
+);
+const IOPHybridInventory = (props) => {
+  const parsedSearchParams = useMemo(
+    () => getSearchParams(props.urlParams),
+    [props.urlParams],
+  );
+  const fullProps = { ...props, ...parsedSearchParams };
+
+  return <IOPConventionalSystemsTab {...fullProps} {...parsedSearchParams} />;
+};
+
+IOPHybridInventory.defaultProps = {
+  initialLoading: true,
+  notificationProp: PropTypes.object,
+};
+IOPHybridInventory.propTypes = {
+  urlParams: PropTypes.string,
+};
+SuspenseWrapper.propTypes = {
+  children: PropTypes.element,
+};
+export default IOPHybridInventory;

--- a/src/modules/IOPInventoryTableModule.js
+++ b/src/modules/IOPInventoryTableModule.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import AsyncInventory from './AsyncInventory';
-import { InventoryTable as InventoryTableCmp } from '../components/InventoryTable';
+import { IOPInventoryTable as InventoryTableCmp } from '../components/InventoryTable/IOPInventoryTable';
 
 const BaseIOPInventoryTable = (props) => (
   <AsyncInventory {...props} component={InventoryTableCmp} />
 );
-const IOPInventoryTable = React.forwardRef((props, ref) => (
+const IOPInventoryTableModule = React.forwardRef((props, ref) => (
   <BaseIOPInventoryTable {...props} innerRef={ref} />
 ));
 
-export default IOPInventoryTable;
+export default IOPInventoryTableModule;
 
 export { useOperatingSystemFilter } from '../components/filters/useOperatingSystemFilter';


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-19382

1. Renamed IOPInventoryTable module into IOPInventoryTableModule file
2. Made a new inventory table for IOP without useSearchparams
3. Made a new entitytabletoolbar for IOP without export enabled.
4. Added a ConventionalSystemTab for IOP
5. Added IOPHybridInventory file. I skipped the IopHybridInventoryTabs module wrapping because we don't need it. So instead of IOPHybridInventoryTabs we'll habe IOPHybridInventory with ConventionalSystemTab

## Summary by Sourcery

Introduce a dedicated IOP inventory feature set comprising a custom inventory table, toolbar, conventional systems tab, and hybrid inventory entry point while renaming the existing module for clarity

New Features:
- Add IOPInventoryTable component providing a full IOP inventory table with custom caching, toolbar, list, and pagination
- Introduce IOPEntityTableToolbar component for IOP inventory tables without export functionality
- Create IOPConventionalSystemsTab under InventoryTabs to display and manage conventional IOP systems with bulk operations
- Add IOPHybridInventory component to parse URL parameters and lazily load IOPConventionalSystemsTab

Enhancements:
- Rename IOPInventoryTable module file to IOPInventoryTableModule and update fec.config alias