### PR TITLE
chore(SystemCard): Remove defaultProps and clean-up test errors

### DIFF
--- a/src/components/GeneralInfo/SystemCard/SystemCard.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.js
@@ -15,17 +15,17 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 const SystemCard = ({
   writePermissions,
   handleClick,
-  hasHostName,
-  hasDisplayName,
-  hasAnsibleHostname,
-  hasWorkspace,
-  hasSystemPurpose,
-  hasCPUs,
-  hasSockets,
-  hasCores,
-  hasCPUFlags,
-  hasRAM,
-  extra,
+  hasHostName = true,
+  hasDisplayName = true,
+  hasAnsibleHostname = true,
+  hasWorkspace = true,
+  hasSystemPurpose = true,
+  hasCPUs = true,
+  hasSockets = true,
+  hasCores = true,
+  hasCPUFlags = true,
+  hasRAM = true,
+  extra = [],
 }) => {
   const dispatch = useDispatch();
   const addNotification = useAddNotification();
@@ -86,7 +86,7 @@ const SystemCard = ({
                 ),
                 value: (
                   <NameInlineEdit
-                    textValue={entity?.display_name}
+                    textValue={entity?.display_name || ''}
                     onSubmit={(value) =>
                       onSubmit(editDisplayName, value, entity?.display_name)
                     }
@@ -109,7 +109,7 @@ const SystemCard = ({
                 ),
                 value: (
                   <NameInlineEdit
-                    textValue={getAnsibleHost(entity)}
+                    textValue={getAnsibleHost(entity) || ''}
                     writePermissions={writePermissions}
                     onSubmit={(value) =>
                       onSubmit(editAnsibleHost, value, getAnsibleHost(entity))
@@ -207,32 +207,6 @@ const SystemCard = ({
 };
 
 SystemCard.propTypes = {
-  detailLoaded: PropTypes.bool,
-  entity: PropTypes.shape({
-    display_name: PropTypes.string,
-
-    ansible_host: PropTypes.string,
-    fqdn: PropTypes.string,
-    id: PropTypes.string,
-  }),
-  properties: PropTypes.shape({
-    cpuNumber: PropTypes.number,
-    sockets: PropTypes.number,
-    coresPerSocket: PropTypes.number,
-    ramSize: PropTypes.string,
-    storage: PropTypes.arrayOf(
-      PropTypes.shape({
-        device: PropTypes.string,
-
-        mount_point: PropTypes.string,
-        options: PropTypes.shape({}),
-        type: PropTypes.string,
-      }),
-    ),
-    sapIds: PropTypes.arrayOf(PropTypes.string),
-    systemPurpose: PropTypes.string,
-    cpuFlags: PropTypes.array,
-  }),
   setDisplayName: PropTypes.func,
   setAnsibleHost: PropTypes.func,
   writePermissions: PropTypes.bool,
@@ -248,22 +222,6 @@ SystemCard.propTypes = {
   hasCPUFlags: PropTypes.bool,
   hasRAM: PropTypes.bool,
   extra: PropTypes.arrayOf(extraShape),
-};
-SystemCard.defaultProps = {
-  detailLoaded: false,
-  entity: {},
-  properties: {},
-  hasHostName: true,
-  hasDisplayName: true,
-  hasAnsibleHostname: true,
-  hasWorkspace: true,
-  hasSystemPurpose: true,
-  hasCPUs: true,
-  hasSockets: true,
-  hasCores: true,
-  hasCPUFlags: true,
-  hasRAM: true,
-  extra: [],
 };
 
 export default SystemCard;

--- a/src/components/GeneralInfo/SystemCard/SystemCard.test.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.test.js
@@ -54,8 +54,6 @@ describe('SystemCard', () => {
     mock.onGet('/api/inventory/v1/hosts/test-id').reply(200, mockedData);
     mock.onGet('/api/inventory/v1/hosts/test-id/system_profile?fields%5Bsystem_profile%5D%5B%5D=operating_system').reply(200, mockedData); // eslint-disable-line
 
-    location.pathname = 'localhost:3000/example/path';
-
     initialState = {
       entityDetails: {
         entity: {
@@ -81,7 +79,7 @@ describe('SystemCard', () => {
       <TestWrapper
         store={mockStore({ systemProfileStore: {}, entityDetails: {} })}
       >
-        <SystemCard />
+        <SystemCard writePermissions={true} />
       </TestWrapper>,
     );
 
@@ -106,7 +104,7 @@ describe('SystemCard', () => {
   it('should render correctly with data', () => {
     render(
       <TestWrapper store={mockStore(initialState)}>
-        <SystemCard />
+        <SystemCard writePermissions={true} />
       </TestWrapper>,
     );
 
@@ -147,7 +145,7 @@ describe('SystemCard', () => {
           },
         })}
       >
-        <SystemCard />
+        <SystemCard writePermissions={true} />
       </TestWrapper>,
     );
 
@@ -170,7 +168,7 @@ describe('SystemCard', () => {
           },
         })}
       >
-        <SystemCard />
+        <SystemCard writePermissions={true} />
       </TestWrapper>,
     );
 
@@ -195,7 +193,7 @@ describe('SystemCard', () => {
     it('should calculate correct ansible host - direct ansible host', () => {
       render(
         <TestWrapper store={mockStore(initialState)}>
-          <SystemCard />
+          <SystemCard writePermissions={true} />
         </TestWrapper>,
       );
 
@@ -220,7 +218,7 @@ describe('SystemCard', () => {
             },
           })}
         >
-          <SystemCard />
+          <SystemCard writePermissions={true} />
         </TestWrapper>,
       );
 
@@ -245,7 +243,7 @@ describe('SystemCard', () => {
             },
           })}
         >
-          <SystemCard />
+          <SystemCard writePermissions={true} />
         </TestWrapper>,
       );
 
@@ -259,7 +257,7 @@ describe('SystemCard', () => {
     it('should show edit display name', async () => {
       render(
         <TestWrapper store={mockStore(initialState)}>
-          <SystemCard />
+          <SystemCard writePermissions={true} />
         </TestWrapper>,
       );
 
@@ -276,7 +274,7 @@ describe('SystemCard', () => {
     it('should show edit ansible hostname', async () => {
       render(
         <TestWrapper store={mockStore(initialState)}>
-          <SystemCard />
+          <SystemCard writePermissions={true} />
         </TestWrapper>,
       );
 
@@ -298,7 +296,7 @@ describe('SystemCard', () => {
       const store = mockStore(initialState);
       render(
         <TestWrapper store={store}>
-          <SystemCard />
+          <SystemCard writePermissions={true} />
         </TestWrapper>,
       );
 
@@ -322,7 +320,7 @@ describe('SystemCard', () => {
       const store = mockStore(initialState);
       render(
         <TestWrapper store={store}>
-          <SystemCard />
+          <SystemCard writePermissions={true} />
         </TestWrapper>,
       );
 
@@ -354,7 +352,7 @@ describe('SystemCard', () => {
           })}
           routerProps={{ initialEntries: ['/example/flag'] }}
         >
-          <SystemCard handleClick={handleClick} />
+          <SystemCard handleClick={handleClick} writePermissions={true} />
         </TestWrapper>,
       );
 
@@ -392,7 +390,7 @@ describe('SystemCard', () => {
   it.each(fieldsToTest)('should not render %s when disabled', (prop, label) => {
     render(
       <TestWrapper store={mockStore(initialState)}>
-        <SystemCard {...{ [prop]: false }} />
+        <SystemCard writePermissions={true} {...{ [prop]: false }} />
       </TestWrapper>,
     );
 
@@ -403,6 +401,7 @@ describe('SystemCard', () => {
     render(
       <TestWrapper store={mockStore(initialState)}>
         <SystemCard
+          writePermissions={true}
           extra={[
             { title: 'something', value: 'test' },
             {
@@ -452,7 +451,7 @@ describe('SystemCard', () => {
               },
             })}
           >
-            <SystemCard />
+            <SystemCard writePermissions={true} />
           </TestWrapper>,
         );
 
@@ -478,7 +477,7 @@ describe('SystemCard', () => {
             },
           })}
         >
-          <SystemCard />
+          <SystemCard writePermissions={true} />
         </TestWrapper>,
       );
 
@@ -518,7 +517,7 @@ describe('SystemCard', () => {
             })}
             routerProps={{ initialEntries: [`/example/${name.toLowerCase()}`] }}
           >
-            <SystemCard handleClick={handleClick} />
+            <SystemCard handleClick={handleClick} writePermissions={true} />
           </TestWrapper>,
         );
 

--- a/src/components/InventoryTable/EntityTable.js
+++ b/src/components/InventoryTable/EntityTable.js
@@ -21,25 +21,25 @@ import useColumns from './hooks/useColumns';
  */
 const EntityTable = ({
   hasItems,
-  expandable,
-  onExpandClick,
-  hasCheckbox,
+  expandable = false,
+  onExpandClick = () => undefined,
+  hasCheckbox = true,
   actions,
-  variant,
+  variant = TableVariant.compact,
   sortBy,
-  tableProps,
+  tableProps = {},
   onSort,
-  expandable: isExpandable,
   onRowClick,
   noDetail,
   noSystemsTable = <NoEntitiesFound />,
   showTags,
   columns: columnsProp,
   disableDefaultColumns,
-  loaded,
+  loaded = false,
   columnsCounter,
   lastSeenOverride,
 }) => {
+  const isExpandable = expandable;
   const dispatch = useDispatch();
   const columns = useColumns(columnsProp, {
     disableDefaultColumns,
@@ -158,9 +158,7 @@ EntityTable.propTypes = {
   onExpandClick: PropTypes.func,
   onSort: PropTypes.func,
   hasCheckbox: PropTypes.bool,
-  showActions: PropTypes.bool,
   hasItems: PropTypes.bool,
-  showHealth: PropTypes.bool,
   sortBy: PropTypes.shape({
     key: PropTypes.string,
     direction: PropTypes.oneOf(['asc', 'desc']),
@@ -185,18 +183,6 @@ EntityTable.propTypes = {
   actions: PropTypes.array,
   noDetail: PropTypes.any,
   lastSeenOverride: PropTypes.string,
-};
-
-EntityTable.defaultProps = {
-  loaded: false,
-  showHealth: false,
-  expandable: false,
-  hasCheckbox: true,
-  showActions: false,
-  rows: [],
-  variant: TableVariant.compact,
-  onExpandClick: () => undefined,
-  tableProps: {},
 };
 
 export default EntityTable;


### PR DESCRIPTION
Move defaultProps to js default values.
Remove unecessary set of path.
Clean-up some old props.
Add required parameter to be passed from tests.