### PR TITLE
feat(SystemsTable): RHINENG-20061 - Integrate global filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@sentry/webpack-plugin": "^2.22.5",
         "@unleash/proxy-client-react": "^3.5.0",
         "awesome-debounce-promise": "^2.1.0",
-        "bastilian-tabletools": "^2.0.0",
+        "bastilian-tabletools": "^2.10.0",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -7186,10 +7186,26 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@tanstack/pacer": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.14.0.tgz",
+      "integrity": "sha512-DCwgDvJoDmApnUIK5/SVeBVtlCn8iDa6hEj81SjxEsYML2Yirv7LCC8AQirHsFCJs9GuiJl6gvX7fDjDuoPduA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/query-core": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
-      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
+      "version": "5.85.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.5.tgz",
+      "integrity": "sha512-KO0WTob4JEApv69iYp1eGvfMSUkgw//IpMnq+//cORBzXf0smyRwPLrUvEe5qtAEGjwZTXrjxg+oJNP/C00t6w==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -7197,14 +7213,35 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/react-pacer": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-pacer/-/react-pacer-0.15.0.tgz",
+      "integrity": "sha512-6ycBIh5Hd0WW3/iv1vwiNDewQuzrkULhAM80/zlIMLLIaSWsfxtSj5eo7vO5dCtvwZCD8oWnF3V1eCmx658Z3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/pacer": "0.14.0",
+        "@tanstack/react-store": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/@tanstack/react-query": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
-      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
+      "version": "5.85.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.5.tgz",
+      "integrity": "sha512-/X4EFNcnPiSs8wM2v+b6DqS5mmGeuJQvxBglmDxl6ZQb5V26ouD2SJYAcC3VjbNwqhY2zjxVD15rDA5nGbMn3A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tanstack/query-core": "5.83.0"
+        "@tanstack/query-core": "5.85.5"
       },
       "funding": {
         "type": "github",
@@ -7212,6 +7249,34 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.4.tgz",
+      "integrity": "sha512-DyG1e5Qz/c1cNLt/NdFbCA7K1QGuFXQYT6EfUltYMJoQ4LzBOGnOl5IjuxepNcRtmIKkGpmdMzdFZEkevgU9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.7.4",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.4.tgz",
+      "integrity": "sha512-F1XqZQici1Aq6WigEfcxJSml92nW+85Om8ElBMokPNg5glCYVOmPkZGIQeieYFxcPiKTfwo0MTOQpUyJtwncrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -9646,10 +9711,13 @@
       "license": "MIT"
     },
     "node_modules/bastilian-tabletools": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.0.0.tgz",
-      "integrity": "sha512-lHwuvg6zLszXLAwKTL8gDJF1oGm5FNoDaZx956Dnt/V/7/SEtH3AdYgBqNijgwucnfLbvglso07L1aq892+meg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.10.0.tgz",
+      "integrity": "sha512-ekVWVNBGxVw+mxeVqp6G7XtZ54qdxaTLlLT66FJc5Js3QG9/KJoyuOHcoBCcZGLeTsfIj5agILrs2e4v2ZtZgg==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@tanstack/react-pacer": "^0.15.0"
+      },
       "engines": {
         "node": ">=22.0.0"
       },
@@ -9659,8 +9727,8 @@
         "@patternfly/react-component-groups": "^6.0.0",
         "@patternfly/react-core": "^6.0.0",
         "@patternfly/react-table": "^6.0.0",
-        "@redhat-cloud-services/frontend-components": "^6.1.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^6.1.0",
+        "@redhat-cloud-services/frontend-components": ">= 6.1.0",
+        "@redhat-cloud-services/frontend-components-utilities": ">= 6.1.0",
         "@tanstack/react-query": "^5.83.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -28139,6 +28207,15 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@sentry/webpack-plugin": "^2.22.5",
     "@unleash/proxy-client-react": "^3.5.0",
     "awesome-debounce-promise": "^2.1.0",
-    "bastilian-tabletools": "^2.0.0",
+    "bastilian-tabletools": "^2.10.0",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",

--- a/src/routes/Systems/components/SystemsTable/SystemsTable.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.js
@@ -1,14 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TableToolsTable } from 'bastilian-tabletools';
+import { TableToolsTable, TableStateProvider } from 'bastilian-tabletools';
 
 import filters, { CUSTOM_FILTER_TYPES } from './filters';
 import { fetchSystems, resolveColumns } from '../../helpers.js';
 import { DEFAULT_OPTIONS } from './constants';
+import useGlobalFilterForItems from './hooks/useGlobalFilterForItems';
 
 // TODO Filters should be customisable enable/disable, extend, etc.
 // TODO "global filter" needs to be integrated
