### PR TITLE
fix(RHINENG-20703): update yum to dnf

### DIFF
--- a/src/components/InventoryDetail/InsightsPrompt.js
+++ b/src/components/InventoryDetail/InsightsPrompt.js
@@ -62,7 +62,7 @@ const InsightsPrompt = () => {
                 <CardFooter>
                   <ClipboardCopy isCode isReadOnly variant={'expansion'}>
                     {
-                      'yum install -y insights-client \ninsights-client --register'
+                      'dnf install -y insights-client \ninsights-client --register'
                     }
                   </ClipboardCopy>
                 </CardFooter>


### PR DESCRIPTION
This PR replaces `yum` with `dnf` in the "Client setup" directions for System details.

## Summary by Sourcery

Bug Fixes:
- Use dnf install command in the InsightsPrompt component instead of yum