### PR TITLE
fix(RHINENG-19976): Remove comma from update org level modal

### DIFF
--- a/src/components/InventoryHostStaleness/HostStalenessCard.js
+++ b/src/components/InventoryHostStaleness/HostStalenessCard.js
@@ -404,7 +404,6 @@ const HostStalenessCard = ({ canModifyHostStaleness }) => {
                     >
                       Update
                     </Button>
-                    ,
                     <Button
                       key="cancel"
                       variant="link"


### PR DESCRIPTION
In the Update organization level setting modal footer, there is a comma between the "Update" button and the "Cancel" button. This PR removes it.

## Summary by Sourcery

Bug Fixes:
- Eliminate the comma separating the Update and Cancel buttons in the modal footer