### PR TITLE
feat(SystemViews): Add Workload filter

### DIFF
--- a/src/components/SystemsView/DataViewFiltersContext.tsx
+++ b/src/components/SystemsView/DataViewFiltersContext.tsx
@@ -12,6 +12,7 @@ export const INITIAL_INVENTORY_FILTERS: InventoryFilters = {
   last_seen: undefined,
   tags: [],
   operating_system: [],
+  workloads: [],
 };
 
 export interface DataViewFiltersContextValue {

--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -15,6 +15,7 @@ import { ToolbarLabel } from '@patternfly/react-core';
 import LastSeenFilterExtension from './LastSeenFilterExtension';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { useDataViewFiltersContext } from '../DataViewFiltersContext';
+import { WORKLOAD_FILTER_OPTIONS } from '../utils/workloadsFilter';
 
 export interface InventoryFilters {
   hostname_or_id: string;
@@ -24,8 +25,8 @@ export interface InventoryFilters {
   system_type: string[];
   workspace: string[];
   tags: string[];
-  /** Selected OS minors as `${osName}:${major.minor}` (e.g. `RHEL:9.0`) */
   operating_system: string[];
+  workloads: string[];
   last_seen?: LastSeenFilterItem;
 }
 
@@ -206,6 +207,12 @@ export const SystemsViewFilters = () => {
             );
           }}
           isMultiGroup={true}
+        />
+        <DataViewCheckboxFilter
+          filterId="workloads"
+          title="Workload"
+          placeholder="Filter by workload"
+          options={[...WORKLOAD_FILTER_OPTIONS]}
         />
       </DataViewFilters>
       <LastSeenFilterExtension

--- a/src/components/SystemsView/hooks/useSystemsQuery.ts
+++ b/src/components/SystemsView/hooks/useSystemsQuery.ts
@@ -9,6 +9,7 @@ import qs from 'qs';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import { SortDirection } from '../SystemsView';
 import { buildOperatingSystemProfileFilter } from '../utils/operatingSystemSelectOptions';
