### PR TITLE
chore(RHINENG-17215): Frontend operator migration

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/RedHatInsights/frontend-components/refs/heads/master/packages/config-utils/src/feo/spec/frontend-crd.schema.json
+---
 apiVersion: v1
 kind: Template
 metadata:
@@ -8,6 +10,7 @@ objects:
     metadata:
       name: inventory
     spec:
+      feoConfigEnabled: true
       envName: ${ENV_NAME}
       title: Inventory
       deploymentRepo: https://github.com/RedHatInsights/insights-inventory-frontend
@@ -18,18 +21,149 @@ objects:
         paths:
           - /apps/inventory
       image: ${IMAGE}:${IMAGE_TAG}
-      navItems:
-        - appId: "inventory"
-          title: "Inventory"
-          href: "/insights/inventory"
-          product: "Red Hat Insights"
       module:
-        manifestLocation: "/apps/inventory/fed-mods.json"
+        analytics:
+          APIKey: apRCg9V6oMXCcnTingqRYW6m1er4hkCW
+          APIKeyDev: aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg
+        manifestLocation: /apps/inventory/fed-mods.json
+        config:
+          supportCaseData:
+            product: Red Hat Insights
+            version: Inventory
         modules:
-          - id: "inventory"
-            module: "./RootApp"
+          - id: inventory
+            module: ./RootApp
             routes:
               - pathname: /insights/inventory
+              - pathname: /ansible/inventory
+
+      bundleSegments:
+        - segmentId: inventory-insights
+          bundleId: insights
+          position: 500
+          navItems:
+            - id: inventory
+              title: Inventory
+              expandable: true
+              routes:
+                - id: systems
+                  title: Systems
+                  href: /insights/inventory
+                  product: Red Hat Insights
+                - id: workspaces
+                  title: Workspaces
+                  href: /insights/inventory/workspaces
+                  product: Red Hat Insights
+                - id: images
+                  title: Images
+                  href: /insights/image-builder
+                  product: Red Hat Insights
+                - id: system-configuration
+                  title: System Configuration
+                  expandable: true
+                  routes:
+                    - id: rhc
+                      title: Remote Host Configuration
+                      href: /insights/connector
+                      product: Red Hat Insights
+                    - id: activation-keys
+                      title: Activation Keys
+                      href: /insights/connector/activation-keys
+                      product: Red Hat Insights
+                    - id: staleness-and-deletion
+                      title: Staleness and Deletion
+                      href: /insights/inventory/staleness-and-deletion
+                      product: Red Hat Insights
+        - segmentId: inventory-ansible
+          bundleId: ansible
+          position: 1000
+          navItems:
+            - title: Inventory
+              id: inventory
+              href: /ansible/inventory
+              product: Red Hat Insights
+
+      serviceTiles:
+        - id: inventory-ansible-automation
+          title: Inventory
+          description: "View details about your Ansible Automation Platform systems."
+          href: /ansible/inventory
+          group: ansible
+          section: automation
+          icon: AnsibleIcon
+        - id: inventory-rhel-inventories
+          title: Inventory
+          description: "View details about your Red Hat Enterprise Linux systems."
+          href: /insights/inventory
+          group: rhel
+          section: inventories
+          icon: InsightsIcon
+        - id: inventory-ansible-inventories
+          title: Inventory
+          description: "View details about your Ansible Automation Platform systems."
+          href: /ansible/inventory
+          group: ansible
+          section: inventories
+          icon: AnsibleIcon
+        - id: inventory-workspaces-rhel-inventories
+          title: Workspaces
+          description: "Group your Red Hat Enterprise Linux systems for more granular User Access."
+          href: /insights/inventory/workspaces
+          group: rhel
+          section: inventories
+          icon: InsightsIcon
+        - id: inventory-staleness-and-deletion-rhel-systemConfiguration
+          title: Staleness and Deletion
+          description: "Configure when your systems should be marked as stale, marked as stale warning, and be deleted."
+          href: /insights/inventory/staleness-and-deletion
+          group: rhel
+          section: systemConfiguration
+          icon: InsightsIcon
+
+      searchEntries:
+        - id: inventory-systems-rhel
+          title: Systems - Inventory
+          description: "View details about your Red Hat Enterprise Linux systems."
+          href: /insights/inventory
+          alt_title:
+            - inventory
+            - rhel systems
+            - my systems
+            - hosts
+            - boxes
+            - rhel
+            - linux
+            - insights
+            - systems
+            - hosts
+            - rhel
+            - hostname(s)
+            - machine(s)
+            - server(s)
+        - id: inventory-workspaces-rhel
+          title: Workspaces - Inventory
+          description: "Organize your Red Hat Enterprise Linux systems with workspaces for more granular User Access."
+          href: /insights/inventory/workspaces
+          alt_title:
+            - workspaces
+            - workspace
+            - groups
+            - group
+        - id: systemConfiguration-rhc-rhel
+          title: Remote Host Configuration - System Configuration
+          description: "Configure your systems to execute Ansible Playbooks."
+          href: /insights/connector
+          alt_title:
+            - Remote host configuration
+            - remote host configuration
+            - connect systems
+            - connection options
+            - connect settings
+            - settings
+            - Register
+            - rhc
+            - RHC
+            - rhcd
 
 parameters:
   - name: ENV_NAME

