### PR TITLE
feat(RHINENG-25733): Handle Kessel perms Staleness and Deletion

### DIFF
--- a/src/Utilities/hooks/useHostStalenessKesselAccess.test.ts
+++ b/src/Utilities/hooks/useHostStalenessKesselAccess.test.ts
@@ -1,0 +1,237 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  HOST_WORKSPACE_RELATION_UPDATE,
+  HOST_WORKSPACE_RELATION_VIEW,
+  KESSEL_WORKSPACE_REPORTER,
+  STALENESS_WORKSPACE_RELATION_UPDATE,
+  STALENESS_WORKSPACE_RELATION_VIEW,
+  WORKSPACE_RESOURCE_TYPE,
+} from '../../constants';
+import { useHostStalenessKesselAccess } from './useHostStalenessKesselAccess';
+
+const DEFAULT_WS_ID = 'default-ws-1';
+
+const mockUseKesselMigrationFeatureFlag = jest.fn();
+const mockUseSelfAccessCheck = jest.fn();
+const mockFetchDefaultWorkspace = jest.fn();
+
+jest.mock('./useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
+}));
+
+jest.mock('@project-kessel/react-kessel-access-check', () => ({
+  useSelfAccessCheck: (opts: object) => mockUseSelfAccessCheck(opts),
+  fetchDefaultWorkspace: (...args: unknown[]) =>
+    mockFetchDefaultWorkspace(...args),
+}));
+
+const defaultWorkspaceKesselResources = () => {
+  const base = {
+    id: DEFAULT_WS_ID,
+    type: WORKSPACE_RESOURCE_TYPE,
+    reporter: KESSEL_WORKSPACE_REPORTER,
+  };
+  return [
+    { ...base, relation: STALENESS_WORKSPACE_RELATION_VIEW },
+    { ...base, relation: STALENESS_WORKSPACE_RELATION_UPDATE },
+    { ...base, relation: HOST_WORKSPACE_RELATION_VIEW },
+    { ...base, relation: HOST_WORKSPACE_RELATION_UPDATE },
+  ];
+};
+
+const check = (relation: string, allowed: boolean) => ({
+  relation,
+  allowed,
+  resource: {
+    id: DEFAULT_WS_ID,
+    type: WORKSPACE_RESOURCE_TYPE,
+    reporter: KESSEL_WORKSPACE_REPORTER,
+  },
+});
+
+describe('useHostStalenessKesselAccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+    mockUseSelfAccessCheck.mockReturnValue({ data: [], loading: false });
+    mockFetchDefaultWorkspace.mockResolvedValue({
+      id: DEFAULT_WS_ID,
+      type: 'default',
+      name: 'Default',
+      created: '',
+      modified: '',
+    });
+  });
+
+  it('when Kessel is off, returns rbac mode', () => {
+    const { result } = renderHook(() => useHostStalenessKesselAccess());
+    expect(result.current).toEqual({ mode: 'rbac' });
+    expect(mockFetchDefaultWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('when Kessel is on, requests four rbac/workspace checks on the Default workspace id', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({ data: [], loading: false });
+
+    renderHook(() => useHostStalenessKesselAccess());
+
+    await waitFor(() => {
+      expect(mockUseSelfAccessCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resources: defaultWorkspaceKesselResources(),
+        }),
+      );
+    });
+  });
+
+  it('when Default workspace fetch fails, user cannot view the page', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockFetchDefaultWorkspace.mockRejectedValue(new Error('network'));
+
+    const { result } = renderHook(() => useHostStalenessKesselAccess());
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          mode: 'kessel',
+          isLoading: false,
+          canViewPage: false,
+          canEditStaleness: false,
+        }),
+      );
+    });
+  });
+
+  it('when staleness view and inventory_host_view are allowed, user can view the page', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [
+        check(STALENESS_WORKSPACE_RELATION_VIEW, true),
+        check(STALENESS_WORKSPACE_RELATION_UPDATE, false),
+        check(HOST_WORKSPACE_RELATION_VIEW, true),
+        check(HOST_WORKSPACE_RELATION_UPDATE, false),
+      ],
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useHostStalenessKesselAccess());
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          mode: 'kessel',
+          isLoading: false,
+          canViewPage: true,
+          canEditStaleness: false,
+          editDisabledTooltip: expect.stringContaining('staleness update'),
+        }),
+      );
+    });
+  });
+
+  it('when staleness_staleness_view is denied, user cannot view the page', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [
+        check(STALENESS_WORKSPACE_RELATION_VIEW, false),
+        check(STALENESS_WORKSPACE_RELATION_UPDATE, true),
+        check(HOST_WORKSPACE_RELATION_VIEW, true),
+        check(HOST_WORKSPACE_RELATION_UPDATE, true),
+      ],
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useHostStalenessKesselAccess());
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          mode: 'kessel',
+          canViewPage: false,
+          canEditStaleness: false,
+        }),
+      );
+    });
+  });
+
+  it('when inventory_host_view is denied, user cannot view the page', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [
+        check(STALENESS_WORKSPACE_RELATION_VIEW, true),
+        check(STALENESS_WORKSPACE_RELATION_UPDATE, true),
+        check(HOST_WORKSPACE_RELATION_VIEW, false),
+        check(HOST_WORKSPACE_RELATION_UPDATE, true),
+      ],
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useHostStalenessKesselAccess());
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          mode: 'kessel',
+          canViewPage: false,
+          canEditStaleness: false,
+        }),
+      );
+    });
+  });
+
+  it('when staleness_staleness_update and inventory_host_update are allowed, user can edit', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [
+        check(STALENESS_WORKSPACE_RELATION_VIEW, true),
+        check(STALENESS_WORKSPACE_RELATION_UPDATE, true),
+        check(HOST_WORKSPACE_RELATION_VIEW, true),
+        check(HOST_WORKSPACE_RELATION_UPDATE, true),
+      ],
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useHostStalenessKesselAccess());
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          mode: 'kessel',
+          canViewPage: true,
+          canEditStaleness: true,
+        }),
+      );
+    });
+  });
+
+  it('when inventory_host_update is denied, user cannot edit even if staleness update is allowed', async () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [
+        check(STALENESS_WORKSPACE_RELATION_VIEW, true),
+        check(STALENESS_WORKSPACE_RELATION_UPDATE, true),
+        check(HOST_WORKSPACE_RELATION_VIEW, true),
+        check(HOST_WORKSPACE_RELATION_UPDATE, false),
+      ],
+      loading: false,
+    });
+
+    const { result } = renderHook(() => useHostStalenessKesselAccess());
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          mode: 'kessel',
+          canViewPage: true,
+          canEditStaleness: false,
+          editDisabledTooltip: expect.stringContaining('host update'),
+        }),
+      );
+    });
+  });
+});

