### PR TITLE
feat(RHINENG-25960): Add kessel permissions to workspace details

### DIFF
--- a/_playwright-tests/helpers/kesselAccessRouteMock.ts
+++ b/_playwright-tests/helpers/kesselAccessRouteMock.ts
@@ -1,0 +1,72 @@
+import type { Page, Route } from '@playwright/test';
+
+/**
+ * Matches Kessel CheckSelfBulk calls from the Kessel access-check SDK
+ * (`Inventory` uses `apiPath` `/api/kessel/v1beta2` on `AccessCheck.Provider`).
+ */
+export const KESSEL_CHECKSELFBULK_ROUTE_GLOB =
+  '**/api/kessel/v1beta2/checkselfbulk**';
+
+type CheckSelfBulkRequestItem = {
+  object?: {
+    resourceId?: string;
+    resourceType?: string;
+    reporter?: { type?: string };
+  };
+  relation?: string;
+};
+
+type CheckSelfBulkBody = {
+  items?: CheckSelfBulkRequestItem[];
+};
+
+/**
+ * Fulfills Kessel `POST …/checkselfbulk` with `ALLOWED_TRUE` for every item so
+ * workspace (and any other) self-access checks succeed in E2E without relying
+ * on stage Kessel policy for the Playwright user.
+ *
+ * Pair with `uninstallKesselCheckSelfBulkMock` in `afterEach` so handlers do
+ * not accumulate across tests.
+ *
+ *  @param page - Playwright page
+ */
+export async function installKesselCheckSelfBulkAllowAll(
+  page: Page,
+): Promise<void> {
+  await page.route(KESSEL_CHECKSELFBULK_ROUTE_GLOB, async (route: Route) => {
+    const req = route.request();
+    if (req.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    let body: CheckSelfBulkBody;
+    try {
+      body = req.postDataJSON() as CheckSelfBulkBody;
+    } catch {
+      await route.continue();
+      return;
+    }
+
+    const items = body?.items ?? [];
+    const pairs = items.map((item) => ({
+      request: item,
+      item: { allowed: 'ALLOWED_TRUE' },
+    }));
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ pairs }),
+    });
+  });
+}
+
+/**
+ *  @param page - Playwright page
+ */
+export async function uninstallKesselCheckSelfBulkMock(
+  page: Page,
+): Promise<void> {
+  await page.unroute(KESSEL_CHECKSELFBULK_ROUTE_GLOB);
+}

--- a/_playwright-tests/helpers/kesselAccessRouteMock.ts
+++ b/_playwright-tests/helpers/kesselAccessRouteMock.ts
@@ -70,3 +70,99 @@ export async function uninstallKesselCheckSelfBulkMock(
 ): Promise<void> {
   await page.unroute(KESSEL_CHECKSELFBULK_ROUTE_GLOB);
 }
+
+const WORKSPACE_RESOURCE_TYPE = 'workspace';
+const WORKSPACE_RELATION_VIEW = 'view';
+const WORKSPACE_RELATION_EDIT = 'edit';
+
+function isWorkspaceRelationItem(
+  item: CheckSelfBulkRequestItem,
+  relation: string,
+): boolean {
+  return (
+    item.object?.resourceType === WORKSPACE_RESOURCE_TYPE &&
+    item.relation === relation
+  );
+}
+
+/**
+ * Denies only workspace **view** self-access; all other bulk items (including
+ * workspace **edit**) are allowed. Use on workspace details to assert the
+ * AccessDenied path while keeping list/create flows workable.
+ */
+export async function installKesselCheckSelfBulkDenyView(
+  page: Page,
+): Promise<void> {
+  await page.route(KESSEL_CHECKSELFBULK_ROUTE_GLOB, async (route: Route) => {
+    const req = route.request();
+    if (req.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    let body: CheckSelfBulkBody;
+    try {
+      body = req.postDataJSON() as CheckSelfBulkBody;
+    } catch {
+      await route.continue();
+      return;
+    }
+
+    const items = body?.items ?? [];
+    const pairs = items.map((item) => ({
+      request: item,
+      item: {
+        allowed: isWorkspaceRelationItem(item, WORKSPACE_RELATION_VIEW)
+          ? 'ALLOWED_FALSE'
+          : 'ALLOWED_TRUE',
+      },
+    }));
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ pairs }),
+    });
+  });
+}
+
+/**
+ * Denies only workspace **edit** self-access; **view** and all other items
+ * stay allowed. Workspace details should still load Systems while header
+ * Actions stay disabled.
+ */
+export async function installKesselCheckSelfBulkDenyEdit(
+  page: Page,
+): Promise<void> {
+  await page.route(KESSEL_CHECKSELFBULK_ROUTE_GLOB, async (route: Route) => {
+    const req = route.request();
+    if (req.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    let body: CheckSelfBulkBody;
+    try {
+      body = req.postDataJSON() as CheckSelfBulkBody;
+    } catch {
+      await route.continue();
+      return;
+    }
+
+    const items = body?.items ?? [];
+    const pairs = items.map((item) => ({
+      request: item,
+      item: {
+        allowed: isWorkspaceRelationItem(item, WORKSPACE_RELATION_EDIT)
+          ? 'ALLOWED_FALSE'
+          : 'ALLOWED_TRUE',
+      },
+    }));
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ pairs }),
+    });
+  });
+}

--- a/_playwright-tests/helpers/workspaceHelpers.ts
+++ b/_playwright-tests/helpers/workspaceHelpers.ts
@@ -10,6 +10,35 @@ import { INVENTORY_API_BASE } from './apiHelpers';
 export const workspaceHeaderActionsToggle = (page: Page) =>
   page.locator('#group-dropdown-toggle');
 
