### PR TITLE
fix(RHINENG-10851): subscription card not populating

### DIFF
--- a/src/__mocks__/selectors.js
+++ b/src/__mocks__/selectors.js
@@ -68,10 +68,18 @@ export const collectInfoTest = {
   insights_egg_version: 'test-egg',
 };
 
-export const subscriptionsTest = {
+export const subscriptionsTestFacts = {
   facts: {
     SYSPURPOSE_USAGE: 'Development',
     SYSPURPOSE_SLA: 'Self-Support',
     SYSPURPOSE_ROLE: 'Red Hat Enterprise Linux Server',
+  },
+};
+
+export const subscriptionsTestSystemPurpose = {
+  system_purpose: {
+    usage: 'Development',
+    sla: 'Self-Support',
+    role: 'Red Hat Enterprise Linux Server',
   },
 };

--- a/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.js
+++ b/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.js
@@ -47,7 +47,7 @@ SubscriptionCardCore.defaultProps = {
 
 export const SubscriptionCard = connect(
   ({ entityDetails: { entity }, systemProfileStore: { systemProfile } }) => ({
-    subscriptionFacts: subscriptionsSelector(entity),
+    subscriptionFacts: subscriptionsSelector(entity, systemProfile),
     detailLoaded: systemProfile && systemProfile.loaded,
   }),
 )(SubscriptionCardCore);

--- a/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.test.js
+++ b/src/components/GeneralInfo/SubscriptionCard/SubscriptionCard.test.js
@@ -1,9 +1,13 @@
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import { TestWrapper } from '../../../Utilities/TestingUtilities';
-import { subscriptionsTest } from '../../../__mocks__/selectors';
+import {
+  subscriptionsTestFacts,
+  subscriptionsTestSystemPurpose,
+} from '../../../__mocks__/selectors';
 import SubscriptionCard from './SubscriptionCard';
+import '@testing-library/jest-dom';
 
 describe('SubscriptionCard', () => {
   let initialState;
@@ -20,7 +24,7 @@ describe('SubscriptionCard', () => {
       },
       entityDetails: {
         entity: {
-          ...subscriptionsTest,
+          ...subscriptionsTestFacts,
         },
       },
     };
@@ -57,4 +61,21 @@ describe('SubscriptionCard', () => {
       expect(view.asFragment()).toMatchSnapshot();
     }),
   );
+
+  it('should render correctly with subscription system_purpose data', async () => {
+    initialState.systemProfileStore.systemProfile.system_purpose =
+      subscriptionsTestSystemPurpose.system_purpose;
+    initialState.entityDetails.entity.facts = undefined;
+
+    const store = mockStore(initialState);
+    render(
+      <TestWrapper store={store}>
+        <SubscriptionCard />
+      </TestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Development')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/GeneralInfo/selectors/selectors.js
+++ b/src/components/GeneralInfo/selectors/selectors.js
@@ -8,11 +8,16 @@ function safeParser(toParse, key) {
   }
 }
 
-export const subscriptionsSelector = ({ facts } = {}) => ({
-  usage: facts?.SYSPURPOSE_USAGE,
-  sla: facts?.SYSPURPOSE_SLA,
-  role: facts?.SYSPURPOSE_ROLE,
-});
+export const subscriptionsSelector = (
+  { facts } = {},
+  { system_purpose } = {},
+) => {
+  return {
+    usage: facts?.SYSPURPOSE_USAGE || system_purpose?.usage,
+    sla: facts?.SYSPURPOSE_SLA || system_purpose?.sla,
+    role: facts?.SYSPURPOSE_ROLE || system_purpose?.role,
+  };
+};
 
 export const propertiesSelector = (
   {

--- a/src/components/GeneralInfo/selectors/selectors.test.js
+++ b/src/components/GeneralInfo/selectors/selectors.test.js
@@ -5,6 +5,7 @@ import {
   infrastructureSelector,
   operatingSystem,
   propertiesSelector,
+  subscriptionsSelector,
 } from './selectors';
 import {
   biosTest,
@@ -12,6 +13,8 @@ import {
   configTest,
   infraTest,
   osTest,
+  subscriptionsTestFacts,
+  subscriptionsTestSystemPurpose,
   testProperties,
 } from '../../../__mocks__/selectors';
 
@@ -137,5 +140,21 @@ it('collectionInformationSelector - no data', () => {
   expect(collectionInformationSelector()).toEqual({
     client: undefined,
     egg: undefined,
+  });
+});
+
+it('subscriptionsSelector should return facts data', () => {
+  expect(subscriptionsSelector(subscriptionsTestFacts, {})).toEqual({
+    usage: 'Development',
+    sla: 'Self-Support',
+    role: 'Red Hat Enterprise Linux Server',
+  });
+});
+
+it('subscriptionsSelector should return system_purpose data', () => {
+  expect(subscriptionsSelector({}, subscriptionsTestSystemPurpose)).toEqual({
+    usage: 'Development',
+    sla: 'Self-Support',
+    role: 'Red Hat Enterprise Linux Server',
   });
 });


### PR DESCRIPTION
When registering a new system with subscription-manager, the subscription card details are populated under the systemProfile details instead of the entityDetails. So this code is updated to read the subscription info from either location.

## Summary by Sourcery

Ensure SubscriptionCard can retrieve subscription data from either entity facts or system_profile system_purpose and update related selectors and tests accordingly.

Bug Fixes:
- Fix subscription card not populating when subscription data is under systemProfile.system_purpose instead of entityDetails

Enhancements:
- Extend subscriptionsSelector to fall back to system_purpose fields when facts are unavailable
- Update SubscriptionCard connector to pass both entity and systemProfile into subscriptionsSelector

Tests:
- Add unit tests for subscriptionsSelector to cover both facts-based and system_purpose-based data
- Update SubscriptionCard tests to verify rendering with system_purpose subscription data
- Rename and separate mock fixtures for facts and system_purpose subscription data