### PR TITLE
feat(RHINENG-24137): SystemsView: add OperatingSystemsFilter

### DIFF
--- a/src/components/SystemsView/DataViewFiltersContext.tsx
+++ b/src/components/SystemsView/DataViewFiltersContext.tsx
@@ -11,6 +11,7 @@ export const INITIAL_INVENTORY_FILTERS: InventoryFilters = {
   workspace: [],
   last_seen: undefined,
   tags: [],
+  operating_system: [],
 };
 
 export interface DataViewFiltersContextValue {

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -40,11 +40,6 @@ import { useDebouncedValue } from '../../Utilities/hooks/useDebouncedValue';
 import { INITIAL_PAGE, NO_HEADER } from '../InventoryViews/constants';
 import { PER_PAGE } from '../../constants';
 import { DEBOUNCE_TIMEOUT_MS } from '../../constants';
-import { useOperatingSystemsQuery } from './hooks/useOperatingSystemsQuery';
-import {
-  buildOperatingSystemSelectGroups,
-  mapOperatingSystemApiResultsToVersionRows,
-} from './utils/operatingSystemSelectOptions';
 
 export type SortDirection = ISortBy['direction'];
 export type SortBy = ApiOrderByEnum | undefined;
@@ -64,12 +59,6 @@ const SystemsViewInner = ({
   setSearchParams,
 }: SystemsViewInnerProps) => {
   const { filters, clearAllFilters } = useDataViewFiltersContext();
-
-  // TODO remove after implementing Operating Systems filter
-  // const { data: osData, total: osTotal } = useOperatingSystemsQuery();
-  // const osVersionRows = mapOperatingSystemApiResultsToVersionRows(osData);
-  // const osGroupItems = buildOperatingSystemSelectGroups(osVersionRows);
-  // console.log({ osData, osTotal, osVersionRows, osGroupItems });
 
   const debouncedName = useDebouncedValue(
     filters.hostname_or_id,

--- a/src/components/SystemsView/constants.ts
+++ b/src/components/SystemsView/constants.ts
@@ -1,0 +1,2 @@
+export const FILTER_DROPDOWN_WIDTH = '300px';
+export const LOADER_ID = 'loader';

--- a/src/components/SystemsView/filters/OperatingSystemsFilter.test.js
+++ b/src/components/SystemsView/filters/OperatingSystemsFilter.test.js
@@ -1,0 +1,200 @@
+/* eslint-disable react/prop-types -- test file; no PropTypes */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { useState } from 'react';
+import { OperatingSystemsFilter } from './OperatingSystemsFilter';
+import { useOperatingSystemsQuery } from '../hooks/useOperatingSystemsQuery';
+
+jest.mock('../hooks/useOperatingSystemsQuery', () => ({
+  useOperatingSystemsQuery: jest.fn(),
+}));
+
+/** Shape matches mapOperatingSystemApiResultsToVersionRows input; hook returns `data` as this array. */
+const rhel9Results = [
+  { value: { name: 'RHEL', major: 9, minor: 0 } },
+  { value: { name: 'RHEL', major: 9, minor: 1 } },
+];
+
+/** Order matches `osVersionSorter` within a major (higher minor first). */
+const GROUP_TOKENS = ['RHEL:9.1', 'RHEL:9.0'];
+
+function mockLoadedOperatingSystems(data = rhel9Results) {
+  useOperatingSystemsQuery.mockReturnValue({
+    data,
+    isLoading: false,
+    isError: false,
+    isFetched: true,
+  });
+}
+
+async function openOperatingSystemsMenu(
+  user,
+  placeholder = /filter by operating system/i,
+) {
+  await user.click(screen.getByRole('button', { name: placeholder }));
+}
+
+function ControlledOperatingSystemsFilter({
+  initialValue = [],
+  onChange,
+  ...rest
+}) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <OperatingSystemsFilter
+      {...rest}
+      value={value}
+      onChange={(event, next) => {
+        onChange?.(event, next);
+        setValue(Array.isArray(next) ? next : []);
+      }}
+    />
+  );
+}
+
+describe('OperatingSystemsFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the toggle and lists RHEL major group and versions after open', async () => {
+    mockLoadedOperatingSystems();
+    const user = userEvent.setup();
+    render(<OperatingSystemsFilter />);
+    await openOperatingSystemsMenu(user);
+    expect(
+      screen.getByRole('checkbox', { name: /^RHEL 9$/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'RHEL 9.0' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'RHEL 9.1' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a loading spinner while operating systems are loading', async () => {
+    useOperatingSystemsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      isFetched: false,
+    });
+    const user = userEvent.setup();
+    render(<OperatingSystemsFilter />);
+    await openOperatingSystemsMenu(user);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the query fails', async () => {
+    useOperatingSystemsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      isFetched: true,
+    });
+    const user = userEvent.setup();
+    render(<OperatingSystemsFilter />);
+    await openOperatingSystemsMenu(user);
+    expect(
+      screen.getByRole('option', { name: /unable to load operating systems/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows "No versions available" when fetch completed with no rows', async () => {
+    useOperatingSystemsQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      isFetched: true,
+    });
+    const user = userEvent.setup();
+    render(<OperatingSystemsFilter />);
+    await openOperatingSystemsMenu(user);
+    expect(screen.getByText('No versions available')).toBeInTheDocument();
+  });
+
+  it('selects all nested versions when group checkbox is clicked and none were selected', async () => {
+    mockLoadedOperatingSystems();
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<OperatingSystemsFilter value={[]} onChange={onChange} />);
+    await openOperatingSystemsMenu(user);
+    await user.click(screen.getByRole('checkbox', { name: /^RHEL 9$/ }));
+    expect(onChange).toHaveBeenCalledWith(undefined, GROUP_TOKENS);
+  });
+
+  it('clears all nested versions when group checkbox is clicked while indeterminate', async () => {
+    mockLoadedOperatingSystems();
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<OperatingSystemsFilter value={['RHEL:9.0']} onChange={onChange} />);
+    await openOperatingSystemsMenu(user);
+    await user.click(screen.getByRole('checkbox', { name: /^RHEL 9$/ }));
+    expect(onChange).toHaveBeenCalledWith(undefined, []);
+  });
+
+  it('clears the group when fully selected and group checkbox is unchecked', async () => {
+    mockLoadedOperatingSystems();
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(
+      <OperatingSystemsFilter value={[...GROUP_TOKENS]} onChange={onChange} />,
+    );
+    await openOperatingSystemsMenu(user);
+    await user.click(screen.getByRole('checkbox', { name: /^RHEL 9$/ }));
+    expect(onChange).toHaveBeenCalledWith(undefined, []);
+  });
+
+  it('when one version is toggled on from empty selection, group becomes indeterminate', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    try {
+      mockLoadedOperatingSystems();
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      render(
+        <ControlledOperatingSystemsFilter
+          initialValue={[]}
+          onChange={onChange}
+        />,
+      );
+      await openOperatingSystemsMenu(user);
+      await user.click(screen.getByRole('checkbox', { name: 'RHEL 9.0' }));
+      expect(onChange).toHaveBeenCalledWith(undefined, ['RHEL:9.0']);
+      const groupInput = screen.getByRole('checkbox', { name: /^RHEL 9$/ });
+      expect(groupInput).toHaveProperty('indeterminate', true);
+      expect(screen.getByRole('checkbox', { name: 'RHEL 9.0' })).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'RHEL 9.1' }),
+      ).not.toBeChecked();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('when the second version is selected, the group checkbox is fully checked', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    try {
+      mockLoadedOperatingSystems();
+      const user = userEvent.setup();
+      render(<ControlledOperatingSystemsFilter initialValue={['RHEL:9.0']} />);
+      await openOperatingSystemsMenu(user);
+      expect(screen.getByRole('checkbox', { name: /^RHEL 9$/ })).toHaveProperty(
+        'indeterminate',
+        true,
+      );
+      await user.click(screen.getByRole('checkbox', { name: 'RHEL 9.1' }));
+      const groupInput = screen.getByRole('checkbox', { name: /^RHEL 9$/ });
+      expect(groupInput).toBeChecked();
+      expect(groupInput).toHaveProperty('indeterminate', false);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
+++ b/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
@@ -14,8 +14,8 @@ import xor from 'lodash/xor';
 import { useOperatingSystemsQuery } from '../hooks/useOperatingSystemsQuery';
 import {
   buildOperatingSystemSelectGroups,
+  buildOsFilterTokens,
   mapOperatingSystemApiResultsToVersionRows,
-  type OperatingSystemSelectGroup,
 } from '../utils/operatingSystemSelectOptions';
 import { FILTER_DROPDOWN_WIDTH } from '../constants';
 
@@ -24,9 +24,6 @@ interface OperatingSystemsFilterProps {
   value?: string[];
   onChange?: (event?: React.MouseEvent, values?: string[]) => void;
 }
-
-const groupTokens = (group: OperatingSystemSelectGroup): string[] =>
-  group.items.map((item) => `${group.value}:${item.value}`);
 
 /* PF MenuItem doesn't support indeterminate checkbox state,
  so we've re-created custom OsFilterOption which does */
@@ -94,11 +91,8 @@ export const OperatingSystemsFilter = ({
     </MenuToggle>
   );
 
-  const notifyChange = (
-    event: React.FormEvent<HTMLInputElement>,
-    next: string[],
-  ) => {
-    onChange?.(event as unknown as React.MouseEvent, next);
+  const notifyChange = (next: string[]) => {
+    onChange?.(undefined, next);
   };
 
   return (
@@ -130,7 +124,7 @@ export const OperatingSystemsFilter = ({
         {!isLoading &&
           !isError &&
           groups.map((group, groupIndex) => {
-            const tokens = groupTokens(group);
+            const tokens = buildOsFilterTokens(group);
             const selectedCount = tokens.filter((t) =>
               value.includes(t),
             ).length;
@@ -149,22 +143,19 @@ export const OperatingSystemsFilter = ({
                   id={`${idPrefix}-major-${groupIndex}`}
                   text={group.label}
                   isChecked={majorChecked}
-                  onCheckboxChange={(event, checked) => {
+                  onCheckboxChange={(_event, checked) => {
                     if (!tokens.length) {
                       return;
                     }
                     // if indeterminate, we clear the group instead
                     if (someSelected) {
-                      notifyChange(
-                        event,
-                        value.filter((t) => !tokens.includes(t)),
-                      );
+                      notifyChange(value.filter((t) => !tokens.includes(t)));
                       return;
                     }
                     const next = checked
                       ? [...new Set([...value, ...tokens])]
                       : value.filter((t) => !tokens.includes(t));
-                    notifyChange(event, next);
+                    notifyChange(next);
                   }}
                 />
                 {group.items.map((item, itemIndex) => {
@@ -176,8 +167,8 @@ export const OperatingSystemsFilter = ({
                       text={item.label}
                       isChecked={value.includes(token)}
                       listItemClassName="pf-v6-u-pl-lg"
-                      onCheckboxChange={(event) => {
-                        notifyChange(event, xor(value, [token]));
+                      onCheckboxChange={() => {
+                        notifyChange(xor(value, [token]));
                       }}
                     />
                   );

--- a/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
+++ b/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
@@ -1,0 +1,156 @@
+import React, { Ref, useMemo, useState } from 'react';
+import {
+  MenuToggle,
+  Select,
+  SelectList,
+  SelectOption,
+  Spinner,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import xor from 'lodash/xor';
+import { useOperatingSystemsQuery } from '../hooks/useOperatingSystemsQuery';
+import {
+  buildOperatingSystemSelectGroups,
+  mapOperatingSystemApiResultsToVersionRows,
+  type OperatingSystemSelectGroup,
+} from '../utils/operatingSystemSelectOptions';
+
+const MAJOR_TOKEN_PREFIX = '__major__|';
+const FILTER_DROPDOWN_WIDTH = '300px';
+
+interface OperatingSystemsFilterProps {
+  placeholder?: string;
+  value?: string[];
+  onChange?: (event?: React.MouseEvent, values?: string[]) => void;
+}
+
+const majorSelectValue = (group: OperatingSystemSelectGroup) =>
+  `${MAJOR_TOKEN_PREFIX}${group.label}`;
+
+const groupTokens = (group: OperatingSystemSelectGroup): string[] =>
+  group.items.map((item) => `${group.value}:${item.value}`);
+
+export const OperatingSystemsFilter = ({
+  placeholder,
+  value = [],
+  onChange,
+}: OperatingSystemsFilterProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { data, isLoading, isError, isFetched } = useOperatingSystemsQuery({
+    enabled: isOpen,
+  });
+
+  const groups = useMemo(() => {
+    const rows = mapOperatingSystemApiResultsToVersionRows(data);
+    return buildOperatingSystemSelectGroups(rows);
+  }, [data]);
+
+  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen(!isOpen)}
+      isExpanded={isOpen}
+    >
+      {placeholder ?? 'Filter by operating system'}
+    </MenuToggle>
+  );
+
+  const onSelect = (
+    _event: React.MouseEvent | undefined,
+    selected: string | number | undefined,
+  ) => {
+    if (selected === undefined) {
+      return;
+    }
+    const selectedStr = String(selected);
+    if (selectedStr.startsWith(MAJOR_TOKEN_PREFIX)) {
+      const label = selectedStr.slice(MAJOR_TOKEN_PREFIX.length);
+      const group = groups.find((g) => g.label === label);
+      if (!group) {
+        return;
+      }
+      const tokens = groupTokens(group);
+      if (!tokens.length) {
+        return;
+      }
+      const allSelected = tokens.every((t) => value.includes(t));
+      const next = allSelected
+        ? value.filter((t) => !tokens.includes(t))
+        : [...new Set([...value, ...tokens])];
+      onChange?.(_event, next);
+      return;
+    }
+    onChange?.(_event, xor(value, [selectedStr]));
+  };
+
+  return (
+    <Select
+      id="operating-systems-filter-select"
+      isOpen={isOpen}
+      selected={value}
+      onSelect={onSelect}
+      onOpenChange={(open) => setIsOpen(open)}
+      toggle={toggle}
+      isScrollable
+      popperProps={{
+        width: FILTER_DROPDOWN_WIDTH,
+      }}
+    >
+      <SelectList isAriaMultiselectable>
+        {isLoading && (
+          <SelectOption isLoading>
+            <Spinner size="lg" />
+          </SelectOption>
+        )}
+        {isError && !isLoading && (
+          <SelectOption isDisabled>
+            Unable to load operating systems
+          </SelectOption>
+        )}
+        {!isLoading && !isError && isFetched && groups.length === 0 && (
+          <SelectOption isDisabled>No versions available</SelectOption>
+        )}
+        {!isLoading &&
+          !isError &&
+          groups.map((group) => {
+            const tokens = groupTokens(group);
+            const selectedCount = tokens.filter((t) =>
+              value.includes(t),
+            ).length;
+            const allSelected =
+              tokens.length > 0 && selectedCount === tokens.length;
+            const someSelected = selectedCount > 0 && !allSelected;
+
+            return (
+              <React.Fragment key={group.label}>
+                <SelectOption
+                  value={majorSelectValue(group)}
+                  hasCheckbox
+                  isSelected={allSelected}
+                  {...(someSelected ? { isIndeterminate: true } : {})}
+                >
+                  {group.label}
+                </SelectOption>
+                {group.items.map((item) => {
+                  const token = `${group.value}:${item.value}`;
+                  return (
+                    <SelectOption
+                      key={token}
+                      value={token}
+                      hasCheckbox
+                      isSelected={value.includes(token)}
+                      className="pf-v6-u-pl-lg"
+                    >
+                      {item.label}
+                    </SelectOption>
+                  );
+                })}
+              </React.Fragment>
+            );
+          })}
+      </SelectList>
+    </Select>
+  );
+};
+
+export default OperatingSystemsFilter;

--- a/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
+++ b/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
@@ -1,5 +1,6 @@
-import React, { Ref, useMemo, useState } from 'react';
+import React, { Ref, useId, useMemo, useState } from 'react';
 import {
+  Checkbox,
   MenuToggle,
   Select,
   SelectList,
@@ -7,6 +8,8 @@ import {
   Spinner,
   MenuToggleElement,
 } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import menuStyles from '@patternfly/react-styles/css/components/Menu/menu';
 import xor from 'lodash/xor';
 import { useOperatingSystemsQuery } from '../hooks/useOperatingSystemsQuery';
 import {
@@ -14,9 +17,7 @@ import {
   mapOperatingSystemApiResultsToVersionRows,
   type OperatingSystemSelectGroup,
 } from '../utils/operatingSystemSelectOptions';
-
-const MAJOR_TOKEN_PREFIX = '__major__|';
-const FILTER_DROPDOWN_WIDTH = '300px';
+import { FILTER_DROPDOWN_WIDTH } from '../constants';
 
 interface OperatingSystemsFilterProps {
   placeholder?: string;
@@ -24,17 +25,55 @@ interface OperatingSystemsFilterProps {
   onChange?: (event?: React.MouseEvent, values?: string[]) => void;
 }
 
-const majorSelectValue = (group: OperatingSystemSelectGroup) =>
-  `${MAJOR_TOKEN_PREFIX}${group.label}`;
-
 const groupTokens = (group: OperatingSystemSelectGroup): string[] =>
   group.items.map((item) => `${group.value}:${item.value}`);
+
+/* PF MenuItem doesn't support indeterminate checkbox state,
+ so we've re-created custom OsFilterOption which does */
+const OsFilterOption = ({
+  id,
+  text,
+  isChecked,
+  onCheckboxChange,
+  listItemClassName,
+}: {
+  id: string;
+  text: string;
+  isChecked: boolean | null;
+  onCheckboxChange: (
+    event: React.FormEvent<HTMLInputElement>,
+    checked: boolean,
+  ) => void;
+  listItemClassName?: string;
+}) => (
+  <li
+    className={css(menuStyles.menuListItem, listItemClassName)}
+    role="option"
+    aria-selected={isChecked === true}
+  >
+    <label className={css(menuStyles.menuItem)} htmlFor={id} tabIndex={-1}>
+      <span className={css(menuStyles.menuItemMain)}>
+        <span className={css(menuStyles.menuItemCheck)}>
+          <Checkbox
+            id={id}
+            component="span"
+            isChecked={isChecked}
+            onChange={onCheckboxChange}
+            aria-label={text}
+          />
+        </span>
+        <span className={css(menuStyles.menuItemText)}>{text}</span>
+      </span>
+    </label>
+  </li>
+);
 
 export const OperatingSystemsFilter = ({
   placeholder,
   value = [],
   onChange,
 }: OperatingSystemsFilterProps) => {
+  const idPrefix = useId();
   const [isOpen, setIsOpen] = useState(false);
   const { data, isLoading, isError, isFetched } = useOperatingSystemsQuery({
     enabled: isOpen,
@@ -55,32 +94,11 @@ export const OperatingSystemsFilter = ({
     </MenuToggle>
   );
 
-  const onSelect = (
-    _event: React.MouseEvent | undefined,
-    selected: string | number | undefined,
+  const notifyChange = (
+    event: React.FormEvent<HTMLInputElement>,
+    next: string[],
   ) => {
-    if (selected === undefined) {
-      return;
-    }
-    const selectedStr = String(selected);
-    if (selectedStr.startsWith(MAJOR_TOKEN_PREFIX)) {
-      const label = selectedStr.slice(MAJOR_TOKEN_PREFIX.length);
-      const group = groups.find((g) => g.label === label);
-      if (!group) {
-        return;
-      }
-      const tokens = groupTokens(group);
-      if (!tokens.length) {
-        return;
-      }
-      const allSelected = tokens.every((t) => value.includes(t));
-      const next = allSelected
-        ? value.filter((t) => !tokens.includes(t))
-        : [...new Set([...value, ...tokens])];
-      onChange?.(_event, next);
-      return;
-    }
-    onChange?.(_event, xor(value, [selectedStr]));
+    onChange?.(event as unknown as React.MouseEvent, next);
   };
 
   return (
@@ -88,7 +106,6 @@ export const OperatingSystemsFilter = ({
       id="operating-systems-filter-select"
       isOpen={isOpen}
       selected={value}
-      onSelect={onSelect}
       onOpenChange={(open) => setIsOpen(open)}
       toggle={toggle}
       isScrollable
@@ -112,7 +129,7 @@ export const OperatingSystemsFilter = ({
         )}
         {!isLoading &&
           !isError &&
-          groups.map((group) => {
+          groups.map((group, groupIndex) => {
             const tokens = groupTokens(group);
             const selectedCount = tokens.filter((t) =>
               value.includes(t),
@@ -120,29 +137,49 @@ export const OperatingSystemsFilter = ({
             const allSelected =
               tokens.length > 0 && selectedCount === tokens.length;
             const someSelected = selectedCount > 0 && !allSelected;
+            const majorChecked: boolean | null = allSelected
+              ? true
+              : someSelected
+                ? null
+                : false;
 
             return (
               <React.Fragment key={group.label}>
-                <SelectOption
-                  value={majorSelectValue(group)}
-                  hasCheckbox
-                  isSelected={allSelected}
-                  {...(someSelected ? { isIndeterminate: true } : {})}
-                >
-                  {group.label}
-                </SelectOption>
-                {group.items.map((item) => {
+                <OsFilterOption
+                  id={`${idPrefix}-major-${groupIndex}`}
+                  text={group.label}
+                  isChecked={majorChecked}
+                  onCheckboxChange={(event, checked) => {
+                    if (!tokens.length) {
+                      return;
+                    }
+                    // if indeterminate, we clear the group instead
+                    if (someSelected) {
+                      notifyChange(
+                        event,
+                        value.filter((t) => !tokens.includes(t)),
+                      );
+                      return;
+                    }
+                    const next = checked
+                      ? [...new Set([...value, ...tokens])]
+                      : value.filter((t) => !tokens.includes(t));
+                    notifyChange(event, next);
+                  }}
+                />
+                {group.items.map((item, itemIndex) => {
                   const token = `${group.value}:${item.value}`;
                   return (
-                    <SelectOption
+                    <OsFilterOption
                       key={token}
-                      value={token}
-                      hasCheckbox
-                      isSelected={value.includes(token)}
-                      className="pf-v6-u-pl-lg"
-                    >
-                      {item.label}
-                    </SelectOption>
+                      id={`${idPrefix}-g${groupIndex}-i${itemIndex}`}
+                      text={item.label}
+                      isChecked={value.includes(token)}
+                      listItemClassName="pf-v6-u-pl-lg"
+                      onCheckboxChange={(event) => {
+                        notifyChange(event, xor(value, [token]));
+                      }}
+                    />
                   );
                 })}
               </React.Fragment>

--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  DataViewCheckboxFilter,
-  useDataViewPagination,
-} from '@patternfly/react-data-view';
+import { DataViewCheckboxFilter } from '@patternfly/react-data-view';
 import DataViewFilters from '@patternfly/react-data-view/dist/cjs/DataViewFilters';
 import {
   ApiHostGetHostListRegisteredWithEnum,
@@ -13,6 +10,7 @@ import WorkspaceFilter from './WorkspaceFilter';
 import DataViewTextFilterWithChipTitle from './DataViewTextFilterWithChipTitle';
 import LastSeenFilter, { LastSeenFilterItem } from './LastSeenFilter';
 import TagsFilter from './TagsFilter';
+import OperatingSystemsFilter from './OperatingSystemsFilter';
 import { ToolbarLabel } from '@patternfly/react-core';
 import LastSeenFilterExtension from './LastSeenFilterExtension';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
@@ -28,6 +26,8 @@ export interface InventoryFilters {
   system_type: string[];
   workspace: string[];
   tags: string[];
+  /** Selected OS minors as `${osName}:${major.minor}` (e.g. `RHEL:9.0`) */
+  operating_system: string[];
   last_seen?: LastSeenFilterItem;
 }
 
@@ -106,6 +106,28 @@ export const SystemsViewFilters = ({ pagination }: SystemsViewFiltersProps) => {
             { label: 'Package-based system', value: 'conventional' },
             { label: 'Image-based system', value: 'image' },
           ]}
+        />
+        <DataViewCustomFilter
+          filterId="operating_system"
+          title="Operating system"
+          placeholder="Filter by operating system"
+          ouiaId="SystemsViewOperatingSystemsFilter"
+          filterComponent={OperatingSystemsFilter}
+          createLabel={(value, title) =>
+            value?.map((item: string) => ({
+              key: title,
+              node: item.replace(':', ' '),
+            })) ?? []
+          }
+          deleteLabel={(_category, label, value, onChange) => {
+            const chipText = isToolbarLabel(label)
+              ? String(label.node)
+              : String(label);
+            onChange?.(
+              undefined,
+              value?.filter((item) => item.replace(':', ' ') !== chipText),
+            );
+          }}
         />
         <DataViewCustomFilter
           filterId="workspace"

--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -69,6 +69,28 @@ export const SystemsViewFilters = ({ pagination }: SystemsViewFiltersProps) => {
             { label: 'Stale warning', value: 'stale_warning' },
           ]}
         />
+        <DataViewCustomFilter
+          filterId="operating_system"
+          title="Operating system"
+          placeholder="Filter by operating system"
+          ouiaId="SystemsViewOperatingSystemsFilter"
+          filterComponent={OperatingSystemsFilter}
+          createLabel={(value, title) =>
+            value?.map((item: string) => ({
+              key: title,
+              node: item.replace(':', ' '),
+            })) ?? []
+          }
+          deleteLabel={(_category, label, value, onChange) => {
+            const chipText = isToolbarLabel(label)
+              ? String(label.node)
+              : String(label);
+            onChange?.(
+              undefined,
+              value?.filter((item) => item.replace(':', ' ') !== chipText),
+            );
+          }}
+        />
         <DataViewCheckboxFilter
           filterId="source"
           title="Data Collector"
@@ -106,28 +128,6 @@ export const SystemsViewFilters = ({ pagination }: SystemsViewFiltersProps) => {
             { label: 'Package-based system', value: 'conventional' },
             { label: 'Image-based system', value: 'image' },
           ]}
-        />
-        <DataViewCustomFilter
-          filterId="operating_system"
-          title="Operating system"
-          placeholder="Filter by operating system"
-          ouiaId="SystemsViewOperatingSystemsFilter"
-          filterComponent={OperatingSystemsFilter}
-          createLabel={(value, title) =>
-            value?.map((item: string) => ({
-              key: title,
-              node: item.replace(':', ' '),
-            })) ?? []
-          }
-          deleteLabel={(_category, label, value, onChange) => {
-            const chipText = isToolbarLabel(label)
-              ? String(label.node)
-              : String(label);
-            onChange?.(
-              undefined,
-              value?.filter((item) => item.replace(':', ' ') !== chipText),
-            );
-          }}
         />
         <DataViewCustomFilter
           filterId="workspace"

--- a/src/components/SystemsView/filters/TagsFilter.tsx
+++ b/src/components/SystemsView/filters/TagsFilter.tsx
@@ -20,9 +20,7 @@ import { useDebouncedValue } from '../../../Utilities/hooks/useDebouncedValue';
 import { useSystemActionModalsContext } from '../SystemActionModalsContext';
 import { useTagsQuery } from '../hooks/useTagsQuery';
 import { DEBOUNCE_TIMEOUT_MS, PER_PAGE } from '../../../constants';
-
-const LOADER_ID = 'loader';
-const FILTER_DROPDOWN_WIDTH = '300px';
+import { FILTER_DROPDOWN_WIDTH, LOADER_ID } from '../constants';
 
 interface TagsFilterProps {
   placeholder?: string;

--- a/src/components/SystemsView/hooks/useOperatingSystemsQuery.ts
+++ b/src/components/SystemsView/hooks/useOperatingSystemsQuery.ts
@@ -8,7 +8,7 @@ interface UseOperatingSystemsQueryParams {
 export const useOperatingSystemsQuery = ({
   enabled = true,
 }: UseOperatingSystemsQueryParams = {}) => {
-  const { data, isLoading, isFetching, isError, error } = useQuery({
+  const { data, isLoading, isFetching, isError, error, isFetched } = useQuery({
     queryKey: ['operatingSystems'],
     queryFn: async () => await getOperatingSystems(),
     refetchOnWindowFocus: false,
@@ -22,5 +22,6 @@ export const useOperatingSystemsQuery = ({
     isFetching,
     isError,
     error,
+    isFetched,
   };
 };

--- a/src/components/SystemsView/hooks/useSystemsQuery.ts
+++ b/src/components/SystemsView/hooks/useSystemsQuery.ts
@@ -8,6 +8,7 @@ import {
 import qs from 'qs';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import { SortDirection } from '../SystemsView';
+import { buildOperatingSystemProfileFilter } from '../utils/operatingSystemSelectOptions';
 
 const serializeSystemType = (values: string[]) => {
   const validValues = Object.values(ApiHostGetHostListSystemTypeEnum);
@@ -37,6 +38,19 @@ const fetchSystems = async ({
   sortBy,
   direction,
 }: FetchSystemsParams) => {
+  const operatingSystemFilter = buildOperatingSystemProfileFilter(
+    filters.operating_system,
+  );
+
+  const systemProfileFilter: Record<string, unknown> = {
+    ...(filters?.rhcStatus?.length && {
+      rhc_client_id: filters.rhcStatus,
+    }),
+    ...(operatingSystemFilter && { operating_system: operatingSystemFilter }),
+  };
+
+  const hasSystemProfileFilter = Object.keys(systemProfileFilter).length > 0;
+
   const params: ApiHostGetHostListParams = {
     page,
     perPage,
@@ -70,11 +84,9 @@ const fetchSystems = async ({
             'host_type',
           ],
         },
-        ...(filters?.rhcStatus && {
+        ...(hasSystemProfileFilter && {
           filter: {
-            system_profile: {
-              rhc_client_id: filters.rhcStatus,
-            },
+            system_profile: systemProfileFilter,
           },
         }),
       },

--- a/src/components/SystemsView/utils/operatingSystemSelectOptions.test.ts
+++ b/src/components/SystemsView/utils/operatingSystemSelectOptions.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@jest/globals';
 import '@testing-library/jest-dom';
 import type { OperatingSystemVersionRow } from './operatingSystemSelectOptions';
 import {
+  buildOperatingSystemProfileFilter,
   getOsSelectOptions,
   mapOperatingSystemApiResultsToVersionRows,
   osVersionSorter,
@@ -44,6 +45,35 @@ describe('osVersionSorter', () => {
     expect(
       [a, b, c].sort(osVersionSorter).map((x) => `${x.major}.${x.minor}`),
     ).toEqual(['9.0', '8.10', '8.4']);
+  });
+});
+
+describe('buildOperatingSystemProfileFilter', () => {
+  it('returns undefined for empty or undefined input', () => {
+    expect(buildOperatingSystemProfileFilter(undefined)).toBeUndefined();
+    expect(buildOperatingSystemProfileFilter([])).toBeUndefined();
+  });
+
+  it('groups tokens by OS name and dedupes versions', () => {
+    expect(
+      buildOperatingSystemProfileFilter([
+        'RHEL:9.0',
+        'RHEL:8.4',
+        'RHEL:9.0',
+        'CentOS Linux:7.9',
+      ]),
+    ).toEqual({
+      RHEL: { version: { eq: ['9.0', '8.4'] } },
+      'CentOS Linux': { version: { eq: ['7.9'] } },
+    });
+  });
+
+  it('skips malformed tokens', () => {
+    expect(
+      buildOperatingSystemProfileFilter(['nocolon', ':onlyversion', 'OK:1.0']),
+    ).toEqual({
+      OK: { version: { eq: ['1.0'] } },
+    });
   });
 });
 

--- a/src/components/SystemsView/utils/operatingSystemSelectOptions.ts
+++ b/src/components/SystemsView/utils/operatingSystemSelectOptions.ts
@@ -23,10 +23,26 @@ export type OperatingSystemProfileFilter = Record<
   { version: { eq: string[] } }
 >;
 
+export const toOsToken = (os: string, version: string) => `${os}:${version}`;
+export const fromOsToken = (token: string) => {
+  const [os, version] = token.split(':', 2);
+  return { os, version };
+};
+
+/**
+ * Maps one `OperatingSystemSelectGroup` to `${osName}:${major.minor}` tokens stored in toolbar filter state.
+ *
+ *  @param group - One major-version group from the OS filter (`value` is the OS name; each item is `major.minor`)
+ *  @returns     Token strings such as `RHEL:9.0`, one per item in the group
+ */
+export const buildOsFilterTokens = (
+  group: OperatingSystemSelectGroup,
+): string[] => group.items.map((item) => toOsToken(group.value, item.value));
+
 /**
  * Maps `${osName}:${major.minor}` tokens to `filter.system_profile.operating_system` for the host list API.
  *
- *  @param tokens - Toolbar selections (e.g. `RHEL:9.0`), or undefined
+ *  @param tokens - Toolbar Filter selection (e.g. `RHEL:9.0`), or undefined
  *  @returns      Profile Filter or undefined when there is nothing to filter
  */
 export const buildOperatingSystemProfileFilter = (
@@ -37,25 +53,19 @@ export const buildOperatingSystemProfileFilter = (
   }
 
   const byOs: Record<string, string[]> = {};
-
   for (const token of tokens) {
-    const index = token.indexOf(':');
-    if (index === -1) {
+    const { os, version } = fromOsToken(token);
+    if (!os || !version) {
       continue;
     }
-    const osName = token.slice(0, index);
-    const version = token.slice(index + 1);
-    if (!osName || !version) {
-      continue;
+    if (!byOs[os]) {
+      byOs[os] = [];
     }
-    if (!byOs[osName]) {
-      byOs[osName] = [];
-    }
-    byOs[osName].push(version);
+    byOs[os].push(version);
   }
 
-  const entries = Object.entries(byOs).map(([osName, versions]) => [
-    osName,
+  const entries = Object.entries(byOs).map(([os, versions]) => [
+    os,
     { version: { eq: [...new Set(versions)] } },
   ]);
 

--- a/src/components/SystemsView/utils/operatingSystemSelectOptions.ts
+++ b/src/components/SystemsView/utils/operatingSystemSelectOptions.ts
@@ -17,6 +17,55 @@ export interface OperatingSystemSelectGroup {
   items: OperatingSystemSelectItem[];
 }
 
+/** Nested `filter.system_profile.operating_system` fragment for host list API */
+export type OperatingSystemProfileFilter = Record<
+  string,
+  { version: { eq: string[] } }
+>;
+
+/**
+ * Maps `${osName}:${major.minor}` tokens to `filter.system_profile.operating_system` for the host list API.
+ *
+ *  @param tokens - Toolbar selections (e.g. `RHEL:9.0`), or undefined
+ *  @returns      Profile Filter or undefined when there is nothing to filter
+ */
+export const buildOperatingSystemProfileFilter = (
+  tokens: string[] | undefined,
+): OperatingSystemProfileFilter | undefined => {
+  if (!tokens?.length) {
+    return undefined;
+  }
+
+  const byOs: Record<string, string[]> = {};
+
+  for (const token of tokens) {
+    const index = token.indexOf(':');
+    if (index === -1) {
+      continue;
+    }
+    const osName = token.slice(0, index);
+    const version = token.slice(index + 1);
+    if (!osName || !version) {
+      continue;
+    }
+    if (!byOs[osName]) {
+      byOs[osName] = [];
+    }
+    byOs[osName].push(version);
+  }
+
+  const entries = Object.entries(byOs).map(([osName, versions]) => [
+    osName,
+    { version: { eq: [...new Set(versions)] } },
+  ]);
+
+  if (!entries.length) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+};
+
 export const mapOperatingSystemApiResultsToVersionRows = (
   results: SystemProfileOperatingSystemOut['results'] | undefined,
 ): OperatingSystemVersionRow[] => {


### PR DESCRIPTION
## Jira
Implements RHINENG-24137

## What
Adds Operating Systems filter to SystemsView. It supports the bulkSelection for group items so be sure to test that. I thinkg I got it right but considering current version in InventoryTable doesn't work quite well its hard to say. 

## How
We created brand new filter component which is based on custom MenuItem, the PF SelectOption and MenuItem components couldn't be used for items as they don't support indeterminate (dash) state of checkbox

## Testing
1. enable SystemsView by running localStorage.setItem("ui-inventory-views", "true")
2. go to Inventory / Systems
3. Select Operating Systems from filters dropdown
4. try stuff

!!!Beware sync of set filters to/from URL params currently doesn't work in SystemsView its a new bug which needs to be investigated

## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->

## Summary by Sourcery

Add an Operating Systems filter to SystemsView and wire it into the systems query via system profile filters.

New Features:
- Introduce an Operating Systems multiselect filter component with support for grouped major/minor versions and indeterminate group selection.
- Expose an operating_system field in SystemsView filters and map selected values into the host list system_profile.operating_system API filter.

Enhancements:
- Refine operating systems data fetching hook to expose fetch state needed by the new filter UI.
- Centralize shared SystemsView UI constants for filter dropdown sizing and loader identifiers.

Tests:
- Add unit tests for transforming selected OS tokens into the system profile operating_system filter structure used by the API.

## Summary by Sourcery

Add an operating system multiselect filter to SystemsView and wire its selections into the host list system profile query.

New Features:
- Introduce an OperatingSystemsFilter component that fetches OS version data and provides grouped, indeterminate-checkbox multiselect UI for major and minor versions.
- Expose an operating_system field in SystemsView filters and surface it through the filters toolbar.

Enhancements:
- Convert selected OS tokens into the system_profile.operating_system filter shape for the host list API and merge it with existing system profile filters.
- Refine the operating systems query hook to expose fetch state flags used by the new filter UI and centralize shared SystemsView UI constants.

Tests:
- Extend operating system select options tests to cover building the system profile filter from selected OS tokens.