### PR TITLE
fix(RHINENG-11655): Update workspace actions dropdown

### DIFF
--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -109,6 +109,9 @@ const GroupDetailHeader = ({ groupId }) => {
             onOpenChange={(dropdownOpen) => setDropdownOpen(dropdownOpen)}
             onSelect={() => setDropdownOpen(false)}
             autoFocus={false}
+            popperProps={{
+              position: 'right',
+            }}
             toggle={(toggleRef) => (
               <MenuToggle
                 ref={toggleRef}
@@ -119,7 +122,7 @@ const GroupDetailHeader = ({ groupId }) => {
                 isDisabled={!canModify || uninitialized || loading}
                 ouiaId="group-actions-dropdown-toggle"
               >
-                Workspace actions
+                Actions
               </MenuToggle>
             )}
           >
@@ -129,14 +132,14 @@ const GroupDetailHeader = ({ groupId }) => {
                 onClick={() => setRenameModalOpen(true)}
                 isAriaDisabled={isKesselEnabled && ungrouped}
               >
-                Rename
+                Rename workspace
               </DropdownItem>
               <DropdownItem
                 key="delete-group"
                 onClick={() => setDeleteModalOpen(true)}
                 isAriaDisabled={isKesselEnabled && ungrouped}
               >
-                Delete
+                Delete workspace
               </DropdownItem>
             </DropdownList>
           </Dropdown>

--- a/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
+++ b/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
@@ -59,12 +59,12 @@ describe('group detail header', () => {
     );
 
     screen.getByRole('button', {
-      name: /workspace actions/i,
+      name: /actions/i,
     });
 
     await userEvent.click(
       screen.getByRole('button', {
-        name: /workspace actions/i,
+        name: /actions/i,
       }),
     );
 


### PR DESCRIPTION
When looking at the details page for a workspace, the kebab action menu is inconsistent with the rest of Insights.

Use 'Actions' instead of 'Workspace actions' in the header Use 'Rename workspace' instead of 'Rename'
Use 'Delete workspace' instead of 'Delete'

## Summary by Sourcery

Standardize the workspace detail kebab menu labeling for consistency with Insights and improve its positioning

Enhancements:
- Standardize actions dropdown header label from "Workspace actions" to "Actions"
- Clarify menu items by renaming "Rename" to "Rename workspace" and "Delete" to "Delete workspace"
- Align the dropdown position by adding popperProps with position set to "right"

Tests:
- Update header and dropdown item tests to expect the updated "Actions" label