### PR TITLE
ci(playwright): add PR checks pipeline for test automationn

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,99 @@
+name: build-playwright-test
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  playwright-tests:
+    runs-on:
+      - codebuild-host-inventory-frontend-${{ github.run_id }}-${{ github.run_attempt }}
+      - instance-size:large
+      - buildspec-override:true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Create front-end .env file
+        run: |
+          # Check if the secrets are set
+          if [ -z "$PLAYWRIGHT_USER" ]; then
+            echo "Error: PLAYWRIGHT_USER secret is not set."
+            exit 1
+          fi
+
+          if [ -z "$PLAYWRIGHT_PASSWORD" ]; then
+            echo "Error: PLAYWRIGHT_PASSWORD secret is not set."
+            exit 1
+          fi
+
+          # Create the .env file and write the secrets and other variables to it
+          {
+            echo "PLAYWRIGHT_USER=$PLAYWRIGHT_USER"
+            echo "PLAYWRIGHT_PASSWORD=$PLAYWRIGHT_PASSWORD"
+            echo "BASE_URL=https://stage.foo.redhat.com:1337"
+            echo "CI=true"
+          } >> .env
+
+          echo ".env file created successfully."
+      
+      - name: Get current PR URL
+        id: get-pr-url
+        run: |
+          # Extract the pull request URL from the event payload
+          pr_url=$(jq -r '.pull_request.html_url' < "$GITHUB_EVENT_PATH")
+          echo "Pull Request URL: $pr_url"
+          # Set the PR URL as an output using the environment file
+          echo "pr_url=$pr_url" >> $GITHUB_ENV
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+      
+      - name: Install front-end dependencies
+        run: npm ci
+
+      - name: Install playwright
+        run: npx playwright install --with-deps
+
+      # This prevents an error related to minimum watchers when running the front-end and playwright
+      - name: Increase file watchers limit
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      
+      - name: Update /etc/hosts
+        run: sudo npm run patch:hosts
+
+      - name: Run testing proxy
+        run: docker run -d --network=host -e HTTPS_PROXY=$RH_PROXY_URL -e ROUTES_JSON_PATH=/config/routes-ci.json  -v "$(pwd)/config:/config:ro,Z" --name consoledot-testing-proxy quay.io/dvagner/consoledot-testing-proxy
+
+      - name: Start front-end server
+        run: |
+          npm run static &
+          npx wait-on http://localhost:8003/apps/inventory/
+
+      - name: Run front-end Playwright tests
+        run: npx playwright test
+
+      - name: Publish front-end Test Report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: './playwright-ctrf/playwright-ctrf.json'
+        if: ${{ !cancelled() }}
+
+      - name: Store front-end Test report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 10

--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ If using any OS other than Fedora/Rhel (i.e., Mac, Ubuntu Linux):
 
 `npx playwright install  --with-deps`
 
-## Proxy setup to execute the test case using the local frontend : [consoledot-testing-proxy](https://github.com/dvagner/consoledot-testing-proxy)
+## Proxy setup to execute the test case using the local frontend in static mode : [consoledot-testing-proxy](https://github.com/dominikvagner/consoledot-testing-proxy)
 ```
+ npm run static
+
  podman run -d -e HTTPS_PROXY=$RH_PROXY_URL -p 1337:1337 -v "$(pwd)/config:/config:ro,Z" --replace --name consoledot-testing-proxy quay.io/dvagner/consoledot-testing-proxy
 ```
 
@@ -63,6 +65,8 @@ If using any OS other than Fedora/Rhel (i.e., Mac, Ubuntu Linux):
 **Run a single test:**
 
 `npx playwright test test_navigation.test.ts -g "User can navigate to the workspaces page via the menu"`
