### PR TITLE
fix(RHINENG-25732): show no access on workspace page RBAC v2

### DIFF
--- a/src/Utilities/hooks/useWorkspacesPageKesselAccess.test.js
+++ b/src/Utilities/hooks/useWorkspacesPageKesselAccess.test.js
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useWorkspacesPageKesselAccess } from './useWorkspacesPageKesselAccess';
+import {
+  WORKSPACE_RESOURCE_TYPE,
+  WORKSPACE_RELATION_VIEW,
+  KESSEL_WORKSPACE_REPORTER,
+} from '../../constants';
+
+const mockUseKesselMigrationFeatureFlag = jest.fn();
+const mockUseSelfAccessCheck = jest.fn();
+const mockFetchDefaultWorkspace = jest.fn();
+
+jest.mock('./useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
+}));
+
+jest.mock('@project-kessel/react-kessel-access-check', () => ({
+  fetchDefaultWorkspace: (...args) => mockFetchDefaultWorkspace(...args),
+  useSelfAccessCheck: (opts) => mockUseSelfAccessCheck(opts),
+}));
+
+describe('useWorkspacesPageKesselAccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+    mockFetchDefaultWorkspace.mockResolvedValue({ id: 'default-ws-id' });
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [],
+      loading: false,
+      error: undefined,
+    });
+  });
+
+  it('when Kessel flag is off, does not call fetchDefaultWorkspace and returns inactive gate', () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+
+    const { result } = renderHook(() => useWorkspacesPageKesselAccess());
+
+    expect(mockFetchDefaultWorkspace).not.toHaveBeenCalled();
+    expect(result.current).toMatchObject({
+      isKesselGated: false,
+      isWorkspaceAccessLoading: false,
+      canViewDefaultWorkspace: undefined,
+      defaultWorkspaceFetchError: null,
+    });
+  });
+
+  it('when Kessel flag is on, calls fetchDefaultWorkspace with window origin', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockImplementation(() => ({
+      data: [
+        {
+          allowed: true,
+          relation: WORKSPACE_RELATION_VIEW,
+          resource: { id: 'default-ws-id', type: WORKSPACE_RESOURCE_TYPE },
+        },
+      ],
+      loading: false,
+      error: undefined,
+    }));
+
+    renderHook(() => useWorkspacesPageKesselAccess());
+
+    await waitFor(() => {
+      expect(mockFetchDefaultWorkspace).toHaveBeenCalledWith(
+        window.location.origin,
+      );
+    });
+  });
+
+  it('passes workspace view resource into useSelfAccessCheck after fetch resolves', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [
+        {
+          allowed: true,
+          relation: WORKSPACE_RELATION_VIEW,
+          resource: { id: 'default-ws-id', type: WORKSPACE_RESOURCE_TYPE },
+        },
+      ],
+      loading: false,
+      error: undefined,
+    });
+
+    renderHook(() => useWorkspacesPageKesselAccess());
+
+    await waitFor(() => {
+      expect(mockUseSelfAccessCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resources: [
+            expect.objectContaining({
+              id: 'default-ws-id',
+              type: WORKSPACE_RESOURCE_TYPE,
+              relation: WORKSPACE_RELATION_VIEW,
+              reporter: KESSEL_WORKSPACE_REPORTER,
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it('when fetchDefaultWorkspace fails, exposes error and canViewDefaultWorkspace is false', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockFetchDefaultWorkspace.mockRejectedValue({
+      code: 403,
+      message: 'Forbidden',
+    });
+
+    const { result } = renderHook(() => useWorkspacesPageKesselAccess());
+
+    await waitFor(() => {
+      expect(result.current.defaultWorkspaceFetchError).toEqual({
+        code: 403,
+        message: 'Forbidden',
+      });
+      expect(result.current.canViewDefaultWorkspace).toBe(false);
+    });
+  });
+});

--- a/src/Utilities/hooks/useWorkspacesPageKesselAccess.test.js
+++ b/src/Utilities/hooks/useWorkspacesPageKesselAccess.test.js
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useWorkspacesPageKesselAccess } from './useWorkspacesPageKesselAccess';
+import {
+  WORKSPACE_RESOURCE_TYPE,
+  WORKSPACE_RELATION_VIEW,
+  KESSEL_WORKSPACE_REPORTER,
+} from '../../constants';
+
+const mockUseKesselMigrationFeatureFlag = jest.fn();
+const mockUseSelfAccessCheck = jest.fn();
+const mockFetchDefaultWorkspace = jest.fn();
+
+jest.mock('./useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
+}));
+
+jest.mock('@project-kessel/react-kessel-access-check', () => ({
+  fetchDefaultWorkspace: (...args) => mockFetchDefaultWorkspace(...args),
+  useSelfAccessCheck: (opts) => mockUseSelfAccessCheck(opts),
+}));
+
+describe('useWorkspacesPageKesselAccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+    mockFetchDefaultWorkspace.mockResolvedValue({ id: 'default-ws-id' });
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [],
+      loading: false,
+      error: undefined,
+    });
+  });
+
+  it('when Kessel flag is off, does not call fetchDefaultWorkspace and returns inactive gate', () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+
+    const { result } = renderHook(() => useWorkspacesPageKesselAccess());
+
+    expect(mockFetchDefaultWorkspace).not.toHaveBeenCalled();
+    expect(result.current).toMatchObject({
+      isKesselGated: false,
+      isWorkspaceAccessLoading: false,
+      canViewDefaultWorkspace: undefined,
+      defaultWorkspaceFetchError: null,
+    });
+  });
+
+  it('when Kessel flag is on, calls fetchDefaultWorkspace with window origin', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockImplementation(() => ({
+      data: [
+        {
+          allowed: true,
+          relation: WORKSPACE_RELATION_VIEW,
+          resource: { id: 'default-ws-id', type: WORKSPACE_RESOURCE_TYPE },
+        },
+      ],
+      loading: false,
+      error: undefined,
+    }));
+
+    renderHook(() => useWorkspacesPageKesselAccess());
+
+    await waitFor(() => {
+      expect(mockFetchDefaultWorkspace).toHaveBeenCalledWith(
+        window.location.origin,
+      );
+    });
+  });
+
+  it('passes workspace view resource into useSelfAccessCheck after fetch resolves', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [
+        {
+          allowed: true,
+          relation: WORKSPACE_RELATION_VIEW,
+          resource: { id: 'default-ws-id', type: WORKSPACE_RESOURCE_TYPE },
+        },
+      ],
+      loading: false,
+      error: undefined,
+    });
+
+    renderHook(() => useWorkspacesPageKesselAccess());
+
+    await waitFor(() => {
+      expect(mockUseSelfAccessCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resources: [
+            expect.objectContaining({
+              id: 'default-ws-id',
+              type: WORKSPACE_RESOURCE_TYPE,
+              relation: WORKSPACE_RELATION_VIEW,
+              reporter: KESSEL_WORKSPACE_REPORTER,
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it('when fetchDefaultWorkspace fails, exposes error and leaves canViewDefaultWorkspace unset', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockFetchDefaultWorkspace.mockRejectedValue({
+      code: 403,
+      message: 'Forbidden',
+    });
+
+    const { result } = renderHook(() => useWorkspacesPageKesselAccess());
+
+    await waitFor(() => {
+      expect(result.current.defaultWorkspaceFetchError).toEqual({
+        code: 403,
+        message: 'Forbidden',
+      });
+      expect(result.current.canViewDefaultWorkspace).toBeUndefined();
+    });
+  });
+});

--- a/src/Utilities/hooks/useWorkspacesPageKesselAccess.ts
+++ b/src/Utilities/hooks/useWorkspacesPageKesselAccess.ts
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  fetchDefaultWorkspace,
+  useSelfAccessCheck,
+} from '@project-kessel/react-kessel-access-check';
+import { type BulkSelfAccessCheckNestedRelationsParams } from '@project-kessel/react-kessel-access-check/types';
+import { useKesselMigrationFeatureFlag } from './useKesselMigrationFeatureFlag';
+import {
+  WORKSPACE_RESOURCE_TYPE,
+  WORKSPACE_RELATION_VIEW,
+  KESSEL_WORKSPACE_REPORTER,
+} from '../../constants';
+
+export type WorkspacesPageKesselAccess = {
+  /** Kessel migration flag is on — use RBAC default workspace + Kessel view to interpret empty group lists */
+  isKesselGated: boolean;
+  /** Wait before choosing empty vs no-access when Kessel is gated */
+  isWorkspaceAccessLoading: boolean;
+  /** When gated and settled: user may view the default workspace (undefined while loading or when not gated) */
+  canViewDefaultWorkspace: boolean | undefined;
+  /** Set when `fetchDefaultWorkspace` rejects (caller may choose ErrorState vs empty-state) */
+  defaultWorkspaceFetchError: { code?: number; message?: string } | null;
+  /** Kessel `checkself` failure after workspace id was resolved */
+  kesselCheckError: { code?: number; message?: string } | undefined;
+};
+
+/**
+ * Resolves default workspace id via RBAC and runs a Kessel self check for `view`.
+ * Only used from the Workspaces (inventory groups) page — do not import elsewhere until intentionally reused.
+ *  @returns Kessel gate state for the workspaces page (loading, permission, errors).
+ */
+export const useWorkspacesPageKesselAccess = (): WorkspacesPageKesselAccess => {
+  const isKesselEnabled = useKesselMigrationFeatureFlag();
+
+  const [rbacPhase, setRbacPhase] = useState<
+    'disabled' | 'loading' | 'ready' | 'error'
+  >(() => (isKesselEnabled ? 'loading' : 'disabled'));
+  const [defaultWorkspaceId, setDefaultWorkspaceId] = useState<string | null>(
+    null,
+  );
+  const [defaultWorkspaceFetchError, setDefaultWorkspaceFetchError] = useState<{
+    code?: number;
+    message?: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!isKesselEnabled) {
+      setRbacPhase('disabled');
+      setDefaultWorkspaceId(null);
+      setDefaultWorkspaceFetchError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setRbacPhase('loading');
+    setDefaultWorkspaceFetchError(null);
+    setDefaultWorkspaceId(null);
+
+    const base = typeof window !== 'undefined' ? window.location.origin : '';
+
+    // prefix it with void: void (async () => { ... })(); so ESLint treats it as an intentional fire-and-forget async effect.
+    void (async () => {
+      try {
+        const workspace = await fetchDefaultWorkspace(base);
+        if (!cancelled) {
+          setDefaultWorkspaceId(workspace.id);
+          setDefaultWorkspaceFetchError(null);
+          setRbacPhase('ready');
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const e = err as { code?: number; message?: string };
+          setDefaultWorkspaceId(null);
+          setDefaultWorkspaceFetchError({
+            code: e?.code,
+            message: e?.message,
+          });
+          setRbacPhase('error');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isKesselEnabled]);
+
+  const resources = useMemo(() => {
+    if (!isKesselEnabled || !defaultWorkspaceId) {
+      return [];
+    }
+    return [
+      {
+        id: defaultWorkspaceId,
+        type: WORKSPACE_RESOURCE_TYPE,
+        relation: WORKSPACE_RELATION_VIEW,
+        reporter: KESSEL_WORKSPACE_REPORTER,
+      },
+    ];
+  }, [isKesselEnabled, defaultWorkspaceId]);
+
+  const {
+    data: checks,
+    loading: kesselCheckLoading,
+    error: kesselCheckError,
+  } = useSelfAccessCheck({
+    resources,
+  } as BulkSelfAccessCheckNestedRelationsParams);
+
+  const canViewDefaultWorkspace = useMemo((): boolean | undefined => {
+    if (!isKesselEnabled) {
+      return undefined;
+    }
+    if (rbacPhase === 'error') {
+      return false;
+    }
+    if (rbacPhase !== 'ready' || !defaultWorkspaceId) {
+      return undefined;
+    }
+    if (kesselCheckLoading) {
+      return undefined;
+    }
+    if (kesselCheckError) {
+      return undefined;
+    }
+    const viewCheck = checks?.find(
+      (c) => c.relation === WORKSPACE_RELATION_VIEW,
+    );
+    if (!viewCheck) {
+      return false;
+    }
+    return viewCheck.allowed === true;
+  }, [
+    isKesselEnabled,
+    rbacPhase,
+    defaultWorkspaceId,
+    kesselCheckLoading,
+    kesselCheckError,
+    checks,
+  ]);
+
+  const isKesselGated = isKesselEnabled;
+
+  const isWorkspaceAccessLoading =
+    isKesselGated &&
+    (rbacPhase === 'loading' ||
+      (rbacPhase === 'ready' && !!defaultWorkspaceId && kesselCheckLoading));
+
+  return {
+    isKesselGated,
+    isWorkspaceAccessLoading,
+    canViewDefaultWorkspace,
+    defaultWorkspaceFetchError:
+      rbacPhase === 'error' ? defaultWorkspaceFetchError : null,
+    kesselCheckError,
+  };
+};

--- a/src/Utilities/hooks/useWorkspacesPageKesselAccess.ts
+++ b/src/Utilities/hooks/useWorkspacesPageKesselAccess.ts
@@ -1,0 +1,168 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  fetchDefaultWorkspace,
+  useSelfAccessCheck,
+} from '@project-kessel/react-kessel-access-check';
+import { type BulkSelfAccessCheckNestedRelationsParams } from '@project-kessel/react-kessel-access-check/types';
+import { useKesselMigrationFeatureFlag } from './useKesselMigrationFeatureFlag';
+import {
+  WORKSPACE_RESOURCE_TYPE,
+  WORKSPACE_RELATION_VIEW,
+  KESSEL_WORKSPACE_REPORTER,
+} from '../../constants';
+import { type RbacFetchError } from '../kesselRbacFetchErrors';
+
+export type WorkspacesPageKesselAccess = {
+  /** Kessel migration flag is on — use RBAC default workspace + Kessel view to interpret empty group lists */
+  isKesselGated: boolean;
+  /** Wait before choosing empty vs no-access when Kessel is gated */
+  isWorkspaceAccessLoading: boolean;
+  /** When gated and settled: user may view the default workspace (undefined while loading or when not gated) */
+  canViewDefaultWorkspace: boolean | undefined;
+  /** Set when `fetchDefaultWorkspace` rejects (caller may choose ErrorState vs empty-state) */
+  defaultWorkspaceFetchError: RbacFetchError;
+  /** Kessel `checkself` failure after workspace id was resolved */
+  kesselCheckError: { code?: number; message?: string } | undefined;
+};
+
+type RbacState =
+  | { kind: 'disabled' }
+  | { kind: 'loading' }
+  | { kind: 'ready'; workspaceId: string }
+  | { kind: 'error'; error: RbacFetchError };
+
+const emptySelfAccessParams: BulkSelfAccessCheckNestedRelationsParams = {
+  resources: [],
+};
+
+/**
+ * Resolves default workspace id via RBAC and runs a Kessel self check for `view`.
+ * Only used from the Workspaces (inventory groups) page — do not import elsewhere until intentionally reused.
+ *  @returns Kessel gate state for the workspaces page (loading, permission, errors).
+ */
+export const useWorkspacesPageKesselAccess = (): WorkspacesPageKesselAccess => {
+  const isKesselEnabled = useKesselMigrationFeatureFlag();
+
+  const [rbacState, setRbacState] = useState<RbacState>(() =>
+    isKesselEnabled ? { kind: 'loading' } : { kind: 'disabled' },
+  );
+
+  useEffect(() => {
+    if (!isKesselEnabled) {
+      setRbacState({ kind: 'disabled' });
+      return;
+    }
+
+    let cancelled = false;
+    setRbacState({ kind: 'loading' });
+
+    const base = typeof window !== 'undefined' ? window.location.origin : '';
+
+    void (async () => {
+      try {
+        const workspace = await fetchDefaultWorkspace(base);
+        if (!cancelled) {
+          setRbacState({ kind: 'ready', workspaceId: workspace.id });
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const e = err as { code?: number; message?: string };
+          setRbacState({
+            kind: 'error',
+            error: { code: e?.code, message: e?.message },
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isKesselEnabled]);
+
+  const selfAccessParams: BulkSelfAccessCheckNestedRelationsParams =
+    useMemo(() => {
+      if (!isKesselEnabled || rbacState.kind !== 'ready') {
+        return emptySelfAccessParams;
+      }
+
+      return {
+        resources: [
+          {
+            id: rbacState.workspaceId,
+            type: WORKSPACE_RESOURCE_TYPE,
+            relation: WORKSPACE_RELATION_VIEW,
+            reporter: KESSEL_WORKSPACE_REPORTER,
+          },
+        ],
+      };
+    }, [isKesselEnabled, rbacState]);
+
+  const {
+    data: checks,
+    loading: kesselCheckLoading,
+    error: kesselCheckError,
+  } = useSelfAccessCheck(selfAccessParams);
+
+  const {
+    isWorkspaceAccessLoading,
+    canViewDefaultWorkspace,
+    defaultWorkspaceFetchError,
+  } = useMemo(() => {
+    if (!isKesselEnabled || rbacState.kind === 'disabled') {
+      return {
+        isWorkspaceAccessLoading: false,
+        canViewDefaultWorkspace: undefined,
+        defaultWorkspaceFetchError: null,
+      };
+    }
+
+    if (rbacState.kind === 'loading') {
+      return {
+        isWorkspaceAccessLoading: true,
+        canViewDefaultWorkspace: undefined,
+        defaultWorkspaceFetchError: null,
+      };
+    }
+
+    if (rbacState.kind === 'error') {
+      return {
+        isWorkspaceAccessLoading: false,
+        canViewDefaultWorkspace: undefined,
+        defaultWorkspaceFetchError: rbacState.error,
+      };
+    }
+
+    if (kesselCheckLoading || kesselCheckError) {
+      return {
+        isWorkspaceAccessLoading: !!kesselCheckLoading,
+        canViewDefaultWorkspace: undefined,
+        defaultWorkspaceFetchError: null,
+      };
+    }
+
+    const viewCheck = checks?.find(
+      (c) => c.relation === WORKSPACE_RELATION_VIEW,
+    );
+
+    return {
+      isWorkspaceAccessLoading: false,
+      canViewDefaultWorkspace: viewCheck ? viewCheck.allowed === true : false,
+      defaultWorkspaceFetchError: null,
+    };
+  }, [
+    isKesselEnabled,
+    rbacState,
+    kesselCheckLoading,
+    kesselCheckError,
+    checks,
+  ]);
+
+  return {
+    isKesselGated: isKesselEnabled,
+    isWorkspaceAccessLoading,
+    canViewDefaultWorkspace,
+    defaultWorkspaceFetchError,
+    kesselCheckError,
+  };
+};

--- a/src/Utilities/kesselRbacFetchErrors.ts
+++ b/src/Utilities/kesselRbacFetchErrors.ts
@@ -1,0 +1,14 @@
+import { RBAC_FETCH_ACCESS_DENIED_CODES } from '../constants';
+
+export type RbacFetchError = { code?: number; message?: string } | null;
+
+/** True when a default-workspace RBAC fetch error likely indicates missing access (vs a transport failure). */
+export const isRbacFetchAccessDenied = (
+  error: RbacFetchError | undefined,
+): boolean => {
+  const code = error?.code;
+  return (
+    typeof code === 'number' &&
+    (RBAC_FETCH_ACCESS_DENIED_CODES as readonly number[]).includes(code)
+  );
+};

--- a/src/components/InventoryGroups/InventoryGroups.js
+++ b/src/components/InventoryGroups/InventoryGroups.js
@@ -9,6 +9,9 @@ import { EmptyStateNoAccessToGroups } from '../InventoryGroupDetail/EmptyStateNo
 import GetHelpExpandable from './GetHelpExpandable';
 import CreateGroupModal from './Modals/CreateGroupModal';
 import { PageSection } from '@patternfly/react-core';
+import { useWorkspacesPageKesselAccess } from '../../Utilities/hooks/useWorkspacesPageKesselAccess';
+
+const rbacFetchDeniedCodes = [401, 403, 404];
 
 const InventoryGroups = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -16,6 +19,14 @@ const InventoryGroups = () => {
   const [hasError, setHasError] = useState(false);
   const [error, setError] = useState(null);
   const [createModalOpen, setCreateModalOpen] = useState(false);
+
+  const {
+    isKesselGated,
+    isWorkspaceAccessLoading,
+    canViewDefaultWorkspace,
+    defaultWorkspaceFetchError,
+    kesselCheckError,
+  } = useWorkspacesPageKesselAccess();
 
   const ignore = useRef(false); // https://react.dev/learn/synchronizing-with-effects#fetching-data
 
@@ -51,6 +62,13 @@ const InventoryGroups = () => {
     };
   }, []);
 
+  const pageLoading = isLoading || (isKesselGated && isWorkspaceAccessLoading);
+
+  const rbacFetchCode = defaultWorkspaceFetchError?.code;
+  const isRbacFetchLikelyAccessDenied =
+    typeof rbacFetchCode === 'number' &&
+    rbacFetchDeniedCodes.includes(rbacFetchCode);
+
   return (
     <PageSection
       hasBodyWrapper={false}
@@ -71,10 +89,20 @@ const InventoryGroups = () => {
         ) : (
           <ErrorState />
         )
-      ) : isLoading ? (
+      ) : pageLoading ? (
         <Bullseye>
           <Spinner />
         </Bullseye>
+      ) : isKesselGated && kesselCheckError ? (
+        <ErrorState />
+      ) : isKesselGated && defaultWorkspaceFetchError ? (
+        isRbacFetchLikelyAccessDenied ? (
+          <EmptyStateNoAccessToGroups />
+        ) : (
+          <ErrorState />
+        )
+      ) : isKesselGated && canViewDefaultWorkspace === false ? (
+        <EmptyStateNoAccessToGroups />
       ) : hasGroups ? (
         <GroupsTable onCreateGroupClick={onCreateGroupClick} />
       ) : (

--- a/src/components/InventoryGroups/InventoryGroups.js
+++ b/src/components/InventoryGroups/InventoryGroups.js
@@ -9,6 +9,52 @@ import { EmptyStateNoAccessToGroups } from '../InventoryGroupDetail/EmptyStateNo
 import GetHelpExpandable from './GetHelpExpandable';
 import CreateGroupModal from './Modals/CreateGroupModal';
 import { PageSection } from '@patternfly/react-core';
+import { useWorkspacesPageKesselAccess } from '../../Utilities/hooks/useWorkspacesPageKesselAccess';
+import { isRbacFetchAccessDenied } from '../../Utilities/kesselRbacFetchErrors';
+
+const computeViewState = ({
+  hasError,
+  error,
+  pageLoading,
+  isKesselGated,
+  kesselCheckError,
+  defaultWorkspaceFetchError,
+  canViewDefaultWorkspace,
+  hasGroups,
+}) => {
+  if (hasError) {
+    if (error?.status === 403 || error?.response?.status === 403) {
+      return 'globalNoAccess';
+    }
+    return 'globalError';
+  }
+
+  if (pageLoading) {
+    return 'loading';
+  }
+
+  if (isKesselGated) {
+    if (kesselCheckError) {
+      return 'kesselError';
+    }
+
+    if (defaultWorkspaceFetchError) {
+      return isRbacFetchAccessDenied(defaultWorkspaceFetchError)
+        ? 'kesselNoAccess'
+        : 'kesselWorkspaceError';
+    }
+
+    if (canViewDefaultWorkspace === false) {
+      return 'kesselNoAccess';
+    }
+  }
+
+  if (hasGroups) {
+    return 'groups';
+  }
+
+  return 'noGroups';
+};
 
 const InventoryGroups = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -16,6 +62,14 @@ const InventoryGroups = () => {
   const [hasError, setHasError] = useState(false);
   const [error, setError] = useState(null);
   const [createModalOpen, setCreateModalOpen] = useState(false);
+
+  const {
+    isKesselGated,
+    isWorkspaceAccessLoading,
+    canViewDefaultWorkspace,
+    defaultWorkspaceFetchError,
+    kesselCheckError,
+  } = useWorkspacesPageKesselAccess();
 
   const ignore = useRef(false); // https://react.dev/learn/synchronizing-with-effects#fetching-data
 
@@ -51,6 +105,19 @@ const InventoryGroups = () => {
     };
   }, []);
 
+  const pageLoading = isLoading || (isKesselGated && isWorkspaceAccessLoading);
+
+  const viewState = computeViewState({
+    hasError,
+    error,
+    pageLoading,
+    isKesselGated,
+    kesselCheckError,
+    defaultWorkspaceFetchError,
+    canViewDefaultWorkspace,
+    hasGroups,
+  });
+
   return (
     <PageSection
       hasBodyWrapper={false}
@@ -65,17 +132,17 @@ const InventoryGroups = () => {
         />
       )}
       <GetHelpExpandable />
-      {hasError ? (
-        error?.status === 403 || error?.response?.status === 403 ? (
-          <EmptyStateNoAccessToGroups />
-        ) : (
-          <ErrorState />
-        )
-      ) : isLoading ? (
+      {viewState === 'globalNoAccess' || viewState === 'kesselNoAccess' ? (
+        <EmptyStateNoAccessToGroups />
+      ) : viewState === 'globalError' ||
+        viewState === 'kesselError' ||
+        viewState === 'kesselWorkspaceError' ? (
+        <ErrorState />
+      ) : viewState === 'loading' ? (
         <Bullseye>
           <Spinner />
         </Bullseye>
-      ) : hasGroups ? (
+      ) : viewState === 'groups' ? (
         <GroupsTable onCreateGroupClick={onCreateGroupClick} />
       ) : (
         <NoGroupsEmptyState onCreateGroupClick={onCreateGroupClick} />

--- a/src/constants.js
+++ b/src/constants.js
@@ -330,6 +330,7 @@ export const INITIAL_PAGE = 1;
 export const EMPTY_CELL = '';
 export const DEBOUNCE_TIMEOUT_MS = 300;
 export const WORKSPACE_RESOURCE_TYPE = 'workspace';
+export const WORKSPACE_RELATION_VIEW = 'view';
 export const WORKSPACE_RELATION_EDIT = 'edit';
 /** Reporter for host access checks (HBI). */
 export const KESSEL_REPORTER = { type: 'hbi' };

--- a/src/constants.js
+++ b/src/constants.js
@@ -361,15 +361,13 @@ export const INITIAL_PAGE = 1;
 export const EMPTY_CELL = '';
 export const DEBOUNCE_TIMEOUT_MS = 300;
 export const WORKSPACE_RESOURCE_TYPE = 'workspace';
-/**
- * Kessel self-access relation for read access on a `workspace` resource (RBAC reporter).
- * Aligns with `docs/kessel-frontend-design-document.md` (workspace `view` = read / list / detail).
- */
 export const WORKSPACE_RELATION_VIEW = 'view';
 export const WORKSPACE_RELATION_EDIT = 'edit';
 export const WORKSPACE_RELATION_DELETE = 'delete';
 export const KESSEL_REPORTER = { type: 'hbi' };
 export const KESSEL_WORKSPACE_REPORTER = { type: 'rbac' };
+/** HTTP status codes from `fetchDefaultWorkspace` that indicate access denied (vs transient failures). */
+export const RBAC_FETCH_ACCESS_DENIED_CODES = [401, 403, 404];
 /**
  * Self-access `relation` values on {@link WORKSPACE_RESOURCE_TYPE} with Default workspace id
  * (see kessel-sdk-browser README “Fetching Workspace IDs for Access Checks”).

--- a/src/routes/InventoryGroups.test.js
+++ b/src/routes/InventoryGroups.test.js
@@ -2,7 +2,22 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { AccessCheck } from '@project-kessel/react-kessel-access-check';
+import { KESSEL_API_PATH } from '../constants';
 import InventoryGroups from './InventoryGroups';
+
+const accessCheckWrapper = ({ children }) => (
+  <AccessCheck.Provider
+    baseUrl={
+      typeof window !== 'undefined'
+        ? window.location.origin
+        : 'http://localhost'
+    }
+    apiPath={KESSEL_API_PATH}
+  >
+    {children}
+  </AccessCheck.Provider>
+);
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -26,8 +41,10 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   }),
 }));
 jest.mock('../Utilities/useFeatureFlag', () => ({
-  __esModule: false,
-  default: jest.fn(() => true),
+  __esModule: true,
+  default: jest.fn((flag) =>
+    flag === 'inventory-frontend.kessel-enabled' ? false : true,
+  ),
   useFeatureVariant: jest.fn(() => ({
     isEnabled: false,
   })),
@@ -35,7 +52,7 @@ jest.mock('../Utilities/useFeatureFlag', () => ({
 
 describe('workspaces route', () => {
   it('renders header and table wrapper', () => {
-    render(<InventoryGroups />);
+    render(<InventoryGroups />, { wrapper: accessCheckWrapper });
 
     screen.getByRole('heading', {
       name: /workspaces/i,
@@ -44,7 +61,7 @@ describe('workspaces route', () => {
   });
 
   it('should contain get help expandable', async () => {
-    render(<InventoryGroups />);
+    render(<InventoryGroups />, { wrapper: accessCheckWrapper });
 
     await userEvent.click(
       screen.getByText(/help get started with new features/i),


### PR DESCRIPTION
Implement Kessel permissions check for users with zero workspace access on the Workspaces page.

## Jira
[RHINENG-25732](https://redhat.atlassian.net/browse/RHINENG-25732)

## What
Currently, the /groups endpoint returns a 200 status with an empty array for both scenarios:

- User has no workspaces (empty list)
- User has no permission to view workspaces (access denied)

This makes it impossible to distinguish between these two states and show the appropriate UI.

## How
Use Kessel SDK to check if user has 'view' permission on the default workspace:

- Fetch default workspace ID via RBAC API (fetchDefaultWorkspace)
- Check 'view' permission using Kessel SDK (useSelfAccessCheck)
- Show "no permissions" message if user cannot view default workspace
- Show empty state (with "Create workspace" button) if user has permission but no workspaces


[RHINENG-25732]: https://redhat.atlassian.net/browse/RHINENG-25732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add Kessel-based workspace access checks to distinguish between no workspaces and no permissions on the Workspaces page.

Bug Fixes:
- Show a dedicated no-access state on the Workspaces page when the user lacks permission to view the default workspace instead of treating it as an empty workspace list.

Enhancements:
- Introduce a dedicated hook to resolve the default workspace via RBAC and perform Kessel self-access checks for workspace view permissions.
- Update the Workspaces page loading and error handling flow to incorporate Kessel permission results and RBAC error codes.
- Adjust Workspaces route tests and add unit tests for the new Kessel access hook, including wiring Kessel providers into relevant tests.

Tests:
- Add unit tests for the new useWorkspacesPageKesselAccess hook to cover flag states, RBAC fetching, self-access checks, and error handling.
- Update InventoryGroups route tests to run within a Kessel AccessCheck provider and respect the Kessel feature flag behavior.