### PR TITLE
feat(iop): temporary changes for future refactor

### DIFF
--- a/src/components/InventoryTabs/HybridInventoryTabs.js
+++ b/src/components/InventoryTabs/HybridInventoryTabs.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import {
   Tab,
   TabTitleText,
@@ -11,12 +11,10 @@ import {
   Button,
 } from '@patternfly/react-core';
 import { hybridInventoryTabKeys } from '../../Utilities/constants';
-import { useNavigate } from 'react-router-dom';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 const HybridInventoryTabs = ({
   ConventionalSystemsTab,
-  ImmutableDevicesTab,
   tabPathname,
   isImmutableTabOpen,
   isEdgeParityEnabled,
@@ -25,8 +23,7 @@ const HybridInventoryTabs = ({
 }) => {
   const { search } = useLocation();
   const prevSearchRef = useRef('');
-  const navigate = useNavigate();
-
+  const history = useHistory();
   useEffect(() => {
     if (accountHasEdgeImages && !hasConventionalSystems) {
       handleTabClick(undefined, hybridInventoryTabKeys.immutable.key);
@@ -45,9 +42,7 @@ const HybridInventoryTabs = ({
 
     if (tabIndex !== activeTab) {
       prevSearchRef.current = search.toString();
-      navigate(pathWithParams, {
-        replace: true,
-      });
+      history.replace(pathWithParams); // Replaced navigate with history.replace
     }
   };
 
@@ -104,7 +99,6 @@ const HybridInventoryTabs = ({
             </Text>
           </TextContent>
         </Alert>
-        {ImmutableDevicesTab}
       </Tab>
     </Tabs>
   ) : (
@@ -114,7 +108,6 @@ const HybridInventoryTabs = ({
 
 HybridInventoryTabs.propTypes = {
   ConventionalSystemsTab: PropTypes.element.isRequired,
-  ImmutableDevicesTab: PropTypes.element.isRequired,
   isImmutableTabOpen: PropTypes.bool,
   tabPathname: PropTypes.string,
   isEdgeParityEnabled: PropTypes.bool,

--- a/src/routes/InventoryComponents/HybridInventory.js
+++ b/src/routes/InventoryComponents/HybridInventory.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import '../inventory.scss';
 import HybridInventoryTabs from '../../components/InventoryTabs/HybridInventoryTabs';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { getSearchParams } from '../../constants';
 import useFeatureFlag from '../../Utilities/useFeatureFlag';
 import { AccountStatContext } from '../../Contexts';
@@ -30,16 +30,18 @@ const SuspenseWrapper = ({ children }) => (
     {children}
   </Suspense>
 );
+
 const HybridInventory = (props) => {
-  const [searchParams] = useSearchParams();
+  const { search } = useLocation();
   const parsedSearchParams = useMemo(
-    () => getSearchParams(searchParams),
-    [searchParams.toString()],
+    () => getSearchParams(new URLSearchParams(search)),
+    [search],
   );
   const fullProps = { ...props, ...parsedSearchParams };
   const isEdgeParityEnabled = useFeatureFlag('edgeParity.inventory-list');
   const { hasEdgeDevices, hasConventionalSystems } =
     useContext(AccountStatContext);
+
   return (
     <HybridInventoryTabs
       ConventionalSystemsTab={


### PR DESCRIPTION
This PR is a draft to gather advice/suggestions on how I should refactor rhel advisor based on this https://github.com/RedHatInsights/insights-advisor-frontend/tree/master/src/SmartComponents/HybridInventoryTabs

I don't think I can downgrade react-router-dom to version 5 specifically for the iop environment 

I assume that the best solution would be -> avoid using Hybrid inventory tabs and use a pure inventory table in the IOP environment. 