### PR TITLE
feat(iop): proptypes update and cleanup

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -669,6 +669,12 @@ const EntityTableToolbar = ({
 };
 
 EntityTableToolbar.propTypes = {
+  className: PropTypes.string,
+  columns: PropTypes.func,
+  'data-testid': PropTypes.string,
+  id: PropTypes.string,
+  store: PropTypes.object,
+  loadChromelessInventory: PropTypes.bool,
   showTags: PropTypes.bool,
   getTags: PropTypes.func,
   hasAccess: PropTypes.bool,

--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -220,7 +220,6 @@ const InventoryTable = forwardRef(
         ...options,
         globalFilter: cachedProps?.customFilters?.globalFilter,
       };
-      console.log(newParams, 'newParams');
 
       //Check for the rbac permissions
       const cachedParams = cache.current.getParams();

--- a/src/modules/AsyncInventory.js
+++ b/src/modules/AsyncInventory.js
@@ -42,6 +42,49 @@ AsyncInventory.propTypes = {
   innerRef: PropTypes.shape({
     current: PropTypes.any,
   }),
+  actionsConfig: PropTypes.shape({
+    actions: PropTypes.arrayOf(PropTypes.object),
+  }),
+  activeFiltersConfig: PropTypes.shape({
+    deleteTitle: PropTypes.string,
+    filters: PropTypes.arrayOf(PropTypes.object),
+    onDelete: PropTypes.func,
+  }),
+  autoRefresh: PropTypes.bool,
+  axios: PropTypes.func,
+  bulkSelect: PropTypes.shape({
+    toggleProps: PropTypes.object,
+    count: PropTypes.number,
+    isDisabled: PropTypes.bool,
+    items: PropTypes.arrayOf(PropTypes.object),
+    checked: PropTypes.bool,
+  }),
+  className: PropTypes.string,
+  columns: PropTypes.func,
+  customFilters: PropTypes.shape({
+    advisorFilters: PropTypes.object,
+    SID: PropTypes.arrayOf(PropTypes.string),
+  }),
+  exportConfig: PropTypes.bool,
+  getEntities: PropTypes.func,
+  hasCheckbox: PropTypes.bool,
+  hideFilters: PropTypes.shape({
+    all: PropTypes.bool,
+    name: PropTypes.bool,
+    tags: PropTypes.bool,
+    operatingSystem: PropTypes.bool,
+    hostGroupFilter: PropTypes.bool,
+  }),
+  id: PropTypes.string,
+  initialLoading: PropTypes.bool,
+  showTags: PropTypes.bool,
+  tableProps: PropTypes.shape({
+    variant: PropTypes.string,
+    canSelectAll: PropTypes.bool,
+    isStickyHeader: PropTypes.bool,
+    actionResolver: PropTypes.func,
+    onSelect: PropTypes.func,
+  }),
 };
 
 AsyncInventory.defaultProps = {

--- a/src/modules/IOPInventoryTable.js
+++ b/src/modules/IOPInventoryTable.js
@@ -1,13 +1,71 @@
 import React from 'react';
 import AsyncInventory from './AsyncInventory';
+import PropTypes from 'prop-types';
 import { InventoryTable as InventoryTableCmp } from '../components/InventoryTable';
 
-const BaseIOPInventoryTable = (props) => (
-  <AsyncInventory {...props} component={InventoryTableCmp} />
-);
+const BaseIOPInventoryTable = (props) => {
+  return <AsyncInventory {...props} component={InventoryTableCmp} />;
+};
 const IOPInventoryTable = React.forwardRef((props, ref) => (
   <BaseIOPInventoryTable {...props} innerRef={ref} />
 ));
+
+BaseIOPInventoryTable.propTypes = {
+  actionsConfig: PropTypes.shape({
+    actions: PropTypes.arrayOf(PropTypes.object),
+  }),
+  activeFiltersConfig: PropTypes.shape({
+    deleteTitle: PropTypes.string,
+    filters: PropTypes.arrayOf(PropTypes.object),
+    onDelete: PropTypes.func,
+  }),
+  autoRefresh: PropTypes.bool,
+  axios: PropTypes.func,
+  bulkSelect: PropTypes.shape({
+    toggleProps: PropTypes.object,
+    count: PropTypes.number,
+    isDisabled: PropTypes.bool,
+    items: PropTypes.arrayOf(PropTypes.object),
+    checked: PropTypes.bool,
+  }),
+  className: PropTypes.string,
+  columns: PropTypes.func,
+  customFilters: PropTypes.shape({
+    advisorFilters: PropTypes.object,
+    SID: PropTypes.arrayOf(PropTypes.string),
+  }),
+  exportConfig: PropTypes.bool,
+  getEntities: PropTypes.func,
+  hasCheckbox: PropTypes.bool,
+  hideFilters: PropTypes.shape({
+    all: PropTypes.bool,
+    name: PropTypes.bool,
+    tags: PropTypes.bool,
+    operatingSystem: PropTypes.bool,
+    hostGroupFilter: PropTypes.bool,
+  }),
+  id: PropTypes.string,
+  initialLoading: PropTypes.bool,
+  innerRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any }),
+  ]),
+  onLoad: PropTypes.func,
+  showTags: PropTypes.bool,
+  store: PropTypes.shape({
+    dispatch: PropTypes.func,
+    subscribe: PropTypes.func,
+    getState: PropTypes.func,
+    replaceReducer: PropTypes.func,
+  }),
+  tableProps: PropTypes.shape({
+    variant: PropTypes.string,
+    canSelectAll: PropTypes.bool,
+    isStickyHeader: PropTypes.bool,
+    actionResolver: PropTypes.func,
+    onSelect: PropTypes.func,
+  }),
+};
 
 export default IOPInventoryTable;
 

--- a/src/routes/Systems/helpers.js
+++ b/src/routes/Systems/helpers.js
@@ -12,9 +12,7 @@ const fetchHostTags = async (hosts) => {
   }
 };
 
-export const fetchTags = async (...args) => {
-  console.log('args tags', ...args);
-
+export const fetchTags = async () => {
   return await getTags();
 };
 


### PR DESCRIPTION
During the development for IOP, we missed 2 console.logs that we merged into master. Removing them
Adding proptypes to some of the components we utilize in IO,P so it would be easier to track