### PR TITLE
fix(RHINENG-25691): SystemsView: filter change isn't being reflected in url params

### DIFF
--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -37,6 +37,7 @@ import {
   useDataViewFiltersContext,
 } from './DataViewFiltersContext';
 import { useDebouncedValue } from '../../Utilities/hooks/useDebouncedValue';
+import { useResetPage } from './hooks/useResetPage';
 import { INITIAL_PAGE, NO_HEADER } from '../InventoryViews/constants';
 import { PER_PAGE } from '../../constants';
 import { DEBOUNCE_TIMEOUT_MS } from '../../constants';
@@ -60,6 +61,15 @@ const SystemsViewInner = ({
 }: SystemsViewInnerProps) => {
   const { filters, clearAllFilters } = useDataViewFiltersContext();
 
+  const pagination = useDataViewPagination({
+    perPage: PER_PAGE,
+    page: INITIAL_PAGE,
+    searchParams,
+    setSearchParams,
+  });
+
+  useResetPage(filters, pagination);
+
   const debouncedName = useDebouncedValue(
     filters.hostname_or_id,
     DEBOUNCE_TIMEOUT_MS,
@@ -71,13 +81,6 @@ const SystemsViewInner = ({
     }),
     [filters, debouncedName],
   );
-
-  const pagination = useDataViewPagination({
-    perPage: PER_PAGE,
-    page: INITIAL_PAGE,
-    searchParams,
-    setSearchParams,
-  });
 
   const selection = useDataViewSelection({
     matchOption: (a, b) => a.id === b.id,
@@ -159,7 +162,7 @@ const SystemsViewInner = ({
                   onSelect={onBulkSelect}
                 />
               }
-              filters={<SystemsViewFilters pagination={pagination} />}
+              filters={<SystemsViewFilters />}
               actions={
                 <SystemsViewBulkActions
                   selectedSystems={selectedSystems}

--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -15,8 +15,6 @@ import { ToolbarLabel } from '@patternfly/react-core';
 import LastSeenFilterExtension from './LastSeenFilterExtension';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { useDataViewFiltersContext } from '../DataViewFiltersContext';
-import { INITIAL_PAGE } from '../../InventoryViews/constants';
-import type { Pagination } from '../SystemsView';
 
 export interface InventoryFilters {
   hostname_or_id: string;
@@ -35,11 +33,7 @@ export const isToolbarLabel = (
   label: string | ToolbarLabel,
 ): label is ToolbarLabel => typeof label === 'object' && 'key' in label;
 
-interface SystemsViewFiltersProps {
-  pagination: Pagination;
-}
-
-export const SystemsViewFilters = ({ pagination }: SystemsViewFiltersProps) => {
+export const SystemsViewFilters = () => {
   const { filters, onSetFilters } = useDataViewFiltersContext();
   const isHideRHCFilterFlagEnabled = useFeatureFlag('hbi.ui.hide_rhc_filter');
 
@@ -49,7 +43,6 @@ export const SystemsViewFilters = ({ pagination }: SystemsViewFiltersProps) => {
       <DataViewFilters
         onChange={(_, values) => {
           onSetFilters(values);
-          pagination.onSetPage(undefined, INITIAL_PAGE);
         }}
         values={filters}
       >

--- a/src/components/SystemsView/hooks/useResetPage.test.tsx
+++ b/src/components/SystemsView/hooks/useResetPage.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useDataViewPagination } from '@patternfly/react-data-view';
+import { INITIAL_PAGE } from '../../InventoryViews/constants';
+import { INITIAL_INVENTORY_FILTERS } from '../DataViewFiltersContext';
+import { useResetPage } from './useResetPage';
+import { jest, expect } from '@jest/globals';
+import '@testing-library/jest-dom';
+
+type DataViewPagination = ReturnType<typeof useDataViewPagination>;
+
+const paginationStub = (onSetPage: jest.Mock): DataViewPagination =>
+  ({ onSetPage }) as unknown as DataViewPagination;
+
+describe('useResetPage (SystemsView pagination reset on filter change)', () => {
+  it('does not reset page on initial render', async () => {
+    const onSetPage = jest.fn();
+
+    renderHook(() =>
+      useResetPage(INITIAL_INVENTORY_FILTERS, paginationStub(onSetPage)),
+    );
+
+    await waitFor(() => {
+      expect(onSetPage).not.toHaveBeenCalled();
+    });
+  });
+
+  it('resets page when filters change after initial render', async () => {
+    const onSetPage = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ filters }) => useResetPage(filters, paginationStub(onSetPage)),
+      {
+        initialProps: {
+          filters: INITIAL_INVENTORY_FILTERS,
+        },
+      },
+    );
+
+    rerender({
+      filters: { ...INITIAL_INVENTORY_FILTERS, status: ['fresh'] },
+    });
+
+    await waitFor(() => {
+      expect(onSetPage).toHaveBeenCalledTimes(1);
+    });
+    expect(onSetPage).toHaveBeenCalledWith(undefined, INITIAL_PAGE);
+  });
+});

--- a/src/components/SystemsView/hooks/useResetPage.ts
+++ b/src/components/SystemsView/hooks/useResetPage.ts
@@ -1,5 +1,6 @@
 import { useDataViewPagination } from '@patternfly/react-data-view';
 import { useEffect, useMemo, useRef } from 'react';
+import type { InventoryFilters } from '../filters/SystemsViewFilters';
 import { INITIAL_PAGE } from '../../InventoryViews/constants';
 
 type DataViewPagination = ReturnType<typeof useDataViewPagination>;
@@ -13,7 +14,7 @@ type DataViewPagination = ReturnType<typeof useDataViewPagination>;
  *  @param pagination - Return value of `useDataViewPagination`.
  */
 export const useResetPage = (
-  filters: unknown,
+  filters: InventoryFilters,
   pagination: DataViewPagination,
 ) => {
   /* `pagination.onSetPage` is a new function each render;

--- a/src/components/SystemsView/hooks/useResetPage.ts
+++ b/src/components/SystemsView/hooks/useResetPage.ts
@@ -1,0 +1,34 @@
+import { useDataViewPagination } from '@patternfly/react-data-view';
+import { useEffect, useMemo, useRef } from 'react';
+import { INITIAL_PAGE } from '../../InventoryViews/constants';
+
+type DataViewPagination = ReturnType<typeof useDataViewPagination>;
+
+/**
+ * Resets DataView pagination to the first page whenever `filters` meaningfully
+ * change, after the initial mount. Runs in an effect so URL updates from the
+ * filter hook and pagination hook do not race in the same event handler.
+ *
+ *  @param filters    - Filter state; compared via JSON serialization between runs.
+ *  @param pagination - Return value of `useDataViewPagination`.
+ */
+export const useResetPage = (
+  filters: unknown,
+  pagination: DataViewPagination,
+) => {
+  /* `pagination.onSetPage` is a new function each render;
+  The ref holds the latest version so we can use it in Effect. */
+  const onSetPageRef = useRef(pagination.onSetPage);
+  onSetPageRef.current = pagination.onSetPage;
+
+  const filtersSignature = useMemo(() => JSON.stringify(filters), [filters]);
+  const isInitialRun = useRef(true);
+
+  useEffect(() => {
+    if (isInitialRun.current) {
+      isInitialRun.current = false;
+      return;
+    }
+    onSetPageRef.current(undefined, INITIAL_PAGE);
+  }, [filtersSignature]);
+};


### PR DESCRIPTION
## Jira
Fixes RHINENG-25691

## What
This fixes a race condition in updating URL params via setSearchParams. When it happens old snapshot of url params overwrites new changes coming from filter change 
I've also added unit tests for new useResetPage which does the reseting.

## How
I fixed it by reseting page via Effect after component renders with help of new useResetPage hook 

## Testing
Make sure you that paginating forward and applying filters both is reflected in URL params.

## Summary by Sourcery

Reset SystemsView pagination on filter changes via a dedicated hook to ensure URL query params stay in sync without race conditions.

Bug Fixes:
- Ensure SystemsView URL query params correctly reflect pagination and filter changes by resetting pagination after filter updates instead of in the filter change handler.

Enhancements:
- Introduce a reusable useResetPage hook that resets DataView pagination to the first page when filters change after initial render.
- Decouple SystemsViewFilters from pagination by removing direct pagination manipulation from the filter component.

Tests:
- Add unit tests for the useResetPage hook to verify it skips the initial render and resets the page on subsequent filter changes.