+/**
+ * Reads the workspace UUID from the Workspaces list row link after search.
+ *
+ *  @param page          - Playwright page on `/insights/inventory/workspaces`
+ *  @param workspaceName - Exact visible name of the workspace link
+ *  @returns             Workspace (group) id from the link href
+ */
+export const getWorkspaceIdFromWorkspacesListLink = async (
+  page: Page,
+  workspaceName: string,
+): Promise<string> => {
+  const workspaceLink = page.getByRole('link', { name: workspaceName });
+  await expect(workspaceLink).toBeVisible({ timeout: 100000 });
+  const href = await workspaceLink.getAttribute('href');
+  if (!href) {
+    throw new Error(`Workspace link for "${workspaceName}" is missing href`);
+  }
+  const fromPath = href.match(/\/workspaces\/([^/?#]+)/);
+  if (fromPath?.[1]) {
+    return fromPath[1];
+  }
+  const trimmed = href.replace(/\/$/, '');
+  const lastSegment = trimmed.split('/').pop();
+  if (lastSegment && !lastSegment.includes('.')) {
+    return lastSegment;
+  }
+  throw new Error(`Could not parse workspace id from href: ${href}`);
+};
+
 export type WaitForWorkspaceDetailOptions = {
   /**
    * Also wait until the header Actions menu is enabled (group detail fetch

--- a/_playwright-tests/helpers/workspaceHelpers.ts
+++ b/_playwright-tests/helpers/workspaceHelpers.ts
@@ -2,6 +2,46 @@ import { Response, expect, type Page } from '@playwright/test';
 import { INVENTORY_API_BASE } from './apiHelpers';
 
 /**
+ * Locator for the workspace details page header "Actions" menu toggle (not table bulk Actions).
+ *
+ *  @param page - Playwright page on workspace details
+ *  @returns    Locator for the header Actions toggle
+ */
+export const workspaceHeaderActionsToggle = (page: Page) =>
+  page.locator('#group-dropdown-toggle');
+
+export type WaitForWorkspaceDetailOptions = {
+  /**
+   * Also wait until the header Actions menu is enabled (group detail fetch
+   * finished and workspace-edit checks passed). Required for rename/delete
+   * from the header; the Systems tab can appear before this is true.
+   */
+  waitForEditableHeader?: boolean;
+};
+
+/**
+ * Waits until workspace details main UI is ready (Systems tab visible).
+ * Optionally waits until the header Actions toggle is enabled.
+ *
+ *  @param page    - Playwright page on workspace details
+ *  @param options - When `waitForEditableHeader` is true, waits for `#group-dropdown-toggle` to be enabled
+ *  @returns       Resolves when ready conditions are met
+ */
+export const waitForWorkspaceDetailPageReady = async (
+  page: Page,
+  options?: WaitForWorkspaceDetailOptions,
+) => {
+  await expect(page.getByRole('tab', { name: 'Systems' })).toBeVisible({
+    timeout: 120000,
+  });
+  if (options?.waitForEditableHeader) {
+    await expect(workspaceHeaderActionsToggle(page)).toBeEnabled({
+      timeout: 120000,
+    });
+  }
+};
+
+/**
  *  @returns randomized workspace name
  */
 export const generateUniqueWorkspaceName = async () => {

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -6,11 +6,14 @@ import {
 import { searchByName, waitForTableKebabReady } from './helpers/filterHelpers';
 import {
   installKesselCheckSelfBulkAllowAll,
+  installKesselCheckSelfBulkDenyEdit,
+  installKesselCheckSelfBulkDenyView,
   uninstallKesselCheckSelfBulkMock,
 } from './helpers/kesselAccessRouteMock';
 import {
   generateUniqueWorkspaceName,
   createNewWorkspace,
+  getWorkspaceIdFromWorkspacesListLink,
   isWorkspaceResponse,
   waitForWorkspaceDetailPageReady,
   workspaceHeaderActionsToggle,
@@ -29,6 +32,77 @@ test.beforeEach(async ({ page }) => {
 
 test.afterEach(async ({ page }) => {
   await uninstallKesselCheckSelfBulkMock(page);
+});
+
+test('Workspace details shows AccessDenied when Kessel denies view', async ({
+  page,
+}) => {
+  const workspaceName = `${WORKSPACE_NAME_SORT_PREFIX}_kessel_view_denied_${Date.now()}`;
+
+  await navigateToWorkspacesFunc(page);
+  await createNewWorkspace(page, workspaceName);
+
+  await page.reload({ waitUntil: 'load' });
+  const searchInput = page.locator('input[placeholder="Filter by name"]');
+  await expect(searchInput).toBeVisible();
+  await searchInput.fill(workspaceName);
+
+  const workspaceId = await getWorkspaceIdFromWorkspacesListLink(
+    page,
+    workspaceName,
+  );
+
+  await uninstallKesselCheckSelfBulkMock(page);
+  await installKesselCheckSelfBulkDenyView(page);
+
+  await page.goto(`/insights/inventory/workspaces/${workspaceId}`, {
+    waitUntil: 'load',
+  });
+
+  await expect(
+    page.getByRole('heading', {
+      name: 'You do not have access to this workspace',
+    }),
+  ).toBeVisible({ timeout: 120000 });
+
+  await expect(page.locator('.ins-c-inventory__no--access')).toBeVisible();
+
+  await expect(page.getByRole('tab', { name: 'Systems' })).toHaveCount(0);
+  await expect(page.getByRole('tab', { name: 'Workspace info' })).toHaveCount(
+    0,
+  );
+});
+
+test('Workspace details disables header Actions when Kessel denies edit', async ({
+  page,
+}) => {
+  const workspaceName = `${WORKSPACE_NAME_SORT_PREFIX}_kessel_edit_denied_${Date.now()}`;
+
+  await navigateToWorkspacesFunc(page);
+  await createNewWorkspace(page, workspaceName);
+
+  await page.reload({ waitUntil: 'load' });
+  const searchInput = page.locator('input[placeholder="Filter by name"]');
+  await expect(searchInput).toBeVisible();
+  await searchInput.fill(workspaceName);
+
+  const workspaceId = await getWorkspaceIdFromWorkspacesListLink(
+    page,
+    workspaceName,
+  );
+
+  await uninstallKesselCheckSelfBulkMock(page);
+  await installKesselCheckSelfBulkDenyEdit(page);
+
+  await page.goto(`/insights/inventory/workspaces/${workspaceId}`, {
+    waitUntil: 'load',
+  });
+
+  await expect(page.getByRole('tab', { name: 'Systems' })).toBeVisible({
+    timeout: 120000,
+  });
+
+  await expect(workspaceHeaderActionsToggle(page)).toBeDisabled();
 });
 
 test('User can create, rename, and delete a workspace from Workspace Details page', async ({
@@ -65,7 +139,7 @@ test('User can create, rename, and delete a workspace from Workspace Details pag
   await test.step('Search and open newly created workspace', async () => {
     const searchInput = page.locator('input[placeholder="Filter by name"]');
     await expect(searchInput).toBeVisible();
-    await page.reload({ waitUntil: 'networkidle' });
+    await page.reload({ waitUntil: 'load' });
     await searchInput.fill(workspaceName);
 
     const workspaceLink = page.getByRole('link', { name: workspaceName });
@@ -139,7 +213,7 @@ test('User cannot delete a workspace with systems from Workspace Details page', 
   await test.step('Search and open workspace with systems', async () => {
     const searchInput = page.locator('input[placeholder="Filter by name"]');
     await expect(searchInput).toBeVisible();
-    await page.reload({ waitUntil: 'networkidle' });
+    await page.reload({ waitUntil: 'load' });
     await searchInput.fill(WORKSPACE_WITH_SYSTEMS);
 
     const workspaceLink = page.getByRole('link', {
@@ -192,7 +266,7 @@ test.skip('User able to bulk delete empty workspaces', async ({ page }) => {
       await expect(dialog).toBeVisible({ timeout: 100000 });
       await dialog.locator('input').first().fill(workspaceName);
       await dialog.getByRole('button', { name: 'Create' }).click();
-      await page.reload({ waitUntil: 'networkidle' });
+      await page.reload({ waitUntil: 'load' });
     }
   });
 

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -5,9 +5,15 @@ import {
 } from './helpers/navHelpers';
 import { searchByName, waitForTableKebabReady } from './helpers/filterHelpers';
 import {
+  installKesselCheckSelfBulkAllowAll,
+  uninstallKesselCheckSelfBulkMock,
+} from './helpers/kesselAccessRouteMock';
+import {
   generateUniqueWorkspaceName,
   createNewWorkspace,
   isWorkspaceResponse,
+  waitForWorkspaceDetailPageReady,
+  workspaceHeaderActionsToggle,
 } from './helpers/workspaceHelpers';
 import { test } from './helpers/fixtures';
 import {
@@ -15,6 +21,15 @@ import {
   WORKSPACE_NAME_MODIFIED_PREFIX,
   WORKSPACE_NAME_SORT_PREFIX,
 } from './helpers/constants';
+
+test.beforeEach(async ({ page }) => {
+  await uninstallKesselCheckSelfBulkMock(page);
+  await installKesselCheckSelfBulkAllowAll(page);
+});
+
+test.afterEach(async ({ page }) => {
+  await uninstallKesselCheckSelfBulkMock(page);
+});
 
 test('User can create, rename, and delete a workspace from Workspace Details page', async ({
   page,
@@ -56,10 +71,13 @@ test('User can create, rename, and delete a workspace from Workspace Details pag
     const workspaceLink = page.getByRole('link', { name: workspaceName });
     await expect(workspaceLink).toBeVisible({ timeout: 100000 });
     await workspaceLink.click();
+    await waitForWorkspaceDetailPageReady(page, {
+      waitForEditableHeader: true,
+    });
   });
 
   await test.step('Rename the workspace', async () => {
-    const actionsButton = page.getByRole('button', { name: 'Actions' });
+    const actionsButton = workspaceHeaderActionsToggle(page);
     await expect(actionsButton).toBeVisible();
     await actionsButton.click();
 
@@ -74,11 +92,11 @@ test('User can create, rename, and delete a workspace from Workspace Details pag
     await dialog.getByRole('button', { name: 'Save' }).click();
     await expect(
       page.getByRole('heading', { name: renamedWorkspace }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 60000 });
   });
 
   await test.step.skip('Delete the renamed workspace', async () => {
-    const actionsButton = page.getByRole('button', { name: 'Actions' });
+    const actionsButton = workspaceHeaderActionsToggle(page);
     await expect(actionsButton).toBeVisible();
     await actionsButton.click();
 
@@ -129,16 +147,24 @@ test('User cannot delete a workspace with systems from Workspace Details page', 
     });
     await expect(workspaceLink).toBeVisible({ timeout: 100000 });
     await workspaceLink.click();
+    await waitForWorkspaceDetailPageReady(page, {
+      waitForEditableHeader: true,
+    });
   });
 
   await test.step('Attempt to delete workspace with systems and verify warning', async () => {
-    const actionsButton = page.getByRole('button', { name: 'Actions' });
+    const actionsButton = workspaceHeaderActionsToggle(page);
     await expect(actionsButton).toBeVisible();
     await actionsButton.click();
 
-    await page.getByRole('menuitem', { name: 'Delete' }).first().click();
+    await page
+      .getByRole('menuitem', { name: 'Delete workspace' })
+      .first()
+      .click();
 
-    await expect(page.locator('text=Cannot delete workspace')).toBeVisible();
+    await expect(page.locator('text=Cannot delete workspace')).toBeVisible({
+      timeout: 120000,
+    });
   });
 });
 
@@ -317,6 +343,9 @@ test('User can add and remove system from workspace', async ({
     const workspaceLink = page.getByRole('link', { name: workspaceName });
     await expect(workspaceLink).toBeVisible({ timeout: 100000 });
     await workspaceLink.click();
+    await waitForWorkspaceDetailPageReady(page, {
+      waitForEditableHeader: true,
+    });
   });
 
   await test.step('Add system to workspace', async () => {
@@ -416,6 +445,7 @@ test('User can navigate to Workspace Info Tab', async ({ page }) => {
     });
     await expect(workspaceLink).toBeVisible({ timeout: 100000 });
     await workspaceLink.click();
+    await waitForWorkspaceDetailPageReady(page);
   });
 
   await test.step('Verify Workspace info shows User access configuration section', async () => {

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -5,15 +5,8 @@ import {
 } from './helpers/navHelpers';
 import { searchByName, waitForTableKebabReady } from './helpers/filterHelpers';
 import {
-  installKesselCheckSelfBulkAllowAll,
-  installKesselCheckSelfBulkDenyEdit,
-  installKesselCheckSelfBulkDenyView,
-  uninstallKesselCheckSelfBulkMock,
-} from './helpers/kesselAccessRouteMock';
-import {
   generateUniqueWorkspaceName,
   createNewWorkspace,
-  getWorkspaceIdFromWorkspacesListLink,
   isWorkspaceResponse,
   waitForWorkspaceDetailPageReady,
   workspaceHeaderActionsToggle,
@@ -24,86 +17,6 @@ import {
   WORKSPACE_NAME_MODIFIED_PREFIX,
   WORKSPACE_NAME_SORT_PREFIX,
 } from './helpers/constants';
-
-test.beforeEach(async ({ page }) => {
-  await uninstallKesselCheckSelfBulkMock(page);
-  await installKesselCheckSelfBulkAllowAll(page);
-});
-
-test.afterEach(async ({ page }) => {
-  await uninstallKesselCheckSelfBulkMock(page);
-});
-
-test('Workspace details shows AccessDenied when Kessel denies view', async ({
-  page,
-}) => {
-  const workspaceName = `${WORKSPACE_NAME_SORT_PREFIX}_kessel_view_denied_${Date.now()}`;
-
-  await navigateToWorkspacesFunc(page);
-  await createNewWorkspace(page, workspaceName);
-
-  await page.reload({ waitUntil: 'load' });
-  const searchInput = page.locator('input[placeholder="Filter by name"]');
-  await expect(searchInput).toBeVisible();
-  await searchInput.fill(workspaceName);
-
-  const workspaceId = await getWorkspaceIdFromWorkspacesListLink(
-    page,
-    workspaceName,
-  );
-
-  await uninstallKesselCheckSelfBulkMock(page);
-  await installKesselCheckSelfBulkDenyView(page);
-
-  await page.goto(`/insights/inventory/workspaces/${workspaceId}`, {
-    waitUntil: 'load',
-  });
-
-  await expect(
-    page.getByRole('heading', {
-      name: 'You do not have access to this workspace',
-    }),
-  ).toBeVisible({ timeout: 120000 });
-
-  await expect(page.locator('.ins-c-inventory__no--access')).toBeVisible();
-
-  await expect(page.getByRole('tab', { name: 'Systems' })).toHaveCount(0);
-  await expect(page.getByRole('tab', { name: 'Workspace info' })).toHaveCount(
-    0,
-  );
-});
-
-test('Workspace details disables header Actions when Kessel denies edit', async ({
-  page,
-}) => {
-  const workspaceName = `${WORKSPACE_NAME_SORT_PREFIX}_kessel_edit_denied_${Date.now()}`;
-
-  await navigateToWorkspacesFunc(page);
-  await createNewWorkspace(page, workspaceName);
-
-  await page.reload({ waitUntil: 'load' });
-  const searchInput = page.locator('input[placeholder="Filter by name"]');
-  await expect(searchInput).toBeVisible();
-  await searchInput.fill(workspaceName);
-
-  const workspaceId = await getWorkspaceIdFromWorkspacesListLink(
-    page,
-    workspaceName,
-  );
-
-  await uninstallKesselCheckSelfBulkMock(page);
-  await installKesselCheckSelfBulkDenyEdit(page);
-
-  await page.goto(`/insights/inventory/workspaces/${workspaceId}`, {
-    waitUntil: 'load',
-  });
-
-  await expect(page.getByRole('tab', { name: 'Systems' })).toBeVisible({
-    timeout: 120000,
-  });
-
-  await expect(workspaceHeaderActionsToggle(page)).toBeDisabled();
-});
 
 test('User can create, rename, and delete a workspace from Workspace Details page', async ({
   page,

--- a/src/Utilities/hooks/useWorkspaceDetailEditActionsAccess.ts
+++ b/src/Utilities/hooks/useWorkspaceDetailEditActionsAccess.ts
@@ -21,26 +21,26 @@ export const useWorkspaceDetailEditActionsAccess = ({
   workspaceKesselPermissionsLoading,
   rbacCanModify,
 }: Params) => {
-  const useKesselEditGate =
+  const isKesselEditGating =
     workspaceKesselGateActive === true &&
     typeof workspaceKesselCanEdit === 'boolean';
 
-  const canModifyWorkspaceForActions = useKesselEditGate
+  const canModifyWorkspaceForActions = isKesselEditGating
     ? !workspaceKesselPermissionsLoading && workspaceKesselCanEdit
     : rbacCanModify;
 
-  const noAccessEditTooltip = useKesselEditGate
+  const noAccessEditTooltip = isKesselEditGating
     ? workspaceKesselPermissionsLoading
       ? NO_WORKSPACE_PERMISSIONS_LOADING_TOOLTIP_MESSAGE
       : NO_EDIT_WORKSPACE_KESSEL_TOOLTIP_MESSAGE
     : NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE;
 
-  const kesselActionOverride = useKesselEditGate
+  const kesselActionOverride = isKesselEditGating
     ? !workspaceKesselPermissionsLoading && workspaceKesselCanEdit
     : undefined;
 
   return {
-    useKesselEditGate,
+    isKesselEditGating,
     canModifyWorkspaceForActions,
     noAccessEditTooltip,
     kesselActionOverride,

--- a/src/Utilities/hooks/useWorkspaceDetailEditActionsAccess.ts
+++ b/src/Utilities/hooks/useWorkspaceDetailEditActionsAccess.ts
@@ -1,0 +1,48 @@
+import {
+  NO_EDIT_WORKSPACE_KESSEL_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
+  NO_WORKSPACE_PERMISSIONS_LOADING_TOOLTIP_MESSAGE,
+} from '../../constants';
+
+type Params = {
+  workspaceKesselGateActive: boolean;
+  workspaceKesselCanEdit: boolean | undefined;
+  workspaceKesselPermissionsLoading: boolean;
+  rbacCanModify: boolean;
+};
+
+/**
+ * Merges RBAC workspace write with Kessel `edit` for workspace-details actions
+ * (Add systems, Remove from workspace) when {@link Params.workspaceKesselGateActive} is true.
+ */
+export const useWorkspaceDetailEditActionsAccess = ({
+  workspaceKesselGateActive,
+  workspaceKesselCanEdit,
+  workspaceKesselPermissionsLoading,
+  rbacCanModify,
+}: Params) => {
+  const useKesselEditGate =
+    workspaceKesselGateActive === true &&
+    typeof workspaceKesselCanEdit === 'boolean';
+
+  const canModifyWorkspaceForActions = useKesselEditGate
+    ? !workspaceKesselPermissionsLoading && workspaceKesselCanEdit
+    : rbacCanModify;
+
+  const noAccessEditTooltip = useKesselEditGate
+    ? workspaceKesselPermissionsLoading
+      ? NO_WORKSPACE_PERMISSIONS_LOADING_TOOLTIP_MESSAGE
+      : NO_EDIT_WORKSPACE_KESSEL_TOOLTIP_MESSAGE
+    : NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE;
+
+  const kesselActionOverride = useKesselEditGate
+    ? !workspaceKesselPermissionsLoading && workspaceKesselCanEdit
+    : undefined;
+
+  return {
+    useKesselEditGate,
+    canModifyWorkspaceForActions,
+    noAccessEditTooltip,
+    kesselActionOverride,
+  };
+};

--- a/src/Utilities/hooks/useWorkspaceDetailKesselPermissions.test.ts
+++ b/src/Utilities/hooks/useWorkspaceDetailKesselPermissions.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { renderHook } from '@testing-library/react';
+import { useWorkspaceDetailKesselPermissions } from './useWorkspaceDetailKesselPermissions';
+import {
+  KESSEL_WORKSPACE_REPORTER,
+  WORKSPACE_RELATION_EDIT,
+  WORKSPACE_RELATION_VIEW,
+  WORKSPACE_RESOURCE_TYPE,
+} from '../../constants';
+
+const mockUseKesselMigrationFeatureFlag = jest.fn();
+const mockUseSelfAccessCheck = jest.fn();
+
+jest.mock('./useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
+}));
+
+jest.mock('@project-kessel/react-kessel-access-check', () => ({
+  useSelfAccessCheck: (opts: unknown) => mockUseSelfAccessCheck(opts),
+}));
+
+describe('useWorkspaceDetailKesselPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+    mockUseSelfAccessCheck.mockReturnValue({ data: undefined, loading: false });
+  });
+
+  describe('when Kessel migration flag is OFF', () => {
+    it('returns inactive Kessel gate and undefined permission flags', () => {
+      mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+
+      const { result } = renderHook(() =>
+        useWorkspaceDetailKesselPermissions('ws-1', { skipKessel: false }),
+      );
+
+      expect(result.current).toEqual({
+        appliesKesselWorkspaceChecks: false,
+        canView: undefined,
+        canEdit: undefined,
+        isLoading: false,
+      });
+    });
+  });
+
+  describe('when Kessel migration flag is ON', () => {
+    beforeEach(() => {
+      mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    });
+
+    it('returns inactive gate when skipKessel is true', () => {
+      const { result } = renderHook(() =>
+        useWorkspaceDetailKesselPermissions('ws-1', { skipKessel: true }),
+      );
+
+      expect(result.current).toEqual({
+        appliesKesselWorkspaceChecks: false,
+        canView: undefined,
+        canEdit: undefined,
+        isLoading: false,
+      });
+    });
+
+    it('returns all false when workspaceId is undefined', () => {
+      const { result } = renderHook(() =>
+        useWorkspaceDetailKesselPermissions(undefined, { skipKessel: false }),
+      );
+
+      expect(result.current).toEqual({
+        appliesKesselWorkspaceChecks: true,
+        canView: false,
+        canEdit: false,
+        isLoading: false,
+      });
+    });
+
+    it('maps view and edit from two one-item nested bulk checks', () => {
+      mockUseSelfAccessCheck.mockImplementation(
+        (params: { resources?: Array<{ relation?: string }> }) => {
+          const rel = params.resources?.[0]?.relation;
+          if (rel === WORKSPACE_RELATION_VIEW) {
+            return {
+              data: [
+                {
+                  relation: WORKSPACE_RELATION_VIEW,
+                  allowed: true,
+                  resource: { id: 'w1', type: WORKSPACE_RESOURCE_TYPE },
+                },
+              ],
+              loading: false,
+            };
+          }
+          if (rel === WORKSPACE_RELATION_EDIT) {
+            return {
+              data: [
+                {
+                  relation: WORKSPACE_RELATION_EDIT,
+                  allowed: false,
+                  resource: { id: 'w1', type: WORKSPACE_RESOURCE_TYPE },
+                },
+              ],
+              loading: false,
+            };
+          }
+          return { data: [], loading: false };
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useWorkspaceDetailKesselPermissions('w1', { skipKessel: false }),
+      );
+
+      expect(result.current).toEqual({
+        appliesKesselWorkspaceChecks: true,
+        canView: true,
+        canEdit: false,
+        isLoading: false,
+      });
+    });
+
+    it('requests view and edit as two one-item nested bulk payloads', () => {
+      mockUseSelfAccessCheck.mockReturnValue({ data: [], loading: false });
+
+      renderHook(() =>
+        useWorkspaceDetailKesselPermissions('my-ws-id', { skipKessel: false }),
+      );
+
+      expect(mockUseSelfAccessCheck).toHaveBeenCalledTimes(2);
+      expect(mockUseSelfAccessCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resources: [
+            expect.objectContaining({
+              id: 'my-ws-id',
+              type: WORKSPACE_RESOURCE_TYPE,
+              relation: WORKSPACE_RELATION_VIEW,
+              reporter: KESSEL_WORKSPACE_REPORTER,
+            }),
+          ],
+        }),
+      );
+      expect(mockUseSelfAccessCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resources: [
+            expect.objectContaining({
+              id: 'my-ws-id',
+              type: WORKSPACE_RESOURCE_TYPE,
+              relation: WORKSPACE_RELATION_EDIT,
+              reporter: KESSEL_WORKSPACE_REPORTER,
+            }),
+          ],
+        }),
+      );
+    });
+
+    it('returns isLoading true while either check is loading', () => {
+      mockUseSelfAccessCheck.mockReturnValue({
+        data: undefined,
+        loading: true,
+      });
+
+      const { result } = renderHook(() =>
+        useWorkspaceDetailKesselPermissions('ws-x', { skipKessel: false }),
+      );
+
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+});

--- a/src/Utilities/hooks/useWorkspaceDetailKesselPermissions.ts
+++ b/src/Utilities/hooks/useWorkspaceDetailKesselPermissions.ts
@@ -1,10 +1,5 @@
-import { useMemo } from 'react';
 import { useSelfAccessCheck } from '@project-kessel/react-kessel-access-check';
-import {
-  type BulkSelfAccessCheckNestedRelationsParams,
-  type SelfAccessCheckResource,
-  type SelfAccessCheckResourceWithRelation,
-} from '@project-kessel/react-kessel-access-check/types';
+import { type BulkSelfAccessCheckNestedRelationsParams } from '@project-kessel/react-kessel-access-check/types';
 import {
   KESSEL_WORKSPACE_REPORTER,
   WORKSPACE_RELATION_EDIT,
@@ -13,32 +8,10 @@ import {
 } from '../../constants';
 import { useKesselMigrationFeatureFlag } from './useKesselMigrationFeatureFlag';
 
-/**
- * Nested bulk params only — keeps `useSelfAccessCheck` on one overload so TypeScript is satisfied.
- * When `run` is false, `resources` is empty and the SDK completes immediately (no network).
- * When `run` is true, a single `{ ...resource, relation }` entry avoids bulk index/order bugs vs two relations in one request.
- *
- *  @param run      - Whether to include the workspace resource in `resources`
- *  @param resource - Workspace resource without relation, or null when idle
- *  @param relation - Kessel relation for the single bulk item
- *  @returns        Params for `useSelfAccessCheck` nested bulk overload
- */
-function workspaceNestedBulkParams(
-  run: boolean,
-  resource: SelfAccessCheckResource | null,
-  relation: string,
-): BulkSelfAccessCheckNestedRelationsParams {
-  if (!run || !resource) {
-    return {
-      resources: [],
-    } as unknown as BulkSelfAccessCheckNestedRelationsParams;
-  }
-  const withRelation: SelfAccessCheckResourceWithRelation = {
-    ...resource,
-    relation,
-  };
-  return { resources: [withRelation] };
-}
+/** Empty bulk payload when Kessel checks are skipped; SDK completes without network. */
+const emptyBulkParams = {
+  resources: [],
+} as unknown as BulkSelfAccessCheckNestedRelationsParams;
 
 export type WorkspaceDetailKesselPermissions = {
   /** When false, callers should use RBAC only (Kessel off or ungrouped hosts workspace). */
@@ -71,40 +44,33 @@ export const useWorkspaceDetailKesselPermissions = (
   const appliesKesselWorkspaceChecks =
     isKesselEnabled === true && skipKessel !== true;
 
-  const workspaceResource = useMemo(
-    () =>
-      workspaceId
-        ? {
-            id: workspaceId,
-            type: WORKSPACE_RESOURCE_TYPE,
-            reporter: KESSEL_WORKSPACE_REPORTER,
-          }
-        : null,
-    [workspaceId],
-  );
+  const viewAccessParams: BulkSelfAccessCheckNestedRelationsParams =
+    appliesKesselWorkspaceChecks && workspaceId
+      ? {
+          resources: [
+            {
+              id: workspaceId,
+              type: WORKSPACE_RESOURCE_TYPE,
+              reporter: KESSEL_WORKSPACE_REPORTER,
+              relation: WORKSPACE_RELATION_VIEW,
+            },
+          ],
+        }
+      : emptyBulkParams;
 
-  const runSingleChecks =
-    appliesKesselWorkspaceChecks && workspaceResource != null;
-
-  const viewAccessParams = useMemo(
-    () =>
-      workspaceNestedBulkParams(
-        runSingleChecks,
-        workspaceResource,
-        WORKSPACE_RELATION_VIEW,
-      ),
-    [runSingleChecks, workspaceResource],
-  );
-
-  const editAccessParams = useMemo(
-    () =>
-      workspaceNestedBulkParams(
-        runSingleChecks,
-        workspaceResource,
-        WORKSPACE_RELATION_EDIT,
-      ),
-    [runSingleChecks, workspaceResource],
-  );
+  const editAccessParams: BulkSelfAccessCheckNestedRelationsParams =
+    appliesKesselWorkspaceChecks && workspaceId
+      ? {
+          resources: [
+            {
+              id: workspaceId,
+              type: WORKSPACE_RESOURCE_TYPE,
+              reporter: KESSEL_WORKSPACE_REPORTER,
+              relation: WORKSPACE_RELATION_EDIT,
+            },
+          ],
+        }
+      : emptyBulkParams;
 
   const viewCheck = useSelfAccessCheck(viewAccessParams);
   const editCheck = useSelfAccessCheck(editAccessParams);

--- a/src/Utilities/hooks/useWorkspaceDetailKesselPermissions.ts
+++ b/src/Utilities/hooks/useWorkspaceDetailKesselPermissions.ts
@@ -1,0 +1,139 @@
+import { useMemo } from 'react';
+import { useSelfAccessCheck } from '@project-kessel/react-kessel-access-check';
+import {
+  type BulkSelfAccessCheckNestedRelationsParams,
+  type SelfAccessCheckResource,
+  type SelfAccessCheckResourceWithRelation,
+} from '@project-kessel/react-kessel-access-check/types';
+import {
+  KESSEL_WORKSPACE_REPORTER,
+  WORKSPACE_RELATION_EDIT,
+  WORKSPACE_RELATION_VIEW,
+  WORKSPACE_RESOURCE_TYPE,
+} from '../../constants';
+import { useKesselMigrationFeatureFlag } from './useKesselMigrationFeatureFlag';
+
+/**
+ * Nested bulk params only — keeps `useSelfAccessCheck` on one overload so TypeScript is satisfied.
+ * When `run` is false, `resources` is empty and the SDK completes immediately (no network).
+ * When `run` is true, a single `{ ...resource, relation }` entry avoids bulk index/order bugs vs two relations in one request.
+ *
+ *  @param run      - Whether to include the workspace resource in `resources`
+ *  @param resource - Workspace resource without relation, or null when idle
+ *  @param relation - Kessel relation for the single bulk item
+ *  @returns        Params for `useSelfAccessCheck` nested bulk overload
+ */
+function workspaceNestedBulkParams(
+  run: boolean,
+  resource: SelfAccessCheckResource | null,
+  relation: string,
+): BulkSelfAccessCheckNestedRelationsParams {
+  if (!run || !resource) {
+    return {
+      resources: [],
+    } as unknown as BulkSelfAccessCheckNestedRelationsParams;
+  }
+  const withRelation: SelfAccessCheckResourceWithRelation = {
+    ...resource,
+    relation,
+  };
+  return { resources: [withRelation] };
+}
+
+export type WorkspaceDetailKesselPermissions = {
+  /** When false, callers should use RBAC only (Kessel off or ungrouped hosts workspace). */
+  appliesKesselWorkspaceChecks: boolean;
+  canView: boolean | undefined;
+  canEdit: boolean | undefined;
+  isLoading: boolean;
+};
+
+/**
+ * Kessel self-access checks for a single workspace on the workspace details page: `view` and `edit`.
+ *
+ * Uses **two** `useSelfAccessCheck` calls, each with nested bulk params containing **one** resource
+ * (one relation per request), so `checkselfbulk` cannot mis-associate pairs when the API returns
+ * items out of order (see `transformBulkResponse` in the SDK).
+ *
+ * When the Kessel migration flag is off, or `skipKessel` is true (e.g. ungrouped hosts),
+ * returns inactive flags so callers fall back to RBAC.
+ *
+ *  @param workspaceId      - RBAC workspace id from the route
+ *  @param root0            - Options object
+ *  @param root0.skipKessel - When true, no API checks are made (ungrouped workspace)
+ *  @returns                View/edit flags, loading, and whether Kessel should gate the page
+ */
+export const useWorkspaceDetailKesselPermissions = (
+  workspaceId: string | undefined,
+  { skipKessel = false }: { skipKessel?: boolean } = {},
+): WorkspaceDetailKesselPermissions => {
+  const isKesselEnabled = useKesselMigrationFeatureFlag();
+  const appliesKesselWorkspaceChecks =
+    isKesselEnabled === true && skipKessel !== true;
+
+  const workspaceResource = useMemo(
+    () =>
+      workspaceId
+        ? {
+            id: workspaceId,
+            type: WORKSPACE_RESOURCE_TYPE,
+            reporter: KESSEL_WORKSPACE_REPORTER,
+          }
+        : null,
+    [workspaceId],
+  );
+
+  const runSingleChecks =
+    appliesKesselWorkspaceChecks && workspaceResource != null;
+
+  const viewAccessParams = useMemo(
+    () =>
+      workspaceNestedBulkParams(
+        runSingleChecks,
+        workspaceResource,
+        WORKSPACE_RELATION_VIEW,
+      ),
+    [runSingleChecks, workspaceResource],
+  );
+
+  const editAccessParams = useMemo(
+    () =>
+      workspaceNestedBulkParams(
+        runSingleChecks,
+        workspaceResource,
+        WORKSPACE_RELATION_EDIT,
+      ),
+    [runSingleChecks, workspaceResource],
+  );
+
+  const viewCheck = useSelfAccessCheck(viewAccessParams);
+  const editCheck = useSelfAccessCheck(editAccessParams);
+
+  if (!appliesKesselWorkspaceChecks) {
+    return {
+      appliesKesselWorkspaceChecks: false,
+      canView: undefined,
+      canEdit: undefined,
+      isLoading: false,
+    };
+  }
+
+  if (!workspaceId) {
+    return {
+      appliesKesselWorkspaceChecks: true,
+      canView: false,
+      canEdit: false,
+      isLoading: false,
+    };
+  }
+
+  const viewAllowed = viewCheck.data?.[0]?.allowed === true;
+  const editAllowed = editCheck.data?.[0]?.allowed === true;
+
+  return {
+    appliesKesselWorkspaceChecks: true,
+    canView: viewAllowed,
+    canEdit: editAllowed,
+    isLoading: viewCheck.loading || editCheck.loading,
+  };
+};

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -26,14 +26,23 @@ import { generateFilter } from '../../Utilities/constants';
 import { prepareColumns } from './helpers';
 import { useDeepCompareMemo } from 'use-deep-compare';
 
+const defaultWorkspaceAccess = {
+  canEdit: undefined,
+  isLoading: false,
+  gateActive: false,
+};
+
 const GroupSystems = ({
   groupName,
   groupId,
   ungrouped,
-  workspaceKesselGateActive = false,
-  workspaceKesselCanEdit,
-  workspaceKesselPermissionsLoading = false,
+  workspaceAccess = defaultWorkspaceAccess,
 }) => {
+  const {
+    canEdit: workspaceKesselCanEdit,
+    isLoading: workspaceKesselPermissionsLoading,
+    gateActive: workspaceKesselGateActive,
+  } = workspaceAccess;
   const dispatch = useDispatch();
   const globalFilter = useGlobalFilter();
   const [removeHostsFromGroupModalOpen, setRemoveHostsFromGroupModalOpen] =
@@ -173,9 +182,12 @@ const GroupSystems = ({
                     requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                       groupId,
                     )}
-                    isAriaDisabled={ungrouped}
+                    isAriaDisabled={ungrouped || !canModifyWorkspaceForActions}
                     noAccessTooltip={noAccessEditTooltip}
                     override={kesselActionOverride}
+                    {...(!canModifyWorkspaceForActions && {
+                      tooltipProps: { content: noAccessEditTooltip },
+                    })}
                     onClick={() => {
                       setCurrentSystem([row]);
                       setRemoveHostsFromGroupModalOpen(true);
@@ -244,9 +256,11 @@ GroupSystems.propTypes = {
   groupId: PropTypes.string.isRequired,
   ungrouped: PropTypes.string,
   hostType: PropTypes.string,
-  workspaceKesselGateActive: PropTypes.bool,
-  workspaceKesselCanEdit: PropTypes.bool,
-  workspaceKesselPermissionsLoading: PropTypes.bool,
+  workspaceAccess: PropTypes.shape({
+    canEdit: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    gateActive: PropTypes.bool,
+  }),
 };
 
 GroupSystems.defaultProps = {

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -7,8 +7,8 @@ import InventoryTable from '../InventoryTable/InventoryTable';
 import { useSearchParams } from 'react-router-dom';
 import RemoveHostsFromGroupModal from '../InventoryGroups/Modals/RemoveHostsFromGroupModal';
 import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
+import { useWorkspaceDetailEditActionsAccess } from '../../Utilities/hooks/useWorkspaceDetailEditActionsAccess';
 import {
-  NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
   getSearchParams,
 } from '../../constants';
@@ -26,7 +26,14 @@ import { generateFilter } from '../../Utilities/constants';
 import { prepareColumns } from './helpers';
 import { useDeepCompareMemo } from 'use-deep-compare';
 
-const GroupSystems = ({ groupName, groupId, ungrouped }) => {
+const GroupSystems = ({
+  groupName,
+  groupId,
+  ungrouped,
+  workspaceKesselGateActive = false,
+  workspaceKesselCanEdit,
+  workspaceKesselPermissionsLoading = false,
+}) => {
   const dispatch = useDispatch();
   const globalFilter = useGlobalFilter();
   const [removeHostsFromGroupModalOpen, setRemoveHostsFromGroupModalOpen] =
@@ -49,8 +56,18 @@ const GroupSystems = ({ groupName, groupId, ungrouped }) => {
     REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(groupId),
   );
 
+  const {
+    canModifyWorkspaceForActions,
+    noAccessEditTooltip,
+    kesselActionOverride,
+  } = useWorkspaceDetailEditActionsAccess({
+    workspaceKesselGateActive,
+    workspaceKesselCanEdit,
+    workspaceKesselPermissionsLoading,
+    rbacCanModify: canModify,
+  });
+
   const [searchParams] = useSearchParams();
-  const noAccessTooltip = NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE;
   const removeLabel = 'Remove from workspace';
 
   /*eslint-disable react-hooks/exhaustive-deps*/
@@ -157,7 +174,8 @@ const GroupSystems = ({ groupName, groupId, ungrouped }) => {
                       groupId,
                     )}
                     isAriaDisabled={ungrouped}
-                    noAccessTooltip={noAccessTooltip}
+                    noAccessTooltip={noAccessEditTooltip}
+                    override={kesselActionOverride}
                     onClick={() => {
                       setCurrentSystem([row]);
                       setRemoveHostsFromGroupModalOpen(true);
@@ -176,13 +194,14 @@ const GroupSystems = ({ groupName, groupId, ungrouped }) => {
                 requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(
                   groupId,
                 )}
-                noAccessTooltip={noAccessTooltip}
+                noAccessTooltip={noAccessEditTooltip}
+                override={kesselActionOverride}
                 onClick={() => {
                   dispatch(clearEntitiesAction());
                   setAddToGroupModalOpen(true);
                 }}
                 ouiaId="add-systems-button"
-                isAriaDisabled={ungrouped || !canModify}
+                isAriaDisabled={ungrouped || !canModifyWorkspaceForActions}
               >
                 Add systems
               </ActionButton>,
@@ -190,10 +209,12 @@ const GroupSystems = ({ groupName, groupId, ungrouped }) => {
                 label: removeLabel,
                 props: {
                   isAriaDisabled:
-                    ungrouped || !canModify || calculateSelected() === 0,
-                  ...(!canModify && {
+                    ungrouped ||
+                    !canModifyWorkspaceForActions ||
+                    calculateSelected() === 0,
+                  ...(!canModifyWorkspaceForActions && {
                     tooltipProps: {
-                      content: noAccessTooltip,
+                      content: noAccessEditTooltip,
                     },
                   }),
                 },
@@ -223,6 +244,9 @@ GroupSystems.propTypes = {
   groupId: PropTypes.string.isRequired,
   ungrouped: PropTypes.string,
   hostType: PropTypes.string,
+  workspaceKesselGateActive: PropTypes.bool,
+  workspaceKesselCanEdit: PropTypes.bool,
+  workspaceKesselPermissionsLoading: PropTypes.bool,
 };
 
 GroupSystems.defaultProps = {

--- a/src/components/GroupSystems/index.js
+++ b/src/components/GroupSystems/index.js
@@ -9,9 +9,7 @@ const GroupSystemsWrapper = ({
   groupName,
   groupId,
   ungrouped,
-  workspaceKesselCanEdit,
-  workspaceKesselPermissionsLoading,
-  workspaceKesselGateActive,
+  workspaceAccess,
 }) => {
   const { uninitialized, loading, data } = useSelector(
     (state) => state.groupDetail,
@@ -27,17 +25,13 @@ const GroupSystemsWrapper = ({
       groupId={groupId}
       groupName={groupName}
       ungrouped={ungrouped ?? false}
-      workspaceKesselCanEdit={workspaceKesselCanEdit}
-      workspaceKesselPermissionsLoading={workspaceKesselPermissionsLoading}
-      workspaceKesselGateActive={workspaceKesselGateActive}
+      workspaceAccess={workspaceAccess}
     />
   ) : (
     <NoSystemsEmptyState
       groupId={groupId}
       groupName={groupName}
-      workspaceKesselCanEdit={workspaceKesselCanEdit}
-      workspaceKesselPermissionsLoading={workspaceKesselPermissionsLoading}
-      workspaceKesselGateActive={workspaceKesselGateActive}
+      workspaceAccess={workspaceAccess}
     />
   );
 };
@@ -46,9 +40,11 @@ GroupSystemsWrapper.propTypes = {
   groupName: PropTypes.string.isRequired,
   groupId: PropTypes.string.isRequired,
   ungrouped: PropTypes.bool,
-  workspaceKesselCanEdit: PropTypes.bool,
-  workspaceKesselPermissionsLoading: PropTypes.bool,
-  workspaceKesselGateActive: PropTypes.bool,
+  workspaceAccess: PropTypes.shape({
+    canEdit: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    gateActive: PropTypes.bool,
+  }),
 };
 
 export default GroupSystemsWrapper;

--- a/src/components/GroupSystems/index.js
+++ b/src/components/GroupSystems/index.js
@@ -5,7 +5,14 @@ import { useSelector } from 'react-redux';
 import NoSystemsEmptyState from '../InventoryGroupDetail/NoSystemsEmptyState';
 import GroupSystems from './GroupSystems';
 
-const GroupSystemsWrapper = ({ groupName, groupId, ungrouped }) => {
+const GroupSystemsWrapper = ({
+  groupName,
+  groupId,
+  ungrouped,
+  workspaceKesselCanEdit,
+  workspaceKesselPermissionsLoading,
+  workspaceKesselGateActive,
+}) => {
   const { uninitialized, loading, data } = useSelector(
     (state) => state.groupDetail,
   );
@@ -20,9 +27,18 @@ const GroupSystemsWrapper = ({ groupName, groupId, ungrouped }) => {
       groupId={groupId}
       groupName={groupName}
       ungrouped={ungrouped ?? false}
+      workspaceKesselCanEdit={workspaceKesselCanEdit}
+      workspaceKesselPermissionsLoading={workspaceKesselPermissionsLoading}
+      workspaceKesselGateActive={workspaceKesselGateActive}
     />
   ) : (
-    <NoSystemsEmptyState groupId={groupId} groupName={groupName} />
+    <NoSystemsEmptyState
+      groupId={groupId}
+      groupName={groupName}
+      workspaceKesselCanEdit={workspaceKesselCanEdit}
+      workspaceKesselPermissionsLoading={workspaceKesselPermissionsLoading}
+      workspaceKesselGateActive={workspaceKesselGateActive}
+    />
   );
 };
 
@@ -30,6 +46,9 @@ GroupSystemsWrapper.propTypes = {
   groupName: PropTypes.string.isRequired,
   groupId: PropTypes.string.isRequired,
   ungrouped: PropTypes.bool,
+  workspaceKesselCanEdit: PropTypes.bool,
+  workspaceKesselPermissionsLoading: PropTypes.bool,
+  workspaceKesselGateActive: PropTypes.bool,
 };
 
 export default GroupSystemsWrapper;

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -18,13 +18,19 @@ import DeleteGroupModal from '../InventoryGroups/Modals/DeleteGroupModal';
 import RenameGroupModal from '../InventoryGroups/Modals/RenameGroupModal';
 import { fetchGroupDetail } from '../../store/inventory-actions';
 import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
+import { useWorkspaceDetailEditActionsAccess } from '../../Utilities/hooks/useWorkspaceDetailEditActionsAccess';
 import {
   REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
   REQUIRED_PERMISSIONS_TO_READ_GROUP,
 } from '../../constants';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
 
-const GroupDetailHeader = ({ groupId }) => {
+const GroupDetailHeader = ({
+  groupId,
+  workspaceKesselGateActive = false,
+  workspaceKesselCanEdit,
+  workspaceKesselPermissionsLoading = false,
+}) => {
   const dispatch = useDispatch();
   const navigate = useInsightsNavigate();
   const { uninitialized, loading, data } = useSelector(
@@ -35,9 +41,17 @@ const GroupDetailHeader = ({ groupId }) => {
     REQUIRED_PERMISSIONS_TO_READ_GROUP(groupId),
   );
 
-  const { hasAccess: canModify } = useConditionalRBAC(
+  const { hasAccess: rbacCanModify } = useConditionalRBAC(
     REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(groupId),
   );
+
+  const { canModifyWorkspaceForActions, noAccessEditTooltip } =
+    useWorkspaceDetailEditActionsAccess({
+      workspaceKesselGateActive,
+      workspaceKesselCanEdit,
+      workspaceKesselPermissionsLoading,
+      rbacCanModify,
+    });
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [renameModalOpen, setRenameModalOpen] = useState(false);
@@ -107,7 +121,9 @@ const GroupDetailHeader = ({ groupId }) => {
                 onClick={() => setDropdownOpen(!dropdownOpen)}
                 id="group-dropdown-toggle"
                 toggleVariant="secondary"
-                isDisabled={!canModify || uninitialized || loading}
+                isDisabled={
+                  !canModifyWorkspaceForActions || uninitialized || loading
+                }
                 ouiaId="group-actions-dropdown-toggle"
               >
                 Actions
@@ -118,14 +134,20 @@ const GroupDetailHeader = ({ groupId }) => {
               <DropdownItem
                 key="rename-group"
                 onClick={() => setRenameModalOpen(true)}
-                isAriaDisabled={ungrouped}
+                isAriaDisabled={ungrouped || !canModifyWorkspaceForActions}
+                {...(!canModifyWorkspaceForActions && {
+                  tooltipProps: { content: noAccessEditTooltip },
+                })}
               >
                 Rename workspace
               </DropdownItem>
               <DropdownItem
                 key="delete-group"
                 onClick={() => setDeleteModalOpen(true)}
-                isAriaDisabled={ungrouped}
+                isAriaDisabled={ungrouped || !canModifyWorkspaceForActions}
+                {...(!canModifyWorkspaceForActions && {
+                  tooltipProps: { content: noAccessEditTooltip },
+                })}
               >
                 Delete workspace
               </DropdownItem>
@@ -139,6 +161,9 @@ const GroupDetailHeader = ({ groupId }) => {
 
 GroupDetailHeader.propTypes = {
   groupId: PropTypes.string.isRequired,
+  workspaceKesselGateActive: PropTypes.bool,
+  workspaceKesselCanEdit: PropTypes.bool,
+  workspaceKesselPermissionsLoading: PropTypes.bool,
 };
 
 export default GroupDetailHeader;

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -25,12 +25,21 @@ import {
 } from '../../constants';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
 
+const defaultWorkspaceAccess = {
+  canEdit: undefined,
+  isLoading: false,
+  gateActive: false,
+};
+
 const GroupDetailHeader = ({
   groupId,
-  workspaceKesselGateActive = false,
-  workspaceKesselCanEdit,
-  workspaceKesselPermissionsLoading = false,
+  workspaceAccess = defaultWorkspaceAccess,
 }) => {
+  const {
+    canEdit: workspaceKesselCanEdit,
+    isLoading: workspaceKesselPermissionsLoading,
+    gateActive: workspaceKesselGateActive,
+  } = workspaceAccess;
   const dispatch = useDispatch();
   const navigate = useInsightsNavigate();
   const { uninitialized, loading, data } = useSelector(
@@ -161,9 +170,11 @@ const GroupDetailHeader = ({
 
 GroupDetailHeader.propTypes = {
   groupId: PropTypes.string.isRequired,
-  workspaceKesselGateActive: PropTypes.bool,
-  workspaceKesselCanEdit: PropTypes.bool,
-  workspaceKesselPermissionsLoading: PropTypes.bool,
+  workspaceAccess: PropTypes.shape({
+    canEdit: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    gateActive: PropTypes.bool,
+  }),
 };
 
 export default GroupDetailHeader;

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -8,7 +8,7 @@ import {
 import AccessDenied from '../../Utilities/AccessDenied';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import PropTypes from 'prop-types';
-import React, { Suspense, lazy, useEffect, useState } from 'react';
+import React, { Suspense, lazy, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchGroupDetail } from '../../store/inventory-actions';
 import GroupSystems from '../GroupSystems';
@@ -48,27 +48,39 @@ const InventoryGroupDetail = ({ groupId }) => {
     skipKessel: isUngroupedHostsWorkspace,
   });
 
+  const workspaceAccess = useMemo(
+    () => ({
+      canEdit: workspaceKessel.canEdit,
+      isLoading: workspaceKessel.isLoading,
+      gateActive: workspaceKessel.appliesKesselWorkspaceChecks,
+    }),
+    [
+      workspaceKessel.canEdit,
+      workspaceKessel.isLoading,
+      workspaceKessel.appliesKesselWorkspaceChecks,
+    ],
+  );
+
+  const kesselWorkspaceChecksActive =
+    isKesselEnabled &&
+    fulfilled &&
+    !isUngroupedHostsWorkspace &&
+    workspaceKessel.appliesKesselWorkspaceChecks;
+
+  const kesselWorkspaceAccessDenied =
+    kesselWorkspaceChecksActive &&
+    !workspaceKessel.isLoading &&
+    workspaceKessel.canView === false;
+
+  const kesselWorkspacePermissionsLoading =
+    kesselWorkspaceChecksActive && workspaceKessel.isLoading;
+
   const { hasAccess: canViewGroup } = useConditionalRBAC(
     REQUIRED_PERMISSIONS_TO_READ_GROUP(groupId),
   );
   const { hasAccess: canViewHosts } = useConditionalRBAC(
     REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId),
   );
-
-  const kesselWorkspaceAccessDenied =
-    isKesselEnabled &&
-    fulfilled &&
-    !isUngroupedHostsWorkspace &&
-    workspaceKessel.appliesKesselWorkspaceChecks &&
-    !workspaceKessel.isLoading &&
-    workspaceKessel.canView === false;
-
-  const kesselWorkspacePermissionsLoading =
-    isKesselEnabled &&
-    fulfilled &&
-    !isUngroupedHostsWorkspace &&
-    workspaceKessel.appliesKesselWorkspaceChecks &&
-    workspaceKessel.isLoading;
 
   useEffect(() => {
     if (canViewGroup === true) {
@@ -92,84 +104,84 @@ const InventoryGroupDetail = ({ groupId }) => {
     navigate('/groups');
   }
 
+  const renderWorkspaceContent = () => {
+    if (kesselWorkspaceAccessDenied) {
+      return (
+        <PageSection hasBodyWrapper={false}>
+          <AccessDenied
+            title="You do not have access to this workspace"
+            description={
+              <div>
+                You do not have permission to view this workspace in inventory.
+              </div>
+            }
+          />
+        </PageSection>
+      );
+    }
+
+    if (kesselWorkspacePermissionsLoading) {
+      return (
+        <PageSection hasBodyWrapper={false}>
+          <Bullseye className="pf-v6-u-p-xl">
+            <Spinner aria-label="Loading workspace permissions" />
+          </Bullseye>
+        </PageSection>
+      );
+    }
+
+    return (
+      <PageSection hasBodyWrapper={false} type="tabs">
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={(_event, value) => setActiveTabKey(value)}
+          aria-label="Group tabs"
+          role="region"
+          inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
+        >
+          <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
+            <PageSection hasBodyWrapper={false}>
+              {canViewHosts ? (
+                <GroupSystems
+                  groupName={groupName}
+                  groupId={groupId}
+                  ungrouped={ungrouped}
+                  workspaceAccess={workspaceAccess}
+                />
+              ) : (
+                <EmptyStateNoAccessToSystems />
+              )}
+            </PageSection>
+          </Tab>
+          <Tab
+            eventKey={1}
+            title="Workspace info"
+            aria-label="Workspace info tab"
+          >
+            {activeTabKey === 1 && ( // helps to lazy load the component
+              <PageSection hasBodyWrapper={false}>
+                <Suspense
+                  fallback={
+                    <Bullseye>
+                      <Spinner />
+                    </Bullseye>
+                  }
+                >
+                  <GroupDetailInfo />
+                </Suspense>
+              </PageSection>
+            )}
+          </Tab>
+        </Tabs>
+      </PageSection>
+    );
+  };
+
   return (
     <React.Fragment>
-      <GroupDetailHeader
-        groupId={groupId}
-        workspaceKesselCanEdit={workspaceKessel.canEdit}
-        workspaceKesselPermissionsLoading={workspaceKessel.isLoading}
-        workspaceKesselGateActive={workspaceKessel.appliesKesselWorkspaceChecks}
-      />
+      <GroupDetailHeader groupId={groupId} workspaceAccess={workspaceAccess} />
       {canViewGroup ? (
-        kesselWorkspaceAccessDenied ? (
-          <PageSection hasBodyWrapper={false}>
-            <AccessDenied
-              title="You do not have access to this workspace"
-              description={
-                <div>
-                  You do not have permission to view this workspace in
-                  inventory.
-                </div>
-              }
-            />
-          </PageSection>
-        ) : kesselWorkspacePermissionsLoading ? (
-          <PageSection hasBodyWrapper={false}>
-            <Bullseye className="pf-v6-u-p-xl">
-              <Spinner aria-label="Loading workspace permissions" />
-            </Bullseye>
-          </PageSection>
-        ) : (
-          <PageSection hasBodyWrapper={false} type="tabs">
-            <Tabs
-              activeKey={activeTabKey}
-              onSelect={(_event, value) => setActiveTabKey(value)}
-              aria-label="Group tabs"
-              role="region"
-              inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
-            >
-              <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
-                <PageSection hasBodyWrapper={false}>
-                  {canViewHosts ? (
-                    <GroupSystems
-                      groupName={groupName}
-                      groupId={groupId}
-                      ungrouped={ungrouped}
-                      workspaceKesselCanEdit={workspaceKessel.canEdit}
-                      workspaceKesselPermissionsLoading={
-                        workspaceKessel.isLoading
-                      }
-                      workspaceKesselGateActive={
-                        workspaceKessel.appliesKesselWorkspaceChecks
-                      }
-                    />
-                  ) : (
-                    <EmptyStateNoAccessToSystems />
-                  )}
-                </PageSection>
-              </Tab>
-              <Tab
-                eventKey={1}
-                title="Workspace info"
-                aria-label="Workspace info tab"
-              >
-                {activeTabKey === 1 && ( // helps to lazy load the component
-                  <PageSection hasBodyWrapper={false}>
-                    <Suspense
-                      fallback={
-                        <Bullseye>
-                          <Spinner />
-                        </Bullseye>
-                      }
-                    >
-                      <GroupDetailInfo />
-                    </Suspense>
-                  </PageSection>
-                )}
-              </Tab>
-            </Tabs>
-          </PageSection>
-        )
+        renderWorkspaceContent()
       ) : (
         <PageSection hasBodyWrapper={false}>
           <EmptyStateNoAccessToGroups isSingle />

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.js
@@ -5,6 +5,7 @@ import {
   Tab,
   Tabs,
 } from '@patternfly/react-core';
+import AccessDenied from '../../Utilities/AccessDenied';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import PropTypes from 'prop-types';
 import React, { Suspense, lazy, useEffect, useState } from 'react';
@@ -13,6 +14,8 @@ import { fetchGroupDetail } from '../../store/inventory-actions';
 import GroupSystems from '../GroupSystems';
 import GroupDetailHeader from './GroupDetailHeader';
 import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
+import { useKesselMigrationFeatureFlag } from '../../Utilities/hooks/useKesselMigrationFeatureFlag';
+import { useWorkspaceDetailKesselPermissions } from '../../Utilities/hooks/useWorkspaceDetailKesselPermissions';
 import {
   REQUIRED_PERMISSIONS_TO_READ_GROUP,
   REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS,
@@ -37,6 +40,13 @@ const InventoryGroupDetail = ({ groupId }) => {
   const chrome = useChrome();
   const groupName = data?.results?.[0]?.name;
   const ungrouped = data?.results?.[0]?.ungrouped;
+  const isUngroupedHostsWorkspace =
+    fulfilled && Boolean(data?.results?.[0]?.ungrouped);
+
+  const isKesselEnabled = useKesselMigrationFeatureFlag();
+  const workspaceKessel = useWorkspaceDetailKesselPermissions(groupId, {
+    skipKessel: isUngroupedHostsWorkspace,
+  });
 
   const { hasAccess: canViewGroup } = useConditionalRBAC(
     REQUIRED_PERMISSIONS_TO_READ_GROUP(groupId),
@@ -44,6 +54,21 @@ const InventoryGroupDetail = ({ groupId }) => {
   const { hasAccess: canViewHosts } = useConditionalRBAC(
     REQUIRED_PERMISSIONS_TO_READ_GROUP_HOSTS(groupId),
   );
+
+  const kesselWorkspaceAccessDenied =
+    isKesselEnabled &&
+    fulfilled &&
+    !isUngroupedHostsWorkspace &&
+    workspaceKessel.appliesKesselWorkspaceChecks &&
+    !workspaceKessel.isLoading &&
+    workspaceKessel.canView === false;
+
+  const kesselWorkspacePermissionsLoading =
+    isKesselEnabled &&
+    fulfilled &&
+    !isUngroupedHostsWorkspace &&
+    workspaceKessel.appliesKesselWorkspaceChecks &&
+    workspaceKessel.isLoading;
 
   useEffect(() => {
     if (canViewGroup === true) {
@@ -69,50 +94,82 @@ const InventoryGroupDetail = ({ groupId }) => {
 
   return (
     <React.Fragment>
-      <GroupDetailHeader groupId={groupId} />
+      <GroupDetailHeader
+        groupId={groupId}
+        workspaceKesselCanEdit={workspaceKessel.canEdit}
+        workspaceKesselPermissionsLoading={workspaceKessel.isLoading}
+        workspaceKesselGateActive={workspaceKessel.appliesKesselWorkspaceChecks}
+      />
       {canViewGroup ? (
-        <PageSection hasBodyWrapper={false} type="tabs">
-          <Tabs
-            activeKey={activeTabKey}
-            onSelect={(_event, value) => setActiveTabKey(value)}
-            aria-label="Group tabs"
-            role="region"
-            inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
-          >
-            <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
-              <PageSection hasBodyWrapper={false}>
-                {canViewHosts ? (
-                  <GroupSystems
-                    groupName={groupName}
-                    groupId={groupId}
-                    ungrouped={ungrouped}
-                  />
-                ) : (
-                  <EmptyStateNoAccessToSystems />
-                )}
-              </PageSection>
-            </Tab>
-            <Tab
-              eventKey={1}
-              title="Workspace info"
-              aria-label="Workspace info tab"
+        kesselWorkspaceAccessDenied ? (
+          <PageSection hasBodyWrapper={false}>
+            <AccessDenied
+              title="You do not have access to this workspace"
+              description={
+                <div>
+                  You do not have permission to view this workspace in
+                  inventory.
+                </div>
+              }
+            />
+          </PageSection>
+        ) : kesselWorkspacePermissionsLoading ? (
+          <PageSection hasBodyWrapper={false}>
+            <Bullseye className="pf-v6-u-p-xl">
+              <Spinner aria-label="Loading workspace permissions" />
+            </Bullseye>
+          </PageSection>
+        ) : (
+          <PageSection hasBodyWrapper={false} type="tabs">
+            <Tabs
+              activeKey={activeTabKey}
+              onSelect={(_event, value) => setActiveTabKey(value)}
+              aria-label="Group tabs"
+              role="region"
+              inset={{ default: 'insetMd' }} // add extra space before the first tab (according to mocks)
             >
-              {activeTabKey === 1 && ( // helps to lazy load the component
+              <Tab eventKey={0} title="Systems" aria-label="Group systems tab">
                 <PageSection hasBodyWrapper={false}>
-                  <Suspense
-                    fallback={
-                      <Bullseye>
-                        <Spinner />
-                      </Bullseye>
-                    }
-                  >
-                    <GroupDetailInfo />
-                  </Suspense>
+                  {canViewHosts ? (
+                    <GroupSystems
+                      groupName={groupName}
+                      groupId={groupId}
+                      ungrouped={ungrouped}
+                      workspaceKesselCanEdit={workspaceKessel.canEdit}
+                      workspaceKesselPermissionsLoading={
+                        workspaceKessel.isLoading
+                      }
+                      workspaceKesselGateActive={
+                        workspaceKessel.appliesKesselWorkspaceChecks
+                      }
+                    />
+                  ) : (
+                    <EmptyStateNoAccessToSystems />
+                  )}
                 </PageSection>
-              )}
-            </Tab>
-          </Tabs>
-        </PageSection>
+              </Tab>
+              <Tab
+                eventKey={1}
+                title="Workspace info"
+                aria-label="Workspace info tab"
+              >
+                {activeTabKey === 1 && ( // helps to lazy load the component
+                  <PageSection hasBodyWrapper={false}>
+                    <Suspense
+                      fallback={
+                        <Bullseye>
+                          <Spinner />
+                        </Bullseye>
+                      }
+                    >
+                      <GroupDetailInfo />
+                    </Suspense>
+                  </PageSection>
+                )}
+              </Tab>
+            </Tabs>
+          </PageSection>
+        )
       ) : (
         <PageSection hasBodyWrapper={false}>
           <EmptyStateNoAccessToGroups isSingle />

--- a/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
+++ b/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
@@ -13,13 +13,23 @@ import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
 import { useWorkspaceDetailEditActionsAccess } from '../../Utilities/hooks/useWorkspaceDetailEditActionsAccess';
 import { ActionButton } from '../InventoryTable/ActionWithRBAC';
 
+const defaultWorkspaceAccess = {
+  canEdit: undefined,
+  isLoading: false,
+  gateActive: false,
+};
+
 const NoSystemsEmptyState = ({
   groupId,
   groupName,
-  workspaceKesselGateActive = false,
-  workspaceKesselCanEdit,
-  workspaceKesselPermissionsLoading = false,
+  workspaceAccess = defaultWorkspaceAccess,
 }) => {
+  const {
+    canEdit: workspaceKesselCanEdit,
+    isLoading: workspaceKesselPermissionsLoading,
+    gateActive: workspaceKesselGateActive,
+  } = workspaceAccess;
+
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { hasAccess: rbacCanModify } = useConditionalRBAC(
@@ -78,8 +88,10 @@ const NoSystemsEmptyState = ({
 NoSystemsEmptyState.propTypes = {
   groupId: PropTypes.string,
   groupName: PropTypes.string,
-  workspaceKesselGateActive: PropTypes.bool,
-  workspaceKesselCanEdit: PropTypes.bool,
-  workspaceKesselPermissionsLoading: PropTypes.bool,
+  workspaceAccess: PropTypes.shape({
+    canEdit: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    gateActive: PropTypes.bool,
+  }),
 };
 export default NoSystemsEmptyState;

--- a/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
+++ b/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
@@ -8,14 +8,35 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 
 import AddSystemsToGroupModal from '../InventoryGroups/Modals/AddSystemsToGroupModal';
 import PropTypes from 'prop-types';
-import {
-  NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
-  REQUIRED_PERMISSIONS_TO_MODIFY_GROUP,
-} from '../../constants';
+import { REQUIRED_PERMISSIONS_TO_MODIFY_GROUP } from '../../constants';
+import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
+import { useWorkspaceDetailEditActionsAccess } from '../../Utilities/hooks/useWorkspaceDetailEditActionsAccess';
 import { ActionButton } from '../InventoryTable/ActionWithRBAC';
 
-const NoSystemsEmptyState = ({ groupId, groupName }) => {
+const NoSystemsEmptyState = ({
+  groupId,
+  groupName,
+  workspaceKesselGateActive = false,
+  workspaceKesselCanEdit,
+  workspaceKesselPermissionsLoading = false,
+}) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { hasAccess: rbacCanModify } = useConditionalRBAC(
+    REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(groupId),
+  );
+
+  const {
+    useKesselEditGate,
+    canModifyWorkspaceForActions,
+    noAccessEditTooltip,
+    kesselActionOverride,
+  } = useWorkspaceDetailEditActionsAccess({
+    workspaceKesselGateActive,
+    workspaceKesselCanEdit,
+    workspaceKesselPermissionsLoading,
+    rbacCanModify,
+  });
 
   return (
     <EmptyState
@@ -38,10 +59,14 @@ const NoSystemsEmptyState = ({ groupId, groupName }) => {
       <EmptyStateFooter>
         <ActionButton
           requiredPermissions={REQUIRED_PERMISSIONS_TO_MODIFY_GROUP(groupId)}
-          noAccessTooltip={NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE}
+          noAccessTooltip={noAccessEditTooltip}
+          override={kesselActionOverride}
           variant="primary"
           onClick={() => setIsModalOpen(true)}
           ouiaId="add-systems-button"
+          isAriaDisabled={
+            useKesselEditGate === true ? !canModifyWorkspaceForActions : false
+          }
         >
           Add systems
         </ActionButton>
@@ -53,5 +78,8 @@ const NoSystemsEmptyState = ({ groupId, groupName }) => {
 NoSystemsEmptyState.propTypes = {
   groupId: PropTypes.string,
   groupName: PropTypes.string,
+  workspaceKesselGateActive: PropTypes.bool,
+  workspaceKesselCanEdit: PropTypes.bool,
+  workspaceKesselPermissionsLoading: PropTypes.bool,
 };
 export default NoSystemsEmptyState;

--- a/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
+++ b/src/components/InventoryGroupDetail/NoSystemsEmptyState.js
@@ -37,7 +37,7 @@ const NoSystemsEmptyState = ({
   );
 
   const {
-    useKesselEditGate,
+    isKesselEditGating,
     canModifyWorkspaceForActions,
     noAccessEditTooltip,
     kesselActionOverride,
@@ -75,7 +75,7 @@ const NoSystemsEmptyState = ({
           onClick={() => setIsModalOpen(true)}
           ouiaId="add-systems-button"
           isAriaDisabled={
-            useKesselEditGate === true ? !canModifyWorkspaceForActions : false
+            isKesselEditGating === true ? !canModifyWorkspaceForActions : false
           }
         >
           Add systems

--- a/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
+++ b/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
@@ -94,9 +94,11 @@ describe('group detail header', () => {
     useKesselMigrationFeatureFlag.mockReturnValue(true);
 
     renderHeader({
-      workspaceKesselGateActive: true,
-      workspaceKesselCanEdit: false,
-      workspaceKesselPermissionsLoading: false,
+      workspaceAccess: {
+        gateActive: true,
+        canEdit: false,
+        isLoading: false,
+      },
     });
 
     expect(screen.getByRole('button', { name: /actions/i })).toBeDisabled();
@@ -106,9 +108,11 @@ describe('group detail header', () => {
     useKesselMigrationFeatureFlag.mockReturnValue(true);
 
     renderHeader({
-      workspaceKesselGateActive: true,
-      workspaceKesselCanEdit: true,
-      workspaceKesselPermissionsLoading: true,
+      workspaceAccess: {
+        gateActive: true,
+        canEdit: true,
+        isLoading: true,
+      },
     });
 
     expect(screen.getByRole('button', { name: /actions/i })).toBeDisabled();
@@ -118,9 +122,11 @@ describe('group detail header', () => {
     useKesselMigrationFeatureFlag.mockReturnValue(true);
 
     renderHeader({
-      workspaceKesselGateActive: true,
-      workspaceKesselCanEdit: true,
-      workspaceKesselPermissionsLoading: false,
+      workspaceAccess: {
+        gateActive: true,
+        canEdit: true,
+        isLoading: false,
+      },
     });
 
     const toggle = screen.getByRole('button', { name: /actions/i });

--- a/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
+++ b/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
@@ -5,47 +5,57 @@ import { MemoryRouter } from 'react-router-dom';
 import GroupDetailHeader from '../GroupDetailHeader';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import userEvent from '@testing-library/user-event';
+import { useKesselMigrationFeatureFlag } from '../../../Utilities/hooks/useKesselMigrationFeatureFlag';
 
 jest.mock('../../../Utilities/useFeatureFlag');
-jest.mock('react-redux', () => {
-  return {
-    ...jest.requireActual('react-redux'),
-    useSelector: () => ({
-      uninitialized: false,
-      loading: false,
-      data: {
-        results: [
-          {
-            name: 'group-name-1',
-          },
-        ],
-      },
-    }),
-    useDispatch: () => {},
-  };
-});
+jest.mock('../../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: jest.fn(() => false),
+}));
+
+const mockUseSelector = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector) => mockUseSelector(selector),
+  useDispatch: () => () => {},
+}));
 
 jest.mock('@redhat-cloud-services/frontend-components-utilities/RBACHook');
 
+const defaultGroupDetailState = {
+  uninitialized: false,
+  loading: false,
+  data: {
+    results: [
+      {
+        name: 'group-name-1',
+      },
+    ],
+  },
+};
+
+const renderHeader = (props = {}) =>
+  render(
+    <MemoryRouter>
+      <GroupDetailHeader groupId="group-id-2" {...props} />
+    </MemoryRouter>,
+  );
+
 describe('group detail header', () => {
-  usePermissionsWithContext.mockImplementation(() => ({ hasAccess: true }));
+  beforeEach(() => {
+    mockUseSelector.mockImplementation(() => defaultGroupDetailState);
+    usePermissionsWithContext.mockImplementation(() => ({ hasAccess: true }));
+    useKesselMigrationFeatureFlag.mockReturnValue(false);
+  });
 
   it('renders title', () => {
-    render(
-      <MemoryRouter>
-        <GroupDetailHeader groupId="group-id-2" />
-      </MemoryRouter>,
-    );
+    renderHeader();
 
     expect(screen.getByRole('heading')).toBeInTheDocument();
   });
 
   it('renders the actions dropdown', async () => {
-    render(
-      <MemoryRouter>
-        <GroupDetailHeader groupId="group-id-2" />
-      </MemoryRouter>,
-    );
+    renderHeader();
 
     screen.getByRole('button', {
       name: /actions/i,
@@ -70,5 +80,82 @@ describe('group detail header', () => {
         name: /delete/i,
       }),
     ).toBeVisible();
+  });
+
+  it('disables the Actions toggle when RBAC denies workspace modify (Kessel migration off)', () => {
+    usePermissionsWithContext.mockImplementation(() => ({ hasAccess: false }));
+
+    renderHeader();
+
+    expect(screen.getByRole('button', { name: /actions/i })).toBeDisabled();
+  });
+
+  it('disables the Actions toggle when Kessel workspace edit is denied', () => {
+    useKesselMigrationFeatureFlag.mockReturnValue(true);
+
+    renderHeader({
+      workspaceKesselGateActive: true,
+      workspaceKesselCanEdit: false,
+      workspaceKesselPermissionsLoading: false,
+    });
+
+    expect(screen.getByRole('button', { name: /actions/i })).toBeDisabled();
+  });
+
+  it('disables the Actions toggle while Kessel workspace permissions are loading', () => {
+    useKesselMigrationFeatureFlag.mockReturnValue(true);
+
+    renderHeader({
+      workspaceKesselGateActive: true,
+      workspaceKesselCanEdit: true,
+      workspaceKesselPermissionsLoading: true,
+    });
+
+    expect(screen.getByRole('button', { name: /actions/i })).toBeDisabled();
+  });
+
+  it('opens the actions menu when Kessel workspace edit is allowed', async () => {
+    useKesselMigrationFeatureFlag.mockReturnValue(true);
+
+    renderHeader({
+      workspaceKesselGateActive: true,
+      workspaceKesselCanEdit: true,
+      workspaceKesselPermissionsLoading: false,
+    });
+
+    const toggle = screen.getByRole('button', { name: /actions/i });
+    expect(toggle).toBeEnabled();
+
+    await userEvent.click(toggle);
+
+    expect(screen.getByRole('menuitem', { name: /rename/i })).toBeVisible();
+    expect(screen.getByRole('menuitem', { name: /delete/i })).toBeVisible();
+  });
+
+  it('disables rename and delete menu items for the ungrouped hosts workspace while keeping Actions enabled', async () => {
+    mockUseSelector.mockImplementation(() => ({
+      ...defaultGroupDetailState,
+      data: {
+        results: [
+          {
+            name: 'group-name-1',
+            ungrouped: true,
+          },
+        ],
+      },
+    }));
+
+    renderHeader();
+
+    await userEvent.click(screen.getByRole('button', { name: /actions/i }));
+
+    expect(screen.getByRole('menuitem', { name: /rename/i })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+    expect(screen.getByRole('menuitem', { name: /delete/i })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -265,6 +265,8 @@ export const NO_WORKSPACE_PERMISSIONS_LOADING_TOOLTIP_MESSAGE =
   'Checking your workspace permissions. Try again in a moment.';
 export const NO_RENAME_WORKSPACE_KESSEL_TOOLTIP_MESSAGE =
   'You do not have permission to rename this workspace. Contact your organization administrator.';
+export const NO_EDIT_WORKSPACE_KESSEL_TOOLTIP_MESSAGE =
+  'You do not have permission to edit this workspace. Contact your organization administrator.';
 export const NO_DELETE_WORKSPACE_KESSEL_TOOLTIP_MESSAGE =
   'You do not have permission to delete this workspace. Contact your organization administrator.';
 export const NO_DELETE_SELECTED_WORKSPACES_KESSEL_TOOLTIP_MESSAGE =
@@ -346,12 +348,14 @@ export const INITIAL_PAGE = 1;
 export const EMPTY_CELL = '';
 export const DEBOUNCE_TIMEOUT_MS = 300;
 export const WORKSPACE_RESOURCE_TYPE = 'workspace';
+/**
+ * Kessel self-access relation for read access on a `workspace` resource (RBAC reporter).
+ * Aligns with `docs/kessel-frontend-design-document.md` (workspace `view` = read / list / detail).
+ */
+export const WORKSPACE_RELATION_VIEW = 'view';
 export const WORKSPACE_RELATION_EDIT = 'edit';
-/** Kessel self-access relation for removing a workspace (see react-kessel-access-check package README). */
 export const WORKSPACE_RELATION_DELETE = 'delete';
-/** Reporter for host access checks (HBI). */
 export const KESSEL_REPORTER = { type: 'hbi' };
-/** Reporter for workspace access checks; README recommends { type: 'rbac' } for RBAC-based authorization. */
 export const KESSEL_WORKSPACE_REPORTER = { type: 'rbac' };
 /**
  * Self-access `relation` values on {@link WORKSPACE_RESOURCE_TYPE} with Default workspace id


### PR DESCRIPTION
## Jira
[RHINENG-25960](https://redhat.atlassian.net/browse/RHINENG-25960)

## What
The Inventory table on the Workspace details page needs kessel permissions implemented. 

## How
- Gate “Remove from workspace” on row action
- Gate “Remove from workspace” in toolbar action
- Gate “Add systems” in toolbar action
- Show no access page when a user doesn’t have view permissions on the workspace


[RHINENG-25960]: https://redhat.atlassian.net/browse/RHINENG-25960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Integrate Kessel-based workspace permission checks into the workspace details page and related actions while keeping RBAC as a fallback.

New Features:
- Add a Kessel workspace permissions hook to derive view/edit capabilities for a single workspace on the details page.
- Gate workspace details header actions, systems table actions, and empty-state actions on combined RBAC and Kessel edit permissions, with appropriate loading and no-access messaging.
- Show a dedicated access-denied or loading state on the workspace details page when Kessel view/edit checks fail or are still in progress.

Enhancements:
- Refine workspace group header behavior to disable and tooltip header actions when edit access is not granted or permissions are loading.
- Propagate workspace permission context through the workspace systems wrapper so child components consistently respect Kessel edit gating.
- Introduce shared helpers for computing workspace edit-action access and Playwright helpers for waiting on an editable workspace header.
- Add a mock Kessel checkselfbulk route and feature-flag aware tests to stabilize Kessel-dependent unit and end-to-end tests.

Tests:
- Extend unit tests for the group detail header to cover Kessel feature-flag scenarios, permission-denied states, and ungrouped workspace behavior.
- Add unit tests for the Kessel workspace permissions hook and update Playwright tests to use new workspace helpers and mocked Kessel access responses.