### PR TITLE
feat(RHINENG-19947): add basic filters to SystemsTable

### DIFF
--- a/src/routes/Systems/Systems.js
+++ b/src/routes/Systems/Systems.js
@@ -8,6 +8,7 @@ import {
   paginationSerialiser,
 } from './serialisers';
 import * as defaultColumns from './components/SystemsTable/columns';
+import * as defaultFilters from './components/SystemsTable/filters';
 
 const Systems = () => (
   <>
@@ -21,6 +22,16 @@ const Systems = () => (
           defaultColumns.operatingSystem,
           defaultColumns.lastSeen,
         ]}
+        filters={{
+          filterConfig: [
+            defaultFilters.displayName,
+            defaultFilters.statusFilter,
+            defaultFilters.dataCollector,
+            defaultFilters.rhcStatus,
+            defaultFilters.tags,
+          ],
+          customFilterTypes: defaultFilters.CUSTOM_FILTER_TYPES,
+        }}
         options={{
           // FIXME: remove debug
           debug: true,

--- a/src/routes/Systems/Systems.js
+++ b/src/routes/Systems/Systems.js
@@ -29,6 +29,8 @@ const Systems = () => (
             defaultFilters.dataCollector,
             defaultFilters.rhcStatus,
             defaultFilters.tags,
+            defaultFilters.systemType,
+            defaultFilters.operatingSystem,
           ],
           customFilterTypes: defaultFilters.CUSTOM_FILTER_TYPES,
         }}

--- a/src/routes/Systems/components/SystemsTable/SystemsTable.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.js
@@ -7,9 +7,7 @@ import {
   useFullTableState,
   useStateCallbacks,
 } from 'bastilian-tabletools';
-
-import filters, { CUSTOM_FILTER_TYPES } from './filters';
-import { fetchSystems, resolveColumns } from '../../helpers.js';
+import { fetchSystems, resolveColumns, resolveFilters } from '../../helpers.js';
 import { DEFAULT_OPTIONS } from './constants';
 import useGlobalFilterForItems from './hooks/useGlobalFilterForItems';
 import DeleteModal from '../../../../Utilities/DeleteModal';
@@ -18,11 +16,10 @@ import useToolbarActions from '../../hooks/useToolbarActions';
 import AddSelectedHostsToGroupModal from '../../../../components/InventoryGroups/Modals/AddSelectedHostsToGroupModal';
 import RemoveHostsFromGroupModal from '../../../../components/InventoryGroups/Modals/RemoveHostsFromGroupModal';
 
