### PR TITLE
fix(RHINENG-22401): change page in Tags Modal on filter

### DIFF
--- a/src/Utilities/TagsModal.js
+++ b/src/Utilities/TagsModal.js
@@ -187,7 +187,11 @@ const TagsModal = ({
           filterValues: {
             value: filterBy,
             onChange: (_e, value) => {
-              debouncedFetch(pagination, value);
+              const nextPagination = {
+                ...(pagination || PAGINATION_DEFAULT),
+                page: 1,
+              };
+              debouncedFetch(nextPagination, value);
               setFilterBy(value);
             },
           },

--- a/src/Utilities/TagsModal.test.js
+++ b/src/Utilities/TagsModal.test.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import debounce from 'lodash/debounce';
 import React from 'react';
@@ -301,6 +301,66 @@ describe('TagsModal', () => {
       );
       const actions = store.getActions();
       expect(actions[0]).toMatchObject({ type: 'ALL_TAGS_PENDING' });
+    });
+
+    it('requests page 1 when the in-modal tag search filter changes', async () => {
+      jest.useFakeTimers();
+      const tagListResponse = {
+        results: [],
+        total: 0,
+        page: 1,
+        per_page: 10,
+      };
+      const getTags = jest.fn().mockResolvedValue(tagListResponse);
+      const store = mockStore({
+        entities: {
+          ...initialState.entities,
+          allTagsLoaded: true,
+          allTagsTotal: 50,
+          allTagsPagination: {
+            page: 4,
+            perPage: 10,
+          },
+          allTags: [
+            {
+              tags: [
+                {
+                  tag: {
+                    key: 'some',
+                    value: 'test',
+                    namespace: 'something',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      try {
+        render(
+          <Provider store={store}>
+            <TagsModal getTags={getTags} />
+          </Provider>,
+        );
+
+        getTags.mockClear();
+
+        const filterInput = screen.getByPlaceholderText('Filter tags');
+        fireEvent.change(filterInput, { target: { value: 'prod' } });
+
+        await act(async () => {
+          jest.advanceTimersByTime(800);
+        });
+
+        expect(getTags).toHaveBeenCalledTimes(1);
+        expect(getTags).toHaveBeenCalledWith(
+          'prod',
+          expect.objectContaining({ page: 1, perPage: 10 }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -422,7 +422,10 @@ const EntityTableToolbar = ({
 
   useEffect(() => {
     if (shouldReload && showTags && enabledFilters.tags) {
-      onSetFilter(mapGroups(selectedTags), 'tagFilters', debouncedRefresh);
+      // Use immediate refresh (not debouncedRefresh) so tag changes from the Tags modal
+      // apply with page 1; a shared debounced refresh can be superseded by another call
+      // and leave pagination on the previous page.
+      onSetFilter(mapGroups(selectedTags), 'tagFilters', updateData);
     }
   }, [selectedTags, enabledFilters.tags, showTags]);
 


### PR DESCRIPTION
## Jira
[RHINENG-22401](https://redhat.atlassian.net/browse/RHINENG-22401)

## What
Filtering by name on the System Tag modal is not behaving as expected. Things are fine when screen is on page 1, but filtering stops working on page 2.

When applying the Tags filter, it should put you back on page 1.

## Testing
- go to Inventory -> Systems.
- select Tags filter in the filter dropdown.
- scroll to the bottom of the the tags dropdown and select the link to view more tags. this should open the Tags Modal.
- change the pagination so you have at least 2 pages of tags.
- go to page 2.
- filter the table by a string that forces there to only be tags on page 1, but not page 2.

You'll notice that you get an empty state in error even there are tags in the table. This PR updates the page to page 1 whenever a filter is applied to the table.


[RHINENG-22401]: https://redhat.atlassian.net/browse/RHINENG-22401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure tag filtering in the Tags modal correctly resets to the first page and reliably applies tag changes to the inventory table.

Bug Fixes:
- Reset the Tags modal pagination to page 1 whenever the in-modal tag search filter changes so filtered results are visible from the first page.
- Use an immediate data refresh instead of a shared debounced refresh when applying tag filters from the Tags modal to avoid pagination staying on a previous page.

Tests:
- Add a test verifying that changing the in-modal tag search requests tags starting from page 1 with the current page size.