-const SystemsTable = ({ items = fetchSystems, columns = [], options = {} }) => {
+const SystemsTable = ({
+  items: itemsProp = fetchSystems,
+  columns = [],
+  options = {},
+}) => {
+  const items = useGlobalFilterForItems(itemsProp);
+
   return (
     <TableToolsTable
       variant="compact"
@@ -32,4 +39,10 @@ SystemsTable.propTypes = {
   options: PropTypes.object,
 };
 
-export default SystemsTable;
+const SystemsTableWithProvider = (props) => (
+  <TableStateProvider>
+    <SystemsTable {...props} />
+  </TableStateProvider>
+);
+
+export default SystemsTableWithProvider;

--- a/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
@@ -2,12 +2,17 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import SystemsTable from './SystemsTable';
 import { TableToolsTable } from 'bastilian-tabletools';
-import { fetchSystems } from '../../helpers.js';
 
 jest.mock('bastilian-tabletools', () => ({
+  ...jest.requireActual('bastilian-tabletools'),
   TableToolsTable: jest.fn(() => (
     <div data-testid="table-tools-table">TableToolsTable</div>
   )),
+}));
+
+jest.mock('../../../../Utilities/useFeatureFlag', () => ({
+  __esModule: true,
+  default: () => false,
 }));
 
 jest.mock('../../helpers.js', () => {
@@ -27,7 +32,7 @@ describe('SystemsTable', () => {
     render(<SystemsTable />);
     expect(TableToolsTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        items: fetchSystems,
+        items: expect.any(Function),
       }),
       expect.anything(),
     );
@@ -51,7 +56,7 @@ describe('SystemsTable', () => {
     render(<SystemsTable items={items} />);
     expect(TableToolsTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        items: items,
+        items: expect.any(Function),
       }),
       expect.anything(),
     );

--- a/src/routes/Systems/components/SystemsTable/hooks/useGlobalFilterForItems.js
+++ b/src/routes/Systems/components/SystemsTable/hooks/useGlobalFilterForItems.js
@@ -1,0 +1,24 @@
+import { useCallback, useEffect } from 'react';
+import { useStateCallbacks } from 'bastilian-tabletools';
+
+import useGlobalFilter from '../../../../../components/filters/useGlobalFilter';
+
+const useGlobalFilterForItems = (itemsProp) => {
+  const { current: { reload } = {} } = useStateCallbacks();
+  const globalFilter = useGlobalFilter();
+
+  const fetch = useCallback(
+    (...args) => itemsProp(...args, globalFilter),
+    [globalFilter, itemsProp],
+  );
+
+  useEffect(() => {
+    if (globalFilter) {
+      reload?.();
+    }
+  }, [reload, globalFilter]);
+
+  return typeof itemsProp === 'function' ? fetch : itemsProp;
+};
+
+export default useGlobalFilterForItems;

--- a/src/routes/Systems/helpers.js
+++ b/src/routes/Systems/helpers.js
@@ -17,7 +17,11 @@ export const fetchTags = async () => {
   return await getTags();
 };
 
-export const fetchSystems = async (serialisedTableState) => {
+export const fetchSystems = async (
+  serialisedTableState,
+  _rawTableState,
+  { filter: globalFilter, tags: globalFilterTags } = {},
+) => {
   const fields = {
     system_profile: [
       'operating_system',
@@ -27,12 +31,24 @@ export const fetchSystems = async (serialisedTableState) => {
   };
 
   const params = {
-    // TODO Add global filter
     ...(serialisedTableState?.pagination || {}),
     ...(serialisedTableState?.filters || {}),
     ...(serialisedTableState?.sort || {}),
+    // Currently tags set in the global filter only appear in the global filter
+    // If we wanted to keep the toolbar filters and global filters in sync
+    // we should use `setFilter` instead and not add the global filter tags here
+    tags: [
+      ...(serialisedTableState?.filters?.tags || []),
+      ...(globalFilterTags || []),
+    ],
     options: {
-      params: generateFilter(fields, 'fields'),
+      params: {
+        // There is a bug in the JS clients that requires us to pass "filter" and "fields" as "raw" params.
+        // the issue is that JS clients convert that object wrongly to something like filter.systems_profile.sap_system as the param name
+        // it should rather be something like `filter[systems_profile][sap_system]`
+        ...generateFilter(fields, 'fields'),
+        ...generateFilter(globalFilter),
+      },
     },
   };
 


### PR DESCRIPTION
This PR adds integration of the global filter to the `SystemsTable` component.

https://github.com/user-attachments/assets/c0c0a8ba-e1e9-4627-9b16-773e4cf6dde0


**How to test:**

1) Enable the `ui.systems-table` (or enable the new SystemsTable any other way)
2) Open the Systems page
3) Change the "Global filter" 
4) Verify the results are the same as in the current InventoryTable

## Summary by Sourcery

Integrate the global filter into the SystemsTable component by enhancing the global filter hook, creating a useGlobalFilterForItems wrapper to apply filter values to data fetching and trigger reloads, and wrapping the table in TableStateProvider. Also update the bastilian-tabletools dependency.

New Features:
- Apply global filter values to system list fetching by passing them to fetchSystems and triggering reloads when the filter changes
- Wrap SystemsTable in TableStateProvider and use useGlobalFilterForItems hook to seamlessly integrate global filtering

Enhancements:
- Refactor useGlobalFilter hook to leverage useCallback for cleaner state updates and rename its state setter
- Adjust SystemsTable component props and imports to support the new global filter hook

Build:
- Upgrade bastilian-tabletools dependency to version ^2.10.0

## Summary by Sourcery

Integrate the global filter into the SystemsTable component by refactoring the filter hook, creating a data-fetch wrapper to apply global filter values and reload the table, enhancing the fetchSystems helper to include global filter parameters, wrapping the table in TableStateProvider, and upgrading the tabletools dependency.

New Features:
- Apply global filter values to system list fetching by passing them to fetchSystems and triggering reloads when the filter changes
- Wrap SystemsTable in TableStateProvider and use useGlobalFilterForItems hook to integrate global filtering

Enhancements:
- Refactor useGlobalFilter hook to leverage useCallback for cleaner state updates and rename its setter function
- Extend fetchSystems helper to merge global filter and tags into the request parameters

Build:
- Upgrade bastilian-tabletools dependency to version ^2.10.0

Tests:
- Update SystemsTable tests to expect a function for the items prop when using global filtering