### PR TITLE
test(RHINENG-21087): Add E2E test to rename and delete workspace from  Workpsaces page

### DIFF
--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -96,5 +96,6 @@ export const expectAllRowsHaveText = async (rowLocator: Locator, expectedText: s
 export const searchByName = async (page: Page, name: string): Promise<void> => {
   const searchInput = page.locator('input[placeholder="Filter by name"]');
   await expect(searchInput).toBeVisible();
+  await page.reload({ waitUntil: 'networkidle' });
   await searchInput.fill(name);
 };

--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -96,6 +96,5 @@ export const expectAllRowsHaveText = async (rowLocator: Locator, expectedText: s
 export const searchByName = async (page: Page, name: string): Promise<void> => {
   const searchInput = page.locator('input[placeholder="Filter by name"]');
   await expect(searchInput).toBeVisible();
-  await page.reload({ waitUntil: 'networkidle' });
   await searchInput.fill(name);
 };

--- a/_playwright-tests/helpers/loginHelpers.ts
+++ b/_playwright-tests/helpers/loginHelpers.ts
@@ -107,6 +107,14 @@ export const ensureInPreview = async (page: Page) => {
   await expect(toggle).toBeChecked();
 };
 
+
+/**
+ * Registers Playwright `addLocatorHandler` listeners to automatically close
+ * common intrusive pop-ups, such as toast notifications, Pendo guides,
+ * and consent banners, before test actions proceed.
+ *
+ * @param {Page} page - The Playwright Page object.
+ */
 export const closePopupsIfExist = async (page: Page) => {
   const locatorsToCheck = [
     page.locator('.pf-v6-c-alert.notification-item button'), // This closes all toast pop-ups

--- a/_playwright-tests/helpers/navHelpers.ts
+++ b/_playwright-tests/helpers/navHelpers.ts
@@ -2,11 +2,19 @@ import { type Page } from '@playwright/test';
 import { test as base, expect } from '@playwright/test';
 import { closePopupsIfExist } from './loginHelpers';
 
-export const navigateToInventoryFunc = async (page: Page) => {
+/**
+ * Navigates the browser to the Systems inventory page and waits for the
+ * main 'Systems' heading to become visible.
+ */
+export const navigateToInventorySystemsFunc = async (page: Page) => {
   await page.goto('/insights/inventory/', { timeout: 100000 });
   await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible({ timeout: 100000 });
 };
 
+/**
+ * Navigates the browser to the Workspaces inventory page and waits for the
+ * main 'Workspaces' heading to become visible.
+ */
 export const navigateToWorkspacesFunc = async (page: Page) => {
   await page.goto('/insights/inventory/workspaces', { timeout: 100000 });
   await expect(page.getByRole('heading', { name: 'Workspaces' })).toBeVisible({ timeout: 100000 });

--- a/_playwright-tests/helpers/workspaceHelpers.ts
+++ b/_playwright-tests/helpers/workspaceHelpers.ts
@@ -2,7 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 
 
 /**
- * Help function to generate unique workpsace name
+ * Help function to generate unique workspace name
  */
 export const generateUniqueWorkspaceName = async () => {
   return `Workspace_${Date.now()}_${Math.floor(Math.random() * 1000)}`;

--- a/_playwright-tests/helpers/workspaceHelpers.ts
+++ b/_playwright-tests/helpers/workspaceHelpers.ts
@@ -1,0 +1,27 @@
+import { test, expect, type Page } from '@playwright/test';
+
+
+/**
+ * Help function to generate unique workpsace name
+ */
+export const generateUniqueWorkspaceName = async () => {
+  return `Workspace_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+};
+
+
+/**
+ * Help function to create a new workspace via the UI modal
+ *
+ * @param page - The Playwright Page object for interaction.
+ * @param name - The unique name to be given to the new workspace.
+ * @returns {Promise<void>}
+ */
+export const createNewWorkspace = async (page: Page, name: string) => {
+  // 1. Click the "Create Workspace" button
+  await page.click('button:has-text("Create workspace")');
+  // 2. Wait for dialog to appear and fill in the workspace name
+  const dialog = page.locator('[role="dialog"]');
+  await expect(dialog).toBeVisible({ timeout: 100000 });
+  await dialog.locator('input').first().fill(name);
+  await dialog.getByRole('button', { name: 'Create' }).click();
+};

--- a/_playwright-tests/test_navigation.test.ts
+++ b/_playwright-tests/test_navigation.test.ts
@@ -1,16 +1,16 @@
 import { expect } from '@playwright/test';
-import { test,navigateToInventoryFunc } from './helpers/navHelpers';
+import { test,navigateToInventorySystemsFunc } from './helpers/navHelpers';
 
 test('User can navigate to the inventory page', async ({ page }) => {
   await test.step('Navigate to Inventory page', async () => {
-    await navigateToInventoryFunc(page);
+    await navigateToInventorySystemsFunc(page);
   });
 });
 
 
 test('User can navigate to the Staleness and Deletion page via the menu', async ({ page }) => {
   await test.step('Navigate to Inventory page', async () => {
-    await navigateToInventoryFunc(page);
+    await navigateToInventorySystemsFunc(page);
   });
 
   await test.step('Open System Configuration menu and click Staleness and Deletion', async () => {
@@ -31,7 +31,7 @@ test('User can navigate to the Staleness and Deletion page via the menu', async 
 
 test('User can navigate to the workspaces page via the menu', async ({ page }) => {
   await test.step('Navigate to Inventory page', async () => {
-    await navigateToInventoryFunc(page);
+    await navigateToInventorySystemsFunc(page);
   });
 
   await test.step('Click on Workspaces menu item and reload page', async () => {

--- a/_playwright-tests/test_ungrouped_workspace.test.ts
+++ b/_playwright-tests/test_ungrouped_workspace.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { type Page } from '@playwright/test';
-import { test,navigateToInventoryFunc, navigateToWorkspacesFunc } from './helpers/navHelpers';
+import { test,navigateToInventorySystemsFunc, navigateToWorkspacesFunc } from './helpers/navHelpers';
 import { filterSystemsWithConditionalFilter, expectAllRowsHaveText, searchByName } from './helpers/filterHelpers';
 
 test('User can filter, search and see deatils of "Ungrouped Hosts" workspace', async ({ page }: { page: Page }) => {
@@ -20,7 +20,7 @@ test('User can filter, search and see deatils of "Ungrouped Hosts" workspace', a
  */
   const ungroupedWorkspaceName: string = "Ungrouped Hosts";
   await test.step('Filter systems by "Ungrouped Hosts" workspace in Systems page', async () => {
-    await navigateToInventoryFunc(page);
+    await navigateToInventorySystemsFunc(page);
     await filterSystemsWithConditionalFilter(page, "Workspace", "Ungrouped hosts");
     const workspaceColumnLocator = page.locator('td[data-label="Workspace"]');
     await expectAllRowsHaveText(workspaceColumnLocator, ungroupedWorkspaceName);

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -67,6 +67,17 @@ test('User can create, rename, and delete a workspace', async ({ page }) => {
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();
     await page.getByRole('button', { name: 'Delete' }).click();
+<<<<<<< HEAD
+=======
+
+    // search for the deleted workspace to confirm deletion worked
+    const resetFiltersButton = page.getByRole('button', { name: 'Reset filters' });
+    await resetFiltersButton.click();
+    await searchByName(page, renamedWorkspace);
+    const deletedWorkspaceLocator = page.locator(`text=${renamedWorkspace}`);
+    await expect(deletedWorkspaceLocator).toHaveCount(0, { timeout: 60000 });
+    await expect(page.locator('text=No matching workspaces found')).toBeVisible();
+>>>>>>> f2c5885 (test(RHINENG-21087-1): Add E2E test to rename and delete workpsce from Workpsaces page)
   });
 
   await test.step('Verify workspace deletion', async () => {

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -1,8 +1,10 @@
 import { expect } from '@playwright/test';
 import { test,navigateToWorkspacesFunc } from './helpers/navHelpers';
+import { searchByName } from './helpers/filterHelpers';
+import { generateUniqueWorkspaceName, createNewWorkspace } from './helpers/workspaceHelpers';
 
 
-test('User can create, rename, and delete a workspace', async ({ page }) => {
+test('User can create, rename, and delete a workspace from Workspace Details page', async ({ page }) => {
   /** 
    * Jira References:
        - https://issues.redhat.com/browse/ESSNTL-3871 – Create workspace
@@ -21,14 +23,14 @@ test('User can create, rename, and delete a workspace', async ({ page }) => {
     await navigateToWorkspacesFunc(page);
   });
 
-  const WorkspaceName = `Workspace_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
-  const RenamedWorkspace = `${WorkspaceName}_Renamed`;
+  const workspaceName = await generateUniqueWorkspaceName();
+  const renamedWorkspace = `${workspaceName}_Renamed`;
 
   await test.step('Create a new workspace', async () => {
     await page.click('button:has-text("Create workspace")');
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible({ timeout: 100000 });
-    await dialog.locator('input').first().fill(WorkspaceName);
+    await dialog.locator('input').first().fill(workspaceName);
     await dialog.getByRole('button', { name: 'Create' }).click();
   });
 
@@ -36,9 +38,9 @@ test('User can create, rename, and delete a workspace', async ({ page }) => {
     const searchInput = page.locator('input[placeholder="Filter by name"]');
     await expect(searchInput).toBeVisible();
     await page.reload({ waitUntil: 'networkidle' });
-    await searchInput.fill(WorkspaceName);
+    await searchInput.fill(workspaceName);
 
-    const workspaceLink = page.getByRole('link', { name: WorkspaceName });
+    const workspaceLink = page.getByRole('link', { name: workspaceName });
     await expect(workspaceLink).toBeVisible({ timeout: 100000 });
     await workspaceLink.click();
   });
@@ -52,12 +54,12 @@ test('User can create, rename, and delete a workspace', async ({ page }) => {
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();
-    await dialog.locator('input').first().fill(RenamedWorkspace);
+    await dialog.locator('input').first().fill(renamedWorkspace);
     await dialog.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByRole('heading', { name: renamedWorkspace })).toBeVisible();
   });
 
   await test.step('Delete the renamed workspace', async () => {
-    await expect(page.getByRole('heading', { name: RenamedWorkspace })).toBeVisible();
     const actionsButton = page.getByRole('button', { name: 'Actions' });
     await expect(actionsButton).toBeVisible();
     await actionsButton.click();
@@ -67,29 +69,18 @@ test('User can create, rename, and delete a workspace', async ({ page }) => {
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();
     await page.getByRole('button', { name: 'Delete' }).click();
-<<<<<<< HEAD
-=======
-
-    // search for the deleted workspace to confirm deletion worked
-    const resetFiltersButton = page.getByRole('button', { name: 'Reset filters' });
-    await resetFiltersButton.click();
-    await searchByName(page, renamedWorkspace);
-    const deletedWorkspaceLocator = page.locator(`text=${renamedWorkspace}`);
-    await expect(deletedWorkspaceLocator).toHaveCount(0, { timeout: 60000 });
-    await expect(page.locator('text=No matching workspaces found')).toBeVisible();
->>>>>>> f2c5885 (test(RHINENG-21087-1): Add E2E test to rename and delete workpsce from Workpsaces page)
   });
 
   await test.step('Verify workspace deletion', async () => {
     await navigateToWorkspacesFunc(page);
     const searchInput = page.locator('input[placeholder="Filter by name"]');
-    await searchInput.fill(RenamedWorkspace);
+    await searchInput.fill(renamedWorkspace);
     await expect(page.locator('text=No matching workspaces found')).toBeVisible();
   });
 });
 
 
-test('User cannot delete a workspace with systems', async ({ page }) => {
+test('User cannot delete a workspace with systems from Workspace Details page', async ({ page }) => {
   /** 
    * Jira References:
        - https://issues.redhat.com/browse/ESSNTL-4370 – Delete workspace with systems
@@ -101,7 +92,7 @@ test('User cannot delete a workspace with systems', async ({ page }) => {
        - assignee: addubey
    */
 
-  const WorkspaceName = "Workspace_with_systems";
+  const workspaceName = "Workspace_with_systems";
 
   await test.step('Navigate to Workspaces', async () => {
     await navigateToWorkspacesFunc(page);
@@ -111,9 +102,9 @@ test('User cannot delete a workspace with systems', async ({ page }) => {
     const searchInput = page.locator('input[placeholder="Filter by name"]');
     await expect(searchInput).toBeVisible();
     await page.reload({ waitUntil: 'networkidle' });
-    await searchInput.fill(WorkspaceName);
+    await searchInput.fill(workspaceName);
 
-    const workspaceLink = page.getByRole('link', { name: WorkspaceName });
+    const workspaceLink = page.getByRole('link', { name: workspaceName });
     await expect(workspaceLink).toBeVisible({ timeout: 100000 });
     await workspaceLink.click();
   });
@@ -146,6 +137,7 @@ test('User able to bulk delete empty workspaces', async ({ page }) => {
   });
 
   const dialog = page.locator('[role="dialog"]');
+  const searchInput = page.locator('input[placeholder="Filter by name"]');
 
   await test.step('Create 3 empty workspaces', async () => {
     for (let i = 1; i <= 3; i++) {
@@ -159,7 +151,6 @@ test('User able to bulk delete empty workspaces', async ({ page }) => {
   });
 
   await test.step('Search for empty workspaces and bulk delete', async () => {
-    const searchInput = page.locator('input[placeholder="Filter by name"]');
     await expect(searchInput).toBeVisible();
     await page.reload({ waitUntil: 'networkidle' });
     await searchInput.fill("empty");
@@ -179,9 +170,71 @@ test('User able to bulk delete empty workspaces', async ({ page }) => {
   });
 
   await test.step('Verify all empty workspaces are deleted', async () => {
-    const searchInput = page.locator('input[placeholder="Filter by name"]');
     await page.reload({ waitUntil: 'networkidle' });
     await searchInput.fill("empty");
+    await expect(page.locator('text=No matching workspaces found')).toBeVisible();
+  });
+});
+
+
+test('User can create, rename and delete a workspace from Workspaces page', async ({ page }) => {
+/** 
+ * Jira References:
+     - https://issues.redhat.com/browse/ESSNTL-3871 – Create workspace
+     - https://issues.redhat.com/browse/ESSNTL-4370 – Rename workspace
+     - https://issues.redhat.com/browse/ESSNTL-4370 – Delete workspace
+ 
+ * Metadata:
+     - requirements:
+         - inv-groups-post
+         - inv-groups-patch
+         - inv-groups-delete
+     - importance: critical
+     - assignee: zabikeno
+ */
+  const workspaceName = await generateUniqueWorkspaceName();
+  const renamedWorkspace = `${workspaceName}_Renamed`;
+  const dialogModal = page.locator('[data-ouia-component-id="group-modal"]');
+  const perRowKebabButton = page.getByRole('button', { name: 'Kebab toggle' });
+  const perRowMenu = page.locator('[class="pf-v6-c-menu"]'); 
+  const nameColumnLocator = page.locator('td[data-label="Name"]');
+
+  await test.step('Test setup: navigate to Workspaces page, create workspace to work with', async () => {
+    await navigateToWorkspacesFunc(page);
+    await createNewWorkspace(page, workspaceName);
+    // serach for workspace and via 'Name' column make sure only 1 workspace is found
+    await searchByName(page, workspaceName);
+    await expect(nameColumnLocator).toHaveCount(1);
+    await expect(nameColumnLocator).toHaveText(workspaceName);  
+  });
+
+  await test.step('Rename workspace via per-row action from Workspaces page and verify renaming via search', async () => {
+    await perRowKebabButton.click();
+    await expect(perRowMenu).toBeVisible(); 
+    const renameWorkspaceButton = page.getByRole('menuitem', { name: 'Rename workspace' }).first();
+    await renameWorkspaceButton.click();
+
+    await expect(dialogModal).toBeVisible();
+    await dialogModal.locator('input').first().fill(renamedWorkspace);
+    await dialogModal.getByRole('button', { name: 'Save' }).click();
+
+    // search for the new name to confirm rename worked
+    await searchByName(page, renamedWorkspace);
+    await expect(nameColumnLocator).toHaveCount(1);
+    await expect(nameColumnLocator).toHaveText(renamedWorkspace);
+  });
+
+  await test.step('Delete workspace via per-row action from Workspaces page and verify deletion via search', async () => {
+    await searchByName(page, renamedWorkspace);
+    await perRowKebabButton.click();
+    await expect(perRowMenu).toBeVisible(); 
+    await page.getByRole('menuitem', { name: 'Delete workspace' }).first().click();
+
+    await expect(dialogModal).toBeVisible();
+    await dialogModal.getByRole('button', { name: 'Delete' }).click();
+    
+    // search for the workspace to confirm workspace is removed
+    await searchByName(page, renamedWorkspace);
     await expect(page.locator('text=No matching workspaces found')).toBeVisible();
   });
 });


### PR DESCRIPTION
1. Add E2E test to rename/delete workspace from main Workspaces page
2. Add` workspaceHelper.ts `with repeated actions
3. Add docstring to function to not repeat comments
4. Rename `navigateToInventoryFunc()` navigation to `navigateToInventorySystemsFunc()` -  use the most specific name possible that still accurately describes the function's responsibility.
5. Fix-up conventional style for variables



## Summary by Sourcery

Add and refactor workspace-related E2E tests by introducing reusable helpers, renaming navigation utilities, and covering negative delete scenarios for workspaces with systems

New Features:
- Add E2E test ensuring a workspace with attached systems cannot be deleted

Enhancements:
- Introduce workspaceHelpers with generateUniqueWorkspaceName and createNewWorkspace utilities
- Refactor existing workspace test to leverage helper functions and streamline naming and search flows
- Rename navigateToInventoryFunc to navigateToInventorySystemsFunc and update all references
- Add JSDoc comments to navigation and popup helper functions

Tests:
- Restructure workspace CRUD tests into discrete test.step blocks with improved modal and heading assertions

## Summary by Sourcery

Introduce reusable workspace test helpers, rename navigation utility, and expand E2E coverage for workspace actions

New Features:
- Add E2E test preventing deletion of workspaces with attached systems
- Add E2E test for renaming and deleting workspaces directly from the Workspaces page

Enhancements:
- Introduce workspaceHelpers.ts with generateUniqueWorkspaceName and createNewWorkspace utilities
- Refactor workspace tests to leverage helper functions, test.step blocks, and consistent naming conventions
- Rename navigateToInventoryFunc to navigateToInventorySystemsFunc and update all references
- Add JSDoc comments to navigation and popup helper functions

Documentation:
- Add docstrings to reduce duplicated inline comments in helper modules

Tests:
- Improve modal and heading assertions and split workspace tests into granular steps
- Update navigation and ungrouped workspace tests to use the renamed inventory navigation function