### PR TITLE
fix(RHINENG-19751) Disable global filter on workspaces

### DIFF
--- a/src/routes/InventoryGroups.js
+++ b/src/routes/InventoryGroups.js
@@ -11,10 +11,12 @@ import InventoryGroupsPopover from '../components/InventoryGroups/SmallComponent
 const Groups = () => {
   const chrome = useChrome();
 
+  /*eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
-    chrome?.hideGlobalFilter?.();
+    chrome?.hideGlobalFilter?.(true);
     chrome?.updateDocumentTitle?.(`Workspaces - Inventory`);
   }, []);
+  /*eslint-enable react-hooks/exhaustive-deps */
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Since workspaces doesn't use the global filter, we are disabling/removing the global filter from the Worspaces table page.

The card requests us to disable it, but we can only hide it with hideGlobalFilter, which removes it altogether.

## Summary by Sourcery

Hide the global filter on the Workspaces table page and disable the related lint rule for the effect hook

Bug Fixes:
- Disable the global filter on the Workspaces InventoryGroups page by passing a true flag to hideGlobalFilter

Enhancements:
- Suppress react-hooks/exhaustive-deps lint warning around the useEffect containing hideGlobalFilter