--- a/src/Utilities/hooks/useHostStalenessKesselAccess.ts
+++ b/src/Utilities/hooks/useHostStalenessKesselAccess.ts
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  fetchDefaultWorkspace,
+  useSelfAccessCheck,
+} from '@project-kessel/react-kessel-access-check';
+import { type BulkSelfAccessCheckNestedRelationsParams } from '@project-kessel/react-kessel-access-check/types';
+import {
+  HOST_WORKSPACE_RELATION_UPDATE,
+  HOST_WORKSPACE_RELATION_VIEW,
+  KESSEL_WORKSPACE_REPORTER,
+  STALENESS_WORKSPACE_RELATION_UPDATE,
+  STALENESS_WORKSPACE_RELATION_VIEW,
+  WORKSPACE_RESOURCE_TYPE,
+} from '../../constants';
+import { useKesselMigrationFeatureFlag } from './useKesselMigrationFeatureFlag';
+
+type DefaultWorkspaceStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export type HostStalenessKesselAccess =
+  | { mode: 'rbac' }
+  | {
+      mode: 'kessel';
+      isLoading: boolean;
+      /** `staleness_staleness_view` + `inventory_host_view` on the Default workspace (`rbac/workspace`). */
+      canViewPage: boolean;
+      /** `staleness_staleness_update` + `inventory_host_update` on the Default workspace. */
+      canEditStaleness: boolean;
+      editDisabledTooltip?: string;
+    };
+
+/**
+ * Kessel migration gating for the Staleness and Deletion page.
+ *
+ * Follows **Fetching Workspace IDs for Access Checks** in
+ * [kessel-sdk-browser `react-kessel-access-check` README](https://github.com/project-kessel/kessel-sdk-browser/tree/master/packages/react-kessel-access-check#fetching-workspace-ids-for-access-checks):
+ * resolve the Default workspace UUID with {@link fetchDefaultWorkspace}, then use it as `resource.id`
+ * with `type: {@link WORKSPACE_RESOURCE_TYPE}` and `reporter: {@link KESSEL_WORKSPACE_REPORTER}`.
+ *
+ * Permissions are modeled on **`rbac/workspace`** in RedHatInsights/rbac-config `configs/stage/schemas/schema.zed`
+ * (not a separate `staleness` or `hosts` resource type):
+ * - **Staleness**: `staleness_staleness_view` (read / `inventory:staleness:read`–class access) and
+ * `staleness_staleness_update` (write / update, includes `staleness_staleness_write` in schema).
+ * - **Hosts in workspace**: `inventory_host_view` and `inventory_host_update` (inventory hosts read/write
+ * for that workspace). Per-host checks use `type: 'host'` elsewhere; here everything uses the workspace object.
+ *
+ * Four nested bulk items, same `id`, same `type`/`reporter`, different `relation`.
+ */
+export const useHostStalenessKesselAccess = (): HostStalenessKesselAccess => {
+  const isKesselEnabled = useKesselMigrationFeatureFlag();
+
+  const [defaultWorkspaceStatus, setDefaultWorkspaceStatus] =
+    useState<DefaultWorkspaceStatus>('idle');
+  const [defaultWorkspaceId, setDefaultWorkspaceId] = useState<
+    string | undefined
+  >();
+
+  useEffect(() => {
+    if (!isKesselEnabled || typeof window === 'undefined') {
+      setDefaultWorkspaceStatus('idle');
+      setDefaultWorkspaceId(undefined);
+      return;
+    }
+
+    let cancelled = false;
+    setDefaultWorkspaceStatus('loading');
+    fetchDefaultWorkspace(window.location.origin, undefined, undefined)
+      .then((ws) => {
+        if (!cancelled) {
+          if (ws?.id) {
+            setDefaultWorkspaceId(ws.id);
+            setDefaultWorkspaceStatus('ready');
+          } else {
+            setDefaultWorkspaceId(undefined);
+            setDefaultWorkspaceStatus('error');
+          }
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDefaultWorkspaceId(undefined);
+          setDefaultWorkspaceStatus('error');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isKesselEnabled]);
+
+  const resources = useMemo(() => {
+    if (
+      !isKesselEnabled ||
+      defaultWorkspaceStatus !== 'ready' ||
+      !defaultWorkspaceId
+    ) {
+      return [];
+    }
+    const id = defaultWorkspaceId;
+    const base = {
+      id,
+      type: WORKSPACE_RESOURCE_TYPE,
+      reporter: KESSEL_WORKSPACE_REPORTER,
+    };
+    return [
+      { ...base, relation: STALENESS_WORKSPACE_RELATION_VIEW },
+      { ...base, relation: STALENESS_WORKSPACE_RELATION_UPDATE },
+      { ...base, relation: HOST_WORKSPACE_RELATION_VIEW },
+      { ...base, relation: HOST_WORKSPACE_RELATION_UPDATE },
+    ];
+  }, [isKesselEnabled, defaultWorkspaceStatus, defaultWorkspaceId]);
+
+  const { data: checks, loading: checksLoading } = useSelfAccessCheck({
+    resources,
+  } as BulkSelfAccessCheckNestedRelationsParams);
+
+  return useMemo((): HostStalenessKesselAccess => {
+    if (!isKesselEnabled) {
+      return { mode: 'rbac' };
+    }
+
+    const isLoading =
+      defaultWorkspaceStatus === 'idle' ||
+      defaultWorkspaceStatus === 'loading' ||
+      (resources.length > 0 && checksLoading);
+
+    if (isLoading) {
+      return {
+        mode: 'kessel',
+        isLoading: true,
+        canViewPage: false,
+        canEditStaleness: false,
+      };
+    }
+
+    if (defaultWorkspaceStatus === 'error' || !defaultWorkspaceId) {
+      return {
+        mode: 'kessel',
+        isLoading: false,
+        canViewPage: false,
+        canEditStaleness: false,
+      };
+    }
+
+    let stalenessReadAllowed = false;
+    let stalenessWriteAllowed = false;
+    let hostsReadAllowed = false;
+    let hostsWriteAllowed = false;
+
+    for (const check of checks ?? []) {
+      if (check.resource?.id !== defaultWorkspaceId) {
+        continue;
+      }
+      switch (check.relation) {
+        case STALENESS_WORKSPACE_RELATION_VIEW:
+          stalenessReadAllowed = check.allowed === true;
+          break;
+        case STALENESS_WORKSPACE_RELATION_UPDATE:
+          stalenessWriteAllowed = check.allowed === true;
+          break;
+        case HOST_WORKSPACE_RELATION_VIEW:
+          hostsReadAllowed = check.allowed === true;
+          break;
+        case HOST_WORKSPACE_RELATION_UPDATE:
+          hostsWriteAllowed = check.allowed === true;
+          break;
+        default:
+          break;
+      }
+    }
+
+    const canViewPage = stalenessReadAllowed && hostsReadAllowed;
+    const canEditStaleness = stalenessWriteAllowed && hostsWriteAllowed;
+
+    const isReadOnlyGranular = canViewPage && !canEditStaleness;
+
+    const editDisabledTooltip = isReadOnlyGranular
+      ? 'You can view these settings, but editing requires staleness update and inventory host update permissions on the Default workspace.'
+      : undefined;
+
+    return {
+      mode: 'kessel',
+      isLoading: false,
+      canViewPage,
+      canEditStaleness,
+      editDisabledTooltip,
+    };
+  }, [
+    isKesselEnabled,
+    defaultWorkspaceStatus,
+    defaultWorkspaceId,
+    resources.length,
+    checksLoading,
+    checks,
+  ]);
+};

--- a/src/Utilities/hooks/useHostStalenessKesselAccess.ts
+++ b/src/Utilities/hooks/useHostStalenessKesselAccess.ts
@@ -14,7 +14,11 @@ import {
 } from '../../constants';
 import { useKesselMigrationFeatureFlag } from './useKesselMigrationFeatureFlag';
 
-type DefaultWorkspaceStatus = 'idle' | 'loading' | 'ready' | 'error';
+type WorkspaceState = {
+  id?: string;
+  loading: boolean;
+  error: boolean;
+};
 
 export type HostStalenessKesselAccess =
   | { mode: 'rbac' }
@@ -48,38 +52,33 @@ export type HostStalenessKesselAccess =
 export const useHostStalenessKesselAccess = (): HostStalenessKesselAccess => {
   const isKesselEnabled = useKesselMigrationFeatureFlag();
 
-  const [defaultWorkspaceStatus, setDefaultWorkspaceStatus] =
-    useState<DefaultWorkspaceStatus>('idle');
-  const [defaultWorkspaceId, setDefaultWorkspaceId] = useState<
-    string | undefined
-  >();
+  const [workspace, setWorkspace] = useState<WorkspaceState>({
+    id: undefined,
+    loading: false,
+    error: false,
+  });
 
   useEffect(() => {
     if (!isKesselEnabled || typeof window === 'undefined') {
-      setDefaultWorkspaceStatus('idle');
-      setDefaultWorkspaceId(undefined);
+      setWorkspace({ id: undefined, loading: false, error: false });
       return;
     }
 
     let cancelled = false;
-    setDefaultWorkspaceStatus('loading');
+    setWorkspace((prev) => ({ ...prev, loading: true, error: false }));
+
     fetchDefaultWorkspace(window.location.origin, undefined, undefined)
       .then((ws) => {
-        if (!cancelled) {
-          if (ws?.id) {
-            setDefaultWorkspaceId(ws.id);
-            setDefaultWorkspaceStatus('ready');
-          } else {
-            setDefaultWorkspaceId(undefined);
-            setDefaultWorkspaceStatus('error');
-          }
+        if (cancelled) return;
+        if (ws?.id) {
+          setWorkspace({ id: ws.id, loading: false, error: false });
+        } else {
+          setWorkspace({ id: undefined, loading: false, error: true });
         }
       })
       .catch(() => {
-        if (!cancelled) {
-          setDefaultWorkspaceId(undefined);
-          setDefaultWorkspaceStatus('error');
-        }
+        if (cancelled) return;
+        setWorkspace({ id: undefined, loading: false, error: true });
       });
 
     return () => {
@@ -88,16 +87,11 @@ export const useHostStalenessKesselAccess = (): HostStalenessKesselAccess => {
   }, [isKesselEnabled]);
 
   const resources = useMemo(() => {
-    if (
-      !isKesselEnabled ||
-      defaultWorkspaceStatus !== 'ready' ||
-      !defaultWorkspaceId
-    ) {
+    if (!isKesselEnabled || !workspace.id) {
       return [];
     }
-    const id = defaultWorkspaceId;
     const base = {
-      id,
+      id: workspace.id,
       type: WORKSPACE_RESOURCE_TYPE,
       reporter: KESSEL_WORKSPACE_REPORTER,
     };
@@ -107,21 +101,38 @@ export const useHostStalenessKesselAccess = (): HostStalenessKesselAccess => {
       { ...base, relation: HOST_WORKSPACE_RELATION_VIEW },
       { ...base, relation: HOST_WORKSPACE_RELATION_UPDATE },
     ];
-  }, [isKesselEnabled, defaultWorkspaceStatus, defaultWorkspaceId]);
+  }, [isKesselEnabled, workspace.id]);
 
   const { data: checks, loading: checksLoading } = useSelfAccessCheck({
     resources,
   } as BulkSelfAccessCheckNestedRelationsParams);
 
-  return useMemo((): HostStalenessKesselAccess => {
+  const isLoading =
+    isKesselEnabled &&
+    (workspace.loading || checksLoading || (!workspace.id && !workspace.error));
+
+  const byRelation = useMemo(() => {
+    const map = new Map<string, boolean>();
+    for (const check of checks ?? []) {
+      if (!check?.relation) continue;
+      map.set(check.relation, check.allowed === true);
+    }
+    return map;
+  }, [checks]);
+
+  const stalenessReadAllowed =
+    byRelation.get(STALENESS_WORKSPACE_RELATION_VIEW) ?? false;
+  const stalenessWriteAllowed =
+    byRelation.get(STALENESS_WORKSPACE_RELATION_UPDATE) ?? false;
+  const hostsReadAllowed =
+    byRelation.get(HOST_WORKSPACE_RELATION_VIEW) ?? false;
+  const hostsWriteAllowed =
+    byRelation.get(HOST_WORKSPACE_RELATION_UPDATE) ?? false;
+
+  return useMemo<HostStalenessKesselAccess>(() => {
     if (!isKesselEnabled) {
       return { mode: 'rbac' };
     }
-
-    const isLoading =
-      defaultWorkspaceStatus === 'idle' ||
-      defaultWorkspaceStatus === 'loading' ||
-      (resources.length > 0 && checksLoading);
 
     if (isLoading) {
       return {
@@ -132,7 +143,7 @@ export const useHostStalenessKesselAccess = (): HostStalenessKesselAccess => {
       };
     }
 
-    if (defaultWorkspaceStatus === 'error' || !defaultWorkspaceId) {
+    if (!workspace.id || workspace.error) {
       return {
         mode: 'kessel',
         isLoading: false,
@@ -141,41 +152,12 @@ export const useHostStalenessKesselAccess = (): HostStalenessKesselAccess => {
       };
     }
 
-    let stalenessReadAllowed = false;
-    let stalenessWriteAllowed = false;
-    let hostsReadAllowed = false;
-    let hostsWriteAllowed = false;
-
-    for (const check of checks ?? []) {
-      if (check.resource?.id !== defaultWorkspaceId) {
-        continue;
-      }
-      switch (check.relation) {
-        case STALENESS_WORKSPACE_RELATION_VIEW:
-          stalenessReadAllowed = check.allowed === true;
-          break;
-        case STALENESS_WORKSPACE_RELATION_UPDATE:
-          stalenessWriteAllowed = check.allowed === true;
-          break;
-        case HOST_WORKSPACE_RELATION_VIEW:
-          hostsReadAllowed = check.allowed === true;
-          break;
-        case HOST_WORKSPACE_RELATION_UPDATE:
-          hostsWriteAllowed = check.allowed === true;
-          break;
-        default:
-          break;
-      }
-    }
-
     const canViewPage = stalenessReadAllowed && hostsReadAllowed;
     const canEditStaleness = stalenessWriteAllowed && hostsWriteAllowed;
-
-    const isReadOnlyGranular = canViewPage && !canEditStaleness;
-
-    const editDisabledTooltip = isReadOnlyGranular
-      ? 'You can view these settings, but editing requires staleness update and inventory host update permissions on the Default workspace.'
-      : undefined;
+    const editDisabledTooltip =
+      canViewPage && !canEditStaleness
+        ? 'You can view these settings, but editing requires staleness update and inventory host update permissions on the Default workspace.'
+        : undefined;
 
     return {
       mode: 'kessel',
@@ -186,10 +168,12 @@ export const useHostStalenessKesselAccess = (): HostStalenessKesselAccess => {
     };
   }, [
     isKesselEnabled,
-    defaultWorkspaceStatus,
-    defaultWorkspaceId,
-    resources.length,
-    checksLoading,
-    checks,
+    isLoading,
+    workspace.id,
+    workspace.error,
+    stalenessReadAllowed,
+    stalenessWriteAllowed,
+    hostsReadAllowed,
+    hostsWriteAllowed,
   ]);
 };

--- a/src/components/InventoryHostStaleness/HostStalenessCard.tsx
+++ b/src/components/InventoryHostStaleness/HostStalenessCard.tsx
@@ -35,14 +35,20 @@ import isEqual from 'lodash/isEqual';
 
 interface HostStalenessCardProps {
   canModifyHostStaleness: boolean;
+  /** When provided, shown instead of the default RBAC-oriented disabled Edit tooltip. */
+  editDisabledTooltip?: string;
 }
 
 export type Staleness = {
   id?: string;
 } & Partial<Record<HostStalenessApiKey, number>>;
 
+const DEFAULT_EDIT_DISABLED_TOOLTIP =
+  'You do not have the Staleness and deletion admin role and/or Inventory Hosts Administrator role required to perform this action. Contact your org admin for access.';
+
 const HostStalenessCard = ({
   canModifyHostStaleness,
+  editDisabledTooltip,
 }: HostStalenessCardProps) => {
   const [lastSavedStaleness, setLastSavedStaleness] = useState<Staleness>({});
   const [staleness, setStaleness] = useState<Staleness>({});
@@ -215,7 +221,9 @@ const HostStalenessCard = ({
                   Edit
                 </Button>
               ) : (
-                <Tooltip content="You do not have the Staleness and deletion admin role and/or Inventory Hosts Administrator role required to perform this action. Contact your org admin for access.">
+                <Tooltip
+                  content={editDisabledTooltip ?? DEFAULT_EDIT_DISABLED_TOOLTIP}
+                >
                   <div>
                     <Button variant="link" isDisabled={true}>
                       Edit

--- a/src/components/InventoryHostStaleness/InventoryHostStaleness.tsx
+++ b/src/components/InventoryHostStaleness/InventoryHostStaleness.tsx
@@ -17,15 +17,33 @@ const REQUIRED_PERMISSIONS = [
   GENERAL_HOSTS_WRITE_PERMISSIONS,
 ];
 
-const InventoryHostStaleness = () => {
-  const { hasAccess: canModifyHostStaleness } = useConditionalRBAC(
+interface InventoryHostStalenessProps {
+  /** When set (Kessel migration), overrides RBAC for whether the user may edit staleness. */
+  kesselCanModifyHostStaleness?: boolean;
+  /** Optional tooltip when Edit is disabled (e.g. Kessel read-only). */
+  editDisabledTooltip?: string;
+}
+
+const InventoryHostStaleness = ({
+  kesselCanModifyHostStaleness,
+  editDisabledTooltip,
+}: InventoryHostStalenessProps) => {
+  const { hasAccess: canModifyHostStalenessRbac } = useConditionalRBAC(
     REQUIRED_PERMISSIONS,
     true,
   );
 
+  const canModifyHostStaleness =
+    kesselCanModifyHostStaleness !== undefined
+      ? kesselCanModifyHostStaleness
+      : canModifyHostStalenessRbac;
+
   return (
     <section>
-      <HostStalenessCard canModifyHostStaleness={canModifyHostStaleness} />
+      <HostStalenessCard
+        canModifyHostStaleness={canModifyHostStaleness}
+        editDisabledTooltip={editDisabledTooltip}
+      />
     </section>
   );
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -338,6 +338,8 @@ export const HOST_RESOURCE_TYPE = 'host';
 export const HOST_RESOURCE_TYPE_VIEW = 'view';
 export const HOST_RESOURCE_TYPE_UPDATE = 'update';
 export const HOST_RESOURCE_TYPE_DELETE = 'delete';
+export const INVENTORY_STALENESS_READ_PERMISSION = 'inventory:staleness:read';
+export const INVENTORY_STALENESS_WRITE_PERMISSION = 'inventory:staleness:write';
 export const PER_PAGE_MAX = 100;
 export const PER_PAGE = 50;
 export const INITIAL_PAGE = 1;
@@ -351,5 +353,15 @@ export const WORKSPACE_RELATION_DELETE = 'delete';
 export const KESSEL_REPORTER = { type: 'hbi' };
 /** Reporter for workspace access checks; README recommends { type: 'rbac' } for RBAC-based authorization. */
 export const KESSEL_WORKSPACE_REPORTER = { type: 'rbac' };
+/**
+ * Self-access `relation` values on {@link WORKSPACE_RESOURCE_TYPE} with Default workspace id
+ * (see kessel-sdk-browser README “Fetching Workspace IDs for Access Checks”).
+ * Source: RedHatInsights/rbac-config `configs/stage/schemas/schema.zed` (`rbac/workspace`).
+ */
+export const STALENESS_WORKSPACE_RELATION_VIEW = 'staleness_staleness_view';
+export const STALENESS_WORKSPACE_RELATION_UPDATE = 'staleness_staleness_update';
+/** Inventory hosts in workspace: `inventory_host_view` / `inventory_host_update` on that workspace object. */
+export const HOST_WORKSPACE_RELATION_VIEW = 'inventory_host_view';
+export const HOST_WORKSPACE_RELATION_UPDATE = 'inventory_host_update';
 export const DEFAULT_DELETE_ERROR_MESSAGE =
   'There was an error processing the request. Please try again.';

--- a/src/routes/InventoryHostStaleness.tsx
+++ b/src/routes/InventoryHostStaleness.tsx
@@ -7,18 +7,20 @@ import {
 import InventoryHostStaleness from '../components/InventoryHostStaleness';
 import { useConditionalRBAC } from '../Utilities/hooks/useConditionalRBAC';
 import { GENERAL_HOST_STALENESS_READ_PERMISSION } from '../components/InventoryHostStaleness/constants';
-import { PageSection } from '@patternfly/react-core';
+import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import HostStalenessNoAccess from '../components/InventoryHostStaleness/HostStalenessNoAccess';
 import { OutageAlert } from '../components/OutageAlert';
+import { useHostStalenessKesselAccess } from '../Utilities/hooks/useHostStalenessKesselAccess';
 
 const REQUIRED_PERMISSIONS = [GENERAL_HOST_STALENESS_READ_PERMISSION];
 
 const HostStaleness = () => {
   const chrome = useChrome();
-  const { hasAccess: canReadHostStaleness } = useConditionalRBAC(
+  const { hasAccess: canReadHostStalenessRbac } = useConditionalRBAC(
     REQUIRED_PERMISSIONS,
     true,
   );
+  const kesselAccess = useHostStalenessKesselAccess();
 
   useEffect(() => {
     chrome?.updateDocumentTitle?.(
@@ -27,6 +29,19 @@ const HostStaleness = () => {
     chrome.hideGlobalFilter(true);
   }, [chrome]);
 
+  const canReadHostStaleness =
+    kesselAccess.mode === 'kessel'
+      ? kesselAccess.canViewPage
+      : canReadHostStalenessRbac;
+
+  const kesselEditOverride =
+    kesselAccess.mode === 'kessel' ? kesselAccess.canEditStaleness : undefined;
+
+  const editDisabledTooltip =
+    kesselAccess.mode === 'kessel'
+      ? kesselAccess.editDisabledTooltip
+      : undefined;
+
   return (
     <PageSection>
       <PageHeader>
@@ -34,8 +49,15 @@ const HostStaleness = () => {
         <OutageAlert />
       </PageHeader>
       <PageSection hasBodyWrapper={false} variant="default">
-        {canReadHostStaleness ? (
-          <InventoryHostStaleness />
+        {kesselAccess.mode === 'kessel' && kesselAccess.isLoading ? (
+          <Bullseye>
+            <Spinner aria-label="Loading permissions" />
+          </Bullseye>
+        ) : canReadHostStaleness ? (
+          <InventoryHostStaleness
+            kesselCanModifyHostStaleness={kesselEditOverride}
+            editDisabledTooltip={editDisabledTooltip}
+          />
         ) : (
           <HostStalenessNoAccess />
         )}


### PR DESCRIPTION
## Jira
[RHINENG-25733](https://redhat.atlassian.net/browse/RHINENG-25733)

## What
Fix all Kessel permission issues on the Staleness and Deletion page to properly restrict UI based on user role.

## How
User with Zero Access

- Fix infinite loading spinner when user has no permissions
- Show proper "no permissions" message immediately
- Currently shows infinite spinner instead of clear message

User with Read-Only Access

- Disable Edit button for read-only users
- Add tooltip explaining why Edit is disabled
- Currently Edit button is enabled, allowing users to attempt changes they cannot make

Acceptance Criteria

- [ ] Users with zero inventory access see "no permissions" message immediately (no infinite spinner)
- [ ] Users with read-only access have Edit button disabled
- [ ] Disabled Edit button includes tooltip explaining permission requirements
- [ ] All permission checks use Kessel SDK
- [ ] Manually tested with multiple permission levels (zero access, read-only, read-write)


[RHINENG-25733]: https://redhat.atlassian.net/browse/RHINENG-25733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Integrate Kessel-based permission checks into the Staleness and Deletion page while preserving RBAC fallback, ensuring correct access control and UI behavior for different permission levels.

New Features:
- Add a Kessel-aware access hook for the Staleness and Deletion page that evaluates workspace-based view and edit permissions.
- Surface Kessel-derived edit permissions and contextual tooltips in the Staleness and Deletion UI via new component props.

Bug Fixes:
- Prevent infinite loading for users without access by explicitly handling Kessel loading and no-permission states and showing the no-access message.
- Disable the Edit action for users lacking write permissions and display a tooltip explaining the required roles or permissions.

Enhancements:
- Extend staleness-related components to accept optional Kessel overrides while maintaining existing RBAC behavior as a fallback.
- Introduce constants for staleness and host workspace relations and inventory staleness permissions to align with Kessel and workspace-based authorization modeling.

Tests:
- Add unit tests for the new Kessel access hook to cover default workspace fetching, permission combinations, and read-only tooltip behavior.