### PR TITLE
fix(RHINENG-25945): BulkActions are disabled on next page even though rows are selected

### DIFF
--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -26,7 +26,7 @@ import {
   useBulkSelect,
   type DataViewBulkSelection,
 } from './hooks/useBulkSelect';
-import { useRows } from './hooks/useRows';
+import { useRows, type SystemsViewTableRow } from './hooks/useRows';
 import AccessDenied from '../../Utilities/AccessDenied';
 import './SystemsView.scss';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
@@ -89,7 +89,7 @@ const SystemsViewInner = ({
   const selection = useDataViewSelection({
     matchOption: (a, b) => a.id === b.id,
     initialSelected: [],
-  }) as DataViewBulkSelection;
+  }) as DataViewBulkSelection<SystemsViewTableRow>;
   const { selected, setSelected } = selection;
 
   const sortSearchParams = useMemo(
@@ -135,12 +135,7 @@ const SystemsViewInner = ({
     renderableColumns,
   });
 
-  const selectedIds = selected.map(({ id }: { id?: string }) => id);
-  const systemsForSelection = hostsWithPermissions ?? data;
-  const selectedSystems =
-    systemsForSelection?.filter(
-      (sys: { id?: string }) => sys.id && selectedIds.includes(sys.id),
-    ) ?? [];
+  const selectedSystems = selected.map((row) => row.meta);
 
   const activeState =
     isLoading || isFetching

--- a/src/components/SystemsView/hooks/useRows.tsx
+++ b/src/components/SystemsView/hooks/useRows.tsx
@@ -5,13 +5,18 @@ import { RenderableColumn } from './useColumns';
 import type { SystemWithPermissions } from '../../../Utilities/hooks/useHostIdsWithKessel';
 import type { System } from './useSystemsQuery';
 
+/** DataViewTrObject Extension, `meta` points to associated system objects. */
+export type SystemsViewTableRow = DataViewTrObject & {
+  meta: System | SystemWithPermissions;
+};
+
 interface UseRowsParams {
   data?: (System | SystemWithPermissions)[];
   renderableColumns: RenderableColumn[];
 }
 
 interface UseRowsReturnValue {
-  rows: DataViewTrObject[];
+  rows: SystemsViewTableRow[];
 }
 
 export const useRows = ({
@@ -20,13 +25,14 @@ export const useRows = ({
 }: UseRowsParams): UseRowsReturnValue => {
   const mapSystemToRow = (
     system: System | SystemWithPermissions,
-  ): DataViewTrObject => {
+  ): SystemsViewTableRow => {
     const selectableColumnCells = renderableColumns
       .filter((col) => col.isShown)
       .map((col) => col.renderCell(system));
 
     return {
       id: system.id,
+      meta: system,
       row: [
         ...selectableColumnCells,
         {


### PR DESCRIPTION
## Jira
RHINENG-25945

## What
We're fixing this by including systems associated with rows in selection. This allow us to refer them from anywhere, anytime. 

We extend Type for row with `meta` as there might be other structures we would like to associate with rows besides systems. 

## Testing
1. Visit SystemsView
2. Select few systems
3. Paginate forward an observe bulkActions are still enabled 


## Screenshots/Videos (if applicable)
<img width="931" height="525" alt="image" src="https://github.com/user-attachments/assets/7696de63-56d9-4b65-aeee-719ae89423fb" />

## Summary by Sourcery

Ensure SystemsView row selections remain associated with their underlying system data across pagination so bulk actions stay enabled when navigating pages.

Bug Fixes:
- Preserve selected systems in SystemsView across pagination by attaching the system object to each table row and using it directly for bulk actions.

Enhancements:
- Introduce a dedicated SystemsView table row type that extends the data view row with a meta field holding the associated system object.