### PR TITLE
fix(SytemsDetails): RHINENG-14519 - Remove Remediation button

### DIFF
--- a/src/components/SystemDetails/Compliance.js
+++ b/src/components/SystemDetails/Compliance.js
@@ -15,7 +15,6 @@ const ComplianceTab = () => {
         locale: navigator.language.slice(0, 2),
       }}
       inventoryId={inventoryId}
-      remediationsEnabled
     />
   );
 };


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove the remediationsEnabled prop from the ComplianceTab to disable the remediation button