### PR TITLE
fix(deps): bump lodash to 4.18.1 in host-inventory-frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "awesome-debounce-promise": "^2.1.0",
         "bastilian-tabletools": "^2.13.0",
         "classnames": "^2.3.1",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.0",
         "moment": "^2.29.4",
         "p-all": "^4.0.0",
         "qs": "^6.14.1",
@@ -23767,9 +23767,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "awesome-debounce-promise": "^2.1.0",
     "bastilian-tabletools": "^2.13.0",
     "classnames": "^2.3.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.0",
     "moment": "^2.29.4",
     "p-all": "^4.0.0",
     "qs": "^6.14.1",


### PR DESCRIPTION
## Summary

Bumps \`lodash\` in \`host-inventory-frontend\` to resolve 1 security CVE.
Changes are confined to the dependency manifest and lockfile; no application logic was modified.

## CVEs addressed

| CVE ID | Package | Old version | New version | Jira |
|---|---|---|---|---|
| [CVE-2026-4800](https://access.redhat.com/security/cve/CVE-2026-4800) | lodash | 4.17.23 | 4.18.1 | [SAT-43985](https://redhat.atlassian.net/browse/SAT-43985) |

## Changes

| File | Change |
|---|---|
| \`package.json\` | Updated \`lodash\` constraint from \`^4.17.23\` to \`^4.18.0\` (resolves to 4.18.1) |
| \`package-lock.json\` | Bumped \`lodash\` from \`4.17.23\` to \`4.18.1\` |

## Testing

- [ ] CI pipeline passes on this branch.
- [ ] No breaking changes to public API or types introduced by the version bump.

## References

- [CVE-2026-4800](https://access.redhat.com/security/cve/CVE-2026-4800) — lodash arbitrary code execution via untrusted input (prototype pollution)
- [SAT-43985](https://redhat.atlassian.net/browse/SAT-43985) — Jira ticket

[SAT-43985]: https://redhat.atlassian.net/browse/SAT-43985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAT-43985]: https://redhat.atlassian.net/browse/SAT-43985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