### PR TITLE
ci: Adding autolabeling for Konflux checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Jira
-[RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-xxxx)
+[RHINENG-xxxxx](https://redhat.atlassian.net/browse/RHINENG-xxxxx)
 
 ## What
 <!-- Short description of the change -->

--- a/.github/workflows/label-needs-review.yaml
+++ b/.github/workflows/label-needs-review.yaml
@@ -1,48 +1,76 @@
-# Manages PR labels based on check suite results:
-# - All checks pass  → add "ready for review", remove "ci-failing"
-# - Any check fails  → add "ci-failing", remove "ready for review"
+# Labels PRs based on combined CI status (GitHub Actions + Konflux):
+#   All pass → "ready for review" | Any fail → "ci-failing" | Pending → no change
 
 name: Label PR by CI Status
 
 on:
   check_suite:
     types: [completed]
+  status:
+  workflow_dispatch:
 
 jobs:
   update-labels:
-    if: github.event.check_suite.pull_requests[0] != null
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       checks: read
+      statuses: read
     steps:
-      - name: Update PR labels based on CI status
+      - name: Update PR labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.check_suite.pull_requests[0].number }}
+          REPO: ${{ github.repository }}
         run: |
-          echo "Checking PR #$PR_NUMBER..."
+          # --- Resolve PR number and HEAD SHA ---
+          if [ "${{ github.event_name }}" = "check_suite" ]; then
+            PR="${{ github.event.check_suite.pull_requests[0].number }}"
+            SHA="${{ github.event.check_suite.head_sha }}"
+          elif [ "${{ github.event_name }}" = "status" ]; then
+            SHA="${{ github.event.commit.sha }}"
+            PR=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
+              --jq '[.[] | select(.state == "open")][0].number // empty' 2>/dev/null || true)
+          fi
 
-          CONCLUSION=$(gh api \
-            "repos/${{ github.repository }}/commits/${{ github.event.check_suite.head_sha }}/check-suites" \
-            --jq '[.check_suites[].conclusion] | if any(. == null) then "pending" elif all(. == "success") then "all_passed" else "not_all_passed" end')
+          if [ -z "$PR" ]; then
+            echo "No open PR. Skipping."
+            exit 0
+          fi
+          if [ -z "$SHA" ]; then
+            echo "No SHA resolved. Skipping."
+            exit 0
+          fi
+          echo "PR #${PR}, SHA ${SHA}"
 
-          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
+          # --- Query check runs (GitHub Actions) — exclude own job ---
+          CHECKS=$(gh api "repos/${REPO}/commits/${SHA}/check-runs" --jq '
+            [.check_runs[] | select(.name != "update-labels") | .conclusion]
+            | if length == 0 then "none"
+              elif any(. == null) then "pending"
+              elif all(. == "success") then "pass" else "fail" end')
 
-          if [ "$CONCLUSION" = "all_passed" ]; then
-            echo "All checks passed for PR #$PR_NUMBER."
-            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-label "ready for review"
-            if echo "$CURRENT_LABELS" | grep -Fxq "ci-failing"; then
-              gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --remove-label "ci-failing"
-            fi
+          # --- Query commit statuses (Konflux) ---
+          STATUSES=$(gh api "repos/${REPO}/commits/${SHA}/status" --jq '
+            if (.statuses | length) == 0 then "none"
+            elif .state == "success" then "pass"
+            elif .state == "pending" then "pending" else "fail" end')
 
-          elif [ "$CONCLUSION" = "not_all_passed" ]; then
-            echo "Checks failed for PR #$PR_NUMBER."
-            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-label "ci-failing"
-            if echo "$CURRENT_LABELS" | grep -Fxq "ready for review"; then
-              gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --remove-label "ready for review"
-            fi
+          echo "Checks=${CHECKS} Statuses=${STATUSES}"
 
+          # --- Combine: pending > fail > pass ---
+          if [ "$CHECKS" = "pending" ] || [ "$STATUSES" = "pending" ]; then
+            echo "Still pending. No label changes."; exit 0
+          elif [ "$CHECKS" = "fail" ] || [ "$STATUSES" = "fail" ]; then
+            ADD="ci-failing"; REMOVE="ready for review"
+          elif [ "$CHECKS" = "pass" ] || [ "$STATUSES" = "pass" ]; then
+            ADD="ready for review"; REMOVE="ci-failing"
           else
-            echo "Checks still pending for PR #$PR_NUMBER. No label changes."
+            echo "No results yet. Skipping."; exit 0
+          fi
+
+          # --- Apply labels ---
+          gh pr edit "$PR" --repo "$REPO" --add-label "$ADD"
+          LABELS=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name')
+          if echo "$LABELS" | grep -Fxq "$REMOVE"; then
+            gh pr edit "$PR" --repo "$REPO" --remove-label "$REMOVE"
           fi


### PR DESCRIPTION
## Jira
[RHINENG-25556](https://redhat.atlassian.net/browse/RHINENG-25556)

## What
Update the CI auto-labeling workflow and fix the Jira base URL in the PR template.

## Why
The previous label-needs-review workflow only monitored GitHub Actions check suites and missed Konflux commit statuses. The PR template also pointed to the old Jira instance (issues.redhat.com).

## How
- Replaced `.github/workflows/label-needs-review.yaml` with a new workflow that queries both GitHub Actions check runs and Konflux commit statuses, combining the results to label PRs as "ready for review" or "ci-failing".
- Updated the Jira base URL in `.github/PULL_REQUEST_TEMPLATE.md` from `issues.redhat.com` to `redhat.atlassian.net`.

## Testing
- Verified workflow syntax is valid.
- Can be tested by opening a PR and confirming labels are applied after both GitHub Actions and Konflux checks complete.

## Screenshots/Videos (if applicable)
N/A

[RHINENG-25556]: https://redhat.atlassian.net/browse/RHINENG-25556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update CI-based PR auto-labeling to consider both GitHub Actions and Konflux statuses, and refresh the Jira link in the pull request template.

CI:
- Revise the label-needs-review workflow to react to both check_suite and status events and derive PR labels from combined GitHub Actions check runs and Konflux commit statuses.

Documentation:
- Update the Jira base URL in the pull request template to point to redhat.atlassian.net.