### PR TITLE
fix(RHINENG-19915): display correct system name in TagsModal

### DIFF
--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -298,9 +298,8 @@ function selectFilter(
 
 const getActiveSystemTag = (state, meta) => {
   if (state.rows) {
-    return state.rows.find(
-      ({ id, insightsId, insights_id }) =>
-        meta.systemId === insightsId || insights_id || id,
+    return state.rows.find(({ id, insightsId, insights_id }) =>
+      [id, insightsId, insights_id].includes(meta.systemId),
     );
   }
   if (state.entity) {


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/RHINENG-19915

## Before

<img width="1028" height="471" alt="image" src="https://github.com/user-attachments/assets/5254cf67-4ad1-47b4-bc6f-6bd6058611ef" />

## After

<img width="1026" height="551" alt="image" src="https://github.com/user-attachments/assets/4878aa31-fe7e-4565-af09-03f3feeb3077" />

## How to reproduce
- go to HCC platform
- navigate to Inventory / Systems
- click on tags of a system with more than 0 tags. 
- verify name in the title of a Modal with tags is same as system's name from row.

