### PR TITLE
chore(RHINENG-19588): Rebrand to Red Hat Lightspeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/RedhatInsights/insights-inventory-frontend/test.yml?branch=master)](https://github.com/RedHatInsights/insights-inventory-frontend/actions/workflows/test.yml) [![GitHub release](https://img.shields.io/github/release/RedHatInsights/insights-inventory-frontend.svg)](https://github.com/RedHatInsights/insights-inventory-frontend/releases/latest) [![codecov](https://codecov.io/gh/RedHatInsights/insights-inventory-frontend/branch/master/graph/badge.svg?token=XC4AD7NQFW)](https://codecov.io/gh/RedHatInsights/insights-inventory-frontend)
 
-# Insights Inventory Frontend
+# Inventory Frontend
 
-This is the frontend application for [Insights Inventory](https://github.com/RedHatInsights/insights-inventory). It is based on the [insights-frontend-starter-app](git@github.com:RedHatInsights/insights-frontend-starter-app.git).
+This is the frontend application for [Inventory](https://github.com/RedHatInsights/insights-inventory). It is based on the [insights-frontend-starter-app](git@github.com:RedHatInsights/insights-frontend-starter-app.git).
 
 ## Documentation
 

--- a/src/Utilities/InsightsDisconnected.js
+++ b/src/Utilities/InsightsDisconnected.js
@@ -4,8 +4,10 @@ import { Grid, GridItem, Icon, Tooltip } from '@patternfly/react-core';
 import { DisconnectedIcon } from '@patternfly/react-icons';
 
 import './InsightsDisconnected.scss';
+import { useLightspeedFeatureFlag } from './hooks/useLightspeedFeatureFlag';
 
 const InsightsDisconnected = () => {
+  const platformName = useLightspeedFeatureFlag();
   return (
     <Tooltip
       maxWidth="14rem"
@@ -14,7 +16,8 @@ const InsightsDisconnected = () => {
           <GridItem>Insights client not reporting</GridItem>
           <GridItem>
             From the main navigation, open &quot;Register Systems&quot; to learn
-            how to set up Insights.
+            how to set up{' '}
+            {platformName === 'Lightspeed' ? 'Red Hat Lightspeed' : 'Insights'}.
           </GridItem>
         </Grid>
       }

--- a/src/Utilities/LastSeenColumnHeader.js
+++ b/src/Utilities/LastSeenColumnHeader.js
@@ -2,18 +2,20 @@ import React, { useContext } from 'react';
 import { Icon, Tooltip } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { AccountStatContext } from '../Contexts';
+import { useLightspeedFeatureFlag } from './hooks/useLightspeedFeatureFlag';
 
 export const LastSeenColumnHeader = () => {
   const isLastCheckInEnabled = useContext(AccountStatContext);
+  const platformName = useLightspeedFeatureFlag();
   return (
     <span>
       Last seen
       {isLastCheckInEnabled && (
         <Tooltip
-          content="Last seen represents the most recent time a system
-          checked in and uploaded sufficient data for Insights analysis.
+          content={`Last seen represents the most recent time a system
+          checked in and uploaded sufficient data for ${platformName === 'Lightspeed' ? 'Red Hat Lightspeed' : 'Insights'} analysis.
           The timestamps may vary between applications as they rely on
-          different data collectors."
+          different data collectors.`}
         >
           <Icon>
             <OutlinedQuestionCircleIcon

--- a/src/Utilities/hooks/useLightspeedFeatureFlag.js
+++ b/src/Utilities/hooks/useLightspeedFeatureFlag.js
@@ -1,0 +1,6 @@
+import useFeatureFlag from '../useFeatureFlag';
+
+export const useLightspeedFeatureFlag = () => {
+  const isFlagEnabled = useFeatureFlag('platform.lightspeed-rebrand');
+  return isFlagEnabled ? 'Lightspeed' : 'Insights';
+};

--- a/src/components/InventoryDetail/InsightsPrompt.js
+++ b/src/components/InventoryDetail/InsightsPrompt.js
@@ -13,8 +13,10 @@ import {
   ContentVariants,
 } from '@patternfly/react-core';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { useLightspeedFeatureFlag } from '../../Utilities/hooks/useLightspeedFeatureFlag';
 
 const InsightsPrompt = () => {
+  const platformName = useLightspeedFeatureFlag();
   return (
     <Alert
       variant="info"
@@ -32,7 +34,7 @@ const InsightsPrompt = () => {
                 }}
               >
                 <Content component={ContentVariants.p}>
-                  With Insights you can easly:
+                  {`With ${platformName === 'Lightspeed' ? 'Red Hat Lightspeed' : 'Insights'} you can easily:`}
                 </Content>
                 <Content
                   component="ul"
@@ -81,7 +83,7 @@ const InsightsPrompt = () => {
                     href="https://access.redhat.com/solutions/6758841"
                     isInline
                   >
-                    Host not reporting data to Red Hat Insights
+                    {`Host not reporting data to Red Hat ${platformName}`}
                   </Button>
                 </CardFooter>
               </Card>

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <title>Inventory | Insights</title>
+        <title>Inventory | Red Hat Lightspeed</title>
         <esi:include src="/@@env/chrome/snippets/head.html"/>
     </head>
     <body>

--- a/src/routes/InventoryComponents/InventoryPopover.js
+++ b/src/routes/InventoryComponents/InventoryPopover.js
@@ -4,8 +4,10 @@ import {
   ExternalLinkAltIcon,
   OutlinedQuestionCircleIcon,
 } from '@patternfly/react-icons';
+import { useLightspeedFeatureFlag } from '../../Utilities/hooks/useLightspeedFeatureFlag';
 
 export const InventoryPopover = () => {
+  const platformName = useLightspeedFeatureFlag();
   return (
     <Popover
       aria-label="Inventory popover"
@@ -23,7 +25,7 @@ export const InventoryPopover = () => {
             <Content component="p">
               To appear in Inventory, systems must first be registered with Red
               Hat. You can register systems using several methods, including the
-              Red Hat Insights client, Red Hat Satellite, or Red Hat
+              Red Hat {platformName} client, Red Hat Satellite, or Red Hat
               Subscription Manager (RHSM).
             </Content>
             <Content component="p">
@@ -57,7 +59,7 @@ export const InventoryPopover = () => {
                 target="_blank"
                 rel="noreferrer"
               >
-                Client configuration guide for Red Hat Insights
+                Client configuration guide for Red Hat {platformName}
                 <ExternalLinkAltIcon className="pf-v6-u-ml-xs" />
               </a>
             </span>

--- a/src/routes/InventoryDetail.js
+++ b/src/routes/InventoryDetail.js
@@ -23,6 +23,7 @@ import { REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP } from '../constants';
 import ApplicationTab from '../ApplicationTab';
 import { useGetDevice } from '../api/edge/imagesInfo';
 import useFeatureFlag from '../Utilities/useFeatureFlag';
+import { useLightspeedFeatureFlag } from '../Utilities/hooks/useLightspeedFeatureFlag';
 
 const appList = {
   'CENTOS-LINUX': [
@@ -106,6 +107,7 @@ const BreadcrumbWrapper = ({ entity, inventoryId, entityLoaded }) => (
 );
 
 const Inventory = () => {
+  const platformName = useLightspeedFeatureFlag();
   const chrome = useChrome();
   const { inventoryId } = useParams();
   const [searchParams] = useSearchParams();
@@ -178,7 +180,7 @@ const Inventory = () => {
   };
 
   if (entity) {
-    document.title = `${entity.display_name} | Systems | Red Hat Insights`;
+    document.title = `${entity.display_name} | Systems | Red Hat ${platformName}`;
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary by Sourcery

Implement feature flag-driven rebranding to Red Hat Lightspeed by introducing a new hook and updating UI text and documentation accordingly

Enhancements:
- Add useLightspeedFeatureFlag hook to return 'Lightspeed' or 'Insights' based on the platform.lightspeed-rebrand flag
- Replace hardcoded 'Insights' references in components, tooltips, prompts, popovers, page titles, and index.html with dynamic platformName

Documentation:
- Update README to rename the application to Inventory Frontend and reflect the rebrand