### PR TITLE
fix(RHINENG-11656): Update delete workspace modal interactions

### DIFF
--- a/src/components/GroupsTable/GroupsTable.cy.js
+++ b/src/components/GroupsTable/GroupsTable.cy.js
@@ -355,7 +355,7 @@ describe('actions', () => {
         .find('p')
         .should(
           'contain.text',
-          `${fixtures.results[TEST_ID].name} and all its data will be deleted.`,
+          `${fixtures.results[TEST_ID].name} will be deleted.`,
         );
     });
 
@@ -370,7 +370,7 @@ describe('actions', () => {
         .find('p')
         .should(
           'contain.text',
-          `${fixtures.results[TEST_ID].name} and all its data will be deleted.`,
+          `${fixtures.results[TEST_ID].name} will be deleted.`,
         );
     });
 
@@ -404,7 +404,7 @@ describe('actions', () => {
         .find('p')
         .should(
           'contain.text',
-          `${TEST_ROWS.length} workspaces and all their data will be deleted.`,
+          `${TEST_ROWS.length} workspaces will be deleted.`,
         );
     });
 

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
@@ -83,7 +83,6 @@ describe('group detail page', () => {
     cy.get(MENU_TOGGLE).should('be.enabled').click();
     cy.get(MENU_ITEM).contains('Delete').click();
 
-    cy.get(`div[class="pf-v6-c-check"]`).click();
     cy.get(`button[type="submit"]`).click();
     cy.wait('@deleteGroup')
       .its('request.url')

--- a/src/components/InventoryGroups/Modals/DeleteGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/DeleteGroupModal.cy.js
@@ -114,7 +114,7 @@ describe('multiple empty groups', () => {
     cy.get('h1').should('have.text', 'Warning alert:Delete workspaces?');
     cy.get('p').should(
       'have.text',
-      `${fixtures.results.length} workspaces and all their data will be deleted.`,
+      `${fixtures.results.length} workspaces will be deleted.`,
     );
   });
 
@@ -159,10 +159,7 @@ describe('multiple empty groups', () => {
       cy.wait('@getGroups'); // should make 6 batched requests
     }
 
-    cy.get('p').should(
-      'contain.text',
-      `workspaces and all their data will be deleted.`,
-    );
+    cy.get('p').should('contain.text', `workspaces will be deleted.`);
   });
 });
 
@@ -231,7 +228,7 @@ describe('single empty group', () => {
     cy.get('h1').should('have.text', 'Warning alert:Delete workspace?');
     cy.get('p').should(
       'contain.text',
-      `${fixtures.results[0].name} and all its data will be deleted.`,
+      `${fixtures.results[0].name} will be deleted.`,
     );
   });
 

--- a/src/components/InventoryGroups/Modals/DeleteGroupModal.js
+++ b/src/components/InventoryGroups/Modals/DeleteGroupModal.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import RepoModal from './Modal';
 import { deleteGroupsById, getGroupsByIds } from '../utils/api';
@@ -26,20 +25,13 @@ const generateSchema = (groups) => ({
       label:
         groups.length > 1 ? (
           <Content component="p">
-            <strong>{groups.length}</strong> workspaces and all their data will
-            be deleted.
+            <strong>{groups.length}</strong> workspaces will be deleted.
           </Content>
         ) : (
           <Content component="p">
-            <strong>{groups[0]?.name}</strong> and all its data will be deleted.
+            <strong>{groups[0]?.name}</strong> will be deleted.
           </Content>
         ),
-    },
-    {
-      component: componentTypes.CHECKBOX,
-      name: 'confirmation',
-      label: 'I understand that this action cannot be undone.',
-      validate: [{ type: validatorTypes.REQUIRED }],
     },
   ],
 });


### PR DESCRIPTION
The 'Delete workspace' modal should be improved to follow guidelines:

Remove '... and all its data' from the sentence.
Remove checkbox (speedbump) as this is not required.

Steps to Reproduce
Navigate to Inventory > Workspace
Try to delete a workspace (only possible if no system is assigned)

## Summary by Sourcery

Simplify the delete workspace modal by removing the redundant "and all its data" text and the confirmation checkbox, and update related Cypress tests to reflect these UI changes.

Enhancements:
- Remove "and all its data" phrasing from delete workspace modal messaging
- Eliminate the unnecessary confirmation checkbox from the delete workspace modal

Tests:
- Update Cypress tests to validate the updated modal text and absence of the confirmation checkbox