### PR TITLE
fix(RHINENG-25775): SystemsView perPage url param is not compatible with legacy table

### DIFF
--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -65,6 +65,7 @@ const SystemsViewInner = ({
   const pagination = useDataViewPagination({
     perPage: PER_PAGE,
     page: INITIAL_PAGE,
+    perPageParam: 'per_page',
     searchParams,
     setSearchParams,
   });


### PR DESCRIPTION
## Jira
Fixes RHINENG-25775

## What
Changes URL param from perPage to per_page in SystemsView so it's consistent with legacy table.

## Why
Needed for backward support of url links.

## Testing
Verify SystemsView renders per_page.

## Summary by Sourcery

Bug Fixes:
- Use the per_page query parameter instead of perPage in SystemsView pagination to ensure legacy URLs continue to work.