### PR TITLE
fix(RHINENG-19923): properly pass feature flags

### DIFF
--- a/src/components/InventoryTable/InventoryTable.js
+++ b/src/components/InventoryTable/InventoryTable.js
@@ -274,6 +274,9 @@ const InventoryTable = forwardRef(
       }
     });
 
+    const chromelessInventoryCheck = (flag) =>
+      props.loadChromelessInventory ? false : flag;
+
     return hasAccess === false && isFullView ? (
       <AccessDenied
         title="This application requires Inventory permissions"
@@ -311,21 +314,15 @@ const InventoryTable = forwardRef(
           }}
           showCentosVersions={showCentosVersions}
           enableExport={enableExport}
-          isUpdateMethodFFEnabled={
-            props.loadChromelessInventory
-              ? false
-              : statContext.isUpdateMethodFFEnabled
-          }
-          isKesselFFEnabled={
-            props.loadChromelessInventory
-              ? false
-              : statContext.isKesselFFEnabled
-          }
-          edgeParityFilterDeviceEnabled={
-            props.loadChromelessInventory
-              ? false
-              : statContext.edgeParityFilterDeviceEnabled
-          }
+          isUpdateMethodFFEnabled={chromelessInventoryCheck(
+            statContext.isUpdateMethodEnabled,
+          )}
+          isKesselFFEnabled={chromelessInventoryCheck(
+            statContext.isKesselEnabled,
+          )}
+          edgeParityFilterDeviceEnabled={chromelessInventoryCheck(
+            statContext.edgeParityFilterDeviceEnabled,
+          )}
           loadChromelessInventory={props.loadChromelessInventory}
           axios={axios}
         >


### PR DESCRIPTION
The workspace filter on the systems table improperly shows a filter for "No workspace" instead of the updated "Ungrouped hosts" after Kessel phase 0.

This is because of a recent PR that was merged that improperly passed the value of certain flags. With the correct names updated, everything works as normal.

## Summary by Sourcery

Fix improper feature flag passing in the InventoryTable component by ensuring flags honor the loadChromelessInventory prop and use the correct statContext names.

Bug Fixes:
- Ensure feature flags (updateMethod, Kessel, and edgeParityFilterDevice) are disabled when loadChromelessInventory is true and use the correct statContext properties.

Enhancements:
- Add chromelessInventoryCheck helper to centralize the feature flag disabling logic based on loadChromelessInventory.