### PR TITLE
Ignore Author's comment for PR review reminder

### DIFF
--- a/.github/workflows/pr-review-reminder.yaml
+++ b/.github/workflows/pr-review-reminder.yaml
@@ -36,8 +36,9 @@ jobs:
           FILTERED=$(echo "$PRS" | jq --argjson now "$NOW" --argjson day "$ONE_DAY" '
             [ .[]
               | select(.isDraft == false)
-              | select(([.reviews[] | select(.author.login | test("bot|sourcery|github-actions") | not)] | length) == 0)
-              | select(([.comments[] | select(.author.login | test("bot|sourcery|github-actions") | not)] | length) == 0)
+              | .author.login as $pr_author
+              | select(([.reviews[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not))] | length) == 0)
+              | select(([.comments[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not))] | length) == 0)
               | select(.reviewDecision != "APPROVED")
               | (.createdAt | fromdateiso8601) as $created
               | select(($now - $created) > $day)


### PR DESCRIPTION
## Jira
NA

## What
- Fix PR review reminder to not exclude PRs where only the author has commented

## Why
- The PR review reminder was dropping PRs from the reminder list if the author themselves commented, even though no reviewer had interacted

## How
- Updated the jq filter in `pr-review-reminder.yaml` to exclude the PR author's login from the "has human interaction" check

## Testing
- Can verify reminder behavior by manually triggering the workflow and checking that author-commented PRs still appear

## Screenshots/Videos (if applicable)
N/A

## Summary by Sourcery

Bug Fixes:
- Prevent PRs from being excluded from review reminders when only the PR author has left comments or reviews.