### PR TITLE
feat(RHINENG-20062): Add export buttons to SystemsTable

### DIFF
--- a/src/routes/Systems/components/SystemsTable/SystemsTable.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.js
@@ -15,6 +15,7 @@ import useDeleteSystems from '../../hooks/useDeleteSystems';
 import useToolbarActions from '../../hooks/useToolbarActions';
 import AddSelectedHostsToGroupModal from '../../../../components/InventoryGroups/Modals/AddSelectedHostsToGroupModal';
 import RemoveHostsFromGroupModal from '../../../../components/InventoryGroups/Modals/RemoveHostsFromGroupModal';
+import useInventoryExport from '../../../../components/InventoryTable/hooks/useInventoryExport/useInventoryExport';
 
 const SystemsTable = ({
   items: itemsProp = fetchSystems,
@@ -30,6 +31,9 @@ const SystemsTable = ({
   const [addHostGroupModalOpen, setAddHostGroupModalOpen] = useState(false);
   const [removeHostsFromGroupModalOpen, setRemoveHostsFromGroupModalOpen] =
     useState(false);
+  const exportConfig = useInventoryExport({
+    filters,
+  });
 
   const reloadData = () => {
     if (selectedItems.length > 0) {
@@ -94,6 +98,9 @@ const SystemsTable = ({
           dedicatedAction,
           actions: toolbarActions,
           ...options,
+        }}
+        toolbarProps={{
+          exportConfig,
         }}
       />
     </>


### PR DESCRIPTION
Exactly what you think. This PR adds the export buttons to the SystemsTable. As a reminder, filters do not affect the export. The export buttons will always return every system no matter what's filtered out.

## Summary by Sourcery

Add export functionality to the SystemsTable component by integrating the useInventoryExport hook and wiring export controls into the toolbar.

New Features:
- Integrate useInventoryExport hook to provide export configuration based on current filters.
- Add export buttons to the SystemsTable toolbar to enable exporting all systems regardless of active filters.