### PR TITLE
fix(deps): bump axios to 1.15.0 [foreman-3.16]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@sentry/webpack-plugin": "^2.22.5",
         "@unleash/proxy-client-react": "^3.5.0",
         "awesome-debounce-promise": "^2.1.0",
+        "axios": "^1.15.0",
         "bastilian-tabletools": "^1.11.5",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",
@@ -9187,14 +9188,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -9209,6 +9210,15 @@
       },
       "peerDependencies": {
         "axios": ">= 0.17.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/babel-jest": {
@@ -14222,9 +14232,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -14478,9 +14488,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@redhat-cloud-services/javascript-clients-shared": "^2.0.0",
     "@sentry/webpack-plugin": "^2.22.5",
     "@unleash/proxy-client-react": "^3.5.0",
+    "axios": "^1.15.0",
     "awesome-debounce-promise": "^2.1.0",
     "bastilian-tabletools": "^1.11.5",
     "classnames": "^2.3.1",


### PR DESCRIPTION
Adds `axios` as an explicit direct dependency at `^1.15.0` (was previously only a transitive dep resolved to `1.11.0`) and regenerates `package-lock.json`.

## CVEs fixed
- CVE-2026-40175 — Axios RCE via Prototype Pollution
- CVE-2026-25639 — Axios Denial of Service via `__proto__`
- CVE-2026-26996 — Axios improper input validation
- CVE-2026-27904 — Axios improper input validation

## Changes
- `package.json`: added `"axios": "^1.15.0"` to dependencies (was implicit transitive at 1.11.0)
- `package-lock.json`: regenerated via `npm install --package-lock-only --ignore-scripts`

## Summary by Sourcery

Build:
- Regenerate package-lock.json after adding axios as an explicit dependency.