+
+Note: You can run all of the above to the stage env setup as well.
 
 ## Commit conventions
 

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -1,0 +1,34 @@
+version: 0.2
+run-as: root
+
+phases:
+  install:
+    commands:
+      - echo Entered the install phase...
+      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &
+      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
+
+  pre_build:
+    commands:
+      - echo Entered the pre_build phase...
+
+  build:
+    commands:
+      - echo Entered the build phase...
+      - echo Build started on `date`
+    finally:
+      - echo This always runs even if the build command fails
+
+  post_build:
+    commands:
+      - echo Entered the post_build phase...
+      - echo Build completed on `date`
+cache:
+  paths:
+    - "/root/.cache/ms-playwright"
+    - "/root/.docker"
+    - "/root/.npm"
+    - "/root/.yarn"
+    - "/root/.cache/go-build"
+    - "/root/go"
+    - "/root/.composer/cache"

--- a/config/routes-ci.json 
+++ b/config/routes-ci.json 
@@ -1,0 +1,3 @@
+{
+  "/apps/content-sources*": { "url": "http://127.0.0.1:8003" }
+}

--- a/config/routes.json
+++ b/config/routes.json
@@ -1,3 +1,3 @@
 {
-    "/apps/host-inventory*": { "url": "http://host.docker.internal:8003" }
+    "/apps/inventory*": { "url": "http://host.docker.internal:8003" }
 }

--- a/package.json
+++ b/package.json
@@ -171,7 +171,8 @@
     "commitlint": "commitlint --from HEAD~1 --to HEAD --verbose",
     "postinstall": "ts-patch install",
     "docs": "jsdoc --configure .jsdoc.json",
-    "test:pw": "npx playwright test"
+    "test:pw": "npx playwright test",
+    "patch:hosts": "fec patch-etc-hosts"
   },
   "insights": {
     "appname": "inventory"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,21 +2,19 @@ import { defineConfig, devices } from '@playwright/test';
 import 'dotenv/config';
 
 export default defineConfig({
-  testDir: './_playwright-tests',
-  /* Run tests in files in parallel */
+  testDir: './_playwright-tests/',
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 1,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  reporter: [
+    ['list'],
+    ['json', { outputFile: 'playwright-ctrf/playwright-ctrf.json' }],
+    ['html', { outputFolder: 'playwright-report' }],
+  ],
   timeout: 90_000,
   use: {
-    actionTimeout: 90_000, // 90s
+    actionTimeout: 90_000,
     navigationTimeout: 90_000,
     headless: true,
     baseURL: process.env.BASE_URL,
@@ -24,7 +22,6 @@ export default defineConfig({
     trace: 'on',
     ignoreHTTPSErrors: true,
   },
-
   projects: [
     { name: 'setup', testMatch: /.*\.setup\.ts/ },
     {

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+});
+
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Click the get started link.
+  await page.getByRole('link', { name: 'Get started' }).click();
+
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+});


### PR DESCRIPTION
This PR introduces a new CI workflow to run Playwright end-to-end tests as part of pull request checks.

The workflow ensures that:

- Playwright is installed with the required browsers and dependencies
- A front-end server is started for testing
- Tests are executed automatically on PRs
- Test results are published in GitHub using the CTRF JSON reporter
- An HTML test report is uploaded as a build artifact for debugging

## Summary by Sourcery

Introduce a PR checks pipeline that automates Playwright end-to-end tests by adding a GitHub Actions workflow, AWS CodeBuild configuration, updated test reporting in Playwright config, and corresponding documentation and scripts

New Features:
- Add GitHub Actions workflow to run Playwright end-to-end tests on pull requests and publish JSON and HTML reports
- Introduce AWS CodeBuild buildspec configuration to provision Docker and cache dependencies for Playwright test runs

Enhancements:
- Update Playwright configuration to use list, JSON (CTRF) and HTML reporters and adjust test directory
- Add npm scripts for host patching and static front-end server startup

Build:
- Add buildspec.yaml for AWS CodeBuild phases and caching

CI:
- Enable concurrency control in the GitHub Actions workflow and cache Docker, npm, and Playwright artifacts

Documentation:
- Extend README with proxy setup instructions for static mode and test execution commands