### PR TITLE
fix(RHINENG-25727): SystemsView: URL params for filters aren't same as legacy ones

### DIFF
--- a/src/components/SystemsView/DataViewFiltersContext.tsx
+++ b/src/components/SystemsView/DataViewFiltersContext.tsx
@@ -1,6 +1,19 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useDataViewFilters } from '@patternfly/react-data-view';
 import type { InventoryFilters } from './filters/SystemsViewFilters';
+import { normalizeLastSeenFilterValue } from './constants';
+
+export type LastSeenCustomRange = {
+  start?: string;
+  end?: string;
+} | null;
 
 export const INITIAL_INVENTORY_FILTERS: InventoryFilters = {
   hostname_or_id: '',
@@ -9,7 +22,7 @@ export const INITIAL_INVENTORY_FILTERS: InventoryFilters = {
   rhcStatus: [],
   system_type: [],
   group_name: [],
-  last_seen: undefined,
+  last_seen: '',
   tags: [],
   operating_system: [],
   workloads: [],
@@ -19,6 +32,10 @@ export interface DataViewFiltersContextValue {
   filters: InventoryFilters;
   onSetFilters: (_: Partial<InventoryFilters>) => void;
   clearAllFilters: () => void;
+  lastSeenCustomRange: LastSeenCustomRange;
+  setLastSeenCustomRange: React.Dispatch<
+    React.SetStateAction<LastSeenCustomRange>
+  >;
 }
 
 const DataViewFiltersContext =
@@ -52,20 +69,53 @@ export const DataViewFiltersProvider = ({
   searchParams,
   setSearchParams,
 }: DataViewFiltersProviderProps) => {
-  const { filters, onSetFilters, clearAllFilters } =
-    useDataViewFilters<InventoryFilters>({
-      initialFilters: INITIAL_INVENTORY_FILTERS,
-      searchParams,
-      setSearchParams,
-    });
+  const [lastSeenCustomRange, setLastSeenCustomRange] =
+    useState<LastSeenCustomRange>(null);
+
+  const {
+    filters: rawFilters,
+    onSetFilters,
+    clearAllFilters: hookClearAll,
+  } = useDataViewFilters<InventoryFilters>({
+    initialFilters: INITIAL_INVENTORY_FILTERS,
+    searchParams,
+    setSearchParams,
+  });
+
+  const filters = useMemo(
+    () => ({
+      ...rawFilters,
+      last_seen: normalizeLastSeenFilterValue(rawFilters.last_seen),
+    }),
+    [rawFilters],
+  );
+
+  useEffect(() => {
+    if (normalizeLastSeenFilterValue(rawFilters.last_seen) !== 'custom') {
+      setLastSeenCustomRange(null);
+    }
+  }, [rawFilters.last_seen]);
+
+  const clearAllFilters = useCallback(() => {
+    setLastSeenCustomRange(null);
+    hookClearAll();
+  }, [hookClearAll]);
 
   const value = useMemo(
     () => ({
       filters,
       onSetFilters,
       clearAllFilters,
+      lastSeenCustomRange,
+      setLastSeenCustomRange,
     }),
-    [filters, onSetFilters, clearAllFilters],
+    [
+      filters,
+      onSetFilters,
+      clearAllFilters,
+      lastSeenCustomRange,
+      setLastSeenCustomRange,
+    ],
   );
 
   return (

--- a/src/components/SystemsView/DataViewFiltersContext.tsx
+++ b/src/components/SystemsView/DataViewFiltersContext.tsx
@@ -8,7 +8,7 @@ export const INITIAL_INVENTORY_FILTERS: InventoryFilters = {
   source: [],
   rhcStatus: [],
   system_type: [],
-  workspace: [],
+  group_name: [],
   last_seen: undefined,
   tags: [],
   operating_system: [],

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -59,7 +59,8 @@ const SystemsViewInner = ({
   searchParams,
   setSearchParams,
 }: SystemsViewInnerProps) => {
-  const { filters, clearAllFilters } = useDataViewFiltersContext();
+  const { filters, clearAllFilters, lastSeenCustomRange } =
+    useDataViewFiltersContext();
 
   const pagination = useDataViewPagination({
     perPage: PER_PAGE,
@@ -68,7 +69,7 @@ const SystemsViewInner = ({
     setSearchParams,
   });
 
-  useResetPage(filters, pagination);
+  useResetPage(filters, pagination, lastSeenCustomRange);
 
   const debouncedName = useDebouncedValue(
     filters.hostname_or_id,
@@ -110,6 +111,7 @@ const SystemsViewInner = ({
     page: pagination.page,
     perPage: pagination.perPage,
     filters: queryFilters,
+    lastSeenCustomRange,
     sortBy,
     direction,
   });

--- a/src/components/SystemsView/TagsModal/AllTagsModal.test.js
+++ b/src/components/SystemsView/TagsModal/AllTagsModal.test.js
@@ -38,6 +38,8 @@ function renderWithFilters(ui, options) {
     filters,
     onSetFilters = jest.fn(),
     clearAllFilters = jest.fn(),
+    lastSeenCustomRange = null,
+    setLastSeenCustomRange = jest.fn(),
   } = options;
   const queryClient = createTestQueryClient();
   return {
@@ -45,7 +47,13 @@ function renderWithFilters(ui, options) {
     ...render(
       <QueryClientProvider client={queryClient}>
         <DataViewFiltersContext.Provider
-          value={{ filters, onSetFilters, clearAllFilters }}
+          value={{
+            filters,
+            onSetFilters,
+            clearAllFilters,
+            lastSeenCustomRange,
+            setLastSeenCustomRange,
+          }}
         >
           {ui}
         </DataViewFiltersContext.Provider>

--- a/src/components/SystemsView/constants.ts
+++ b/src/components/SystemsView/constants.ts
@@ -1,2 +1,70 @@
+import moment from 'moment';
+
 export const FILTER_DROPDOWN_WIDTH = '300px';
+
 export const LOADER_ID = 'loader';
+
+export const LAST_SEEN_KEYS = [
+  'last24',
+  '24more',
+  '7more',
+  '15more',
+  '30more',
+  'custom',
+] as const;
+
+export type LastSeenKey = (typeof LAST_SEEN_KEYS)[number];
+
+const LAST_SEEN_KEY_SET = new Set<string>(LAST_SEEN_KEYS);
+
+export const isLastSeenKey = (key: string): key is LastSeenKey =>
+  LAST_SEEN_KEY_SET.has(key);
+
+/**
+ * Normalizes URL/state (string, or invalid) to a single valid key or cleared.
+ *
+ *  @param value - Raw `last_seen` from filters or URL parsing.
+ *  @returns     A valid last-seen key, or empty string when unset/invalid.
+ */
+export const normalizeLastSeenFilterValue = (
+  value: unknown,
+): LastSeenKey | '' => {
+  return typeof value === 'string' && isLastSeenKey(value) ? value : '';
+};
+
+/**
+ * Fresh moment() per call — use when building API params, not at module load.
+ *
+ *  @param key - Preset or `custom` (custom returns empty bounds; use separate state for dates).
+ *  @returns   ISO bounds for `last_seen` filter, with optional `start` and `end`.
+ */
+export const resolveLastSeenBounds = (
+  key: LastSeenKey,
+): { start?: string; end?: string } => {
+  switch (key) {
+    case 'last24':
+      return {
+        start: moment().subtract(1, 'days').toISOString(),
+        end: moment().toISOString(),
+      };
+    case '24more':
+      return { end: moment().subtract(1, 'days').toISOString() };
+    case '7more':
+      return { end: moment().subtract(7, 'days').toISOString() };
+    case '15more':
+      return { end: moment().subtract(15, 'days').toISOString() };
+    case '30more':
+      return { end: moment().subtract(30, 'days').toISOString() };
+    case 'custom':
+      return {};
+  }
+};
+
+export const LAST_SEEN_OPTIONS: { label: string; key: LastSeenKey }[] = [
+  { label: 'Within the last 24 hours', key: 'last24' },
+  { label: 'More than 1 day ago', key: '24more' },
+  { label: 'More than 7 days ago', key: '7more' },
+  { label: 'More than 15 days ago', key: '15more' },
+  { label: 'More than 30 days ago', key: '30more' },
+  { label: 'Custom', key: 'custom' },
+];

--- a/src/components/SystemsView/filters/LastSeenFilter.tsx
+++ b/src/components/SystemsView/filters/LastSeenFilter.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Ref, useState } from 'react';
+import React, { Ref, useState } from 'react';
 import {
   Select,
   SelectOption,
@@ -8,43 +8,38 @@ import {
   SplitItem,
   MenuToggleElement,
 } from '@patternfly/react-core';
-import { LAST_SEEN_OPTIONS as selectOptions } from '../../../routes/Systems/components/SystemsTable/components/helpers';
-
-export interface LastSeenFilterItem {
-  label: string;
-  start?: string;
-  end?: string;
-}
+import {
+  LAST_SEEN_OPTIONS as selectOptions,
+  type LastSeenKey,
+} from '../constants';
 
 export interface LastSeenFilterProps {
-  value?: LastSeenFilterItem;
-  onChange?: (
-    event?: React.MouseEvent,
-    values?: LastSeenFilterItem | undefined,
-  ) => void;
+  value?: LastSeenKey | '';
+  onChange?: (event?: React.MouseEvent, values?: LastSeenKey | '') => void;
 }
-const LastSeenFilter: FC<LastSeenFilterProps> = ({ value, onChange }) => {
-  const selectedLabel = value?.label;
+
+const LastSeenFilter = ({ value = '', onChange }: LastSeenFilterProps) => {
+  const selectedKey = value || undefined;
+  const selectedOption = selectedKey
+    ? selectOptions.find((option) => option.key === selectedKey)
+    : undefined;
+  const selectedLabel = selectedOption?.label;
+
   const [isOpen, setIsOpen] = useState(false);
   const onToggleClick = () => {
     setIsOpen(!isOpen);
   };
 
-  const onSelect = (_event: unknown, value: string) => {
-    if (value === selectedLabel) {
+  const onSelect = (_event: unknown, label: string) => {
+    if (label === selectedLabel) {
       setIsOpen(false);
       return;
     }
 
-    const selectedOption = selectOptions.find(
-      (option) => option.label === value,
-    );
+    const option = selectOptions.find((o) => o.label === label);
 
-    if (selectedOption) {
-      onChange?.(undefined, {
-        ...selectedOption.value,
-        label: selectedOption.label,
-      });
+    if (option) {
+      onChange?.(undefined, option.key);
     }
     setIsOpen(false);
   };

--- a/src/components/SystemsView/filters/LastSeenFilterExtension.tsx
+++ b/src/components/SystemsView/filters/LastSeenFilterExtension.tsx
@@ -1,37 +1,30 @@
 import React, { FC } from 'react';
 import DateRangePicker from '../../../routes/Systems/components/SystemsTable/components/DateRangePicker';
 import moment from 'moment';
-import { LastSeenFilterProps } from './LastSeenFilter';
+import { useDataViewFiltersContext } from '../DataViewFiltersContext';
 
-type LastSeenFilterExtensionProps = LastSeenFilterProps;
+export const LastSeenFilterExtension: FC = () => {
+  const { filters, lastSeenCustomRange, setLastSeenCustomRange } =
+    useDataViewFiltersContext();
 
-export const LastSeenFilterExtension: FC<LastSeenFilterExtensionProps> = ({
-  value,
-  onChange,
-}) => {
-  const CUSTOM_LABEL = 'Custom';
+  const isCustomSelected = filters.last_seen === 'custom';
 
-  const [selectedStartDate] = value?.start?.split('T') || [];
-  const [selectedEndDate] = value?.end?.split('T') || [];
+  const [selectedStartDate] = lastSeenCustomRange?.start?.split('T') || [];
+  const [selectedEndDate] = lastSeenCustomRange?.end?.split('T') || [];
   const selectedDateRange = { start: selectedStartDate, end: selectedEndDate };
-  const isCustomSelected = value?.label === CUSTOM_LABEL;
 
   return (
     isCustomSelected && (
       <DateRangePicker
         dateRange={selectedDateRange}
         onDateRangeChange={(next) => {
-          onChange?.(undefined, {
-            ...selectedDateRange,
-            ...{
-              start: next?.start
-                ? moment(next.start).startOf('day').toISOString()
-                : undefined,
-              end: next?.end
-                ? moment(next.end).endOf('day').toISOString()
-                : undefined,
-              label: CUSTOM_LABEL,
-            },
+          setLastSeenCustomRange({
+            start: next?.start
+              ? moment(next.start).startOf('day').toISOString()
+              : undefined,
+            end: next?.end
+              ? moment(next.end).endOf('day').toISOString()
+              : undefined,
           });
         }}
       />

--- a/src/components/SystemsView/filters/OperatingSystemsFilter.test.js
+++ b/src/components/SystemsView/filters/OperatingSystemsFilter.test.js
@@ -18,7 +18,7 @@ const rhel9Results = [
 ];
 
 /** Order matches `osVersionSorter` within a major (higher minor first). */
-const GROUP_TOKENS = ['RHEL:9.1', 'RHEL:9.0'];
+const GROUP_TOKENS = ['RHEL9.1', 'RHEL9.0'];
 
 function mockLoadedOperatingSystems(data = rhel9Results) {
   useOperatingSystemsQuery.mockReturnValue({
@@ -130,7 +130,7 @@ describe('OperatingSystemsFilter', () => {
     mockLoadedOperatingSystems();
     const user = userEvent.setup();
     const onChange = jest.fn();
-    render(<OperatingSystemsFilter value={['RHEL:9.0']} onChange={onChange} />);
+    render(<OperatingSystemsFilter value={['RHEL9.0']} onChange={onChange} />);
     await openOperatingSystemsMenu(user);
     await user.click(screen.getByRole('checkbox', { name: /^RHEL 9$/ }));
     expect(onChange).toHaveBeenCalledWith(undefined, []);
@@ -164,7 +164,7 @@ describe('OperatingSystemsFilter', () => {
       );
       await openOperatingSystemsMenu(user);
       await user.click(screen.getByRole('checkbox', { name: 'RHEL 9.0' }));
-      expect(onChange).toHaveBeenCalledWith(undefined, ['RHEL:9.0']);
+      expect(onChange).toHaveBeenCalledWith(undefined, ['RHEL9.0']);
       const groupInput = screen.getByRole('checkbox', { name: /^RHEL 9$/ });
       expect(groupInput).toHaveProperty('indeterminate', true);
       expect(screen.getByRole('checkbox', { name: 'RHEL 9.0' })).toBeChecked();
@@ -183,7 +183,7 @@ describe('OperatingSystemsFilter', () => {
     try {
       mockLoadedOperatingSystems();
       const user = userEvent.setup();
-      render(<ControlledOperatingSystemsFilter initialValue={['RHEL:9.0']} />);
+      render(<ControlledOperatingSystemsFilter initialValue={['RHEL9.0']} />);
       await openOperatingSystemsMenu(user);
       expect(screen.getByRole('checkbox', { name: /^RHEL 9$/ })).toHaveProperty(
         'indeterminate',

--- a/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
+++ b/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
@@ -16,6 +16,7 @@ import {
   buildOperatingSystemSelectGroups,
   buildOsFilterTokens,
   mapOperatingSystemApiResultsToVersionRows,
+  serializeOperatingSystemFilterValue,
 } from '../utils/operatingSystemSelectOptions';
 import { FILTER_DROPDOWN_WIDTH } from '../constants';
 
@@ -159,7 +160,10 @@ export const OperatingSystemsFilter = ({
                   }}
                 />
                 {group.items.map((item, itemIndex) => {
-                  const token = `${group.value}:${item.value}`;
+                  const token = serializeOperatingSystemFilterValue(
+                    group.value,
+                    item.value,
+                  );
                   return (
                     <OsFilterOption
                       key={token}

--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -8,13 +8,14 @@ import {
 import { DataViewCustomFilter } from './DataViewCustomFilter';
 import WorkspaceFilter from './WorkspaceFilter';
 import DataViewTextFilterWithChipTitle from './DataViewTextFilterWithChipTitle';
-import LastSeenFilter, { LastSeenFilterItem } from './LastSeenFilter';
+import LastSeenFilter from './LastSeenFilter';
 import TagsFilter from './TagsFilter';
 import OperatingSystemsFilter from './OperatingSystemsFilter';
 import { ToolbarLabel } from '@patternfly/react-core';
 import LastSeenFilterExtension from './LastSeenFilterExtension';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { useDataViewFiltersContext } from '../DataViewFiltersContext';
+import { LAST_SEEN_OPTIONS, type LastSeenKey } from '../constants';
 import { WORKLOAD_FILTER_OPTIONS } from '../utils/workloadsFilter';
 import { formatOperatingSystemChipLabel } from '../utils/operatingSystemSelectOptions';
 
@@ -28,7 +29,7 @@ export interface InventoryFilters {
   tags: string[];
   operating_system: string[];
   workloads: string[];
-  last_seen?: LastSeenFilterItem;
+  last_seen: LastSeenKey | '';
 }
 
 export const isToolbarLabel = (
@@ -149,24 +150,27 @@ export const SystemsViewFilters = () => {
             )
           }
         />
-        <DataViewCustomFilter
+        <DataViewCustomFilter<LastSeenKey | ''>
           filterId="last_seen"
           title="Last seen"
           placeholder="Filter by last seen"
           ouiaId="SystemsViewLastSeenFilter"
           filterComponent={LastSeenFilter}
           createLabel={(value, title) => {
-            return value
+            const opt = value
+              ? LAST_SEEN_OPTIONS.find((o) => o.key === value)
+              : undefined;
+            return opt
               ? [
                   {
                     key: title,
-                    node: value?.label,
+                    node: opt.label,
                   },
                 ]
               : [];
           }}
           deleteLabel={(_category, _label, _value, onChange) => {
-            onChange?.(undefined, undefined);
+            onChange?.(undefined, '');
           }}
         />
         <DataViewCustomFilter
@@ -218,12 +222,7 @@ export const SystemsViewFilters = () => {
           options={[...WORKLOAD_FILTER_OPTIONS]}
         />
       </DataViewFilters>
-      <LastSeenFilterExtension
-        value={filters?.last_seen}
-        onChange={(event, value) => {
-          onSetFilters({ ...filters, last_seen: value });
-        }}
-      />
+      <LastSeenFilterExtension />
     </>
   );
 };

--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -16,6 +16,7 @@ import LastSeenFilterExtension from './LastSeenFilterExtension';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { useDataViewFiltersContext } from '../DataViewFiltersContext';
 import { WORKLOAD_FILTER_OPTIONS } from '../utils/workloadsFilter';
+import { formatOperatingSystemChipLabel } from '../utils/operatingSystemSelectOptions';
 
 export interface InventoryFilters {
   hostname_or_id: string;
@@ -72,7 +73,7 @@ export const SystemsViewFilters = () => {
           createLabel={(value, title) =>
             value?.map((item: string) => ({
               key: title,
-              node: item.replace(':', ' '),
+              node: formatOperatingSystemChipLabel(item),
             })) ?? []
           }
           deleteLabel={(_category, label, value, onChange) => {
@@ -81,7 +82,9 @@ export const SystemsViewFilters = () => {
               : String(label);
             onChange?.(
               undefined,
-              value?.filter((item) => item.replace(':', ' ') !== chipText),
+              value?.filter(
+                (item) => formatOperatingSystemChipLabel(item) !== chipText,
+              ),
             );
           }}
         />

--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -24,7 +24,7 @@ export interface InventoryFilters {
   source: ApiHostGetHostListRegisteredWithEnum[];
   rhcStatus: string[];
   system_type: string[];
-  workspace: string[];
+  group_name: string[];
   tags: string[];
   operating_system: string[];
   workloads: string[];
@@ -127,7 +127,7 @@ export const SystemsViewFilters = () => {
           ]}
         />
         <DataViewCustomFilter
-          filterId="workspace"
+          filterId="group_name"
           title="Workspace"
           placeholder="Filter by workspace"
           ouiaId="SystemsViewWorkspaceFilter"

--- a/src/components/SystemsView/hooks/useResetPage.test.tsx
+++ b/src/components/SystemsView/hooks/useResetPage.test.tsx
@@ -45,4 +45,29 @@ describe('useResetPage (SystemsView pagination reset on filter change)', () => {
     });
     expect(onSetPage).toHaveBeenCalledWith(undefined, INITIAL_PAGE);
   });
+
+  it('resets page when additionalSignature changes', async () => {
+    const onSetPage = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ additionalSignature }) =>
+        useResetPage(
+          INITIAL_INVENTORY_FILTERS,
+          paginationStub(onSetPage),
+          additionalSignature,
+        ),
+      {
+        initialProps: {
+          additionalSignature: null as { start?: string } | null,
+        },
+      },
+    );
+
+    rerender({ additionalSignature: { start: '2024-01-01' } });
+
+    await waitFor(() => {
+      expect(onSetPage).toHaveBeenCalledTimes(1);
+    });
+    expect(onSetPage).toHaveBeenCalledWith(undefined, INITIAL_PAGE);
+  });
 });

--- a/src/components/SystemsView/hooks/useResetPage.ts
+++ b/src/components/SystemsView/hooks/useResetPage.ts
@@ -10,19 +10,24 @@ type DataViewPagination = ReturnType<typeof useDataViewPagination>;
  * change, after the initial mount. Runs in an effect so URL updates from the
  * filter hook and pagination hook do not race in the same event handler.
  *
- *  @param filters    - Filter state; compared via JSON serialization between runs.
- *  @param pagination - Return value of `useDataViewPagination`.
+ *  @param filters             - Filter state; compared via JSON serialization between runs.
+ *  @param pagination          - Return value of `useDataViewPagination`.
+ *  @param additionalSignature - Optional extra value merged into the serialized signature (e.g. last-seen custom range).
  */
 export const useResetPage = (
   filters: InventoryFilters,
   pagination: DataViewPagination,
+  additionalSignature?: unknown,
 ) => {
   /* `pagination.onSetPage` is a new function each render;
   The ref holds the latest version so we can use it in Effect. */
   const onSetPageRef = useRef(pagination.onSetPage);
   onSetPageRef.current = pagination.onSetPage;
 
-  const filtersSignature = useMemo(() => JSON.stringify(filters), [filters]);
+  const filtersSignature = useMemo(
+    () => JSON.stringify({ filters, additionalSignature }),
+    [filters, additionalSignature],
+  );
   const isInitialRun = useRef(true);
 
   useEffect(() => {

--- a/src/components/SystemsView/hooks/useSystemsQuery.ts
+++ b/src/components/SystemsView/hooks/useSystemsQuery.ts
@@ -10,6 +10,8 @@ import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-s
 import { SortDirection } from '../SystemsView';
 import { buildOperatingSystemProfileFilter } from '../utils/operatingSystemSelectOptions';
 import { buildWorkloadsFilter } from '../utils/workloadsFilter';
+import { lastSeenKeysToApiParams } from '../utils/lastSeenKeysToApiParams';
+import type { LastSeenCustomRange } from '../DataViewFiltersContext';
 
 const serializeSystemType = (values: string[]) => {
   const validValues = Object.values(ApiHostGetHostListSystemTypeEnum);
@@ -29,6 +31,7 @@ interface FetchSystemsParams {
   page: number;
   perPage: number;
   filters: InventoryFilters;
+  lastSeenCustomRange: LastSeenCustomRange;
   sortBy: ApiOrderByEnum | undefined;
   direction: SortDirection | undefined;
 }
@@ -36,6 +39,7 @@ const fetchSystems = async ({
   page,
   perPage,
   filters,
+  lastSeenCustomRange,
   sortBy,
   direction,
 }: FetchSystemsParams) => {
@@ -54,6 +58,11 @@ const fetchSystems = async ({
 
   const hasSystemProfileFilter = Object.keys(systemProfileFilter).length > 0;
 
+  const lastSeenParams = lastSeenKeysToApiParams(
+    filters.last_seen,
+    lastSeenCustomRange,
+  );
+
   const params: ApiHostGetHostListParams = {
     page,
     perPage,
@@ -67,10 +76,7 @@ const fetchSystems = async ({
     }),
     ...(filters?.group_name && { groupName: filters.group_name }),
     ...(filters?.tags && { tags: filters.tags }),
-    ...(filters?.last_seen && {
-      lastCheckInStart: filters.last_seen?.start,
-      lastCheckInEnd: filters.last_seen?.end,
-    }),
+    ...(lastSeenParams ?? {}),
     /* Override default dot notation from API client: backend requires bracket notation for nested params (fields, filter) */
     options: {
       paramsSerializer: (params) => {
@@ -118,6 +124,7 @@ interface UseSystemsQueryParams {
   page: number;
   perPage: number;
   filters: InventoryFilters;
+  lastSeenCustomRange: LastSeenCustomRange;
   sortBy: ApiOrderByEnum | undefined;
   direction: SortDirection | undefined;
   /** When false, the query is not run (e.g. when user has no access). Default true. */
@@ -127,14 +134,30 @@ export const useSystemsQuery = ({
   page,
   perPage,
   filters,
+  lastSeenCustomRange,
   sortBy,
   direction,
   enabled = true,
 }: UseSystemsQueryParams) => {
   const { data, isLoading, isFetching, isError, error } = useQuery({
-    queryKey: ['systems', page, perPage, filters, sortBy, direction],
+    queryKey: [
+      'systems',
+      page,
+      perPage,
+      filters,
+      lastSeenCustomRange,
+      sortBy,
+      direction,
+    ],
     queryFn: async () => {
-      return await fetchSystems({ page, perPage, filters, sortBy, direction });
+      return await fetchSystems({
+        page,
+        perPage,
+        filters,
+        lastSeenCustomRange,
+        sortBy,
+        direction,
+      });
     },
     placeholderData: keepPreviousData,
     refetchOnWindowFocus: false,

--- a/src/components/SystemsView/hooks/useSystemsQuery.ts
+++ b/src/components/SystemsView/hooks/useSystemsQuery.ts
@@ -65,7 +65,7 @@ const fetchSystems = async ({
     ...(filters?.system_type && {
       systemType: serializeSystemType(filters.system_type),
     }),
-    ...(filters?.workspace && { groupName: filters.workspace }),
+    ...(filters?.group_name && { groupName: filters.group_name }),
     ...(filters?.tags && { tags: filters.tags }),
     ...(filters?.last_seen && {
       lastCheckInStart: filters.last_seen?.start,

--- a/src/components/SystemsView/utils/lastSeenKeysToApiParams.ts
+++ b/src/components/SystemsView/utils/lastSeenKeysToApiParams.ts
@@ -1,0 +1,40 @@
+import type { ApiHostGetHostListParams } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
+import type { LastSeenCustomRange } from '../DataViewFiltersContext';
+import { resolveLastSeenBounds, type LastSeenKey } from '../constants';
+
+/**
+ * Maps toolbar last-seen key (+ in-memory custom range) to host list API params.
+ *
+ *  @param lastSeen            - Selected option key from the Last seen filter, or empty when cleared.
+ *  @param lastSeenCustomRange - Start/end ISO strings when `custom` is selected;
+ *  @returns                   `lastCheckInStart` / `lastCheckInEnd` fragment, or `null` when no effective range.
+ */
+export const lastSeenKeysToApiParams = (
+  lastSeen: LastSeenKey | '',
+  lastSeenCustomRange: LastSeenCustomRange,
+): Pick<
+  ApiHostGetHostListParams,
+  'lastCheckInStart' | 'lastCheckInEnd'
+> | null => {
+  if (!lastSeen) {
+    return null;
+  }
+
+  if (lastSeen === 'custom') {
+    const start = lastSeenCustomRange?.start;
+    const end = lastSeenCustomRange?.end;
+    if (!start || !end) {
+      return null;
+    }
+    return { lastCheckInStart: start, lastCheckInEnd: end };
+  }
+
+  const { start, end } = resolveLastSeenBounds(lastSeen);
+  if (start === undefined && end === undefined) {
+    return null;
+  }
+  return {
+    ...(start !== undefined && { lastCheckInStart: start }),
+    ...(end !== undefined && { lastCheckInEnd: end }),
+  };
+};

--- a/src/components/SystemsView/utils/operatingSystemSelectOptions.test.ts
+++ b/src/components/SystemsView/utils/operatingSystemSelectOptions.test.ts
@@ -57,10 +57,10 @@ describe('buildOperatingSystemProfileFilter', () => {
   it('groups tokens by OS name and dedupes versions', () => {
     expect(
       buildOperatingSystemProfileFilter([
-        'RHEL:9.0',
-        'RHEL:8.4',
-        'RHEL:9.0',
-        'CentOS Linux:7.9',
+        'RHEL9.0',
+        'RHEL8.4',
+        'RHEL9.0',
+        'CentOS Linux7.9',
       ]),
     ).toEqual({
       RHEL: { version: { eq: ['9.0', '8.4'] } },
@@ -70,7 +70,7 @@ describe('buildOperatingSystemProfileFilter', () => {
 
   it('skips malformed tokens', () => {
     expect(
-      buildOperatingSystemProfileFilter(['nocolon', ':onlyversion', 'OK:1.0']),
+      buildOperatingSystemProfileFilter(['nocolon', ':onlyversion', 'OK1.0']),
     ).toEqual({
       OK: { version: { eq: ['1.0'] } },
     });

--- a/src/components/SystemsView/utils/operatingSystemSelectOptions.ts
+++ b/src/components/SystemsView/utils/operatingSystemSelectOptions.ts
@@ -23,26 +23,47 @@ export type OperatingSystemProfileFilter = Record<
   { version: { eq: string[] } }
 >;
 
-export const toOsToken = (os: string, version: string) => `${os}:${version}`;
-export const fromOsToken = (token: string) => {
-  const [os, version] = token.split(':', 2);
+export const serializeOperatingSystemFilterValue = (
+  os: string,
+  version: string,
+) => `${os}${version}`;
+
+export const parseOperatingSystemFilterValue = (
+  token: string,
+): { os: string; version: string } | null => {
+  if (!token) {
+    return null;
+  }
+  const match = token.match(/^(.+?)(\d+\.\d+)$/);
+  if (!match) {
+    return null;
+  }
+  const [, os, version] = match;
   return { os, version };
 };
 
+export const formatOperatingSystemChipLabel = (value: string): string => {
+  const parsed = parseOperatingSystemFilterValue(value);
+  return parsed ? `${parsed.os} ${parsed.version}` : value;
+};
+
 /**
- * Maps one `OperatingSystemSelectGroup` to `${osName}:${major.minor}` tokens stored in toolbar filter state.
+ * Maps one `OperatingSystemSelectGroup` to `${osName}${major.minor}` tokens stored in toolbar filter state / URL.
  *
  *  @param group - One major-version group from the OS filter (`value` is the OS name; each item is `major.minor`)
- *  @returns     Token strings such as `RHEL:9.0`, one per item in the group
+ *  @returns     Token strings such as `RHEL9.0`, one per item in the group
  */
 export const buildOsFilterTokens = (
   group: OperatingSystemSelectGroup,
-): string[] => group.items.map((item) => toOsToken(group.value, item.value));
+): string[] =>
+  group.items.map((item) =>
+    serializeOperatingSystemFilterValue(group.value, item.value),
+  );
 
 /**
- * Maps `${osName}:${major.minor}` tokens to `filter.system_profile.operating_system` for the host list API.
+ * Maps OS filter tokens to `filter.system_profile.operating_system` for the host list API.
  *
- *  @param tokens - Toolbar Filter selection (e.g. `RHEL:9.0`), or undefined
+ *  @param tokens - Toolbar filter selection (e.g. `RHEL9.0`), or undefined
  *  @returns      Profile Filter or undefined when there is nothing to filter
  */
 export const buildOperatingSystemProfileFilter = (
@@ -54,10 +75,11 @@ export const buildOperatingSystemProfileFilter = (
 
   const byOs: Record<string, string[]> = {};
   for (const token of tokens) {
-    const { os, version } = fromOsToken(token);
-    if (!os || !version) {
+    const parsed = parseOperatingSystemFilterValue(token);
+    if (!parsed?.os || !parsed.version) {
       continue;
     }
+    const { os, version } = parsed;
     if (!byOs[os]) {
       byOs[os] = [];
     }


### PR DESCRIPTION
## Jira
Fixes RHINENG-25727

## What
- makes URL param key=values for _OperatingSystem, Workspace and LastSeen_ filters consistent with legacy table


## Testing
1. Go to Inventory / Systems and make sure on Preview is on.
2. Set some of the values for above mentioned filters
3. Observe key=value pairs in URL are same in both SystemsView and InventoryTable

## Screenshots/Videos (if applicable)
<img width="1372" height="246" alt="image" src="https://github.com/user-attachments/assets/d0b4281d-e3f4-4c0e-8977-6a6e5f73b1b9" />

<img width="457" height="72" alt="image" src="https://github.com/user-attachments/assets/20902608-5e7f-4719-bddc-d7a46c302e15" />
