### PR TITLE
fix(RHINENG-11368): spinner on system details is misaligned

### DIFF
--- a/src/components/InventoryDetail/ApplicationDetails.js
+++ b/src/components/InventoryDetail/ApplicationDetails.js
@@ -1,7 +1,13 @@
 import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useStore } from 'react-redux';
-import { Spinner, Tab, TabContent, Tabs } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Spinner,
+  Tab,
+  TabContent,
+  Tabs,
+} from '@patternfly/react-core';
 import { verifyCulledReporter } from '../../Utilities/sharedFunctions';
 import { getFact } from './helpers';
 import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
@@ -140,7 +146,9 @@ const ApplicationDetails = ({
           </section>
         </React.Fragment>
       ) : (
-        <Spinner />
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
       )}
     </React.Fragment>
   );


### PR DESCRIPTION
To test:
- go to Inventory
- click a system to go to the details page

notice that there is a spinner that's a part of the application tabs is left aligned instead of centered on the page. This PR wraps the Spinner in a Bullseye to center it.

## Summary by Sourcery

Bug Fixes:
- Fix misaligned spinner by centering it within a Bullseye container