+import { buildWorkloadsFilter } from '../utils/workloadsFilter';
 
 const serializeSystemType = (values: string[]) => {
   const validValues = Object.values(ApiHostGetHostListSystemTypeEnum);
@@ -41,12 +42,14 @@ const fetchSystems = async ({
   const operatingSystemFilter = buildOperatingSystemProfileFilter(
     filters.operating_system,
   );
+  const workloadsFilter = buildWorkloadsFilter(filters.workloads);
 
   const systemProfileFilter: Record<string, unknown> = {
     ...(filters?.rhcStatus?.length && {
       rhc_client_id: filters.rhcStatus,
     }),
     ...(operatingSystemFilter && { operating_system: operatingSystemFilter }),
+    ...(workloadsFilter && { workloads: workloadsFilter }),
   };
 
   const hasSystemProfileFilter = Object.keys(systemProfileFilter).length > 0;

--- a/src/components/SystemsView/utils/workloadsFilter.test.ts
+++ b/src/components/SystemsView/utils/workloadsFilter.test.ts
@@ -16,11 +16,6 @@ describe('buildWorkloadsFilter', () => {
     expect(buildWorkloadsFilter([])).toBeUndefined();
   });
 
-  it('maps each selected key to { is: not_nil } (presence on system_profile.workloads.<key>)', () => {
-    const keys = ['ansible', 'oracle_db', 'ibm_db2'];
-    expect(buildWorkloadsFilter(keys)).toEqual(presenceFilterForKeys(keys));
-  });
-
   it('when every toolbar workload is selected, includes one not_nil entry per known workload key', () => {
     const allKeys = WORKLOAD_FILTER_OPTIONS.map((o) => o.value);
     expect(buildWorkloadsFilter([...allKeys])).toEqual(

--- a/src/components/SystemsView/utils/workloadsFilter.test.ts
+++ b/src/components/SystemsView/utils/workloadsFilter.test.ts
@@ -1,0 +1,35 @@
+import { expect } from '@jest/globals';
+import {
+  buildWorkloadsFilter,
+  WORKLOAD_FILTER_OPTIONS,
+} from './workloadsFilter';
+
+const NOT_NIL = { is: 'not_nil' as const };
+
+function presenceFilterForKeys(keys: string[]) {
+  return Object.fromEntries(keys.map((key) => [key, NOT_NIL]));
+}
+
+describe('buildWorkloadsFilter', () => {
+  it('returns undefined for empty or undefined input', () => {
+    expect(buildWorkloadsFilter(undefined)).toBeUndefined();
+    expect(buildWorkloadsFilter([])).toBeUndefined();
+  });
+
+  it('maps each selected key to { is: not_nil } (presence on system_profile.workloads.<key>)', () => {
+    const keys = ['ansible', 'oracle_db', 'ibm_db2'];
+    expect(buildWorkloadsFilter(keys)).toEqual(presenceFilterForKeys(keys));
+  });
+
+  it('when every toolbar workload is selected, includes one not_nil entry per known workload key', () => {
+    const allKeys = WORKLOAD_FILTER_OPTIONS.map((o) => o.value);
+    expect(buildWorkloadsFilter([...allKeys])).toEqual(
+      presenceFilterForKeys([...allKeys]),
+    );
+  });
+
+  it('preserves selection order in the filter object key order', () => {
+    const keys = ['sap', 'ansible', 'mssql'];
+    expect(Object.keys(buildWorkloadsFilter(keys)!)).toEqual(keys);
+  });
+});

--- a/src/components/SystemsView/utils/workloadsFilter.ts
+++ b/src/components/SystemsView/utils/workloadsFilter.ts
@@ -1,0 +1,43 @@
+/**
+ * Toolbar workload filter options. `value` is the key under `system_profile.workloads`
+ * (see system_profile.spec.yaml → SystemProfile.properties.workloads.properties).
+ */
+export const WORKLOAD_FILTER_OPTIONS = [
+  { label: 'Ansible Automation Platform', value: 'ansible' },
+  { label: 'CrowdStrike', value: 'crowdstrike' },
+  { label: 'IBM DB2', value: 'ibm_db2' },
+  { label: 'InterSystems', value: 'intersystems' },
+  { label: 'Microsoft SQL', value: 'mssql' },
+  { label: 'Oracle DB', value: 'oracle_db' },
+  { label: 'RHEL AI', value: 'rhel_ai' },
+  { label: 'SAP', value: 'sap' },
+] as const;
+
+/**
+ * Nested `filter.system_profile.workloads` fragment for host list API.
+ * Each key represents a workload name (e.g., 'sap', 'ansible') and uses a
+ * presence check to filter hosts.
+ */
+export type WorkloadsPresenceFilter = Record<string, { is: 'not_nil' }>;
+
+/**
+ * Maps Workload checkbox values to `filter.system_profile.workloads` for the host list API.
+ *
+ * Each selected workload is sent as a presence check on that key. The backend
+ * treats these as `not_nil` checks on the workload JSON object.
+ * Query shape: `filter[system_profile][workloads][sap][is]=not_nil`
+ *
+ *  @param workloadKeys - Workload names from the toolbar filter state (e.g. `['sap', 'ansible']`)
+ *  @returns            Profile Filter or undefined when there is nothing to filter
+ */
+export const buildWorkloadsFilter = (
+  workloadKeys: string[] | undefined,
+): WorkloadsPresenceFilter | undefined => {
+  if (!workloadKeys?.length) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    workloadKeys.map((key) => [key, { is: 'not_nil' as const }]),
+  );
+};


### PR DESCRIPTION
## Jira
[RHINENG-25379](https://redhat.atlassian.net/browse/RHINENG-25379)

## What
New Workload filter
depends on https://github.com/RedHatInsights/insights-host-inventory/pull/3839

## Why
to support use cases currently relying on the Global Filter, ahead of its decommissioning.

## How
<!-- Brief explanation of approach -->

## Testing

1. enable SystemsView by running localStorage.setItem("ui-inventory-views", "true")
2. go to Inventory / Systems
3. Select Workload from filters dropdown
4. try stuff (for example after filtering by SAP check system details Workload filed)

## Screenshots/Videos (if applicable)
<img width="1501" height="596" alt="image" src="https://github.com/user-attachments/assets/8bbeb39e-2c53-43e5-9dd1-e754361dd204" />
<img width="1023" height="838" alt="image" src="https://github.com/user-attachments/assets/7d237766-4c5e-4044-9a2b-df8a47b71a01" />


## Summary by Sourcery

Add workload-based filtering to SystemsView and wire it into the systems query.

New Features:
- Introduce a Workload checkbox filter in SystemsView for selecting systems by workloads such as Ansible, SAP, and databases.

Enhancements:
- Extend the systems query to translate selected workloads into system_profile.workloads presence filters for the host list API.

Tests:
- Add unit tests for the workloads filter utility to validate mapping logic, handling of empty input, and key order preservation.

[RHINENG-25379]: https://redhat.atlassian.net/browse/RHINENG-25379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