### PR TITLE
chore(deps): bump frontend-components-config to v6.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "@faker-js/faker": "^9.6.0",
         "@playwright/test": "^1.54.1",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",
-        "@redhat-cloud-services/frontend-components-config": "^6.6.11",
+        "@redhat-cloud-services/frontend-components-config": "^6.7.0",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.24",
         "@stoplight/prism-cli": "^5.14.2",
         "@swc/jest": "^0.2.37",
@@ -6075,9 +6075,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.6.11",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.6.11.tgz",
-      "integrity": "sha512-97IztUl8PdAUOI/KpCe/iZ/JvFJc/OOfC9b3qPNZ8uipAHRjx06AWDbE4S5TFXpQczZb2DbxA+4OS6xKmGnXMg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.7.0.tgz",
+      "integrity": "sha512-l+ix9/58Juh2YUVw2xpboJQsrQz1ZqAwh03rkJJbLo7J1At+gDOiKCSn1HBBCrCBeGoowKv1SUuDV53nOrLzWA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6086,7 +6086,7 @@
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.21",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
-        "axios": "^0.28.1 || ^1.7.0",
+        "axios": "^1.12.2",
         "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "chalk": "^4.1.2",
@@ -9951,9 +9951,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelint.json",
     "server:ctr": "node src/server/generateServerKey.js",
     "start": "fec dev",
-    "start:proxy": "PROXY=true fec dev",
+    "start:proxy": "fec dev-proxy",
     "static": "fec static",
     "verify": "npm-run-all build lint test",
     "verify:local": "npm-run-all build lint test:local test:ct",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@faker-js/faker": "^9.6.0",
     "@playwright/test": "^1.54.1",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",
-    "@redhat-cloud-services/frontend-components-config": "^6.6.11",
+    "@redhat-cloud-services/frontend-components-config": "^6.7.0",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.24",
     "@stoplight/prism-cli": "^5.14.2",
     "@swc/jest": "^0.2.37",


### PR DESCRIPTION
frontend-components-config v6.7.0 version introduces fec subcommand `fec dev-proxy`. This should be faster & better proxy alternative to our older proxy solution for stage. This new inbuilt proxy was previously known as "static proxy".

This PR bumps frontend-components-config to v6.7.0 and changes start:proxy npm script to use this new proxy.

## How to test
1. npm update @redhat-cloud-services/frontend-components-config
2. npm run start:proxy
3. navigate to stage | run local tests etc see if something breaks

## Summary by Sourcery

Bump frontend-components-config to v6.7.0 and update the start:proxy script to use the new dedicated proxy subcommand

Enhancements:
- Switch start:proxy script to use "fec dev-proxy" instead of the old PROXY flag

Chores:
- Upgrade @redhat-cloud-services/frontend-components-config from v6.6.11 to v6.7.0