### PR TITLE
fix(RHINENG-9836): Fix duplicate api call to fetch hosts data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ docs/*
 
 # Auth files
 .auth/
+
+.claude/
+


### PR DESCRIPTION
This PR addresses [RHINENG-9836](https://issues.redhat.com/browse/RHINENG-9836) 
It fixes a duplicate API call that was happening when rendering the InventoryTable.

It also has may resolve [RHINENG-9836](https://issues.redhat.com/browse/RHINENG-9836), that was reporting a delay during the inventory table load.

## Summary by Sourcery

Prevent duplicate API calls in InventoryTable by refactoring the refresh logic

Enhancements:
- Refactor onRefreshData into a useCallback to stabilize its dependencies
- Consolidate loadSystems dispatch into a single path within onRefreshData to avoid redundant requests
- Update useEffect dependencies to include onRefreshData, autoRefresh, and customFilters to prevent unnecessary fetches