### PR TITLE
fix: improper addition of Lightspeed

### DIFF
--- a/src/routes/InventoryComponents/InventoryPopover.js
+++ b/src/routes/InventoryComponents/InventoryPopover.js
@@ -25,7 +25,7 @@ export const InventoryPopover = () => {
             <Content component="p">
               To appear in Inventory, systems must first be registered with Red
               Hat. You can register systems using several methods, including the
-              Red Hat {platformName} client, Red Hat Satellite, or Red Hat
+              Red Hat Insights client, Red Hat Satellite, or Red Hat
               Subscription Manager (RHSM).
             </Content>
             <Content component="p">


### PR DESCRIPTION
Reverting use of Red Hat Lightspeed in Inventory popover as it is supposed to refer directly to the insights client, which will remain so until a later date.

## Summary by Sourcery

Bug Fixes:
- Replace "Red Hat {platformName} client" label with "Red Hat Insights client" in Inventory popover.