--- a/fec.config.js
+++ b/fec.config.js
@@ -8,6 +8,7 @@ const appName = packageJson[bundle].appname;
 module.exports = {
   appName,
   appUrl: `/${bundle}/${appName}`,
+  publicPath: 'auto',
   useProxy: process.env.PROXY === 'true',
   debug: true,
   devtool: 'hidden-source-map',

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "@faker-js/faker": "^9.6.0",
         "@playwright/test": "^1.54.1",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",
-        "@redhat-cloud-services/frontend-components-config": "^6.6.1",
+        "@redhat-cloud-services/frontend-components-config": "^6.6.11",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.24",
         "@stoplight/prism-cli": "^5.14.2",
         "@swc/jest": "^0.2.37",
@@ -5415,14 +5415,14 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.6.3.tgz",
-      "integrity": "sha512-TV334mhac3pcNwcgCMlHXes14entuSXw2r6HFOaQ9su1fLtWeL5r9KkVP4GXMCkBKwGZdnQydw0lX0Z0Snw92A==",
+      "version": "6.6.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.6.11.tgz",
+      "integrity": "sha512-97IztUl8PdAUOI/KpCe/iZ/JvFJc/OOfC9b3qPNZ8uipAHRjx06AWDbE4S5TFXpQczZb2DbxA+4OS6xKmGnXMg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^4.3.5",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^4.7.0",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.21",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
@@ -5469,9 +5469,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.4.1.tgz",
-      "integrity": "sha512-GG+wCpPWq2i9B6+NeH3UvSVhIGczxrEaRTSH0sFvIrcHMpMoUeFH467GT9w+PUeey24Ap0/Gi+/BiCSzUFrQMQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.7.0.tgz",
+      "integrity": "sha512-MUxsr2qS2x0ALFfgjRGGyTxMiwpzHeMYYZTOvK6TUQXAXTn98JkEo2qxQesZq8zGIGBTeyw5yb+/DQqxCwbpLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@faker-js/faker": "^9.6.0",
     "@playwright/test": "^1.54.1",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",
-    "@redhat-cloud-services/frontend-components-config": "^6.6.1",
+    "@redhat-cloud-services/frontend-components-config": "^6.6.11",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.24",
     "@stoplight/prism-cli": "^5.14.2",
     "@swc/jest": "^0.2.37",


### PR DESCRIPTION
Migrating inventory FE to the frontend operator, so it can use publicPath: auto, which is needed by the IOP effort.

## Summary by Sourcery

Migrate the Inventory frontend to the Frontend Operator by enabling feoConfigEnabled and publicPath auto, consolidating configuration into the frontend operator spec, and updating the required dependency version.

Enhancements:
- Enable feoConfigEnabled in deploy/frontend.yaml and add publicPath: auto in fec.config.js
- Restructure module definitions and routes to support both insights and ansible inventory paths
- Add bundleSegments with nested navItems to group inventory and ansible navigation entries
- Introduce serviceTiles and searchEntries to support new inventory and ansible search and tile layouts
- Update @redhat-cloud-services/frontend-components-config dependency to 6.6.9