### PR TITLE
fix(RHINENG-19975): Fix delete button, delete workspace modal

### DIFF
--- a/src/components/InventoryGroups/Modals/DeleteGroupModal.js
+++ b/src/components/InventoryGroups/Modals/DeleteGroupModal.js
@@ -47,7 +47,6 @@ const generateSchema = (groups) => ({
 const generateContent = (groups = []) => ({
   title: groups.length > 1 ? 'Delete workspaces?' : 'Delete workspace?',
   titleIconVariant: 'warning',
-  variant: 'small',
   submitLabel: 'Delete',
   schema: generateSchema(groups),
 });

--- a/src/components/InventoryGroups/Modals/Modal.js
+++ b/src/components/InventoryGroups/Modals/Modal.js
@@ -13,7 +13,6 @@ const RepoModal = ({
   submitLabel,
   schema,
   initialValues,
-  variant,
   reloadData,
   reloadTimeout,
   size,
@@ -45,9 +44,6 @@ const RepoModal = ({
                     {...props}
                     submitLabel={submitLabel}
                     disableSubmit={['invalid']}
-                    buttonsProps={{
-                      submit: { variant },
-                    }}
                   />
                 )
           }


### PR DESCRIPTION
Description of Problem
Issue with ""Delete" button in "Delete workspace" modal:
1. "Delete" is not in the center of button
2. When checkbox is selected Delete button removes background and it turns white

Steps to Reproduce
- visit https://console.stage.redhat.com/insights/inventory/workspaces
- try to remove empty workspace
- see that "Delete" is not centered in the disabled button
- select checkbox
- see that he background is white on the button

## Summary by Sourcery

Bug Fixes:
- Remove custom variant prop from modal components to properly center the 'Delete' button label and maintain its background color