### PR TITLE
fix: Fix playwright setup steps

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -74,7 +74,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install chromium --only-shell
+        run: npx playwright install chromium
 
       - name: Increase file watchers limit
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -54,6 +54,15 @@ jobs:
           echo "Pull Request URL: $pr_url"
           # Set the PR URL as an output using the environment file
           echo "pr_url=$pr_url" >> $GITHUB_ENV
+      
+      - name: Cache - node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            dist
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-frontend-node-modules-
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -65,7 +74,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --only-shell
 
       - name: Increase file watchers limit
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p

--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install chromium --only-shell
+        run: npx playwright install chromium
 
       - name: Run front-end Playwright tests
         run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert @integration

--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -19,6 +19,15 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+      
+      - name: Cache - node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            dist
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-frontend-node-modules-
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -56,7 +65,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --only-shell
 
       - name: Run front-end Playwright tests
         run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert @integration

--- a/.github/workflows/stage-daily-pw-tests.yml
+++ b/.github/workflows/stage-daily-pw-tests.yml
@@ -21,6 +21,15 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+      
+      - name: Cache - node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            dist
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-frontend-node-modules-
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -57,7 +66,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --only-shell
 
       - name: Run front-end Playwright tests
         run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert @integration

--- a/.github/workflows/stage-daily-pw-tests.yml
+++ b/.github/workflows/stage-daily-pw-tests.yml
@@ -66,7 +66,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install chromium --only-shell
+        run: npx playwright install chromium
 
       - name: Run front-end Playwright tests
         run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert @integration


### PR DESCRIPTION
## Jira
Fix playwright setup steps

## What
use cache step
update playwright dependencies step in CI

## Why
Ubuntu incident https://status.canonical.com/
Take a lot time to fetch ubuntu packages

## How
<!-- Brief explanation of approach -->

## Testing
<!-- How was this tested? -->

## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->

## Summary by Sourcery

Update Playwright CI workflows to use dependency caching and a more targeted Playwright installation command.

CI:
- Add node_modules and dist caching to Playwright-related GitHub Actions workflows to speed up CI runs.
- Change Playwright installation in CI to install only the Chromium browser using the shell-only option across relevant workflows.