### PR TITLE
chore: clean warnings from stage error console

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -38,7 +38,7 @@ const InventoryApp = ({ logger }) => {
 };
 
 InventoryApp.propTypes = {
-  logger: PropTypes.object,
+  logger: PropTypes.func,
 };
 
 export default InventoryApp;

--- a/src/routes/Systems/components/SystemsTable/components/actions/DedicatedAction.js
+++ b/src/routes/Systems/components/SystemsTable/components/actions/DedicatedAction.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@patternfly/react-core';
 
-const DedicatedAction = ({ onClick, selected }) => {
+const DedicatedAction = ({ onClick = () => {}, selected = [] }) => {
   return (
     <Button
       isDisabled={!selected?.length}
@@ -18,11 +18,6 @@ const DedicatedAction = ({ onClick, selected }) => {
 DedicatedAction.propTypes = {
   onClick: PropTypes.func,
   selected: PropTypes.array,
-};
-
-DedicatedAction.defaultProps = {
-  onClick: () => {},
-  selected: [],
 };
 
 export default DedicatedAction;


### PR DESCRIPTION
It's quite hard to see important stuff in error console when there are too many errors with stack traces. So cleaning some of these errors

- one related to wrong validator
- one complaining about defaultProps.

## Summary by Sourcery

Clean up PropType-related console errors by assigning default parameters in DedicatedAction and correcting the logger PropType in InventoryApp

Bug Fixes:
- Move DedicatedAction default values into function parameters and remove defaultProps to suppress related console warnings
- Change InventoryApp.logger PropType from object to func to eliminate mismatched type warnings