### PR TITLE
test(RHINENG-25741): enable tests on SystemsView table with Kessel changes

### DIFF
--- a/.github/workflows/playwright-systems-view.yml
+++ b/.github/workflows/playwright-systems-view.yml
@@ -55,6 +55,15 @@ jobs:
           echo "Pull Request URL: $pr_url"
           # Set the PR URL as an output using the environment file
           echo "pr_url=$pr_url" >> $GITHUB_ENV
+      
+      - name: Cache - node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            dist
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-frontend-node-modules-
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -66,7 +75,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium
 
       - name: Increase file watchers limit
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p

--- a/.github/workflows/playwright-systems-view.yml
+++ b/.github/workflows/playwright-systems-view.yml
@@ -1,4 +1,4 @@
-name: 'E2E: Full Test Suite'
+name: 'E2E: SystemsView + Kessel'
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  playwright-tests:
+  systems_view-tests:
     runs-on:
       - codebuild-host-inventory-frontend-${{ github.run_id }}-${{ github.run_attempt }}
       - instance-size:large
@@ -42,10 +42,11 @@ jobs:
             echo "BASE_URL=https://stage.foo.redhat.com:1337"
             echo "CI=true"
             echo "PROXY=$PROXY"
+            echo "SYSTEMS_VIEW=true"
           } >> .env
 
           echo ".env file created successfully."
-      
+
       - name: Get current PR URL
         id: get-pr-url
         run: |
@@ -54,44 +55,35 @@ jobs:
           echo "Pull Request URL: $pr_url"
           # Set the PR URL as an output using the environment file
           echo "pr_url=$pr_url" >> $GITHUB_ENV
-      
-      - name: Cache - node_modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            node_modules
-            dist
-          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('package-lock.json') }}
-          restore-keys: ${{ runner.os }}-frontend-node-modules-
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: "npm"
-      
+
       - name: Install front-end dependencies
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install chromium
+        run: npx playwright install --with-deps
 
       - name: Increase file watchers limit
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-      
+
       - name: Update /etc/hosts
         run: sudo npm run patch:hosts
 
       - name: Run testing proxy
         run: docker run -d --network=host -e HTTPS_PROXY=$RH_PROXY_URL -e ROUTES_JSON_PATH=/config/routes-ci.json  -v "$(pwd)/config:/config:ro,Z" --name frontend-development-proxy quay.io/redhat-user-workloads/hcc-platex-services-tenant/frontend-development-proxy
-        
+
       - name: Start front-end server
         run: |
           npm run static &
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-full-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert @integration
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-systems-view-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert @integration
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ npx playwright install  --with-deps
 * `npx playwright test test_navigation.test.ts` - run a specific test file
 * `npx playwright test test_navigation.test.ts -g "Test name"` - run a specific test by its name
 * `npx playwright test --grep-invert @integration` - run tests except integration tests
