### PR TITLE
fix(RHINENG-20205): delete custom staleness on reset

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -20,6 +20,7 @@ import {
   getHostSystemProfileById as apiGetHostSystemProfileById,
   getHostTags as apiGetHostTags,
   getStaleness as apiGetStaleness,
+  deleteStaleness as apiDeleteStaleness,
   getTags as apiGetTags,
   getOperatingSystem,
 } from './hostInventoryApi';
@@ -376,6 +377,10 @@ export const fetchDefaultStalenessValues = () => {
 
 export const fetchStalenessData = () => {
   return apiGetStaleness();
+};
+
+export const deleteStalenessData = () => {
+  return apiDeleteStaleness();
 };
 
 export const postStalenessData = (data) => {

--- a/src/api/hostInventoryApi.js
+++ b/src/api/hostInventoryApi.js
@@ -197,6 +197,9 @@ const updateStaleness = async ({
 const getStaleness = async ({ options: { axios, ...options } = {} } = {}) =>
   await hostInventoryApi(axios).apiStalenessGetStaleness({ options });
 
+const deleteStaleness = async ({ options: { axios, ...options } = {} } = {}) =>
+  await hostInventoryApi(axios).apiStalenessDeleteStaleness({ options });
+
 const patchHostById = async ({
   hostIdList,
   patchHostIn,
@@ -328,6 +331,7 @@ export {
   createStaleness,
   updateStaleness,
   getStaleness,
+  deleteStaleness,
   patchHostById,
   deleteHostById,
   getGroupList,

--- a/src/components/InventoryHostStaleness/StalenessSettings.js
+++ b/src/components/InventoryHostStaleness/StalenessSettings.js
@@ -20,6 +20,7 @@ const StalenessSettings = ({
   isFormValid,
   setIsFormValid,
   hostStalenessDefaults,
+  setIsResetToDefault,
 }) => {
   const dropdownArray = () => [
     systemStalenessItems(),
@@ -31,6 +32,7 @@ const StalenessSettings = ({
     const defaultsForSelectedTab = hostStalenessDefaults;
 
     setNewFormValues({ ...newFormValues, ...defaultsForSelectedTab });
+    setIsResetToDefault(true);
   };
 
   return (
@@ -85,14 +87,15 @@ const StalenessSettings = ({
 
 StalenessSettings.propTypes = {
   filter: PropTypes.object,
-  newFormValues: PropTypes.any,
-  setNewFormValues: PropTypes.any,
-  setFilter: PropTypes.any,
+  newFormValues: PropTypes.object,
+  setNewFormValues: PropTypes.func,
+  setFilter: PropTypes.func,
   activeTabKey: PropTypes.number,
   isEditing: PropTypes.bool,
-  isFormValid: PropTypes.any,
-  setIsFormValid: PropTypes.any,
+  isFormValid: PropTypes.bool,
+  setIsFormValid: PropTypes.func,
   defaultValues: PropTypes.object,
   hostStalenessDefaults: PropTypes.object,
+  setIsResetToDefault: PropTypes.func,
 };
 export default StalenessSettings;


### PR DESCRIPTION
When a customer resets its custom staleness & deletion to the default values, this change is saved as a 'custom' staleness & deletion record with the same values as 'default'.

This causes unnecessary computation and additional logs that could be avoided by simply removing the 'custom' staleness & deletion for this account and using default.

Steps to Reproduce
- Open the Staleness and Deletion screen where custom values are set
- Click on 'Reset to default setting' and Save

Actual Behavior
The custom staleness & deletion record for the account is updated with default values.

Expected Behavior
The custom staleness & deletion record for the account should be deleted.

## Summary by Sourcery

Use deleteStaleness endpoint to remove custom staleness records when resetting to defaults instead of updating them, and refactor staleness data fetching with useCallback for stable dependencies.

New Features:
- Delete custom staleness and deletion records when resetting settings to default values

Bug Fixes:
- Prevent saving redundant custom staleness records on reset to defaults

Enhancements:
- Refactor staleness fetching functions to use useCallback with dependency arrays
- Introduce isResetToDefault state to manage reset flow in HostStalenessCard
- Add deleteStaleness API endpoint to hostInventoryApi and export it in API.js
- Update prop types in StalenessSettings to include setIsResetToDefault callback