### PR TITLE
feat(RHINENG-19303): add default items & custom columns for SystemsTable

### DIFF
--- a/src/routes/Systems/Systems.js
+++ b/src/routes/Systems/Systems.js
@@ -7,12 +7,20 @@ import {
   sortSerialiser,
   paginationSerialiser,
 } from './serialisers';
+import * as defaultColumns from './components/SystemsTable/columns';
 
 const Systems = () => (
   <>
     <InventoryPageHeader />
     <PageSection>
       <SystemsTable
+        columns={[
+          defaultColumns.displayName,
+          defaultColumns.workspace,
+          defaultColumns.tags,
+          defaultColumns.operatingSystem,
+          defaultColumns.lastSeen,
+        ]}
         options={{
           // FIXME: remove debug
           debug: true,

--- a/src/routes/Systems/components/SystemsTable/SystemsTable.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.js
@@ -2,31 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TableToolsTable } from 'bastilian-tabletools';
 
-import columns from './columns';
 import filters, { CUSTOM_FILTER_TYPES } from './filters';
-import { fetchSystems } from '../../helpers.js';
+import { fetchSystems, resolveColumns } from '../../helpers.js';
+import { DEFAULT_OPTIONS } from './constants';
 
-// TODO columns should be "customisable" similar to how the current Inventory does it. Allow for fn and objs to be passed in
 // TODO Filters should be customisable enable/disable, extend, etc.
 // TODO "global filter" needs to be integrated
-const defaultOptions = {
-  perPage: 50,
-  // FIXME: selection should not be reloading table
-  onSelect: () => true,
-};
-
-const SystemsTable = ({ items = fetchSystems, options }) => {
+const SystemsTable = ({ items = fetchSystems, columns = [], options = {} }) => {
   return (
     <TableToolsTable
       variant="compact"
       items={items}
-      columns={columns}
+      columns={resolveColumns(columns)}
       filters={{
         customFilterTypes: CUSTOM_FILTER_TYPES,
         filterConfig: filters,
       }}
       options={{
-        ...defaultOptions,
+        ...DEFAULT_OPTIONS,
         ...options,
       }}
     />
@@ -35,6 +28,7 @@ const SystemsTable = ({ items = fetchSystems, options }) => {
 
 SystemsTable.propTypes = {
   items: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
+  columns: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
   options: PropTypes.object,
 };
 

--- a/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import SystemsTable from './SystemsTable';
+import { TableToolsTable } from 'bastilian-tabletools';
+import { fetchSystems } from '../../helpers.js';
+
+jest.mock('bastilian-tabletools', () => ({
+  TableToolsTable: jest.fn(() => (
+    <div data-testid="table-tools-table">TableToolsTable</div>
+  )),
+}));
+
+jest.mock('../../helpers.js', () => {
+  const actual = jest.requireActual('../../helpers.js');
+  return {
+    ...actual,
+    fetchSystems: jest.fn(),
+  };
+});
+
+describe('SystemsTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should pass fetchSystems, when no items are provided', () => {
+    render(<SystemsTable />);
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: fetchSystems,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should pass items array', () => {
+    const items = [{}, {}, {}];
+
+    render(<SystemsTable items={items} />);
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: items,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should pass items fn', () => {
+    const items = () => [{}, {}, {}];
+
+    render(<SystemsTable items={items} />);
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: items,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should pass an empty array, when columns not provided', () => {
+    render(<SystemsTable />);
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: [],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should pass columns array', () => {
+    const columns = [{}, {}, {}];
+
+    render(<SystemsTable columns={columns} />);
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: columns,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should pass array of columns, when columns fn is received', () => {
+    const columns = [{}, {}, {}];
+    const columnsFn = () => columns;
+
+    render(<SystemsTable columns={columnsFn} />);
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: columns,
+      }),
+      expect.anything(),
+    );
+  });
+});

--- a/src/routes/Systems/components/SystemsTable/columns.js
+++ b/src/routes/Systems/components/SystemsTable/columns.js
@@ -8,14 +8,14 @@ import Tags from './components/columns/Tags';
 import OperatingSystem from './components/columns/OperatingSystem';
 import LastSeen from './components/columns/LastSeen';
 
-const displayName = {
+export const displayName = {
   key: 'display_name',
   sortable: 'display_name',
   title: 'Name',
   Component: DisplayName,
 };
 
-const workspace = {
+export const workspace = {
   key: 'groups',
   sortable: 'group_name',
   title: 'Workspace',
@@ -24,14 +24,14 @@ const workspace = {
   transforms: [fitContent],
 };
 
-const tags = {
+export const tags = {
   key: 'tags',
   title: 'Tags',
   props: { width: 10 },
   Component: Tags,
 };
 
-const operatingSystem = {
+export const operatingSystem = {
   key: 'system_profile',
   sortable: 'operating_system',
   // Is that for export?
@@ -45,7 +45,7 @@ const operatingSystem = {
   props: { width: 10 },
 };
 
-const lastSeen = {
+export const lastSeen = {
   key: 'updated',
   sortable: 'updated',
   dataLabel: 'Last seen',

--- a/src/routes/Systems/components/SystemsTable/constants.js
+++ b/src/routes/Systems/components/SystemsTable/constants.js
@@ -1,0 +1,5 @@
+export const DEFAULT_OPTIONS = {
+  perPage: 50,
+  // FIXME: selection should not be reloading table
+  onSelect: () => true,
+};

--- a/src/routes/Systems/helpers.js
+++ b/src/routes/Systems/helpers.js
@@ -1,6 +1,7 @@
 // TODO remove dependency on fec helpers and components
 import { generateFilter } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { getHostList, getHostTags, getTags } from '../../api/hostInventoryApi';
+import defaultColumns from './components/SystemsTable/columns';
 
 const fetchHostTags = async (hosts) => {
   if (hosts.length) {
@@ -44,4 +45,12 @@ export const fetchSystems = async (serialisedTableState) => {
   }));
 
   return [systems, total];
+};
+
+export const resolveColumns = (columns) => {
+  if (typeof columns === 'function') {
+    return columns(defaultColumns);
+  } else {
+    return columns;
+  }
 };


### PR DESCRIPTION
Implements RHINENG-19303

## Changes to SystemsTable
- [x] use default fetch function for SystemsTable when no items are passed
- [x] export individual columns
- [x] add columns customization via fn
- [x] unit tests for handling props

## Design decisions behind columns API

- missing or errorneous columns we pass through to TableTools, that throws 
- to customize users can pass in custom definitions or function for dynamic settings 

<img width="1531" height="492" alt="image" src="https://github.com/user-attachments/assets/9a701e74-4d8c-4e90-9d93-81cddca8898b" />

## How to check
1. go to hcc stage
2. enable feature flag: run in console localStorage.setItem("ui.systems-table", "true")
3. go to Inventory / Systems

## Summary by Sourcery

Implement default data fetching and customizable column support for SystemsTable using a shared columns library

New Features:
- Provide fetchSystems as the default items source when no items prop is passed to SystemsTable
- Allow SystemsTable to accept custom column definitions via an array or a function

Enhancements:
- Introduce SHARED_COLUMNS object containing common column definitions
- Add resolveColumns helper to merge and validate provided columns

Chores:
- Update Systems page to leverage default items and shared columns instead of hardcoding fetch and column details

## Summary by Sourcery

Enhance SystemsTable to support default data fetching and flexible column customization using a shared column library and default options

New Features:
- Use fetchSystems as the default data source when no items prop is provided to SystemsTable
- Allow SystemsTable to accept custom column definitions via an array or a function

Enhancements:
- Introduce SHARED_COLUMNS library of common column definitions for reuse
- Add resolveColumns helper to merge and validate provided column definitions
- Add DEFAULT_OPTIONS for table settings including pagination and selection behavior

Chores:
- Update Systems page to leverage default items and shared columns instead of hardcoding fetch and column details

## Summary by Sourcery

Enhance SystemsTable to default to remote data fetching, support explicit column customization using a shared column library, and apply consistent default table options

New Features:
- Use fetchSystems as the default items source when no items prop is passed to SystemsTable
- Allow SystemsTable to accept custom column definitions via the columns prop (array or function)

Enhancements:
- Introduce SHARED_COLUMNS library of reusable column definitions
- Add resolveColumns helper to merge and validate provided columns
- Add DEFAULT_OPTIONS constant for default pagination and selection behavior
- Update Systems page to leverage shared columns instead of hardcoded column configuration

Tests:
- Add unit tests for SystemsTable to verify default props and column handling