### PR TITLE
fix(RHINENG-20426): Pass connectedToInsights prop Compliance

### DIFF
--- a/src/components/SystemDetails/Compliance.js
+++ b/src/components/SystemDetails/Compliance.js
@@ -1,10 +1,15 @@
 import React from 'react';
-import { useStore } from 'react-redux';
+import { useSelector, useStore } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 
 const ComplianceTab = () => {
-  const { inventoryId } = useParams('/:inventoryId');
+  const { inventoryId } = useParams();
+  const systemProfile = useSelector(
+    ({ entityDetails }) => entityDetails?.entity,
+  );
+  const connectedToInsights = !!systemProfile?.insights_id;
+
   return (
     <AsyncComponent
       scope="compliance"
@@ -15,6 +20,7 @@ const ComplianceTab = () => {
         locale: navigator.language.slice(0, 2),
       }}
       inventoryId={inventoryId}
+      connectedToInsights={connectedToInsights}
     />
   );
 };


### PR DESCRIPTION
This prop will help Compliance to handle EmptyState/Content better. So we do not need to do additional API request to inventory to know if host has been connected to insights or not

## Summary by Sourcery

Pass a derived connectedToInsights boolean to the Compliance AsyncComponent based on the system’s insights_id, replacing the remediationsEnabled prop and eliminating the need for extra inventory API calls.

Bug Fixes:
- Replace remediationsEnabled prop with connectedToInsights to correctly inform Compliance of insights connectivity

Enhancements:
- Use useSelector to derive the connectedToInsights flag from the Redux entityDetails state