### PR TITLE
fix(RHINENG-25669): SystemsView: value Ungroupped hosts is not being displayed in chip label

### DIFF
--- a/src/components/SystemsView/filters/WorkspaceFilter.test.js
+++ b/src/components/SystemsView/filters/WorkspaceFilter.test.js
@@ -1,0 +1,182 @@
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { WorkspaceFilter, UNGROUPED_ID } from './WorkspaceFilter';
+import {
+  makePage,
+  mockGroupsInfiniteQuery,
+  useInfiniteQuery,
+} from './__fixtures__/testHelpers';
+
+jest.mock('../../../constants', () => ({
+  ...jest.requireActual('../../../constants'),
+  DEBOUNCE_TIMEOUT_MS: 0,
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useInfiniteQuery: jest.fn(),
+}));
+
+const WORKSPACE_FILTER_PLACEHOLDER = 'Filter by workspace';
+
+function renderWorkspaceFilter(props = {}) {
+  return render(
+    <WorkspaceFilter placeholder={WORKSPACE_FILTER_PLACEHOLDER} {...props} />,
+  );
+}
+
+async function openWorkspaceMenu(user) {
+  await user.click(screen.getByPlaceholderText(WORKSPACE_FILTER_PLACEHOLDER));
+}
+
+describe('WorkspaceFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the workspace filter', () => {
+    mockGroupsInfiniteQuery({ isPending: true });
+    renderWorkspaceFilter();
+    expect(
+      screen.getByRole('textbox', { name: /type to filter/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(WORKSPACE_FILTER_PLACEHOLDER),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a loading option while groups are pending', async () => {
+    mockGroupsInfiniteQuery({ isPending: true });
+    const user = userEvent.setup();
+    renderWorkspaceFilter();
+    await openWorkspaceMenu(user);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('shows Ungrouped hosts when API returns no groups and user is not searching', async () => {
+    mockGroupsInfiniteQuery({
+      pages: [makePage([])],
+      isPending: false,
+    });
+    const user = userEvent.setup();
+    renderWorkspaceFilter();
+    await openWorkspaceMenu(user);
+    expect(screen.getByText(UNGROUPED_ID)).toBeInTheDocument();
+    expect(
+      screen.queryByText('No workspaces available'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows "No workspaces available" when search has no matches', async () => {
+    useInfiniteQuery.mockImplementation(({ queryKey }) => {
+      const debouncedSearch = queryKey[1] ?? '';
+      const empty = [makePage([], { total: 0 })];
+      const withGroup = [makePage([{ name: 'Workspace 1', host_count: 1 }])];
+      return {
+        data: {
+          pages: debouncedSearch ? empty : withGroup,
+          pageParams: [1],
+        },
+        fetchNextPage: jest.fn().mockResolvedValue(undefined),
+        hasNextPage: false,
+        isFetching: false,
+        isPending: false,
+      };
+    });
+
+    const user = userEvent.setup();
+    renderWorkspaceFilter();
+    await openWorkspaceMenu(user);
+    expect(screen.getByText('Workspace 1')).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText(WORKSPACE_FILTER_PLACEHOLDER);
+    await user.type(input, 'nomatch');
+
+    expect(
+      await screen.findByText('No workspaces available'),
+    ).toBeInTheDocument();
+  });
+
+  it('lists workspace names and host counts after open', async () => {
+    mockGroupsInfiniteQuery({
+      pages: [
+        makePage([
+          { name: 'Alpha', host_count: 10 },
+          { name: 'Beta', host_count: 2 },
+        ]),
+      ],
+    });
+    const user = userEvent.setup();
+    renderWorkspaceFilter();
+    await openWorkspaceMenu(user);
+    expect(screen.getByText(UNGROUPED_ID)).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('shows an em dash in the badge when host_count is not a number', async () => {
+    mockGroupsInfiniteQuery({
+      pages: [makePage([{ name: 'Gamma', host_count: undefined }])],
+    });
+    const user = userEvent.setup();
+    renderWorkspaceFilter();
+    await openWorkspaceMenu(user);
+    expect(screen.getByText('Gamma')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('calls onChange with the selected workspace when an option is chosen', async () => {
+    mockGroupsInfiniteQuery({
+      pages: [makePage([{ name: 'Workspace 1', host_count: 1 }])],
+    });
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    renderWorkspaceFilter({ onChange, value: [] });
+    await openWorkspaceMenu(user);
+    const row = screen.getByRole('menuitem', { name: /Workspace 1/i });
+    await user.click(within(row).getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalled();
+    const last = onChange.mock.calls.at(-1);
+    expect(last[1]).toEqual(['Workspace 1']);
+  });
+
+  it('toggles off a selected workspace when its checkbox is clicked again', async () => {
+    mockGroupsInfiniteQuery({
+      pages: [makePage([{ name: 'Workspace 1', host_count: 1 }])],
+    });
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    renderWorkspaceFilter({ onChange, value: ['Workspace 1'] });
+    await openWorkspaceMenu(user);
+    const row = screen.getByRole('menuitem', { name: /Workspace 1/i });
+    await user.click(within(row).getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalled();
+    const last = onChange.mock.calls.at(-1);
+    expect(last[1]).toEqual([]);
+  });
+
+  it('calls fetchNextPage when Show more is clicked', async () => {
+    const { fetchNextPage } = mockGroupsInfiniteQuery({
+      pages: [
+        makePage(
+          Array.from({ length: 50 }, (_, i) => ({
+            name: `WS-${i}`,
+            host_count: 1,
+          })),
+          { total: 100 },
+        ),
+      ],
+      hasNextPage: true,
+      isFetching: false,
+    });
+    const user = userEvent.setup();
+    renderWorkspaceFilter();
+    await openWorkspaceMenu(user);
+    await user.click(screen.getByText('Show more'));
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+});

--- a/src/components/SystemsView/filters/WorkspaceFilter.tsx
+++ b/src/components/SystemsView/filters/WorkspaceFilter.tsx
@@ -32,6 +32,8 @@ interface WorkspaceFilterProps {
   onChange?: (event?: React.MouseEvent, values?: string[]) => void;
 }
 
+export const UNGROUPED_ID = 'Ungrouped hosts';
+
 export const WorkspaceFilter = ({
   placeholder,
   value = [],
@@ -41,7 +43,6 @@ export const WorkspaceFilter = ({
   const INITIAL_VISIBLE_SIZE = PAGE_SIZE;
   const VIEW_MORE_SIZE = PAGE_SIZE;
   const LOADER_ID = 'loader';
-  const UNGROUPED_ID = 'Ungrouped hosts';
   const hasAccess = true;
 
   const [isOpen, setIsOpen] = useState(false);

--- a/src/components/SystemsView/filters/WorkspaceFilter.tsx
+++ b/src/components/SystemsView/filters/WorkspaceFilter.tsx
@@ -41,7 +41,7 @@ export const WorkspaceFilter = ({
   const INITIAL_VISIBLE_SIZE = PAGE_SIZE;
   const VIEW_MORE_SIZE = PAGE_SIZE;
   const LOADER_ID = 'loader';
-  // TODO plug in access control solution
+  const UNGROUPED_ID = 'Ungrouped hosts';
   const hasAccess = true;
 
   const [isOpen, setIsOpen] = useState(false);
@@ -91,7 +91,9 @@ export const WorkspaceFilter = ({
       }));
 
     return [
-      ...(debouncedSearch ? [] : [{ itemId: '', children: 'Ungrouped hosts' }]),
+      ...(debouncedSearch
+        ? []
+        : [{ itemId: UNGROUPED_ID, children: UNGROUPED_ID }]),
       ...items,
     ];
   }, [data, debouncedSearch]);
@@ -208,7 +210,7 @@ export const WorkspaceFilter = ({
                       hasCheckbox={true}
                       {...option}
                     />
-                    {option.itemId === '' && <Divider />}
+                    {option.itemId === UNGROUPED_ID && <Divider />}
                   </Fragment>
                 );
               })}

--- a/src/components/SystemsView/filters/__fixtures__/testHelpers.js
+++ b/src/components/SystemsView/filters/__fixtures__/testHelpers.js
@@ -1,0 +1,37 @@
+const { useInfiniteQuery } = require('@tanstack/react-query');
+
+export { useInfiniteQuery };
+
+export function makePage(results, { page = 1, perPage = 50, total } = {}) {
+  const resolvedTotal = total ?? results.length;
+  return {
+    results,
+    page,
+    per_page: perPage,
+    total: resolvedTotal,
+  };
+}
+
+export function mockGroupsInfiniteQuery(overrides = {}) {
+  const fetchNextPage = jest.fn().mockResolvedValue(undefined);
+  const {
+    pages = [makePage([{ name: 'Workspace 1', host_count: 3 }])],
+    isPending = false,
+    isFetching = false,
+    hasNextPage = false,
+    ...rest
+  } = overrides;
+
+  useInfiniteQuery.mockReturnValue({
+    data: isPending
+      ? undefined
+      : { pages, pageParams: pages.map((_, i) => i + 1) },
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isPending,
+    ...rest,
+  });
+
+  return { fetchNextPage };
+}


### PR DESCRIPTION
## Jira
Implements RHINENG-25669

## What
Fixes a bug in SystemsView: when "Ungrouped hosts" wouldn't show in chip label in SystemsView.

## Testing
Adds basic unit test coverage for Workspace filter.

Verify "Ungrouped hosts" is being shown as chip label when selected.

## Screenshots/Videos (if applicable)
<img width="1462" height="409" alt="image" src="https://github.com/user-attachments/assets/c6f10ef5-bc49-419a-ac24-ddbfd5e8b7be" />

## Summary by Sourcery

Fix WorkspaceFilter so the Ungrouped hosts option is handled as a proper selectable value and appears correctly in the SystemsView chip label.

Bug Fixes:
- Ensure the Ungrouped hosts workspace option has a stable identifier so it is rendered and selectable in the SystemsView filter and chip label.

Enhancements:
- Introduce shared test helpers for mocking workspace groups infinite query responses in WorkspaceFilter tests.

Tests:
- Add unit tests for WorkspaceFilter covering loading state, Ungrouped hosts visibility, search behavior, selection toggling, host count display, and pagination via Show more.