### PR TITLE
fix(deps): bump lodash to 4.18.1 in host-inventory-frontend [foreman-3.16]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "axios": "^1.15.0",
         "bastilian-tabletools": "^1.11.5",
         "classnames": "^2.3.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "moment": "^2.29.4",
         "p-all": "^4.0.0",
         "react": "^18.3.1",
@@ -20975,9 +20975,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -23695,6 +23695,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/postman-collection/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postman-collection/node_modules/semver": {
       "version": "7.6.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "awesome-debounce-promise": "^2.1.0",
     "bastilian-tabletools": "^1.11.5",
     "classnames": "^2.3.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.0",
     "moment": "^2.29.4",
     "p-all": "^4.0.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

Bumps \`lodash\` in \`host-inventory-frontend\` to resolve 2 security CVEs.
Changes are confined to the dependency manifest and lockfile; no application logic was modified.

## CVEs addressed

| CVE ID | Package | Old version | New version | Jira |
|---|---|---|---|---|
| [CVE-2026-4800](https://access.redhat.com/security/cve/CVE-2026-4800) | lodash | 4.17.21 | 4.18.1 | [SAT-43985](https://redhat.atlassian.net/browse/SAT-43985) |
| [CVE-2025-13465](https://access.redhat.com/security/cve/CVE-2025-13465) | lodash | 4.17.21 | 4.18.1 | [SAT-41939](https://redhat.atlassian.net/browse/SAT-41939) |

## Changes

| File | Change |
|---|---|
| \`package.json\` | Updated \`lodash\` constraint from \`^4.17.21\` to \`^4.18.0\` (resolves to 4.18.1) |
| \`package-lock.json\` | Bumped \`lodash\` from \`4.17.21\` to \`4.18.1\` |

## Testing

- [ ] CI pipeline passes on this branch.
- [ ] No breaking changes to public API or types introduced by the version bump.

## References

- [CVE-2026-4800](https://access.redhat.com/security/cve/CVE-2026-4800) — lodash arbitrary code execution via untrusted input (prototype pollution)
- [SAT-43985](https://redhat.atlassian.net/browse/SAT-43985) — Jira ticket
- [CVE-2025-13465](https://access.redhat.com/security/cve/CVE-2025-13465) — lodash prototype pollution in \`_.unset\` and \`_.omit\` functions
- [SAT-41939](https://redhat.atlassian.net/browse/SAT-41939) — Jira ticket

[SAT-43985]: https://redhat.atlassian.net/browse/SAT-43985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAT-41939]: https://redhat.atlassian.net/browse/SAT-41939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAT-43985]: https://redhat.atlassian.net/browse/SAT-43985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