### PR TITLE
fix(RHINENG-11471): Remove button in remove workspace modal

### DIFF
--- a/src/components/InventoryGroups/Modals/RemoveHostsFromGroupModal.js
+++ b/src/components/InventoryGroups/Modals/RemoveHostsFromGroupModal.js
@@ -92,7 +92,7 @@ const RemoveHostsFromGroupModal = ({
       isModalOpen={isModalOpen}
       closeModal={() => setIsModalOpen(false)}
       title="Remove from workspace"
-      variant="danger"
+      variant="primary"
       submitLabel="Remove"
       schema={schema(hosts)}
       onSubmit={handleRemoveHosts}


### PR DESCRIPTION
According to the guidelines, 'Remove' button should be blue rather than red as this action can be reverted by reassigning the system to the workspace.

Steps to Reproduce
- Navigate to Inventory
- Select a system currently associated to a group/workspace From the kebab
- Select 'remove from workspace' action

## Summary by Sourcery

Bug Fixes:
- Update the Remove button variant in RemoveHostsFromGroupModal from 'danger' (red) to 'primary' (blue)