### PR TITLE
chore: disable test coverage by default for Jest commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "jest": {
     "testEnvironment": "jsdom",
     "coverageDirectory": "coverage-jest",
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
       "!src/**/*.cy.js",


### PR DESCRIPTION
Removes project-wise default test coverage from jest commands

- this saves few secs every time we execute jest command
- countless seconds of scrolling & getting lost in far too long report 
- makes working, writing & debugging tests with jest much less painful

NOTE1: I've checked this shouldn't be affecting our CI, which is using tool other than jest for coverage.

NOTE2: It's still possible to generate same coverage report if you run `jest --coverage` or `npm test -- --coverage`
 