### PR TITLE
refactor(SystemsTable): Improve integrate-ability and customising

### DIFF
--- a/src/routes/Systems/components/SystemsTable/SystemsTable.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.js
@@ -1,162 +1,36 @@
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  TableToolsTable,
-  TableStateProvider,
-  useItemsData,
-  useFullTableState,
-  useStateCallbacks,
-} from 'bastilian-tabletools';
-import { fetchSystems, resolveColumns, resolveFilters } from '../../helpers.js';
-import { DEFAULT_OPTIONS } from './constants';
+import { TableToolsTable, TableStateProvider } from 'bastilian-tabletools';
+import { fetchSystems } from '../../helpers.js';
 import useGlobalFilterForItems from './hooks/useGlobalFilterForItems';
-import DeleteModal from '../../../../Utilities/DeleteModal';
-import useDeleteSystems from '../../hooks/useDeleteSystems';
-import useToolbarActions from '../../hooks/useToolbarActions';
-import AddSelectedHostsToGroupModal from '../../../../components/InventoryGroups/Modals/AddSelectedHostsToGroupModal';
-import RemoveHostsFromGroupModal from '../../../../components/InventoryGroups/Modals/RemoveHostsFromGroupModal';
-import useInventoryExport from '../../../../components/InventoryTable/hooks/useInventoryExport/useInventoryExport';
-import useTableActions from '../../hooks/useTableActions';
-import { TextInputModal } from '../../../../components/SystemDetails/GeneralInfo';
-import useEditDisplayName from '../../hooks/useEditDisplayName';
-import useFeatureFlag from '../../../../Utilities/useFeatureFlag';
+
+import { resolveColumns, resolveFilters, resolveOptions } from './helpers';
 
 const SystemsTable = ({
   items: itemsProp = fetchSystems,
-  columns = [],
+  columns,
   filters,
-  options = {},
+  options,
+  ...props
 }) => {
-  /*tabletools state*/
-  const { items: itemsData } = useItemsData();
-  const tableState = useFullTableState();
-  const { current: { reload, resetSelection } = {} } = useStateCallbacks();
-  const { tableState: { selected } = {} } = tableState || {};
-
-  /*hooks*/
   const items = useGlobalFilterForItems(itemsProp);
-  const exportConfig = useInventoryExport({
-    filters,
-  });
-
-  /*local state*/
-  const [removeHostsFromGroupModalOpen, setRemoveHostsFromGroupModalOpen] =
-    useState(false);
-  const [addHostGroupModalOpen, setAddHostGroupModalOpen] = useState(false);
-  const [currentSystem, setCurrentSystem] = useState({});
-  const [isRowAction, setIsRowAction] = useState(false);
-  const isKesselEnabled = useFeatureFlag('hbi.kessel-migration');
-
-  const reloadData = () => {
-    if (selectedItems.length > 0) {
-      resetSelection?.();
-      reload?.();
-    }
-  };
-
-  const selectedItems = useMemo(
-    () => itemsData?.filter(({ id }) => selected.includes(id)) || [],
-    [itemsData, selected],
-  );
-
-  const toolbarActions = useToolbarActions(
-    selectedItems,
-    setAddHostGroupModalOpen,
-    setRemoveHostsFromGroupModalOpen,
-    setIsRowAction,
-  );
-
-  const {
-    itemsToDelete,
-    onConfirm,
-    dedicatedAction,
-    isModalOpen,
-    handleModalToggle,
-  } = useDeleteSystems(
-    itemsData,
-    reload,
-    resetSelection,
-    isRowAction ? [currentSystem.id] : selected,
-    setIsRowAction,
-  );
-
-  const { editModalOpen, onEditModalOpen, onSubmit } = useEditDisplayName(
-    currentSystem,
-    reload,
-    resetSelection,
-  );
-
-  const tableActions = useTableActions(
-    setCurrentSystem,
-    onEditModalOpen,
-    handleModalToggle,
-    setRemoveHostsFromGroupModalOpen,
-    setAddHostGroupModalOpen,
-    isKesselEnabled,
-    setIsRowAction,
-  );
 
   return (
-    <>
-      {addHostGroupModalOpen && (
-        <AddSelectedHostsToGroupModal
-          isModalOpen={addHostGroupModalOpen}
-          setIsModalOpen={setAddHostGroupModalOpen}
-          modalState={isRowAction ? [currentSystem] : selectedItems}
-          reloadData={() => reloadData()}
-        />
-      )}
-      {removeHostsFromGroupModalOpen && (
-        <RemoveHostsFromGroupModal
-          isModalOpen={removeHostsFromGroupModalOpen}
-          setIsModalOpen={setRemoveHostsFromGroupModalOpen}
-          modalState={isRowAction ? [currentSystem] : selectedItems}
-          reloadData={() => reloadData()}
-        />
-      )}
-      {isModalOpen && (
-        <DeleteModal
-          className="sentry-mask data-hj-suppress"
-          handleModalToggle={handleModalToggle}
-          isModalOpen={isModalOpen}
-          currentSystems={isRowAction ? [currentSystem] : itemsToDelete}
-          onConfirm={onConfirm}
-        />
-      )}
-      {editModalOpen && (
-        <TextInputModal
-          title="Edit display name"
-          isOpen={editModalOpen}
-          value={currentSystem.display_name}
-          onCancel={() => onEditModalOpen(false)}
-          onSubmit={onSubmit}
-        />
-      )}
-      <TableToolsTable
-        variant="compact"
-        items={items}
-        columns={resolveColumns(columns)}
-        filters={resolveFilters(filters)}
-        options={{
-          ...DEFAULT_OPTIONS,
-          dedicatedAction,
-          actions: toolbarActions,
-          actionResolver: tableActions,
-          ...options,
-        }}
-        toolbarProps={{
-          exportConfig,
-        }}
-      />
-    </>
+    <TableToolsTable
+      items={items}
+      columns={resolveColumns(columns)}
+      filters={resolveFilters(filters)}
+      options={resolveOptions(options)}
+      {...props}
+    />
   );
 };
 
 SystemsTable.propTypes = {
   items: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
   columns: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
-  filters: PropTypes.object,
-  options: PropTypes.object,
+  filters: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
+  options: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
 };
 
 const SystemsTableWithProvider = (props) => (

--- a/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
+++ b/src/routes/Systems/components/SystemsTable/SystemsTable.test.js
@@ -3,6 +3,9 @@ import { render } from '@testing-library/react';
 import SystemsTable from './SystemsTable';
 import { TableToolsTable } from 'bastilian-tabletools';
 
+import defaultColumns from './columns';
+import defaultFilterTypes from './filterTypes';
+
 jest.mock('bastilian-tabletools', () => ({
   ...jest.requireActual('bastilian-tabletools'),
   TableToolsTable: jest.fn(() => (
@@ -21,11 +24,6 @@ jest.mock('bastilian-tabletools', () => ({
 jest.mock('../../../../Utilities/useFeatureFlag', () => ({
   __esModule: true,
   default: () => false,
-}));
-
-jest.mock('./hooks/useGlobalFilterForItems', () => ({
-  __esModule: true,
-  default: (itemsProp) => itemsProp,
 }));
 
 jest.mock('../../helpers.js', () => {
@@ -57,7 +55,7 @@ describe('SystemsTable', () => {
     render(<SystemsTable items={items} />);
     expect(TableToolsTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        items: items,
+        items,
       }),
       expect.anything(),
     );
@@ -75,11 +73,11 @@ describe('SystemsTable', () => {
     );
   });
 
-  it('should pass an empty array, when columns not provided', () => {
+  it('should pass default columns, when columns not provided', () => {
     render(<SystemsTable />);
     expect(TableToolsTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        columns: [],
+        columns: defaultColumns,
       }),
       expect.anything(),
     );
@@ -91,7 +89,7 @@ describe('SystemsTable', () => {
     render(<SystemsTable columns={columns} />);
     expect(TableToolsTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        columns: columns,
+        columns,
       }),
       expect.anything(),
     );
@@ -104,31 +102,37 @@ describe('SystemsTable', () => {
     render(<SystemsTable columns={columnsFn} />);
     expect(TableToolsTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        columns: columns,
+        columns,
       }),
       expect.anything(),
     );
   });
 
   it('should pass filters object', () => {
-    const filters = { filterConfig: [{}, {}, {}], customeFilterTypes: {} };
+    const filters = {
+      filterConfig: [{}, {}, {}],
+      customFilterTypes: defaultFilterTypes,
+    };
 
     render(<SystemsTable filters={filters} />);
     expect(TableToolsTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        filters: filters,
+        filters,
       }),
       expect.anything(),
     );
   });
 
   it('should pass filters object, when filters fn is received', () => {
-    const filters = { filterConfig: [{}, {}, {}], customeFilterTypes: {} };
+    const filters = {
+      filterConfig: [{}, {}, {}],
+      customFilterTypes: defaultFilterTypes,
+    };
 
     render(<SystemsTable filters={() => filters} />);
     expect(TableToolsTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        filters: filters,
+        filters,
       }),
       expect.anything(),
     );

--- a/src/routes/Systems/components/SystemsTable/columns.js
+++ b/src/routes/Systems/components/SystemsTable/columns.js
@@ -55,4 +55,9 @@ export const lastSeen = {
   transforms: [fitContent],
 };
 
+/**
+ *
+ * Default set of columns to show when no set of columns or customisation is provided
+ *
+ */
 export default [displayName, workspace, tags, operatingSystem, lastSeen];

--- a/src/routes/Systems/components/SystemsTable/constants.js
+++ b/src/routes/Systems/components/SystemsTable/constants.js
@@ -1,6 +1,17 @@
-export const DEFAULT_OPTIONS = {
-  perPage: 50,
-  onSelect: () => true,
-};
+// TODO Move serialisers.js within SystemsTable directory
+import {
+  filtersSerialiser,
+  sortSerialiser,
+  paginationSerialiser,
+} from '../../serialisers';
 
-export const MAX_PER_PAGE = 100;
+export const DEFAULT_OPTIONS = {
+  // FIXME: remove debug
+  debug: true,
+  perPage: 50,
+  serialisers: {
+    pagination: paginationSerialiser,
+    sort: sortSerialiser,
+    filters: filtersSerialiser,
+  },
+};

--- a/src/routes/Systems/components/SystemsTable/filterTypes.js
+++ b/src/routes/Systems/components/SystemsTable/filterTypes.js
@@ -1,0 +1,17 @@
+import Workspace from './components/filters/Workspace';
+
+export const workspace = {
+  Component: Workspace,
+  chips: (value) => [value],
+  selectValue: (value) => [value, true],
+  deselectValue: () => [undefined, true],
+};
+
+/**
+ *
+ * Default set of filter types to provide
+ *
+ */
+export default {
+  workspace,
+};

--- a/src/routes/Systems/components/SystemsTable/filters.js
+++ b/src/routes/Systems/components/SystemsTable/filters.js
@@ -1,4 +1,3 @@
-import Workspace from './components/filters/Workspace';
 import {
   fetchTags,
   getOsSelectOptions,
@@ -6,15 +5,6 @@ import {
   getWorkspaceSelectOptions,
 } from './helpers';
 import { getOperatingSystems } from '../../../../api';
-
-export const CUSTOM_FILTER_TYPES = {
-  workspace: {
-    Component: Workspace,
-    chips: (value) => [value],
-    selectValue: (value) => [value, true],
-    deselectValue: () => [undefined, true],
-  },
-};
 
 export const displayName = {
   type: 'text',
@@ -75,7 +65,7 @@ export const operatingSystem = {
   },
 };
 
-export const statusFilter = {
+export const status = {
   label: 'Status',
   type: 'checkbox',
   items: [
@@ -201,7 +191,7 @@ export const lastSeen = {
   },
 };
 
-export const workspaceFilter = {
+export const workspace = {
   label: 'Workspace',
   type: 'workspace',
   items: getWorkspaceSelectOptions,
@@ -210,4 +200,17 @@ export const workspaceFilter = {
   },
 };
 
-export default [displayName, statusFilter, tags, dataCollector, rhcStatus];
+/**
+ *
+ * Default set of filters to show when no set of filters or customisation is provided
+ *
+ */
+export default [
+  displayName,
+  status,
+  dataCollector,
+  rhcStatus,
+  tags,
+  systemType,
+  operatingSystem,
+];

--- a/src/routes/Systems/components/SystemsTable/helpers.js
+++ b/src/routes/Systems/components/SystemsTable/helpers.js
@@ -1,4 +1,43 @@
 import { getTags } from '../../../../api/hostInventoryApi';
+import { DEFAULT_OPTIONS } from './constants';
+
+import * as columns from './columns';
+import * as filters from './filters';
+import * as filterTypes from './filterTypes';
+
+const { default: defaultColumns, ...inventoryColumns } = columns;
+const { default: defaultFilters, ...inventoryFilters } = filters;
+const { default: defaultFilterTypes, ...inventoryFilterTypes } = filterTypes;
+
+export const resolveOptions = (options = DEFAULT_OPTIONS) =>
+  typeof options === 'function' ? options(DEFAULT_OPTIONS) : options;
+
+export const resolveColumns = (columns = defaultColumns) =>
+  typeof columns === 'function' ? columns(inventoryColumns) : columns;
+
+export const resolveFilters = (
+  filters = {
+    filterConfig: defaultFilters,
+    customFilterTypes: defaultFilterTypes,
+  },
+) => {
+  if (typeof filters === 'function') {
+    const { filterConfig, customFilterTypes } = filters(
+      inventoryFilters,
+      inventoryFilterTypes,
+    );
+
+    return {
+      filterConfig,
+      customFilterTypes: {
+        ...inventoryFilterTypes,
+        ...(customFilterTypes || {}),
+      },
+    };
+  } else {
+    return filters;
+  }
+};
 
 export const fetchTags = async () => {
   return await getTags();

--- a/src/routes/Systems/helpers.js
+++ b/src/routes/Systems/helpers.js
@@ -1,11 +1,7 @@
 // TODO remove dependency on fec helpers and components
 import { generateFilter } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { getHostList, getHostTags } from '../../api/hostInventoryApi';
-import defaultColumns from './components/SystemsTable/columns';
 import uniq from 'lodash/uniq';
-import defaultFilters, {
-  CUSTOM_FILTER_TYPES,
-} from './components/SystemsTable/filters';
 
 const fetchHostTags = async (hosts) => {
   if (hosts.length) {
@@ -68,25 +64,6 @@ export const fetchSystems = async (
   }));
 
   return [systems, total];
-};
-
-export const resolveColumns = (columns) => {
-  if (typeof columns === 'function') {
-    return columns(defaultColumns);
-  } else {
-    return columns;
-  }
-};
-
-export const resolveFilters = (filters) => {
-  if (typeof filters === 'function') {
-    return filters({
-      customFilterTypes: CUSTOM_FILTER_TYPES,
-      filterConfig: defaultFilters,
-    });
-  } else {
-    return filters;
-  }
 };
 
 export const isBulkAddHostsToGroupsEnabled = (


### PR DESCRIPTION
This refactor better separates the concerns of the `SystemsTable` and `Systems` component and improve the customisation and integrate-ability in apps. 

* It improves the customisability of columns, filters and options.
* Columns and filter customisation functions are now called with objects, instead of arrays
* Exports/imports of columns & filters, where the `default` export is meant as the default if no options or customisation is provided and the "rest" of the exports is the whole set of available inventory systems table columns or filters
* Filter types are in their own file to allow following a similar pattern as columns & filters
* Options can now also be customised via a function similar to filters & columns
* Remaining props are passed on to allow use of all `TableToolsTable` features for consumers
* It moves table features only for the Inventory Systems page from the `SystemsTable` to the `Systems` component
* It refactors the `Systems` component to be a proper "consumer" of the `SystemsTable`


## Summary by Sourcery

Refactor the Systems listing page to leverage bastilian-tabletools for unified state management, customizable columns/filters/options, and centralized action handling via hooks and providers.

Enhancements:
- Wrap Systems component in TableStateProvider and replace custom table state logic with useItemsData, useFullTableState, and useStateCallbacks.
- Convert SystemsTable into a stateless wrapper around TableToolsTable, using resolveColumns, resolveFilters, and resolveOptions helpers for dynamic configuration.
- Extract default columns, filters, filter types, and options into dedicated helpers/constants, removing inline serialisers and legacy resolver functions.
- Centralize all modals (add/remove hosts, delete, edit display name) in the Systems component and delegate action logic to custom hooks (useTableActions, useDeleteSystems, useEditDisplayName, useToolbarActions).

Tests:
- Adapt SystemsTable unit tests to validate new helper-based defaults and function-based APIs for columns, filters, and options.

## Summary by Sourcery

Refactor SystemsTable and Systems components to decouple concerns, integrate bastilian-tabletools for centralized state and actions, and enable dynamic customization of columns, filters, and options via helper functions and hooks.

New Features:
- Enable function-based customization for table columns, filters, and options with default and named exports of available configurations.

Enhancements:
- Wrap Systems component in TableStateProvider and replace internal table state logic with bastilian-tabletools hooks.
- Convert SystemsTable into a stateless wrapper around TableToolsTable and move default columns, filters, filter types, and options into dedicated helper files.
- Centralize modal and action handling in the Systems component using custom hooks (useTableActions, useDeleteSystems, useEditDisplayName, useToolbarActions).

Tests:
- Adapt SystemsTable unit tests to verify helper-based defaults and function API for columns, filters, and options.