### PR TITLE
feat(RHINENG-20062): add SystemsTable action kebab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@sentry/webpack-plugin": "^2.22.5",
         "@unleash/proxy-client-react": "^3.5.0",
         "awesome-debounce-promise": "^2.1.0",
-        "bastilian-tabletools": "^2.12.0",
+        "bastilian-tabletools": "^2.13.0",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -7871,6 +7871,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.14.0.tgz",
       "integrity": "sha512-DCwgDvJoDmApnUIK5/SVeBVtlCn8iDa6hEj81SjxEsYML2Yirv7LCC8AQirHsFCJs9GuiJl6gvX7fDjDuoPduA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/store": "^0.7.2"
       },
@@ -7898,6 +7899,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-pacer/-/react-pacer-0.15.0.tgz",
       "integrity": "sha512-6ycBIh5Hd0WW3/iv1vwiNDewQuzrkULhAM80/zlIMLLIaSWsfxtSj5eo7vO5dCtvwZCD8oWnF3V1eCmx658Z3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/pacer": "0.14.0",
         "@tanstack/react-store": "^0.7.3"
@@ -7936,6 +7938,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.4.tgz",
       "integrity": "sha512-DyG1e5Qz/c1cNLt/NdFbCA7K1QGuFXQYT6EfUltYMJoQ4LzBOGnOl5IjuxepNcRtmIKkGpmdMzdFZEkevgU9bQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/store": "0.7.4",
         "use-sync-external-store": "^1.5.0"
@@ -7954,6 +7957,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.4.tgz",
       "integrity": "sha512-F1XqZQici1Aq6WigEfcxJSml92nW+85Om8ElBMokPNg5glCYVOmPkZGIQeieYFxcPiKTfwo0MTOQpUyJtwncrg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -10414,13 +10418,10 @@
       "license": "MIT"
     },
     "node_modules/bastilian-tabletools": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.12.0.tgz",
-      "integrity": "sha512-fIdVESNQV2oYDy+iQEjpHszmyR5N0B2189iNGk8P9yCT8TpGwSAvzyPyr3yZh43li2YjtHFGGWfAh92CNZiooA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.14.0.tgz",
+      "integrity": "sha512-GyE9v/VdVeWY9+LQNcO+iCyFMuB/Ue5/RoydqEO95DynRR3LCMbbrvbqyKHWJkJdEuuIYggpuLHu3D92knCeNA==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@tanstack/react-pacer": "^0.15.0"
-      },
       "engines": {
         "node": ">=22.0.0"
       },
@@ -10432,7 +10433,9 @@
         "@patternfly/react-table": "^6.0.0",
         "@redhat-cloud-services/frontend-components": ">= 6.1.0",
         "@redhat-cloud-services/frontend-components-utilities": ">= 6.1.0",
-        "@tanstack/react-query": "^5.83.0",
+        "@tanstack/react-pacer": ">= 0.15.0",
+        "@tanstack/react-query": ">= 5.83.0",
+        "p-all": ">= 4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "use-deep-compare": "^1.3.0"
@@ -29527,6 +29530,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
       "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@sentry/webpack-plugin": "^2.22.5",
     "@unleash/proxy-client-react": "^3.5.0",
     "awesome-debounce-promise": "^2.1.0",
-    "bastilian-tabletools": "^2.12.0",
+    "bastilian-tabletools": "^2.13.0",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",

--- a/src/routes/Systems/hooks/useToolbarActions.js
+++ b/src/routes/Systems/hooks/useToolbarActions.js
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { ActionDropdownItem } from '../../../components/InventoryTable/ActionWithRBAC';
+import {
+  GENERAL_GROUPS_WRITE_PERMISSION,
+  NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE,
+  REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
+} from '../../../constants';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
+import {
+  isBulkAddHostsToGroupsEnabled,
+  isBulkRemoveFromGroupsEnabled,
+} from '../helpers';
+
+const useToolbarActions = (
+  selected,
+  setAddHostGroupModalOpen,
+  setRemoveHostsFromGroupModalOpen,
+) => {
+  const isKesselEnabled = useFeatureFlag('hbi.kessel-migration');
+
+  // extract remove‐permissions logic
+  const removePermissions = selected
+    ? selected
+        .flatMap(({ groups }) =>
+          groups?.[0]?.id != null
+            ? REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(groups[0].id)
+            : [],
+        )
+        .filter(Boolean)
+    : [];
+
+  // extract the various booleans
+  const addIsDisabled = !isBulkAddHostsToGroupsEnabled(
+    selected.length,
+    selected,
+    isKesselEnabled,
+  );
+  const removeIsDisabled = !isBulkRemoveFromGroupsEnabled(
+    selected.length,
+    selected,
+    isKesselEnabled,
+  );
+  const removeOverride = selected == null;
+
+  return [
+    {
+      label: (
+        <ActionDropdownItem
+          key="bulk-add-to-group"
+          requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
+          isAriaDisabled={addIsDisabled}
+          noAccessTooltip={NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE}
+          onClick={() => setAddHostGroupModalOpen(true)}
+          ignoreResourceDefinitions
+        >
+          Add to workspace
+        </ActionDropdownItem>
+      ),
+    },
+    {
+      label: (
+        <ActionDropdownItem
+          key="bulk-remove-from-group"
+          requiredPermissions={removePermissions}
+          isAriaDisabled={removeIsDisabled}
+          noAccessTooltip={NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE}
+          onClick={() => setRemoveHostsFromGroupModalOpen(true)}
+          {...(removeOverride && { override: true })}
+          checkAll
+        >
+          Remove from workspace
+        </ActionDropdownItem>
+      ),
+    },
+  ];
+};
+
+export default useToolbarActions;


### PR DESCRIPTION
This PR adds the action kebab to the toolbar of the SystemsTable. To test select systems in bulk from the table and add to and remove from workspaces. When a system already belongs to a workspace, only the Remove from workspace option should be enabled. And when a system doesn't belong to a workspace, only the Add to workspace option should be enabled.

Also, test that this functionality still works for the standard Inventory table, as I moved some of the functionality into a helper. I tested on my end and everything seemed to work correctly.

## Summary by Sourcery

Add bulk workspace management actions to SystemsTable and refactor group action logic into reusable helpers and hook

New Features:
- Add kebab-style bulk “Add to workspace” and “Remove from workspace” actions with modals to the SystemsTable toolbar

Enhancements:
- Extract bulk add/remove enablement checks into shared helper functions
- Introduce useToolbarActions hook to supply toolbar action items
- Update ConventionalSystemsTab to use new bulk-group helpers

Build:
- Bump bastilian-tabletools dependency to ^2.13.0