### PR TITLE
fix(RHINENG-25801): legacy sort URL param not applied in SystemsView

### DIFF
--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -248,8 +248,8 @@ test('User should be able to delete multiple systems from Systems page', async (
 
       // Expected URL sort parameter: ascending = display_name, descending = -display_name
       const expectedSortParam = {
-        ascending: /sort=display_name|order_how=asc/,
-        descending: /sort=-display_name|order_how=desc/,
+        ascending: /sort=display_name|sort_dir=asc/,
+        descending: /sort=-display_name|sort_dir=desc/,
       };
 
       // Keep clicking until we reach the desired sort direction (max 3 clicks)
@@ -266,7 +266,7 @@ test('User should be able to delete multiple systems from Systems page', async (
         await columnHeader.click();
 
         // Wait for the sort to take effect
-        await expect(page).toHaveURL(/sort=|order_how=/);
+        await expect(page).toHaveURL(/sort=|sort_dir=/);
       }
 
       // Verify we reached the target sort direction

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -41,6 +41,8 @@ import { useResetPage } from './hooks/useResetPage';
 import { INITIAL_PAGE, NO_HEADER } from '../InventoryViews/constants';
 import { PER_PAGE } from '../../constants';
 import { DEBOUNCE_TIMEOUT_MS } from '../../constants';
+import { normalizeLegacySortSearchParams } from './utils/normalizeLegacySortSearchParams';
+import { SORT_DIR_URL_PARAM, SORT_URL_PARAM } from './constants';
 
 export type SortDirection = ISortBy['direction'];
 export type SortBy = ApiOrderByEnum | undefined;
@@ -89,16 +91,25 @@ const SystemsViewInner = ({
   }) as DataViewBulkSelection;
   const { selected, setSelected } = selection;
 
+  const sortSearchParams = useMemo(
+    () =>
+      normalizeLegacySortSearchParams(searchParams, {
+        sortParam: SORT_URL_PARAM,
+        directionParam: SORT_DIR_URL_PARAM,
+      }),
+    [searchParams],
+  );
+
   const sort = useDataViewSort({
     initialSort: {
       direction: 'desc',
       sortBy: ApiOrderByEnum.LastCheckIn,
     },
     defaultDirection: 'asc',
-    searchParams,
+    searchParams: sortSearchParams,
     setSearchParams,
-    sortByParam: 'order_by',
-    directionParam: 'order_how',
+    sortByParam: SORT_URL_PARAM,
+    directionParam: SORT_DIR_URL_PARAM,
   });
 
   const sortBy = sort?.sortBy as SortBy;

--- a/src/components/SystemsView/constants.ts
+++ b/src/components/SystemsView/constants.ts
@@ -68,3 +68,7 @@ export const LAST_SEEN_OPTIONS: { label: string; key: LastSeenKey }[] = [
   { label: 'More than 30 days ago', key: '30more' },
   { label: 'Custom', key: 'custom' },
 ];
+
+export const SORT_URL_PARAM = 'sort';
+
+export const SORT_DIR_URL_PARAM = 'sort_dir';

--- a/src/components/SystemsView/utils/normalizeLegacySortSearchParams.test.ts
+++ b/src/components/SystemsView/utils/normalizeLegacySortSearchParams.test.ts
@@ -1,0 +1,63 @@
+import { expect } from '@jest/globals';
+import { SORT_DIR_URL_PARAM, SORT_URL_PARAM } from '../constants';
+import { normalizeLegacySortSearchParams } from './normalizeLegacySortSearchParams';
+
+const systemsViewSortParams = {
+  sortParam: SORT_URL_PARAM,
+  directionParam: SORT_DIR_URL_PARAM,
+} as const;
+
+describe('normalizeLegacySortSearchParams', () => {
+  it('expands legacy descending sort (leading dash)', () => {
+    const params = new URLSearchParams(
+      `${SORT_URL_PARAM}=-last_check_in&page=1`,
+    );
+    const next = normalizeLegacySortSearchParams(params, systemsViewSortParams);
+    expect(next.get(SORT_URL_PARAM)).toBe('last_check_in');
+    expect(next.get(SORT_DIR_URL_PARAM)).toBe('desc');
+    expect(next.get('page')).toBe('1');
+  });
+
+  it('expands no hyphen as ascending', () => {
+    const params = new URLSearchParams(`${SORT_URL_PARAM}=display_name`);
+    const next = normalizeLegacySortSearchParams(params, systemsViewSortParams);
+    expect(next.get(SORT_URL_PARAM)).toBe('display_name');
+    expect(next.get(SORT_DIR_URL_PARAM)).toBe('asc');
+  });
+
+  it('expands only leading hyphen as desc', () => {
+    const params = new URLSearchParams(`${SORT_URL_PARAM}=display-name`);
+    const next = normalizeLegacySortSearchParams(params, systemsViewSortParams);
+    expect(next.get(SORT_URL_PARAM)).toBe('display-name');
+    expect(next.get(SORT_DIR_URL_PARAM)).toBe('asc');
+  });
+
+  it('returns two-param sort URLs unchanged', () => {
+    const params = new URLSearchParams(
+      `${SORT_URL_PARAM}=display_name&${SORT_DIR_URL_PARAM}=desc`,
+    );
+    const next = normalizeLegacySortSearchParams(params, systemsViewSortParams);
+    expect(next.get(SORT_URL_PARAM)).toBe('display_name');
+    expect(next.get(SORT_DIR_URL_PARAM)).toBe('desc');
+  });
+
+  it('returns URLs without sort unchanged', () => {
+    const params = new URLSearchParams('page=2');
+    const next = normalizeLegacySortSearchParams(params, systemsViewSortParams);
+    expect(next.get(SORT_URL_PARAM)).toBeNull();
+    expect(next.get(SORT_DIR_URL_PARAM)).toBeNull();
+    expect(next.get('page')).toBe('2');
+    expect(next).not.toBe(params);
+  });
+
+  it('works with custom param names', () => {
+    const params = new URLSearchParams('order=-hostname');
+    const next = normalizeLegacySortSearchParams(params, {
+      sortParam: 'order',
+      directionParam: 'order_how',
+    });
+    expect(next.get('order')).toBe('hostname');
+    expect(next.get('order_how')).toBe('desc');
+    expect(next.has(SORT_DIR_URL_PARAM)).toBe(false);
+  });
+});

--- a/src/components/SystemsView/utils/normalizeLegacySortSearchParams.ts
+++ b/src/components/SystemsView/utils/normalizeLegacySortSearchParams.ts
@@ -1,0 +1,42 @@
+export interface NormalizeLegacySortSearchParamsOptions {
+  sortParam?: string;
+  directionParam?: string;
+}
+
+/**
+ * Converts legacy inventory sort URLs (`sort` only, with optional leading `-` for desc)
+ * into the shape expected by PatternFly `useDataViewSort` (`sort` + `direction`).
+ * leading `-` means descending; hyphens inside the key do not.
+ *
+ *  @param params  - Current query string.
+ *  @param options - Optional `sortParam` / `directionParam` overrides.
+ *  @returns       Cloned params with legacy `sort` expanded when applicable.
+ */
+export function normalizeLegacySortSearchParams(
+  params: URLSearchParams,
+  options?: NormalizeLegacySortSearchParamsOptions,
+): URLSearchParams {
+  const sortParam = options?.sortParam ?? 'sort';
+  const directionParam = options?.directionParam ?? 'direction';
+  const emptyParams = new URLSearchParams(params);
+
+  const rawSort = params.get(sortParam);
+  if (!rawSort) {
+    return emptyParams;
+  }
+  if (params.has(directionParam)) {
+    return emptyParams;
+  }
+
+  const legacyDesc = rawSort.startsWith('-');
+  const key = legacyDesc ? rawSort.slice(1) : rawSort;
+  if (!key) {
+    return emptyParams;
+  }
+  const direction = legacyDesc ? 'desc' : 'asc';
+
+  const next = new URLSearchParams(params);
+  next.set(sortParam, key);
+  next.set(directionParam, direction);
+  return next;
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -173,9 +173,10 @@ export const getSearchParams = (searchParams) => {
   const lastSeenFilter = searchParams.getAll('last_seen');
   const systemTypeFilter = searchParams.getAll('system_type');
   const workloadFilter = searchParams.getAll(WORKLOAD_FILTER_KEY);
+  const rawSort = searchParams.get('sort');
   const sortBy = {
-    key: searchParams.get('sort')?.replace('-', ''),
-    direction: searchParams.get('sort')?.includes('-') ? 'desc' : 'asc',
+    key: rawSort?.startsWith('-') ? rawSort.slice(1) : rawSort,
+    direction: rawSort?.startsWith('-') ? 'desc' : 'asc',
   };
 
   return {


### PR DESCRIPTION
## Jira
RHINENG-25801

## What
When we reuse url link from legacy table the sorting wouldn't get applied in SystemsView. This PR helps to parse sorging from legacy url and apply it in new table 

## Why
We need this so legacy bookmarks won't break for customer

## Testing
Try to load up legacy InventoryTable & set sorting to some column. Then reload same URL with SystemsView enabled. Verify same sorting state is reflected in the new table

## Summary by Sourcery

Ensure SystemsView correctly interprets and applies legacy sort URL parameters while aligning sort query param names with the new view.

Bug Fixes:
- Apply legacy single-parameter sort URLs (with optional leading dash for descending) to SystemsView so existing bookmarks preserve sorting.

Enhancements:
- Introduce a reusable utility to normalize legacy sort URL parameters into separate sort and direction parameters, configurable by query param name.
- Standardize SystemsView sort-related query parameter names via shared constants and simplify sort parsing logic.
- Add unit tests covering legacy sort URL normalization across various parameter combinations.

Tests:
- Add dedicated tests for the legacy sort search parameter normalization helper to verify behavior for ascending, descending, mixed, and custom parameter cases.

## Summary by Sourcery

Preserve and apply sorting state from legacy inventory table URLs to the SystemsView data table so old bookmarks continue to work.

New Features:
- Add normalization of legacy single-parameter sort URLs into separate sort and direction parameters for SystemsView and other consumers of useDataViewSort.

Bug Fixes:
- Ensure SystemsView correctly interprets and applies legacy sort URLs that use a leading dash to indicate descending order.

Enhancements:
- Introduce shared sort URL parameter constants for SystemsView and use a memoized, normalized view of search parameters when configuring table sorting.
- Refine global search parameter parsing logic to more clearly distinguish leading-dash descending sort syntax from hyphens inside field keys.

Tests:
- Add unit tests covering legacy sort URL normalization, including descending, ascending, mixed-hyphen keys, two-parameter sort URLs, URLs without sort, and custom parameter names.