### PR TITLE
feat(RHINENG-19382): update inventory table for iop

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -66,7 +66,6 @@ import {
   systemTypeFilterReducer,
   systemTypeFilterState,
 } from '../filters';
-import useFeatureFlag from '../../Utilities/useFeatureFlag';
 import useGroupFilter from '../filters/useGroupFilter';
 import { DatePicker, Split, SplitItem } from '@patternfly/react-core';
 import { fromValidator, UNIX_EPOCH, toValidator } from '../filters/helpers';
@@ -185,11 +184,11 @@ const EntityTableToolbar = ({
     setUpdateMethodValue,
   ] = useUpdateMethodFilter(reducer);
 
-  const isKesselEnabled = useFeatureFlag('hbi.kessel-migration');
+  const isKesselEnabled = false;
   const [hostGroupConfig, hostGroupChips, hostGroupValue, setHostGroupValue] =
     useGroupFilter(showNoGroupOption, isKesselEnabled);
 
-  const isUpdateMethodEnabled = useFeatureFlag('hbi.ui.system-update-method');
+  const isUpdateMethodEnabled = false;
   const { tagsFilter, tagsChip, selectedTags, setSelectedTags, filterTagsBy } =
     useTagsFilter(
       allTags,

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -17,9 +17,7 @@ import { loadSystems } from '../../Utilities/sharedFunctions';
 import isEqual from 'lodash/isEqual';
 import { clearErrors, entitiesLoading } from '../../store/actions';
 import cloneDeep from 'lodash/cloneDeep';
-import { useSearchParams } from 'react-router-dom';
 import { ACTION_TYPES } from '../../store/action-types';
-import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 /**
  * A helper function to store props and to always return the latest state.
@@ -139,14 +137,7 @@ const InventoryTable = forwardRef(
         ? isLoaded && entities?.loaded
         : entities?.loaded,
     );
-
-    const [searchParams] = useSearchParams();
-
     const controller = useRef(new AbortController());
-
-    const edgeParityFilterDeviceEnabled = useFeatureFlag(
-      'edgeParity.inventory-list-filter',
-    );
 
     /**
      * If initialLoading is set to true, then the component should be in loading state until
@@ -170,9 +161,7 @@ const InventoryTable = forwardRef(
       };
     }, []);
     const hasLoadEntitiesError =
-      error?.status === 404 &&
-      error?.type === ACTION_TYPES.LOAD_ENTITIES &&
-      parseInt(searchParams.get('page')) !== 1;
+      error?.status === 404 && error?.type === ACTION_TYPES.LOAD_ENTITIES;
     useEffect(() => {
       if (error) {
         if (hasLoadEntitiesError) {
@@ -243,7 +232,7 @@ const InventoryTable = forwardRef(
                   ...newParams,
                   ...options,
                   controller: controller.current,
-                  filterImmutableByDefault: edgeParityFilterDeviceEnabled,
+                  filterImmutableByDefault: false,
                 },
                 cachedProps.showTags,
                 cachedProps.getEntities,
@@ -256,7 +245,7 @@ const InventoryTable = forwardRef(
               {
                 ...newParams,
                 controller: controller.current,
-                filterImmutableByDefault: edgeParityFilterDeviceEnabled,
+                filterImmutableByDefault: false,
               },
               cachedProps.showTags,
               cachedProps.getEntities,

--- a/src/components/filters/useUpdateMethodFilter.js
+++ b/src/components/filters/useUpdateMethodFilter.js
@@ -1,9 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   UPDATE_METHOD_KEY,
   updateMethodOptions as defaultUpdateMethodOptions,
 } from '../../Utilities/index';
-import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 export const updateMethodFilterState = { updateMethodFilter: [] };
 export const UPDATE_METHOD_FILTER = 'UPDATE_METHOD_FILTER';
@@ -16,15 +15,6 @@ export const updateMethodFilterReducer = (_state, { type, payload }) => ({
 export const useUpdateMethodFilter = (
   [state, dispatch] = [updateMethodFilterState],
 ) => {
-  const EdgeParityFilterDeviceEnabled = useFeatureFlag(
-    'edgeParity.inventory-list-filter',
-  );
-  const updateMethodOptions = useMemo(() => {
-    return EdgeParityFilterDeviceEnabled
-      ? defaultUpdateMethodOptions.filter(({ value }) => value !== 'rpm-ostree')
-      : defaultUpdateMethodOptions;
-  }, [EdgeParityFilterDeviceEnabled]);
-
   let [filterStateValue, setStateValue] = useState([]);
   const updateMethodValue = dispatch
     ? state.updateMethodFilter
@@ -40,7 +30,7 @@ export const useUpdateMethodFilter = (
     filterValues: {
       value: updateMethodValue,
       onChange: (_e, value) => setValue(value),
-      items: updateMethodOptions,
+      items: defaultUpdateMethodOptions,
     },
   };
   const chip =
@@ -49,7 +39,7 @@ export const useUpdateMethodFilter = (
           {
             category: 'System Update Method',
             type: UPDATE_METHOD_KEY,
-            chips: updateMethodOptions
+            chips: defaultUpdateMethodOptions
               .filter(({ value }) => updateMethodValue.includes(value))
               .map(({ label, ...props }) => ({ name: label, ...props })),
           },


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-19382

We are updating the inventory table so that we can import it into satellite/IOP as a federated module without any errors/issues.

1. I am not sure about 2 feature flags in the EntityTableToolbar.js
`const isKesselEnabled`
and
`const isUpdateMethodEnabled`
If we still need them or not, because useFeatureFlag calls are throwing errors in the IOP environment.
2. Removed EdgeParityEnabled from Inventory table - because it soon will be deprecated
3. Removed useSearchParams because we don't need it there
4. Removed useEdgeParity function from the useUpdateMethodFilter hook

## Summary by Sourcery

Remove IOP-incompatible feature flag logic and search parameters from the inventory table and related filters to ensure seamless import as a federated module

Enhancements:
- Simplify useUpdateMethodFilter by removing feature-flag based filtering and always using the default update method options
- Remove EdgeParity-dependent code paths and disable immutable filtering in InventoryTable
- Drop useSearchParams and streamline load error detection in InventoryTable
- Hardcode Kessel and system update method feature flags to false in EntityTableToolbar