### PR TITLE
fix(pr_check): Fix workspace test

### DIFF
--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -76,7 +76,6 @@ test('User can create, rename, and delete a workspace', async ({ page }) => {
 
   await page.getByRole('menuitem', { name: 'Delete workspace' }).first().click();
   await expect(dialog).toBeVisible();
-  await dialog.locator('input[type="checkbox"]').first().check();
   await page.getByRole('button', { name: 'Delete' }).click();
 
 


### PR DESCRIPTION


This PR is fixing new changes in workspace deletion modal introduced in https://github.com/RedHatInsights/insights-inventory-frontend/pull/2650

## Summary by Sourcery

Fix Playwright workspace tests to match updated UI labels and remove obsolete interactions

Tests:
- Update workspace rename test to click 'Rename workspace' menu item
- Update workspace delete test to click 'Delete workspace' menu item
- Remove redundant checkbox interaction from workspace deletion test