### PR TITLE
ci(deps): bump Konflux pipeline version

### DIFF
--- a/.tekton/host-inventory-frontend-hermetic-pull-request.yaml
+++ b/.tekton/host-inventory-frontend-hermetic-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-host-inventory

--- a/.tekton/host-inventory-frontend-hermetic-push.yaml
+++ b/.tekton/host-inventory-frontend-hermetic-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-host-inventory

--- a/.tekton/host-inventory-frontend-pull-request.yaml
+++ b/.tekton/host-inventory-frontend-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-host-inventory

--- a/.tekton/host-inventory-frontend-push.yaml
+++ b/.tekton/host-inventory-frontend-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-host-inventory

--- a/.tekton/host-inventory-frontend-sc-pull-request.yaml
+++ b/.tekton/host-inventory-frontend-sc-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build-oci-ta.yaml
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: insights-host-inventory-sc

--- a/.tekton/host-inventory-frontend-sc-push.yaml
+++ b/.tekton/host-inventory-frontend-sc-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build-oci-ta.yaml
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: insights-host-inventory-sc


### PR DESCRIPTION
To fix the current pipeline errors :)

## Summary by Sourcery

Bump Konflux pipeline version in Tekton configurations to v1.37.1 to resolve current pipeline errors.

Bug Fixes:
- Fix CI pipeline failures by upgrading the Konflux pipeline version

Build:
- Update pipelinesascode.tekton.dev/pipeline URLs from v1.36.0 to v1.37.1 across all Tekton YAML files