-// TODO Filters should be customisable enable/disable, extend, etc.
-// TODO "global filter" needs to be integrated
 const SystemsTable = ({
   items: itemsProp = fetchSystems,
   columns = [],
+  filters,
   options = {},
 }) => {
   const items = useGlobalFilterForItems(itemsProp);
@@ -91,10 +88,7 @@ const SystemsTable = ({
         variant="compact"
         items={items}
         columns={resolveColumns(columns)}
-        filters={{
-          customFilterTypes: CUSTOM_FILTER_TYPES,
-          filterConfig: filters,
-        }}
+        filters={resolveFilters(filters)}
         options={{
           ...DEFAULT_OPTIONS,
           dedicatedAction,
@@ -109,6 +103,7 @@ const SystemsTable = ({
 SystemsTable.propTypes = {
   items: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
   columns: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
+  filters: PropTypes.object,
   options: PropTypes.object,
 };
 

--- a/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
@@ -96,4 +96,28 @@ describe('SystemsTable', () => {
       expect.anything(),
     );
   });
+
+  it('should pass filters object', () => {
+    const filters = { filterConfig: [{}, {}, {}], customeFilterTypes: {} };
+
+    render(<SystemsTable filters={filters} />);
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: filters,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should pass filters object, when filters fn is received', () => {
+    const filters = { filterConfig: [{}, {}, {}], customeFilterTypes: {} };
+
+    render(<SystemsTable filters={() => filters} />);
+    expect(TableToolsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: filters,
+      }),
+      expect.anything(),
+    );
+  });
 });

--- a/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
@@ -8,11 +8,24 @@ jest.mock('bastilian-tabletools', () => ({
   TableToolsTable: jest.fn(() => (
     <div data-testid="table-tools-table">TableToolsTable</div>
   )),
+  useItemsData: jest.fn(() => ({
+    items: [],
+  })),
+  useFullTableState: jest.fn(),
+  useStateCallbacks: jest.fn(() => ({
+    current: { reload: jest.fn(), resetSelection: jest.fn() },
+  })),
+  TableStateProvider: jest.fn(({ children }) => <div>{children}</div>),
 }));
 
 jest.mock('../../../../Utilities/useFeatureFlag', () => ({
   __esModule: true,
   default: () => false,
+}));
+
+jest.mock('./hooks/useGlobalFilterForItems', () => ({
+  __esModule: true,
+  default: (itemsProp) => itemsProp,
 }));
 
 jest.mock('../../helpers.js', () => {

--- a/src/routes/Systems/components/SystemsTable/components/filters/Workspace.js
+++ b/src/routes/Systems/components/SystemsTable/components/filters/Workspace.js
@@ -13,11 +13,14 @@ import xor from 'lodash/xor';
 import PropTypes from 'prop-types';
 
 const Workspace = ({
-  initialGroups = [],
-  value: selectedGroupNames,
+  value: selectedGroupNames = [],
   onChange: setSelectedGroupNames,
   showNoGroupOption = false,
+  items: initialGroups = [],
 }) => {
+  useEffect(() => {
+    console.log(initialGroups);
+  }, []);
   const initialValues = useMemo(
     () => [
       ...(showNoGroupOption
@@ -214,6 +217,7 @@ Workspace.propTypes = {
   value: PropTypes.arrayOf(PropTypes.string).isRequired,
   onChange: PropTypes.func.isRequired,
   showNoGroupOption: PropTypes.bool,
+  items: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default Workspace;

--- a/src/routes/Systems/components/SystemsTable/constants.js
+++ b/src/routes/Systems/components/SystemsTable/constants.js
@@ -1,5 +1,6 @@
 export const DEFAULT_OPTIONS = {
   perPage: 50,
-  // FIXME: selection should not be reloading table
   onSelect: () => true,
 };
+
+export const MAX_PER_PAGE = 100;

--- a/src/routes/Systems/components/SystemsTable/filters.js
+++ b/src/routes/Systems/components/SystemsTable/filters.js
@@ -10,7 +10,7 @@ export const CUSTOM_FILTER_TYPES = {
   },
 };
 
-const displayName = {
+export const displayName = {
   type: 'text',
   label: 'Name',
   filterSerialiser: (_config, [value]) => ({
@@ -18,7 +18,7 @@ const displayName = {
   }),
 };
 
-const statusFilter = {
+export const statusFilter = {
   label: 'Status',
   type: 'checkbox',
   items: [
@@ -31,7 +31,7 @@ const statusFilter = {
   }),
 };
 
-const dataCollector = {
+export const dataCollector = {
   label: 'Data collector',
   type: 'checkbox',
   items: [
@@ -52,7 +52,7 @@ const dataCollector = {
   }),
 };
 
-const rhcStatus = {
+export const rhcStatus = {
   label: 'RHC status',
   type: 'checkbox',
   items: [
@@ -61,7 +61,7 @@ const rhcStatus = {
   ],
 };
 
-const tags = {
+export const tags = {
   label: 'Tags',
   type: 'group',
   groups: async () => {

--- a/src/routes/Systems/components/SystemsTable/filters.js
+++ b/src/routes/Systems/components/SystemsTable/filters.js
@@ -174,6 +174,21 @@ export const tags = {
       ],
     },
   },
+  filterSerialiser: (_config, values) => {
+    const tagsGroupedByNamespace = Object.entries(values).map(
+      ([namespace, tagValues]) => {
+        return [namespace, Object.keys(tagValues)];
+      },
+    );
+
+    const tags = tagsGroupedByNamespace
+      .map(([namespace, values]) => {
+        return values.map((value) => `${namespace}/${value}`);
+      })
+      .flat();
+
+    return { tags };
+  },
 };
 
 export const lastSeen = {

--- a/src/routes/Systems/components/SystemsTable/filters.js
+++ b/src/routes/Systems/components/SystemsTable/filters.js
@@ -116,6 +116,15 @@ export const rhcStatus = {
     { label: 'Active', value: 'not_nil' },
     { label: 'Inactive', value: 'nil' },
   ],
+  filterSerialiser: (_config, values) => {
+    return {
+      filter: {
+        system_profile: {
+          rhc_client_id: values,
+        },
+      },
+    };
+  },
 };
 
 export const tags = {

--- a/src/routes/Systems/components/SystemsTable/helpers.js
+++ b/src/routes/Systems/components/SystemsTable/helpers.js
@@ -1,0 +1,98 @@
+import { getTags } from '../../../../api/hostInventoryApi';
+import { getGroups } from '../../../../components/InventoryGroups/utils/api';
+import { MAX_PER_PAGE } from './constants';
+
+export const fetchTags = async () => {
+  return await getTags();
+};
+
+export const osVersionSorter = (a, b) =>
+  b.major === a.major ? b.minor - a.minor : b.major - a.major;
+
+export const getOsSelectOptions = (osName, osData) => {
+  if (!osData) return [];
+
+  const osItems = osData
+    .filter((item) => item.name === osName)
+    .toSorted(osVersionSorter);
+  const majors = [...new Set(osItems.map((item) => item.major))];
+
+  return majors.map((major) => ({
+    label: `${osName} ${major}`,
+    value: `${osName}`,
+    items: osItems
+      .filter((item) => item.major === major)
+      .map((item) => ({
+        label: `${item.name} ${item.major}.${item.minor}`,
+        value: `${item.major}.${item.minor}`,
+      })),
+  }));
+};
+
+export const getDateDaysAgo = (days) => {
+  const today = new Date();
+  const daysAgo = new Date();
+  daysAgo.setDate(today.getDate() - days);
+  return daysAgo.toISOString();
+};
+
+export const getLastSeenSelectOptions = () => {
+  return [
+    {
+      label: 'Within the last 24 hours',
+      value: {
+        updatedEnd: getDateDaysAgo(0),
+        updatedStart: getDateDaysAgo(1),
+      },
+    },
+    {
+      label: 'More than 1 day ago',
+      value: { updatedEnd: getDateDaysAgo(1) },
+    },
+    {
+      label: 'More than 7 days ago',
+      value: { updatedEnd: getDateDaysAgo(7) },
+    },
+    {
+      label: 'More than 15 days ago',
+      value: { updatedEnd: getDateDaysAgo(15) },
+    },
+    {
+      label: 'More than 30 days ago',
+      value: { updatedEnd: getDateDaysAgo(30) },
+    },
+    {
+      label: 'Custom',
+      value: {},
+    },
+  ];
+};
+
+// TODO rework this with using tanstack query
+export const getWorkspaceSelectOptions = async () => {
+  const firstResponse = await getGroups(undefined, {
+    page: 1,
+    per_page: MAX_PER_PAGE,
+  });
+  const { total, results: firstPageResults } = firstResponse;
+
+  if (total <= MAX_PER_PAGE) {
+    return firstPageResults;
+  }
+
+  const remainingPages = Math.ceil((total - MAX_PER_PAGE) / MAX_PER_PAGE);
+  const remainingPagePromises = Array.from(
+    { length: remainingPages },
+    (_, index) =>
+      getGroups(undefined, { page: index + 2, per_page: MAX_PER_PAGE }),
+  );
+
+  const remainingResponses = await Promise.all(remainingPagePromises);
+
+  const allResults = [
+    ...firstPageResults,
+    ...remainingResponses.flatMap((response) => response.results),
+  ];
+
+  return allResults;
+};

--- a/src/routes/Systems/components/SystemsTable/helpers.js
+++ b/src/routes/Systems/components/SystemsTable/helpers.js
@@ -1,6 +1,4 @@
 import { getTags } from '../../../../api/hostInventoryApi';
-import { getGroups } from '../../../../components/InventoryGroups/utils/api';
-import { MAX_PER_PAGE } from './constants';
 
 export const fetchTags = async () => {
   return await getTags();
@@ -27,72 +25,4 @@ export const getOsSelectOptions = (osName, osData) => {
         value: `${item.major}.${item.minor}`,
       })),
   }));
-};
-
-export const getDateDaysAgo = (days) => {
-  const today = new Date();
-  const daysAgo = new Date();
-  daysAgo.setDate(today.getDate() - days);
-  return daysAgo.toISOString();
-};
-
-export const getLastSeenSelectOptions = () => {
-  return [
-    {
-      label: 'Within the last 24 hours',
-      value: {
-        updatedEnd: getDateDaysAgo(0),
-        updatedStart: getDateDaysAgo(1),
-      },
-    },
-    {
-      label: 'More than 1 day ago',
-      value: { updatedEnd: getDateDaysAgo(1) },
-    },
-    {
-      label: 'More than 7 days ago',
-      value: { updatedEnd: getDateDaysAgo(7) },
-    },
-    {
-      label: 'More than 15 days ago',
-      value: { updatedEnd: getDateDaysAgo(15) },
-    },
-    {
-      label: 'More than 30 days ago',
-      value: { updatedEnd: getDateDaysAgo(30) },
-    },
-    {
-      label: 'Custom',
-      value: {},
-    },
-  ];
-};
-
-// TODO rework this with using tanstack query
-export const getWorkspaceSelectOptions = async () => {
-  const firstResponse = await getGroups(undefined, {
-    page: 1,
-    per_page: MAX_PER_PAGE,
-  });
-  const { total, results: firstPageResults } = firstResponse;
-
-  if (total <= MAX_PER_PAGE) {
-    return firstPageResults;
-  }
-
-  const remainingPages = Math.ceil((total - MAX_PER_PAGE) / MAX_PER_PAGE);
-  const remainingPagePromises = Array.from(
-    { length: remainingPages },
-    (_, index) =>
-      getGroups(undefined, { page: index + 2, per_page: MAX_PER_PAGE }),
-  );
-
-  const remainingResponses = await Promise.all(remainingPagePromises);
-
-  const allResults = [
-    ...firstPageResults,
-    ...remainingResponses.flatMap((response) => response.results),
-  ];
-
-  return allResults;
 };

--- a/src/routes/Systems/helpers.js
+++ b/src/routes/Systems/helpers.js
@@ -1,6 +1,6 @@
 // TODO remove dependency on fec helpers and components
 import { generateFilter } from '@redhat-cloud-services/frontend-components-utilities/helpers';
-import { getHostList, getHostTags, getTags } from '../../api/hostInventoryApi';
+import { getHostList, getHostTags } from '../../api/hostInventoryApi';
 import defaultColumns from './components/SystemsTable/columns';
 import uniq from 'lodash/uniq';
 import defaultFilters, {

--- a/src/routes/Systems/helpers.js
+++ b/src/routes/Systems/helpers.js
@@ -3,6 +3,9 @@ import { generateFilter } from '@redhat-cloud-services/frontend-components-utili
 import { getHostList, getHostTags, getTags } from '../../api/hostInventoryApi';
 import defaultColumns from './components/SystemsTable/columns';
 import uniq from 'lodash/uniq';
+import defaultFilters, {
+  CUSTOM_FILTER_TYPES,
+} from './components/SystemsTable/filters';
 
 const fetchHostTags = async (hosts) => {
   if (hosts.length) {
@@ -31,13 +34,15 @@ export const fetchSystems = async (
     ],
   };
 
+  const { filter, ...filterParams } = serialisedTableState?.filters || {};
+
   const params = {
     ...(serialisedTableState?.pagination || {}),
-    ...(serialisedTableState?.filters || {}),
     ...(serialisedTableState?.sort || {}),
     // Currently tags set in the global filter only appear in the global filter
     // If we wanted to keep the toolbar filters and global filters in sync
     // we should use `setFilter` instead and not add the global filter tags here
+    ...filterParams,
     tags: [
       ...(serialisedTableState?.filters?.tags || []),
       ...(globalFilterTags || []),
@@ -49,6 +54,7 @@ export const fetchSystems = async (
         // it should rather be something like `filter[systems_profile][sap_system]`
         ...generateFilter(fields, 'fields'),
         ...generateFilter(globalFilter),
+        ...generateFilter(filter),
       },
     },
   };
@@ -69,6 +75,17 @@ export const resolveColumns = (columns) => {
     return columns(defaultColumns);
   } else {
     return columns;
+  }
+};
+
+export const resolveFilters = (filters) => {
+  if (typeof filters === 'function') {
+    return filters({
+      customFilterTypes: CUSTOM_FILTER_TYPES,
+      filterConfig: defaultFilters,
+    });
+  } else {
+    return filters;
   }
 };
 

--- a/src/routes/Systems/serialisers.js
+++ b/src/routes/Systems/serialisers.js
@@ -1,23 +1,23 @@
-// const textFilterSerialiser = (filterConfigItem, value) =>
-//   `regex(.${filterConfigItem.filterAttribute}, "${value}", "i")`;
-//
-// const checkboxFilterSerialiser = (filterConfigItem, values) =>
-//   `.${filterConfigItem.filterAttribute} in [${values
-//     .map((value) => `"${value}"`)
-//     .join(',')}]`;
-//
-// const raidoFilterSerialiser = (filterConfigItem, values) =>
-//   `.${filterConfigItem.filterAttribute} == "${values[0]}"`;
-//
-// const numberFilterSerialiser = (filterConfigItem, value) =>
-//   `.${filterConfigItem.filterAttribute} == ${value}`;
+const textFilterSerialiser = (filterConfigItem, value) =>
+  `regex(.${filterConfigItem.filterAttribute}, "${value}", "i")`;
+
+const checkboxFilterSerialiser = (filterConfigItem, values) =>
+  `.${filterConfigItem.filterAttribute} in [${values
+    .map((value) => `"${value}"`)
+    .join(',')}]`;
+
+const raidoFilterSerialiser = (filterConfigItem, values) =>
+  `.${filterConfigItem.filterAttribute} == "${values[0]}"`;
+
+const numberFilterSerialiser = (filterConfigItem, value) =>
+  `.${filterConfigItem.filterAttribute} == ${value}`;
 
 const filterSerialisers = {
-  // text: textFilterSerialiser,
-  // checkbox: checkboxFilterSerialiser,
-  // radio: raidoFilterSerialiser,
-  // singleSelect: raidoFilterSerialiser,
-  // number: numberFilterSerialiser,
+  text: textFilterSerialiser,
+  checkbox: checkboxFilterSerialiser,
+  radio: raidoFilterSerialiser,
+  singleSelect: raidoFilterSerialiser,
+  number: numberFilterSerialiser,
 };
 
 const findFilterSerialiser = (filterConfigItem) => {
@@ -47,9 +47,20 @@ export const filtersSerialiser = (state, filters) => {
     [],
   );
 
-  return queryParts.length > 0
-    ? queryParts.reduce((allFilters, part) => ({ ...allFilters, ...part }), {})
-    : undefined;
+  const query =
+    queryParts.length > 0
+      ? queryParts.reduce((allFilters, part) => {
+          if (part.filter) {
+            const newPart = {
+              filter: { ...allFilters.filter, ...part.filter },
+            };
+            return { ...allFilters, ...newPart };
+          }
+          return { ...allFilters, ...part };
+        }, {})
+      : undefined;
+
+  return query;
 };
 
 export const sortSerialiser = ({ index, direction } = {}, columns) =>

--- a/src/routes/Systems/serialisers.js
+++ b/src/routes/Systems/serialisers.js
@@ -47,20 +47,17 @@ export const filtersSerialiser = (state, filters) => {
     [],
   );
 
-  const query =
-    queryParts.length > 0
-      ? queryParts.reduce((allFilters, part) => {
-          if (part.filter) {
-            const newPart = {
-              filter: { ...allFilters.filter, ...part.filter },
-            };
-            return { ...allFilters, ...newPart };
-          }
-          return { ...allFilters, ...part };
-        }, {})
-      : undefined;
-
-  return query;
+  return queryParts.length
+    ? queryParts.reduce((allFilters, part) => {
+        if (part.filter) {
+          const newPart = {
+            filter: { ...allFilters.filter, ...part.filter },
+          };
+          return { ...allFilters, ...newPart };
+        }
+        return { ...allFilters, ...part };
+      }, {})
+    : undefined;
 };
 
 export const sortSerialiser = ({ index, direction } = {}, columns) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts", "src/*'*/*.tsx", "src/**/*.js", "src/**/*.jsx","playwright.config.ts","_playwright-tests/helpers/loginHelpers.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx","playwright.config.ts","_playwright-tests/helpers/loginHelpers.ts"]
 }


### PR DESCRIPTION
Implements partially RHINENG-19947

<img width="665" height="405" alt="image" src="https://github.com/user-attachments/assets/0f1125e4-fa63-4818-ad2a-f13c18eebd97" />

### Description
PR is part of migration to TableTools in Inventory. It improves filter arg of SystemsTable and implements filters mentioned below with same functionality as original filters in inventoryTable.

Note 1: there are bits of Workspace and LastSeen filters introduced, I couldn't figure how to easily remove them. The code bits aren't being rendered though and will be used in following PR.  

Note 2: group selection is disabled for now in operating systems as it doesn't fully work because of underlying issue which is suspected to be between tabletools and frontend-component's conditional filter.

### Features
- pass filters as array or function which will be resolved
- basic filters - Name, Status, Data Collector, RHC status, Tags, System type, Operating systems
