### PR TITLE
fix(RHINENG-14708): fix mount ApplicationTab for connection-gated tabs

### DIFF
--- a/src/ApplicationTab.js
+++ b/src/ApplicationTab.js
@@ -2,6 +2,7 @@ import { useConditionalRBAC } from './Utilities/hooks/useConditionalRBAC';
 import PropTypes from 'prop-types';
 import React from 'react';
 import AccessDenied from './Utilities/AccessDenied';
+import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
 import {
   AdvisorTab,
   ComplianceTab,
@@ -11,7 +12,12 @@ import {
 } from './components/SystemDetails';
 import { TAB_REQUIRED_PERMISSIONS } from './constants';
 
-const ApplicationTab = ({ appName, title, ...props }) => {
+const ApplicationTab = ({
+  appName,
+  title,
+  insightsDisconnected = false,
+  ...props
+}) => {
   const { hasAccess, isOrgAdmin } = useConditionalRBAC(
     TAB_REQUIRED_PERMISSIONS[appName],
     true, // all must be fulfilled
@@ -28,24 +34,31 @@ const ApplicationTab = ({ appName, title, ...props }) => {
 
   const Tab = tabs[appName];
 
-  return hasAccess || isOrgAdmin ? (
-    <Tab {...props} />
-  ) : (
-    <AccessDenied
-      requiredPermission={TAB_REQUIRED_PERMISSIONS[appName].join(', ')}
-      description={
-        <div>
-          Contact your organization administrator(s) for more information.
-        </div>
-      }
-      title={`You do not have access to ${title}`}
-    />
-  );
+  if (!hasAccess && !isOrgAdmin) {
+    return (
+      <AccessDenied
+        requiredPermission={TAB_REQUIRED_PERMISSIONS[appName].join(', ')}
+        description={
+          <div>
+            Contact your organization administrator(s) for more information.
+          </div>
+        }
+        title={`You do not have access to ${title}`}
+      />
+    );
+  }
+
+  if (insightsDisconnected) {
+    return <NotConnected />;
+  }
+
+  return <Tab {...props} />;
 };
 
 ApplicationTab.propTypes = {
   title: PropTypes.string.isRequired,
   appName: PropTypes.string.isRequired,
+  insightsDisconnected: PropTypes.bool,
 };
 
 export default ApplicationTab;

--- a/src/components/InventoryDetail/ApplicationDetails.js
+++ b/src/components/InventoryDetail/ApplicationDetails.js
@@ -10,7 +10,6 @@ import {
 } from '@patternfly/react-core';
 import { verifyCulledReporter } from '../../Utilities/sharedFunctions';
 import { getFact } from './helpers';
-import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
 import {
   APP_NAME_ADVISOR,
   APP_NAME_PATCH,
@@ -69,7 +68,7 @@ const ApplicationDetails = ({
       setActiveTabs(items);
     }
     setCurrentApp(activeApp || items?.[0]?.name);
-  }, [disabledApps, appList]);
+  }, [disabledApps, appList, activeApp]);
 
   const isDisconnected = useMemo(
     () => verifyCulledReporter(perReporterStaleness, REPORTER_PUPTOO),
@@ -137,18 +136,15 @@ const ApplicationDetails = ({
                   {item.name === currentApp && (
                     <Suspense fallback={Spinner}>
                       <PageSection hasBodyWrapper={false}>
-                        {isEmptyState(currentApp) ? (
-                          <NotConnected />
-                        ) : (
-                          <Cmp
-                            {...item}
-                            inventoryId={inventoryId}
-                            store={store}
-                            entity={entity}
-                            fetchEntity={fetchEntity}
-                            writePermissions={writePermissions}
-                          />
-                        )}
+                        <Cmp
+                          {...item}
+                          inventoryId={inventoryId}
+                          store={store}
+                          entity={entity}
+                          fetchEntity={fetchEntity}
+                          writePermissions={writePermissions}
+                          insightsDisconnected={isEmptyState(currentApp)}
+                        />
                       </PageSection>
                     </Suspense>
                   )}


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-14708

## What
The tab wrapper always loads when you open a tab. It gets a flag when the host is not connected to Insights.
`ApplicationTab` shows things in this order: permissions → not connected → real tab content.
The active tab also matches the `?appName=` value in the URL when the query changes.

## Why
For application tabs (for example Vulnerability), we check permission first.
If the user cannot read that tab, they see `Access denied`, not `Not connected`, even when the system is disconnected.

## How
Before: If the host was not connected to Insights, we showed Not connected and we did not load the tab component.
After: We always load the tab component (`ApplicationTab`) when you open that tab.

## Testing

1. Log in as a user without Vulnerability read permission.
2. Open Host details → Vulnerability tab on a disconnected host.
3. You should see `Access denied`, not `Not connected`.

## Screenshots/Videos (if applicable)
before:
https://github.com/user-attachments/assets/e366e36f-d384-4acd-bbf0-366ce279f4cf

after fix
https://github.com/user-attachments/assets/f1fcebdc-5f24-43f2-b768-6b771bd29a60

## Summary by Sourcery

Ensure application detail tabs always mount their content and gate visibility by permissions before host connectivity status.

Bug Fixes:
- Show access denied for disconnected hosts when the user lacks required permissions instead of only showing a not connected state.

Enhancements:
- Pass host connectivity status into application tabs so they can render a not connected state after permission checks.
- Update application tab selection effect to respond to URL query changes for the active app.