+* `SYSTEMS_VIEW=true npx playwright test` - run the complete playwright test suite with enabled `SystemsView` and `Kessel` components
+
 
 For more examples on how to run and debug tests, visit the [official Playwright documentation](https://playwright.dev/docs/running-tests).
 

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -1,12 +1,14 @@
 import { expect, test as setup } from '@playwright/test';
 import {
   ensureNotInPreview,
+  enableSystemsViewAndKessel,
   logInWithUser1,
   storeStorageStateAndToken,
   throwIfMissingEnvVariables,
   closePopupsIfExist,
   closeCookieBanner,
 } from './helpers/loginHelpers';
+import { isSystemsViewEnabled } from './helpers/constants';
 
 setup.describe('Setup', async () => {
   setup.describe.configure({ retries: 3 });
@@ -18,11 +20,14 @@ setup.describe('Setup', async () => {
   setup('Authenticate', async ({ page }) => {
     setup.setTimeout(120_000);
 
+    if (isSystemsViewEnabled) {
+      await enableSystemsViewAndKessel(page);
+    }
+
     await closePopupsIfExist(page);
     await logInWithUser1(page);
     await closeCookieBanner(page);
-    await storeStorageStateAndToken(page);
-
     await ensureNotInPreview(page);
+    await storeStorageStateAndToken(page);
   });
 });

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -1,12 +1,14 @@
 import { expect, test as setup } from '@playwright/test';
 import {
   ensureNotInPreview,
+  enableSystemsViewAndKessel,
   logInWithUser1,
   storeStorageStateAndToken,
   throwIfMissingEnvVariables,
   closePopupsIfExist,
   closeCookieBanner,
 } from './helpers/loginHelpers';
+import { isSystemsViewEnabled } from './helpers/constants';
 
 setup.describe('Setup', async () => {
   setup.describe.configure({ retries: 3 });
@@ -17,6 +19,11 @@ setup.describe('Setup', async () => {
 
   setup('Authenticate', async ({ page }) => {
     setup.setTimeout(120_000);
+
+    if (isSystemsViewEnabled) {
+      await enableSystemsViewAndKessel(page);
+    }
+
     await closePopupsIfExist(page);
     await logInWithUser1(page);
     await closeCookieBanner(page);

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -1,14 +1,12 @@
 import { expect, test as setup } from '@playwright/test';
 import {
   ensureNotInPreview,
-  enableSystemsViewAndKessel,
   logInWithUser1,
   storeStorageStateAndToken,
   throwIfMissingEnvVariables,
   closePopupsIfExist,
   closeCookieBanner,
 } from './helpers/loginHelpers';
-import { isSystemsViewEnabled } from './helpers/constants';
 
 setup.describe('Setup', async () => {
   setup.describe.configure({ retries: 3 });
@@ -19,11 +17,6 @@ setup.describe('Setup', async () => {
 
   setup('Authenticate', async ({ page }) => {
     setup.setTimeout(120_000);
-
-    if (isSystemsViewEnabled) {
-      await enableSystemsViewAndKessel(page);
-    }
-
     await closePopupsIfExist(page);
     await logInWithUser1(page);
     await closeCookieBanner(page);

--- a/_playwright-tests/helpers/constants.ts
+++ b/_playwright-tests/helpers/constants.ts
@@ -12,6 +12,8 @@ export const GLOBAL_DATA_PATH = path.resolve(
   `../.global-data-${RUN_ID}.json`,
 );
 
+export const isSystemsViewEnabled = process.env.SYSTEMS_VIEW === 'true';
+
 // Base archives
 export const CENTOS_ARCHIVE = 'centos79.tar.gz';
 export const BOOTC_ARCHIVE = 'image-mode-rhel94.tar.gz';

--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -22,7 +22,12 @@ export const filterSystemsWithConditionalFilter = async (
 ) => {
   let optionCheckbox: Locator | undefined = undefined;
   // 1. SELECT FILER
-  await page.getByRole('button', { name: 'Conditional filter toggle' }).click();
+  await page
+    .locator(
+      '[data-ouia-component-id="DataViewFilters"] button.pf-v6-c-menu-toggle',
+    )
+    .or(page.getByRole('button', { name: 'Conditional filter toggle' }))
+    .click();
   // Wait for the filter menu to be visible before proceeding
   await page
     .getByRole('menuitem', { name: filterName })
@@ -66,7 +71,15 @@ export const filterSystemsWithConditionalFilter = async (
     await expect(optionCheckbox).toBeVisible({ timeout: 100000 });
     await optionCheckbox.click();
   } else if (filterName === 'Operating system') {
-    await page.getByRole('button', { name: 'Group filter' }).nth(1).click();
+    await page
+      .getByRole('button', { name: 'Group filter' })
+      .nth(1)
+      .or(
+        page.locator(
+          '[data-ouia-component-id="SystemsViewOperatingSystemsFilter"]',
+        ),
+      )
+      .click();
     await page.getByRole('checkbox', { name: option, exact: true }).check();
   } else if (filterName === 'Last seen') {
     const lastSeenToggle = page.locator('button', {
@@ -81,12 +94,9 @@ export const filterSystemsWithConditionalFilter = async (
 
   await page.mouse.click(0, 0); //to make sure menu is closed
   // wait for table to be filtered
-  await expect(
-    page.locator('[data-ouia-component-id="SkeletonTable"]'),
-  ).toBeVisible();
   await page
     .locator('[data-ouia-component-id="SkeletonTable"]')
-    .waitFor({ state: 'hidden' });
+    .waitFor({ state: 'detached', timeout: 10000 });
 };
 
 /**
@@ -118,8 +128,8 @@ export const expectAllRowsHaveText = async (
 /**
  * Searches for an item on the page by entering its name into the "Filter by name" input field.
  *
- * This function ensures the search input is visible, reloads the page to guarantee a clean state
- * (waiting for the network to be idle), and then fills the specified name into the input field.
+ * This function ensures the search input is visible, reloads the page to guarantee a clean state,
+ * then fills the specified name into the input field.
  *
  *  @param   {Page}          page - The Playwright Page object to interact with.
  *  @param   {string}        name - The name to enter into the "Filter by name" input field.
@@ -129,10 +139,19 @@ export const expectAllRowsHaveText = async (
  * await searchByName(page, 'my-system-name');
  */
 export const searchByName = async (page: Page, name: string): Promise<void> => {
-  const searchInput = page.locator('input[placeholder="Filter by name"]');
-  await page.reload({ waitUntil: 'networkidle' });
-  await expect(searchInput).toBeVisible();
+  const searchInput = page
+    .locator('input[placeholder="Filter by name"]')
+    .or(page.getByRole('textbox', { name: /display name filter/i }));
+  if (process.env.SYSTEMS_VIEW !== 'true') {
+    await page.reload({ waitUntil: 'networkidle' });
+  } else {
+    await page.reload({ waitUntil: 'load' });
+  }
+  await expect(searchInput).toBeVisible({ timeout: 60_000 });
   await searchInput.fill(name);
+  await page
+    .locator('[data-ouia-component-id="SkeletonTable"]')
+    .waitFor({ state: 'detached', timeout: 10000 });
 };
 
 /**

--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { type Locator, type Page } from '@playwright/test';
-import { isSystemsViewEnabled } from './constants';
+
+const SKELETON_TABLE = '[data-ouia-component-id="SkeletonTable"]';
 
 /**
  * Applies a conditional filter to the systems list in the UI.
@@ -96,7 +97,7 @@ export const filterSystemsWithConditionalFilter = async (
   await page.mouse.click(0, 0); //to make sure menu is closed
   // wait for table to be filtered
   await page
-    .locator('[data-ouia-component-id="SkeletonTable"]')
+    .locator(SKELETON_TABLE)
     .waitFor({ state: 'hidden', timeout: 10000 });
 };
 
@@ -144,9 +145,23 @@ export const searchByName = async (page: Page, name: string): Promise<void> => {
   await page.reload({ waitUntil: 'networkidle' });
   await expect(searchInput).toBeVisible({ timeout: 30000 });
   await searchInput.fill(name);
-  await page
-    .locator('[data-ouia-component-id="SkeletonTable"]')
-    .waitFor({ state: 'hidden', timeout: 30000 });
+};
+
+export const waitForSystemsTableKebabReady = async (
+  page: Page,
+  rowNameMatch: RegExp,
+): Promise<Locator> => {
+  const row = page.getByRole('row', { name: rowNameMatch });
+  const kebab = row.getByLabel('Kebab toggle');
+
+  await expect(async () => {
+    await expect(page.locator(SKELETON_TABLE)).toBeHidden();
+    await expect(row).toBeVisible();
+    await expect(kebab).toBeVisible();
+    await expect(kebab).toBeEnabled();
+  }).toPass({ timeout: 45000 });
+
+  return kebab;
 };
 
 /**

--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -96,7 +96,7 @@ export const filterSystemsWithConditionalFilter = async (
   // wait for table to be filtered
   await page
     .locator('[data-ouia-component-id="SkeletonTable"]')
-    .waitFor({ state: 'detached', timeout: 10000 });
+    .waitFor({ state: 'hidden', timeout: 10000 });
 };
 
 /**
@@ -151,7 +151,7 @@ export const searchByName = async (page: Page, name: string): Promise<void> => {
   await searchInput.fill(name);
   await page
     .locator('[data-ouia-component-id="SkeletonTable"]')
-    .waitFor({ state: 'detached', timeout: 10000 });
+    .waitFor({ state: 'hidden', timeout: 10000 });
 };
 
 /**

--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { type Locator, type Page } from '@playwright/test';
+import { isSystemsViewEnabled } from './constants';
 
 /**
  * Applies a conditional filter to the systems list in the UI.
@@ -128,8 +129,8 @@ export const expectAllRowsHaveText = async (
 /**
  * Searches for an item on the page by entering its name into the "Filter by name" input field.
  *
- * This function ensures the search input is visible, reloads the page to guarantee a clean state,
- * then fills the specified name into the input field.
+ * This function ensures the search input is visible, reloads the page to guarantee a clean state
+ * (waiting for the network to be idle), and then fills the specified name into the input field.
  *
  *  @param   {Page}          page - The Playwright Page object to interact with.
  *  @param   {string}        name - The name to enter into the "Filter by name" input field.
@@ -139,19 +140,13 @@ export const expectAllRowsHaveText = async (
  * await searchByName(page, 'my-system-name');
  */
 export const searchByName = async (page: Page, name: string): Promise<void> => {
-  const searchInput = page
-    .locator('input[placeholder="Filter by name"]')
-    .or(page.getByRole('textbox', { name: /display name filter/i }));
-  if (process.env.SYSTEMS_VIEW !== 'true') {
-    await page.reload({ waitUntil: 'networkidle' });
-  } else {
-    await page.reload({ waitUntil: 'load' });
-  }
-  await expect(searchInput).toBeVisible({ timeout: 60_000 });
+  const searchInput = page.locator('input[placeholder="Filter by name"]');
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(searchInput).toBeVisible({ timeout: 30000 });
   await searchInput.fill(name);
   await page
     .locator('[data-ouia-component-id="SkeletonTable"]')
-    .waitFor({ state: 'hidden', timeout: 10000 });
+    .waitFor({ state: 'hidden', timeout: 30000 });
 };
 
 /**

--- a/_playwright-tests/helpers/fixtures.ts
+++ b/_playwright-tests/helpers/fixtures.ts
@@ -1,7 +1,7 @@
 import { test as base } from '@playwright/test';
 import fs from 'fs';
-import { closePopupsIfExist, enableSystemsViewAndKessel } from './loginHelpers';
-import { GLOBAL_DATA_PATH, isSystemsViewEnabled } from './constants';
+import { closePopupsIfExist } from './loginHelpers';
+import { GLOBAL_DATA_PATH } from './constants';
 import { System } from './uploadArchive';
 
 type SystemsTestData = {
@@ -33,10 +33,6 @@ export const test = base.extend<{
   systems: SystemsTestData;
 }>({
   page: async ({ page }, use) => {
-    if (isSystemsViewEnabled) {
-      await enableSystemsViewAndKessel(page);
-    }
-
     await closePopupsIfExist(page);
     await use(page);
   },

--- a/_playwright-tests/helpers/fixtures.ts
+++ b/_playwright-tests/helpers/fixtures.ts
@@ -1,7 +1,7 @@
 import { test as base } from '@playwright/test';
 import fs from 'fs';
-import { closePopupsIfExist } from './loginHelpers';
-import { GLOBAL_DATA_PATH } from './constants';
+import { closePopupsIfExist, enableSystemsViewAndKessel } from './loginHelpers';
+import { GLOBAL_DATA_PATH, isSystemsViewEnabled } from './constants';
 import { System } from './uploadArchive';
 
 type SystemsTestData = {
@@ -14,6 +14,7 @@ type SystemsTestData = {
 
 /**
  * Safely loads and validates the global test data file.
+ *  @param path
  */
 function loadGlobalSystemsData(path: string): SystemsTestData {
   if (!fs.existsSync(path)) {
@@ -32,6 +33,10 @@ export const test = base.extend<{
   systems: SystemsTestData;
 }>({
   page: async ({ page }, use) => {
+    if (isSystemsViewEnabled) {
+      await enableSystemsViewAndKessel(page);
+    }
+
     await closePopupsIfExist(page);
     await use(page);
   },

--- a/_playwright-tests/helpers/loginHelpers.ts
+++ b/_playwright-tests/helpers/loginHelpers.ts
@@ -104,6 +104,20 @@ export const closeCookieBanner = async (page: Page) => {
   await iframeLocator.waitFor({ state: 'hidden', timeout: 5000 });
 };
 
+export const enableSystemsViewAndKessel = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('ui.systems-view', 'true');
+    localStorage.setItem('inventory-frontend.kessel-enabled', 'true');
+  });
+};
+
+export const disableSystemsViewAndKessel = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('ui.systems-view', 'false');
+    localStorage.setItem('inventory-frontend.kessel-enabled', 'false');
+  });
+};
+
 export const storeStorageStateAndToken = async (page: Page) => {
   const { cookies } = await page.context().storageState({
     path: path.join(__dirname, '../../.auth/admin_user.json'),
@@ -140,6 +154,7 @@ export const ensureNotInPreview = async (page: Page) => {
     .locator('div')
     .filter({ hasText: 'Preview mode' })
     .getByRole('switch');
+
   if ((await toggle.isVisible()) && (await toggle.isChecked())) {
     await toggle.click();
   }

--- a/_playwright-tests/helpers/navHelpers.ts
+++ b/_playwright-tests/helpers/navHelpers.ts
@@ -11,11 +11,9 @@ export const navigateToInventorySystemsFunc = async (page: Page) => {
   await expect(page.getByRole('heading', { name: 'Systems' })).toBeVisible({
     timeout: 100000,
   });
-
-  // Wait for pagination controls to appear, indicating data is loaded
-  await expect(page.locator('#options-menu-bottom-toggle')).toBeVisible({
-    timeout: 90000,
-  });
+  await page
+    .locator('[data-ouia-component-id="SkeletonTable"]')
+    .waitFor({ state: 'detached', timeout: 10000 });
 };
 
 /**

--- a/_playwright-tests/helpers/navHelpers.ts
+++ b/_playwright-tests/helpers/navHelpers.ts
@@ -13,7 +13,7 @@ export const navigateToInventorySystemsFunc = async (page: Page) => {
   });
   await page
     .locator('[data-ouia-component-id="SkeletonTable"]')
-    .waitFor({ state: 'detached', timeout: 10000 });
+    .waitFor({ state: 'hidden', timeout: 10000 });
 };
 
 /**

--- a/_playwright-tests/helpers/navHelpers.ts
+++ b/_playwright-tests/helpers/navHelpers.ts
@@ -13,7 +13,7 @@ export const navigateToInventorySystemsFunc = async (page: Page) => {
   });
   await page
     .locator('[data-ouia-component-id="SkeletonTable"]')
-    .waitFor({ state: 'hidden', timeout: 10000 });
+    .waitFor({ state: 'hidden', timeout: 30000 });
 };
 
 /**

--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -246,7 +246,6 @@ test('User should be able to delete multiple systems from Systems page', async (
     });
 
     await test.step(`Sort by Name column in ${order} order`, async () => {
-      // const columnHeader = page.locator('th[data-label="Name"] button');
       const columnHeader = page
         .locator('button.pf-v6-c-table__button')
         .filter({ hasText: /^Name$/ })

--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -1,8 +1,9 @@
-import { expect } from '@playwright/test';
+import { expect, Locator } from '@playwright/test';
 import { createSystem } from './helpers/uploadArchive';
 import { navigateToInventorySystemsFunc } from './helpers/navHelpers';
 import { test } from './helpers/fixtures';
 import { searchByName } from './helpers/filterHelpers';
+import { isSystemsViewEnabled } from './helpers/constants';
 
 test('User should be able to edit and delete a system from Systems page', async ({
   page,
@@ -20,7 +21,9 @@ test('User should be able to edit and delete a system from Systems page', async 
   const system = await createSystem();
   const newDisplayName = `${system.hostname}_Renamed`;
   const dialog = page.locator('[role="dialog"]');
-  const nameCell = page.locator('td[data-label="Name"]');
+  const nameCell = page
+    .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')
+    .or(page.locator('td[data-label="Name"]'));
 
   await test.step('Navigate to Inventory → Systems', async () => {
     await navigateToInventorySystemsFunc(page);
@@ -34,12 +37,18 @@ test('User should be able to edit and delete a system from Systems page', async 
       .getByLabel('Kebab toggle')
       .click();
 
-    await page
-      .getByRole('menuitem', { name: 'Edit display name' })
-      .nth(1)
-      .click();
-
+    if (isSystemsViewEnabled) {
+      const editButton = page.getByRole('menuitem', { name: /^\s*Edit\s*$/i });
+      await expect(editButton).toBeEnabled({ timeout: 10000 });
+      await editButton.click();
+    } else {
+      await page
+        .getByRole('menuitem', { name: 'Edit display name' })
+        .first()
+        .click();
+    }
     await expect(dialog).toBeVisible();
+
     await expect(page.getByRole('textbox')).toHaveValue(system.hostname);
     await dialog.locator('input').first().fill(newDisplayName);
     await dialog.getByRole('button', { name: 'Save' }).click();
@@ -54,85 +63,23 @@ test('User should be able to edit and delete a system from Systems page', async 
       .getByLabel('Kebab toggle')
       .click();
 
-    await page
-      .getByRole('menuitem', { name: 'Delete from inventory' })
-      .nth(1)
-      .click();
+    if (isSystemsViewEnabled) {
+      const deleteButton = page.getByRole('menuitem', {
+        name: /^\s*Delete\s*$/i,
+      });
+      await expect(deleteButton).toBeEnabled({ timeout: 10000 });
+      await deleteButton.click();
+    } else {
+      await page
+        .getByRole('menuitem', { name: 'Delete from inventory' })
+        .first()
+        .click();
+    }
     await expect(dialog).toBeVisible();
     await dialog.getByRole('button', { name: 'Delete' }).click();
 
     await searchByName(page, newDisplayName);
     await expect(page.getByText('No matching systems found')).toBeVisible();
-  });
-});
-
-test('User should be able to edit and delete a system from System Details page', async ({
-  page,
-}) => {
-  /**
-   * Jira References:
-     - https://issues.redhat.com/browse/RHINENG-21147 – Edit a system
-     - https://issues.redhat.com/browse/RHINENG-21149 - Delete a system
-   * Metadata:
-     - requirements:
-     - inv-hosts-patch
-     - inv-hosts-delete-by-id
-     - importance: critical
-   */
-  const system = await createSystem();
-  const editButtons = page.getByRole('button', { name: 'Edit' });
-  const dialog = page.locator('[role="dialog"]');
-  const nameCell = page.locator('td[data-label="Name"]');
-  const newDisplayName = `host_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
-  const newAnsibleName = `host_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
-
-  await test.step("Navigate to system's details page", async () => {
-    await navigateToInventorySystemsFunc(page);
-    await searchByName(page, system.hostname);
-    await expect(nameCell).toHaveCount(1);
-
-    const systemLink = page.getByRole('link', { name: system.hostname });
-    await systemLink.click();
-
-    // Detail page heading shows display_name (full or truncated); accept either
-    const heading = page.getByRole('heading', { level: 1 }).first();
-    await expect(heading).toBeVisible({ timeout: 100000 });
-    await expect(heading).toContainText(system.hostname.substring(0, 36));
-  });
-
-  await test.step('Edit the system display name and verify', async () => {
-    await editButtons.nth(0).click();
-    await page.locator('[aria-label="name"]').first().fill(newDisplayName);
-    await page.getByRole('button', { name: 'submit' }).click();
-    await page.waitForTimeout(2000);
-
-    await expect(
-      page.getByRole('heading', { name: newDisplayName, level: 1 }),
-    ).toBeVisible();
-    const displayNameValueLocator = page.getByLabel('Display name value');
-    // UI may truncate with ellipsis (maxCharsDisplayed=36)
-    await expect(displayNameValueLocator).toContainText(newDisplayName);
-  });
-
-  await test.step('Edit the system Ansible name and verify', async () => {
-    await editButtons.nth(1).click();
-    await page.locator('[aria-label="name"]').first().fill(newAnsibleName);
-    await page.getByRole('button', { name: 'submit' }).click();
-    await page.waitForTimeout(2000);
-
-    const ansibleNameValueLocator = page.getByLabel('Ansible hostname value');
-    // UI may truncate with ellipsis (maxCharsDisplayed=36)
-    await expect(ansibleNameValueLocator).toContainText(newAnsibleName);
-  });
-
-  await test.step(`Delete the system and verify it is removed`, async () => {
-    await page.getByRole('button', { name: 'Delete' }).click();
-    await expect(dialog).toBeVisible();
-    await dialog.getByRole('button', { name: 'Delete' }).click();
-    await page.waitForTimeout(2000);
-    await expect(page.getByText('Delete operation finished')).toBeVisible({
-      timeout: 5000,
-    });
   });
 });
 
@@ -238,7 +185,14 @@ test('User should be able to delete multiple systems from Systems page', async (
      - importance: critical
    */
   const dialog = page.locator('[role="dialog"]');
-  const nameCell = page.locator('td[data-label="Name"]');
+  let nameCell: Locator;
+  if (isSystemsViewEnabled) {
+    nameCell = page.locator(
+      'tbody.pf-v6-c-table__tbody tr[data-ouia-component-type="PF6/TableRow"]',
+    );
+  } else {
+    nameCell = page.locator('td[data-label="Name"]');
+  }
 
   await test.step('Navigate to Inventory → Systems', async () => {
     await navigateToInventorySystemsFunc(page);
@@ -248,11 +202,15 @@ test('User should be able to delete multiple systems from Systems page', async (
   });
 
   await test.step('Select all systems using Bulk Select', async () => {
-    await page.locator('[data-ouia-component-id="BulkSelect"]').click();
+    const bulkSelectBtn = page
+      .locator('[data-ouia-component-id="BulkSelect-toggle"]')
+      .or(page.locator('[data-ouia-component-id="BulkSelect"]'));
+    await bulkSelectBtn.click();
+
     await page.getByRole('menuitem', { name: 'Select page' }).click();
-    const bulkSelect = page.locator(
-      '[id="bulk-select-systems-toggle-checkbox"]',
-    );
+    const bulkSelect = page
+      .locator('[id="bulk-select-systems-toggle-checkbox"]')
+      .or(page.locator('[data-ouia-component-id="BulkSelect-text"]'));
     await expect(bulkSelect).toContainText(
       `${systems.deleteSystems.length} selected`,
     );
@@ -288,13 +246,17 @@ test('User should be able to delete multiple systems from Systems page', async (
     });
 
     await test.step(`Sort by Name column in ${order} order`, async () => {
-      const columnHeader = page.locator('th[data-label="Name"] button');
+      // const columnHeader = page.locator('th[data-label="Name"] button');
+      const columnHeader = page
+        .locator('button.pf-v6-c-table__button')
+        .filter({ hasText: /^Name$/ })
+        .or(page.locator('th[data-label="Name"] button'));
       await expect(columnHeader).toBeVisible();
 
       // Expected URL sort parameter: ascending = display_name, descending = -display_name
       const expectedSortParam = {
-        ascending: 'sort=display_name',
-        descending: 'sort=-display_name',
+        ascending: /sort=display_name|order_how=asc/,
+        descending: /sort=-display_name|order_how=desc/,
       };
 
       // Keep clicking until we reach the desired sort direction (max 3 clicks)
@@ -311,10 +273,7 @@ test('User should be able to delete multiple systems from Systems page', async (
         await columnHeader.click();
 
         // Wait for the sort to take effect
-        await expect(async () => {
-          const url = page.url();
-          expect(url).toContain('sort=');
-        }).toPass({ timeout: 5000 });
+        await expect(page).toHaveURL(/sort=|order_how=/);
       }
 
       // Verify we reached the target sort direction
@@ -328,12 +287,14 @@ test('User should be able to delete multiple systems from Systems page', async (
       // Verify URL has exact sort parameter for the expected order
       await expect(async () => {
         const url = page.url();
-        expect(url).toContain(expectedSortParam[order]);
+        expect(url).toMatch(expectedSortParam[order]);
       }).toPass({ timeout: 5000 });
     });
 
     await test.step('Verify systems are sorted alphabetically', async () => {
-      const nameCell = page.locator('td[data-label="Name"] a');
+      const nameCell = page
+        .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')
+        .or(page.locator('td[data-label="Name"]'));
       await expect(nameCell.first()).toBeVisible();
 
       const displayedNames = await nameCell.allTextContents();
@@ -354,7 +315,10 @@ test('User should be able to delete multiple systems from Systems page', async (
     });
 
     await test.step('Verify sort indicator is displayed', async () => {
-      const columnHeader = page.locator('th[data-label="Name"]');
+      const columnHeader = page
+        .locator('th')
+        .filter({ has: page.getByRole('button', { name: 'Name' }) })
+        .or(page.locator('[data-ouia-component-id="systems-view-table-th-0"]'));
       await expect(columnHeader).toHaveAttribute('aria-sort', order);
     });
   });

--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -32,21 +32,18 @@ test('User should be able to edit and delete a system from Systems page', async 
   await test.step(`Edit the system "${system.hostname}" display name and save`, async () => {
     await searchByName(page, system.hostname);
     await expect(nameCell).toHaveCount(1);
-    await page
+    const kebab = page
       .getByRole('row', { name: new RegExp(system.hostname, 'i') })
-      .getByLabel('Kebab toggle')
-      .click();
+      .getByLabel('Kebab toggle');
+    await kebab.click();
+    await expect(kebab).toHaveAttribute('aria-expanded', 'true');
 
-    if (isSystemsViewEnabled) {
-      const editButton = page.getByRole('menuitem', { name: /^\s*Edit\s*$/i });
-      await expect(editButton).toBeEnabled({ timeout: 10000 });
-      await editButton.click();
-    } else {
-      await page
-        .getByRole('menuitem', { name: 'Edit display name' })
-        .first()
-        .click();
-    }
+    const editButton = page.getByRole('menuitem', { name: /^Edit/ }).first();
+    await expect(editButton).toBeEnabled({
+      enabled: isSystemsViewEnabled || undefined,
+      timeout: 50000,
+    });
+    await editButton.click();
     await expect(dialog).toBeVisible();
 
     await expect(page.getByRole('textbox')).toHaveValue(system.hostname);
@@ -57,24 +54,23 @@ test('User should be able to edit and delete a system from Systems page', async 
   await test.step(`Delete the renamed system "${newDisplayName}" and verify it is removed`, async () => {
     await searchByName(page, newDisplayName);
     await expect(nameCell).toHaveCount(1);
+    const row = page.getByRole('row', {
+      name: new RegExp(newDisplayName, 'i'),
+    });
+    await expect(row).toBeVisible();
+    const kebab = row.getByLabel('Kebab toggle');
+    await kebab.click();
+    await expect(kebab).toHaveAttribute('aria-expanded', 'true');
 
-    await page
-      .getByRole('row', { name: new RegExp(newDisplayName, 'i') })
-      .getByLabel('Kebab toggle')
-      .click();
+    const deleteButton = page
+      .getByRole('menuitem', { name: /^Delete/ })
+      .first();
+    await expect(deleteButton).toBeEnabled({
+      enabled: isSystemsViewEnabled || undefined,
+      timeout: 50000,
+    });
+    await deleteButton.click();
 
-    if (isSystemsViewEnabled) {
-      const deleteButton = page.getByRole('menuitem', {
-        name: /^\s*Delete\s*$/i,
-      });
-      await expect(deleteButton).toBeEnabled({ timeout: 10000 });
-      await deleteButton.click();
-    } else {
-      await page
-        .getByRole('menuitem', { name: 'Delete from inventory' })
-        .first()
-        .click();
-    }
     await expect(dialog).toBeVisible();
     await dialog.getByRole('button', { name: 'Delete' }).click();
 
@@ -185,14 +181,9 @@ test('User should be able to delete multiple systems from Systems page', async (
      - importance: critical
    */
   const dialog = page.locator('[role="dialog"]');
-  let nameCell: Locator;
-  if (isSystemsViewEnabled) {
-    nameCell = page.locator(
-      'tbody.pf-v6-c-table__tbody tr[data-ouia-component-type="PF6/TableRow"]',
-    );
-  } else {
-    nameCell = page.locator('td[data-label="Name"]');
-  }
+  const nameCell = page.locator(
+    'tbody.pf-v6-c-table__tbody tr[data-ouia-component-type="PF6/TableRow"]',
+  );
 
   await test.step('Navigate to Inventory → Systems', async () => {
     await navigateToInventorySystemsFunc(page);

--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -2,7 +2,10 @@ import { expect, Locator } from '@playwright/test';
 import { createSystem } from './helpers/uploadArchive';
 import { navigateToInventorySystemsFunc } from './helpers/navHelpers';
 import { test } from './helpers/fixtures';
-import { searchByName } from './helpers/filterHelpers';
+import {
+  searchByName,
+  waitForSystemsTableKebabReady,
+} from './helpers/filterHelpers';
 import { isSystemsViewEnabled } from './helpers/constants';
 
 test('User should be able to edit and delete a system from Systems page', async ({
@@ -32,9 +35,10 @@ test('User should be able to edit and delete a system from Systems page', async 
   await test.step(`Edit the system "${system.hostname}" display name and save`, async () => {
     await searchByName(page, system.hostname);
     await expect(nameCell).toHaveCount(1);
-    const kebab = page
-      .getByRole('row', { name: new RegExp(system.hostname, 'i') })
-      .getByLabel('Kebab toggle');
+    const kebab = await waitForSystemsTableKebabReady(
+      page,
+      new RegExp(system.hostname, 'i'),
+    );
     await kebab.click();
     await expect(kebab).toHaveAttribute('aria-expanded', 'true');
 
@@ -54,11 +58,10 @@ test('User should be able to edit and delete a system from Systems page', async 
   await test.step(`Delete the renamed system "${newDisplayName}" and verify it is removed`, async () => {
     await searchByName(page, newDisplayName);
     await expect(nameCell).toHaveCount(1);
-    const row = page.getByRole('row', {
-      name: new RegExp(newDisplayName, 'i'),
-    });
-    await expect(row).toBeVisible();
-    const kebab = row.getByLabel('Kebab toggle');
+    const kebab = await waitForSystemsTableKebabReady(
+      page,
+      new RegExp(newDisplayName, 'i'),
+    );
     await kebab.click();
     await expect(kebab).toHaveAttribute('aria-expanded', 'true');
 

--- a/_playwright-tests/test_system_details.test.ts
+++ b/_playwright-tests/test_system_details.test.ts
@@ -4,6 +4,7 @@ import { test } from './helpers/fixtures';
 import { searchByName } from './helpers/filterHelpers';
 import { closePopupsIfExist } from './helpers/loginHelpers';
 import { WORKSPACE_UNGROUPED_HOSTS } from './helpers/constants';
+import { createSystem } from './helpers/uploadArchive';
 
 test.describe('System Details tests', () => {
   test.beforeEach(async ({ page }) => {
@@ -161,6 +162,76 @@ test.describe('System Details tests', () => {
       // Complinace doesn't support image-based system
       const complianceTab = page.locator('button[name="compliance"]');
       await expect(complianceTab).toBeDisabled();
+    });
+  });
+
+  test('User should be able to edit and delete a system from System Details page', async ({
+    page,
+  }) => {
+    /**
+     * Jira References:
+       - https://issues.redhat.com/browse/RHINENG-21147 – Edit a system
+       - https://issues.redhat.com/browse/RHINENG-21149 - Delete a system
+     * Metadata:
+       - requirements:
+       - inv-hosts-patch
+       - inv-hosts-delete-by-id
+       - importance: critical
+     */
+    const system = await createSystem();
+    const editButtons = page.getByRole('button', { name: 'Edit' });
+    const dialog = page.locator('[role="dialog"]');
+    const nameCell = page.locator('td[data-label="Name"]');
+    const newDisplayName = `host_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+    const newAnsibleName = `host_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+
+    await test.step("Navigate to system's details page", async () => {
+      await navigateToInventorySystemsFunc(page);
+      await searchByName(page, system.hostname);
+      await expect(nameCell).toHaveCount(1);
+
+      const systemLink = page.getByRole('link', { name: system.hostname });
+      await systemLink.click();
+
+      // Detail page heading shows display_name (full or truncated); accept either
+      const heading = page.getByRole('heading', { level: 1 }).first();
+      await expect(heading).toBeVisible({ timeout: 100000 });
+      await expect(heading).toContainText(system.hostname.substring(0, 36));
+    });
+
+    await test.step('Edit the system display name and verify', async () => {
+      await editButtons.nth(0).click();
+      await page.locator('[aria-label="name"]').first().fill(newDisplayName);
+      await page.getByRole('button', { name: 'submit' }).click();
+      await page.waitForTimeout(2000);
+
+      await expect(
+        page.getByRole('heading', { name: newDisplayName, level: 1 }),
+      ).toBeVisible();
+      const displayNameValueLocator = page.getByLabel('Display name value');
+      // UI may truncate with ellipsis (maxCharsDisplayed=36)
+      await expect(displayNameValueLocator).toContainText(newDisplayName);
+    });
+
+    await test.step('Edit the system Ansible name and verify', async () => {
+      await editButtons.nth(1).click();
+      await page.locator('[aria-label="name"]').first().fill(newAnsibleName);
+      await page.getByRole('button', { name: 'submit' }).click();
+      await page.waitForTimeout(2000);
+
+      const ansibleNameValueLocator = page.getByLabel('Ansible hostname value');
+      // UI may truncate with ellipsis (maxCharsDisplayed=36)
+      await expect(ansibleNameValueLocator).toContainText(newAnsibleName);
+    });
+
+    await test.step(`Delete the system and verify it is removed`, async () => {
+      await page.getByRole('button', { name: 'Delete' }).click();
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole('button', { name: 'Delete' }).click();
+      await page.waitForTimeout(2000);
+      await expect(page.getByText('Delete operation finished')).toBeVisible({
+        timeout: 5000,
+      });
     });
   });
 });

--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -264,9 +264,6 @@ test.describe('Filtering Systems Tests', () => {
       }
 
       // Open conditional filter dropdown and select "Last seen"
-      // await page
-      //   .getByRole('button', { name: 'Conditional filter toggle' })
-      //   .click();
       await page
         .locator(
           '[data-ouia-component-id="DataViewFilters"] button.pf-v6-c-menu-toggle',

--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -10,6 +10,7 @@ import {
   WORKSPACE_WITH_SYSTEMS,
   BASE_ARCHIVE_TAG_COUNT,
   TAG,
+  isSystemsViewEnabled,
 } from './helpers/constants';
 
 test.describe('Filtering Systems Tests', () => {
@@ -300,7 +301,7 @@ test.describe('Filtering Systems Tests', () => {
     });
 
     await test.step('Verify URL contains correct filter parameter', async () => {
-      if (process.env.SYSTEMS_VIEW !== 'true') {
+      if (!isSystemsViewEnabled) {
         await expect(async () => {
           const url = page.url();
           expect(url).toContain('last_seen=last24');

--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -21,9 +21,9 @@ test.describe('Filtering Systems Tests', () => {
   test.beforeEach(async ({ page }) => {
     await closePopupsIfExist(page);
     await navigateToInventorySystemsFunc(page);
-    const resetFiltersButton = page.getByRole('button', {
-      name: 'Reset filters',
-    });
+    const resetFiltersButton = page
+      .getByRole('button', { name: 'Reset filters' })
+      .or(page.getByRole('button', { name: 'Clear filters' }));
     if (await resetFiltersButton.isVisible({ timeout: 100 })) {
       await resetFiltersButton.click();
     }
@@ -55,9 +55,9 @@ test.describe('Filtering Systems Tests', () => {
 
     await test.step('Image-based system option', async () => {
       // Reset previews filter
-      const resetFiltersButton = page.getByRole('button', {
-        name: 'Reset filters',
-      });
+      const resetFiltersButton = page
+        .getByRole('button', { name: 'Reset filters' })
+        .or(page.getByRole('button', { name: 'Clear filters' }));
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (await resetFiltersButton.isVisible({ timeout: 100 })) {
         await resetFiltersButton.click();
@@ -90,12 +90,18 @@ test.describe('Filtering Systems Tests', () => {
       'Workspace',
       WORKSPACE_WITH_SYSTEMS,
     );
-    const workspaceCellWithValue = page.locator(
-      'table tbody td[data-label="Workspace"]',
-      {
+    const workspaceCellWithValue = page
+      .locator('td[data-label="Workspace"]', {
         hasText: WORKSPACE_WITH_SYSTEMS,
-      },
-    );
+      })
+      .or(
+        page.locator(
+          'td[data-ouia-component-id^="systems-view-table-td-"][data-ouia-component-id$="-1"]',
+          {
+            hasText: WORKSPACE_WITH_SYSTEMS,
+          },
+        ),
+      );
     await expect(workspaceCellWithValue.first()).toBeVisible();
     const count = await workspaceCellWithValue.count();
     await expect(workspaceCellWithValue).toHaveText(
@@ -149,12 +155,13 @@ test.describe('Filtering Systems Tests', () => {
       });
 
       await test.step('Verify filtered results show correct OS', async () => {
-        const columnVersionOS = page.locator(
-          'table tbody td[data-label="OS"]',
-          {
-            hasText: testData.OS,
-          },
-        );
+        const columnVersionOS = page
+          .locator('td[data-label="OS"]', { hasText: testData.OS })
+          .or(
+            page.locator('span[aria-label="Formatted OS version"]', {
+              hasText: testData.OS,
+            }),
+          );
         await expect(columnVersionOS.first()).toBeVisible();
         const count = await columnVersionOS.count();
         await expect(columnVersionOS).toHaveText(
@@ -257,8 +264,14 @@ test.describe('Filtering Systems Tests', () => {
       }
 
       // Open conditional filter dropdown and select "Last seen"
+      // await page
+      //   .getByRole('button', { name: 'Conditional filter toggle' })
+      //   .click();
       await page
-        .getByRole('button', { name: 'Conditional filter toggle' })
+        .locator(
+          '[data-ouia-component-id="DataViewFilters"] button.pf-v6-c-menu-toggle',
+        )
+        .or(page.getByRole('button', { name: 'Conditional filter toggle' }))
         .click();
       await page.getByRole('menuitem', { name: 'Last seen' }).click();
 
@@ -290,10 +303,12 @@ test.describe('Filtering Systems Tests', () => {
     });
 
     await test.step('Verify URL contains correct filter parameter', async () => {
-      await expect(async () => {
-        const url = page.url();
-        expect(url).toContain('last_seen=last24');
-      }).toPass({ timeout: 5000 });
+      if (process.env.SYSTEMS_VIEW !== 'true') {
+        await expect(async () => {
+          const url = page.url();
+          expect(url).toContain('last_seen=last24');
+        }).toPass({ timeout: 5000 });
+      }
     });
 
     await test.step('Verify table shows filtered results', async () => {

--- a/playwright_example.env
+++ b/playwright_example.env
@@ -8,6 +8,5 @@ TOKEN="" # This is handled programmatically.
 INTEGRATION="" # When this is true, playwright test will run integration tests directly against stage/prod.
 PROXY="" # Set this if running directly against stage (not using "npm local")
 PROD=""  # Determines the environment used for the tests.
-
 # Run tests with enabled 'SystemsView' and 'Kessel'
 SYSTEMS_VIEW="" # This is set to true for SystemsView CI job

--- a/playwright_example.env
+++ b/playwright_example.env
@@ -8,3 +8,6 @@ TOKEN="" # This is handled programmatically.
 INTEGRATION="" # When this is true, playwright test will run integration tests directly against stage/prod.
 PROXY="" # Set this if running directly against stage (not using "npm local")
 PROD=""  # Determines the environment used for the tests.
+
+# Run tests with enabled 'SystemsView' and 'Kessel'
+SYSTEMS_VIEW="" # This is set to true for SystemsView CI job

--- a/src/Utilities/hooks/useKesselMigrationFeatureFlag.js
+++ b/src/Utilities/hooks/useKesselMigrationFeatureFlag.js
@@ -2,5 +2,7 @@ import useFeatureFlag from '../useFeatureFlag';
 
 export const useKesselMigrationFeatureFlag = () => {
   const isFlagEnabled = useFeatureFlag('inventory-frontend.kessel-enabled');
-  return isFlagEnabled || false;
+  const hasLocalFlag =
+    localStorage.getItem('inventory-frontend.kessel-enabled') === 'true';
+  return isFlagEnabled || hasLocalFlag;
 };

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -188,7 +188,6 @@ const SystemsViewInner = ({
               bodyStates={{
                 loading: (
                   <SkeletonTable
-                    ouiaId="loading-state"
                     isSelectable
                     rowsCount={pagination.perPage}
                     columns={tableHeaderNodes}

--- a/src/components/SystemsView/SystemsViewBulkActions.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.tsx
@@ -60,6 +60,7 @@ export const SystemsViewBulkActions = ({
           <ResponsiveAction
             isPersistent
             variant="secondary"
+            ouiaId="bulk-delete-button"
             onClick={() => openDeleteModal(selectedSystems)}
             isDisabled={moveDisabled}
           >
@@ -75,6 +76,7 @@ export const SystemsViewBulkActions = ({
         <ResponsiveActions ouiaId="systems-view-toolbar-actions">
           <ResponsiveAction
             isPersistent
+            ouiaId="bulk-delete-button"
             onClick={() => openDeleteModal(selectedSystems)}
             isDisabled={moveDisabled || !hasHostsWrite}
           >

--- a/src/components/SystemsView/SystemsViewExport.tsx
+++ b/src/components/SystemsView/SystemsViewExport.tsx
@@ -40,7 +40,8 @@ export const SystemsViewExport = () => {
           toggle={(toggleRef) => (
             <MenuToggle
               ref={toggleRef}
-              aria-label="Persistent example overflow menu"
+              aria-label="Export"
+              ouiaId="Export"
               variant="plain"
               onClick={onToggle}
               isExpanded={isOpen}

--- a/src/routes/InventoryViews.tsx
+++ b/src/routes/InventoryViews.tsx
@@ -31,7 +31,7 @@ const InventoryViews = ({ hasAccess }: InventoryViewsProps) => {
               style={{ alignItems: 'center' }}
               spaceItems={{ default: 'spaceItemsSm' }}
             >
-              <FlexItem>Systems View</FlexItem>
+              <FlexItem>Systems</FlexItem>
               <FlexItem>
                 <InventoryPopover />
               </FlexItem>


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-25741

## What
Added a CI workflow to run E2E tests. These tests specifically validate the integration between `SystemsView` and `Kessel` components within the Systems page to ensure data consistency and UI stability.

## Why
Since `SystemsView` and `Kessel` is planned to be enabled in Prod Preview while the Stable tier continues to use the `InventoryTable` component, these tests ensure that both table implementations remain functional and regression-free.

## How
To avoid flaky tests caused by account-level preview settings, I added a Playwright init script to toggle the view via `localStorage`. This ensures CI isolation and allows parallel testing without affecting the account's global state.

## Testing
<!-- How was this tested? -->

## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->

## Summary by Sourcery

Enable Playwright E2E tests to run reliably in both classic and preview inventory UIs and align table metadata for automated interactions.

New Features:
- Support running E2E inventory systems tests against the preview UI via the E2E_PREVIEW flag.

Bug Fixes:
- Stabilize preview mode toggling to reliably turn preview on or off before tests run.
- Fix flaky selectors in systems table actions and bulk select by using more robust labels and OUIA attributes.
- Relax sort-URL expectations to handle both legacy and new sort parameter formats.

Enhancements:
- Move the system-details edit/delete test into the dedicated System Details test suite.
- Add consistent data-label metadata for systems table headers and cells, including an explicit Actions column label.
- Set clearer labels and OUIA IDs for export and bulk delete toolbar actions.
- Rename the Systems View page title in the inventory views route to 'Systems' for consistency.