### PR TITLE
fix(RHINENG-25907): Add useSearchParamsWithFragment hook to unify query and hash params

### DIFF
--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -37,6 +37,7 @@ import {
   useDataViewFiltersContext,
 } from './DataViewFiltersContext';
 import { useDebouncedValue } from '../../Utilities/hooks/useDebouncedValue';
+import { useSearchParamsWithFragment } from './hooks/useSearchParamsWithFragment';
 import { useResetPage } from './hooks/useResetPage';
 import { INITIAL_PAGE, NO_HEADER } from '../InventoryViews/constants';
 import { PER_PAGE } from '../../constants';
@@ -221,7 +222,7 @@ interface SystemsViewProps {
 }
 
 export const SystemsView = ({ hasAccess = true }: SystemsViewProps) => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParamsWithFragment();
 
   if (!hasAccess) {
     return (

--- a/src/components/SystemsView/hooks/useSearchParamsWithFragment.ts
+++ b/src/components/SystemsView/hooks/useSearchParamsWithFragment.ts
@@ -1,0 +1,38 @@
+import { useSearchParams } from 'react-router-dom';
+import { useMemo } from 'react';
+
+const FRAGMENT_VALUE_MAPPING: Record<string, string> = {
+  'Ansible Automation Platform': 'ansible',
+  SAP: 'sap',
+  'Microsoft SQL': 'mssql',
+};
+
+export const useSearchParamsWithFragment = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const combinedParams = useMemo(() => {
+    const params = new URLSearchParams(searchParams);
+    const hash = window.location.hash.substring(1);
+    const hashParams = new URLSearchParams(hash);
+
+    hashParams.forEach((value, key) => {
+      if (value) {
+        const normalizedValue = FRAGMENT_VALUE_MAPPING[value] || value;
+
+        if (key === 'workloads' || key === 'tags') {
+          // Check if this specific normalized value is already present to avoid ?workloads=sap&workloads=sap
+          const currentValues = params.getAll(key);
+          if (!currentValues.includes(normalizedValue)) {
+            params.append(key, normalizedValue);
+          }
+        } else if (!params.has(key)) {
+          params.set(key, normalizedValue);
+        }
+      }
+    });
+
+    return params;
+  }, [searchParams]);
+
+  return [combinedParams, setSearchParams] as const;
+};


### PR DESCRIPTION
## Jira
[RHINENG-25907](https://redhat.atlassian.net/browse/RHINENG-25907)

## What
 Add `useSearchParamsWithFragment` hook to unify query and hash params

## Why
Global ta filter is not working on `SystemsView` - this change is part of decommissioning of GlobalTag filter

## How
This hook merges standard query strings and hash-based parameters (used in Global tag filter) into a single URLSearchParams object.

## Testing
1. in stable navigate to https://console.redhat.com/ansible/inventory
2. change to preview version - any global tag filter will map to new Workload filter, tags filter stays without normalization 
3. Global tag filter should not  cause any errors when switch between stable and preview UI versions


[RHINENG-25907]: https://redhat.atlassian.net/browse/RHINENG-25907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