### PR TITLE
fix(RHINENG-19977): Edit display name modal not working

### DIFF
--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -95,7 +95,7 @@ const ConventionalSystemsTab = ({
       systemTypeFilter,
     ),
   );
-  const [ediOpen, onEditOpen] = useState(false);
+  const [editOpen, onEditOpen] = useState(false);
   const [addHostGroupModalOpen, setAddHostGroupModalOpen] = useState(false);
   const [removeHostsFromGroupModalOpen, setRemoveHostsFromGroupModalOpen] =
     useState(false);
@@ -119,6 +119,7 @@ const ConventionalSystemsTab = ({
     onSetfilters(options?.filters);
   });
 
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     chrome.updateDocumentTitle('Systems - Inventory');
     chrome.appAction('system-list');
@@ -142,6 +143,7 @@ const ConventionalSystemsTab = ({
       dispatch(actions.clearEntitiesAction());
     };
   }, []);
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   const calculateSelected = () => (selected ? selected.size : 0);
 
@@ -334,18 +336,19 @@ const ConventionalSystemsTab = ({
       />
       <TextInputModal
         title="Edit display name"
-        isOpen={ediOpen}
+        isOpen={editOpen}
         value={currentSystem.display_name}
         onCancel={() => onEditOpen(false)}
-        onSubmit={(value) => {
+        onSubmit={async (value) => {
           dispatch(
-            actions.editDisplayName(
+            await actions.editDisplayName(
               currentSystem.id,
               value,
-              _,
+              currentSystem.display_name,
               addNotification,
             ),
           );
+          inventory?.current?.onRefreshData({}, false, true);
           onEditOpen(false);
         }}
       />


### PR DESCRIPTION
The "Save" button on the Edit display name modal doesn't work after the PF6 upgrade.

To test:
- go to Inventory -> Systems
- click kebab for a system and select "Edit"
- change the name of the system
- click "Save"

Nothing will happen. With this PR, the display name updates properly.

## Summary by Sourcery

Enable the Edit display name modal to save changes by correcting the action parameter and temporarily disabling exhaustive-deps lint checks around useEffect hooks

Bug Fixes:
- Fix Save button in the Edit display name modal by passing the correct display name to the editDisplayName action

Enhancements:
- Suppress react-hooks/exhaustive-deps lint warnings around useEffect hooks