### PR TITLE
fix(RHINENG-25287): SystemsView bulkSelect not following our design guidelines

### DIFF
--- a/src/components/BulkSelect/BulkSelect.tsx
+++ b/src/components/BulkSelect/BulkSelect.tsx
@@ -111,6 +111,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
           ouiaId={`${ouiaId}-select-none`}
           value={BulkSelectValue.none}
           key={BulkSelectValue.none}
+          isDisabled={selectedCount === 0}
         >
           {selectNoneLabel}
         </DropdownItem>
@@ -143,6 +144,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
       selectAllLabel,
       pageCount,
       totalCount,
+      selectedCount,
     ],
   );
 

--- a/src/components/BulkSelect/BulkSelect.tsx
+++ b/src/components/BulkSelect/BulkSelect.tsx
@@ -29,6 +29,8 @@ export const BulkSelectValue = {
 export type BulkSelectValue =
   (typeof BulkSelectValue)[keyof typeof BulkSelectValue];
 
+export type BulkSelectSource = 'checkbox' | 'dropdown';
+
 const defaultSelectPageLabel = (pageCount?: number) =>
   `Select page${pageCount ? ` (${pageCount})` : ''}`;
 const defaultSelectAllLabel = (totalCount?: number) =>
@@ -56,7 +58,7 @@ export interface BulkSelectProps
   /** Indicates if ONLY some current page items are selected */
   pagePartiallySelected?: boolean;
   /** Callback called on item select */
-  onSelect: (value: BulkSelectValue) => void;
+  onSelect: (value: BulkSelectValue, source?: BulkSelectSource) => void;
   /** Custom OUIA ID */
   ouiaId?: string;
   /** Additional props for MenuToggleCheckbox */
@@ -161,7 +163,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
       ouiaId={`${ouiaId}-dropdown`}
       onSelect={(_e, value) => {
         setOpen(!isOpen);
-        onSelect?.(value as BulkSelectValue);
+        onSelect?.(value as BulkSelectValue, 'dropdown');
       }}
       isOpen={isOpen}
       onOpenChange={(isOpen: boolean) => setOpen(isOpen)}
@@ -190,6 +192,7 @@ export const BulkSelect: FC<BulkSelectProps> = ({
               onChange={(checked) =>
                 onSelect?.(
                   !checked || checked === null ? noneOption : allOption,
+                  'checkbox',
                 )
               }
               {...menuToggleCheckboxProps}

--- a/src/components/BulkSelect/BulkSelect.tsx
+++ b/src/components/BulkSelect/BulkSelect.tsx
@@ -1,0 +1,216 @@
+/**
+ * Vendored from PatternFly `react-component-groups` (BulkSelect).
+ * Source: https://github.com/patternfly/react-component-groups/blob/main/packages/module/src/BulkSelect/BulkSelect.tsx
+ * License: MIT (PatternFly / Red Hat)
+ *
+ * Copied locally for customization; keep in sync with upstream when upgrading PatternFly packages.
+ */
+import React, { useMemo, useState, type FC, type Ref } from 'react';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  DropdownListProps,
+  DropdownProps,
+  MenuToggle,
+  MenuToggleCheckbox,
+  MenuToggleCheckboxProps,
+  MenuToggleElement,
+  MenuToggleProps,
+} from '@patternfly/react-core';
+
+export const BulkSelectValue = {
+  all: 'all',
+  none: 'none',
+  page: 'page',
+  nonePage: 'nonePage',
+} as const;
+
+export type BulkSelectValue =
+  (typeof BulkSelectValue)[keyof typeof BulkSelectValue];
+
+const defaultSelectPageLabel = (pageCount?: number) =>
+  `Select page${pageCount ? ` (${pageCount})` : ''}`;
+const defaultSelectAllLabel = (totalCount?: number) =>
+  `Select all${totalCount ? ` (${totalCount})` : ''}`;
+const defaultSelectedLabel = (selectedCount: number) =>
+  `${selectedCount} selected`;
+
+/** extends DropdownProps */
+export interface BulkSelectProps
+  extends Omit<DropdownProps, 'toggle' | 'onSelect'> {
+  /** BulkSelect className */
+  className?: string;
+  /** Indicates whether selectable items are paginated */
+  isDataPaginated?: boolean;
+  /** Indicates whether "Select all" option should be available */
+  canSelectAll?: boolean;
+  /** Number of entries present in current page */
+  pageCount?: number;
+  /** Number of selected entries */
+  selectedCount: number;
+  /** Number of all entries */
+  totalCount?: number;
+  /** Indicates if ALL current page items are selected */
+  pageSelected?: boolean;
+  /** Indicates if ONLY some current page items are selected */
+  pagePartiallySelected?: boolean;
+  /** Callback called on item select */
+  onSelect: (value: BulkSelectValue) => void;
+  /** Custom OUIA ID */
+  ouiaId?: string;
+  /** Additional props for MenuToggleCheckbox */
+  menuToggleCheckboxProps?: Omit<
+    MenuToggleCheckboxProps,
+    'onChange' | 'isChecked' | 'instance' | 'ref'
+  >;
+  /** Additional props for DropdownList */
+  dropdownListProps?: Omit<DropdownListProps, 'children'>;
+  /** Additional props for MenuToggleProps */
+  menuToggleProps?: Omit<
+    MenuToggleProps,
+    'children' | 'splitButtonItems' | 'ref' | 'isExpanded' | 'onClick'
+  >;
+  /** Custom label for "Select none" option. Defaults to "Select none (0)" */
+  selectNoneLabel?: string;
+  /** Custom label for "Select page" option. Receives pageCount as parameter. Defaults to "Select page (N)" */
+  selectPageLabel?: (pageCount?: number) => string;
+  /** Custom label for "Select all" option. Receives totalCount as parameter. Defaults to "Select all (N)" */
+  selectAllLabel?: (totalCount?: number) => string;
+  /** Custom label formatter for selected count. Receives selectedCount as parameter. Defaults to "N selected" */
+  selectedLabel?: (selectedCount: number) => string;
+}
+
+export const BulkSelect: FC<BulkSelectProps> = ({
+  isDataPaginated = true,
+  canSelectAll,
+  pageSelected,
+  pagePartiallySelected,
+  pageCount,
+  selectedCount = 0,
+  totalCount = 0,
+  ouiaId = 'BulkSelect',
+  onSelect,
+  menuToggleCheckboxProps,
+  dropdownListProps,
+  menuToggleProps,
+  selectNoneLabel = 'Select none (0)',
+  selectPageLabel = defaultSelectPageLabel,
+  selectAllLabel = defaultSelectAllLabel,
+  selectedLabel = defaultSelectedLabel,
+  ...props
+}: BulkSelectProps) => {
+  const [isOpen, setOpen] = useState(false);
+
+  const splitButtonDropdownItems = useMemo(
+    () => (
+      <>
+        <DropdownItem
+          ouiaId={`${ouiaId}-select-none`}
+          value={BulkSelectValue.none}
+          key={BulkSelectValue.none}
+        >
+          {selectNoneLabel}
+        </DropdownItem>
+        {isDataPaginated && (
+          <DropdownItem
+            ouiaId={`${ouiaId}-select-page`}
+            value={BulkSelectValue.page}
+            key={BulkSelectValue.page}
+          >
+            {selectPageLabel(pageCount)}
+          </DropdownItem>
+        )}
+        {canSelectAll && (
+          <DropdownItem
+            ouiaId={`${ouiaId}-select-all`}
+            value={BulkSelectValue.all}
+            key={BulkSelectValue.all}
+          >
+            {selectAllLabel(totalCount)}
+          </DropdownItem>
+        )}
+      </>
+    ),
+    [
+      isDataPaginated,
+      canSelectAll,
+      ouiaId,
+      selectNoneLabel,
+      selectPageLabel,
+      selectAllLabel,
+      pageCount,
+      totalCount,
+    ],
+  );
+
+  const selectedLabelText = selectedLabel(selectedCount);
+
+  const allOption = isDataPaginated
+    ? BulkSelectValue.page
+    : BulkSelectValue.all;
+  const noneOption = isDataPaginated
+    ? BulkSelectValue.nonePage
+    : BulkSelectValue.none;
+
+  const onToggleClick = () => setOpen(!isOpen);
+
+  return (
+    <Dropdown
+      shouldFocusToggleOnSelect
+      ouiaId={`${ouiaId}-dropdown`}
+      onSelect={(_e, value) => {
+        setOpen(!isOpen);
+        onSelect?.(value as BulkSelectValue);
+      }}
+      isOpen={isOpen}
+      onOpenChange={(isOpen: boolean) => setOpen(isOpen)}
+      toggle={(toggleRef: Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          isExpanded={isOpen}
+          onClick={onToggleClick}
+          aria-label="Bulk select toggle"
+          ouiaId={`${ouiaId}-toggle`}
+          splitButtonItems={[
+            <MenuToggleCheckbox
+              ouiaId={`${ouiaId}-checkbox`}
+              id={`${ouiaId}-checkbox`}
+              key="bulk-select-checkbox"
+              aria-label={`Select ${allOption}`}
+              isChecked={
+                (isDataPaginated && pagePartiallySelected) ||
+                (!isDataPaginated &&
+                  selectedCount > 0 &&
+                  selectedCount < totalCount)
+                  ? null
+                  : pageSelected ||
+                    (selectedCount === totalCount && totalCount > 0)
+              }
+              onChange={(checked) =>
+                onSelect?.(
+                  !checked || checked === null ? noneOption : allOption,
+                )
+              }
+              {...menuToggleCheckboxProps}
+            >
+              {selectedCount > 0 ? (
+                <span data-ouia-component-id={`${ouiaId}-text`}>
+                  {selectedLabelText}
+                </span>
+              ) : null}
+            </MenuToggleCheckbox>,
+          ]}
+          {...menuToggleProps}
+        />
+      )}
+      {...props}
+    >
+      <DropdownList {...dropdownListProps}>
+        {splitButtonDropdownItems}
+      </DropdownList>
+    </Dropdown>
+  );
+};
+
+export default BulkSelect;

--- a/src/components/BulkSelect/index.ts
+++ b/src/components/BulkSelect/index.ts
@@ -1,0 +1,2 @@
+export * from './BulkSelect';
+export { default } from './BulkSelect';

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -8,7 +8,7 @@ import { DataViewTable } from '@patternfly/react-data-view/dist/dynamic/DataView
 import { useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/Hooks';
 import { PageSection, Pagination } from '@patternfly/react-core';
 import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
-import { BulkSelect } from '@patternfly/react-component-groups';
+import { BulkSelect } from '../BulkSelect';
 import { useSystemsQuery } from './hooks/useSystemsQuery';
 import { useHostIdsWithKessel } from '../../Utilities/hooks/useHostIdsWithKessel';
 import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';

--- a/src/components/SystemsView/TagsModal/TagsModalTable.tsx
+++ b/src/components/SystemsView/TagsModal/TagsModalTable.tsx
@@ -12,7 +12,7 @@ import {
   SearchInput,
   Spinner,
 } from '@patternfly/react-core';
-import { BulkSelect } from '@patternfly/react-component-groups';
+import { BulkSelect } from '../../BulkSelect';
 import { System } from '../hooks/useSystemsQuery';
 import { INITIAL_PAGE, PER_PAGE } from '../../../constants';
 import { NO_HEADER } from '../../InventoryViews/constants';

--- a/src/components/SystemsView/hooks/useBulkSelect.ts
+++ b/src/components/SystemsView/hooks/useBulkSelect.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { DataViewTrObject } from '@patternfly/react-data-view';
-import { BulkSelectValue } from '../../BulkSelect';
+import { BulkSelectSource, BulkSelectValue } from '../../BulkSelect';
 
 export interface DataViewBulkSelection<T = DataViewTrObject> {
   selected: T[];
@@ -28,23 +28,21 @@ export const useBulkSelect = <T = DataViewTrObject>({
     rows.length > 0 && rows.every((row) => isSelected(row));
 
   const onBulkSelect = useCallback(
-    async (value: BulkSelectValue) => {
+    async (value: BulkSelectValue, source: BulkSelectSource) => {
       switch (value) {
         case BulkSelectValue.none:
         case BulkSelectValue.nonePage:
           setSelected([]);
           break;
         case BulkSelectValue.page:
-          /**
-           * Unchecking checkbox event and select page event are conflicting.
-           * They're both encoded by value "page" in page-selected state, hence it's not possible
-           * to implement all behaviors from our BulkSelect Design Doc.
-           * Tracked by JIRA: RHINENG-25287
-           */
-          if (isPartiallySelected) {
-            setSelected([]);
-          } else {
+          if (source === 'dropdown') {
             onSelect(true, rows);
+          } else if (source === 'checkbox') {
+            if (isPartiallySelected) {
+              setSelected([]);
+            } else {
+              onSelect(true, rows);
+            }
           }
           break;
         default:

--- a/src/components/SystemsView/hooks/useBulkSelect.ts
+++ b/src/components/SystemsView/hooks/useBulkSelect.ts
@@ -28,7 +28,7 @@ export const useBulkSelect = <T = DataViewTrObject>({
     rows.length > 0 && rows.every((row) => isSelected(row));
 
   const onBulkSelect = useCallback(
-    async (value: BulkSelectValue, source: BulkSelectSource) => {
+    async (value: BulkSelectValue, source?: BulkSelectSource) => {
       switch (value) {
         case BulkSelectValue.none:
         case BulkSelectValue.nonePage:

--- a/src/components/SystemsView/hooks/useBulkSelect.ts
+++ b/src/components/SystemsView/hooks/useBulkSelect.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { DataViewTrObject } from '@patternfly/react-data-view';
-import { BulkSelectValue } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
+import { BulkSelectValue } from '../../BulkSelect';
 
 export interface DataViewBulkSelection<T = DataViewTrObject> {
   selected: T[];
@@ -22,9 +22,8 @@ export const useBulkSelect = <T = DataViewTrObject>({
 }: UseBulkSelectParams<T>) => {
   const { selected, setSelected, onSelect, isSelected } = selection;
 
-  const isAnySelected = selected.length > 0;
   const isFullySelected = total > 0 && selected.length === total;
-  const isPartiallySelected = isAnySelected && !isFullySelected;
+  const isPartiallySelected = selected.length > 0 && !isFullySelected;
   const isPageSelected =
     rows.length > 0 && rows.every((row) => isSelected(row));
 


### PR DESCRIPTION
Implements RHINENG-25287
## What

This PR copied locally upstream BulkSelect component
We extended API which allowed us to match checkbox actions to different behaviors than dropdown item actions.
We also disabled select none dropdown option when nothing is selected. Which is presribed by our design doc. 


## Testing

Check behaviors of SystemsView bulkSelect as described in
 https://docs.google.com/document/d/1Wk6jH_wjfM2N9jIHft0Qa2lClijsMJ6AbWyFlJ7IKdE/edit?tab=t.fizfebrp68r8

Ignore the fact, the component doesn't open menu on click on text. It seemms like component got updated in upstream. This is fresh finding and it's not clear if we accept that or not I'm in talks with UX designer Maria about this.



## Summary by Sourcery

Align bulk selection behavior in SystemsView with design guidelines by introducing a customized BulkSelect component and updating selection handling logic.

New Features:
- Add a locally vendored BulkSelect component based on PatternFly to allow customized bulk selection behavior.

Bug Fixes:
- Correct bulk selection handling to differentiate between checkbox and menu actions and properly support none/page selection states.

Enhancements:
- Refactor bulk select hook to use the local BulkSelect value enum and simplify partial selection state calculation.

## Summary by Sourcery

Align SystemsView bulk selection behavior with design guidelines by introducing a customized BulkSelect component and updating bulk selection handling.

New Features:
- Add a locally vendored BulkSelect component based on PatternFly to support customized bulk selection behavior in SystemsView.

Bug Fixes:
- Correct bulk selection handling to distinguish between checkbox and dropdown actions and to clear selection appropriately for partial selections.

Enhancements:
- Adjust bulk selection state calculation and wiring in SystemsView to use the local BulkSelect API and improved selection semantics.