### PR TITLE
fix(RHINENG-25664): Move workspaces in Workspace details

### DIFF
--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.cy.js
@@ -77,8 +77,8 @@ describe('AddSystemsToGroupModal', () => {
 
     cy.wait('@getHosts');
     cy.get('h1').contains('Add systems');
-    cy.get('button').contains('Add systems');
-    cy.get('button').contains('Cancel');
+    cy.contains('button', 'Add systems');
+    cy.contains('button', 'Cancel');
   });
 
   it('renders the inventory table', () => {
@@ -100,15 +100,15 @@ describe('AddSystemsToGroupModal', () => {
       'data-ouia-safe',
       'true',
     );
-    cy.get('button').contains('Add systems').should('be.disabled');
+    cy.contains('button', 'Add systems').should('be.disabled');
     selectRowN(3);
-    cy.get('button').contains('Add systems').click();
+    cy.contains('button', 'Add systems').click();
     cy.wait('@postHosts')
       .its('request.body')
       .should('deep.equal', ['consectetur']);
   });
 
-  it.skip('cannot add systems that are already in group', () => {
+  it('can add systems that already belong to another workspace', () => {
     groupDetailInterceptors['post hosts successful']();
     mountModal();
 
@@ -118,10 +118,8 @@ describe('AddSystemsToGroupModal', () => {
       'true',
     );
     selectRowN(0);
-    cy.get(ALERT); // check the alert is shown
-    cy.get('button')
-      .contains('Add systems')
-      .should('have.attr', 'aria-disabled', 'true');
+    cy.get(ALERT).should('not.exist');
+    cy.contains('button', 'Add systems').should('be.enabled');
   });
 
   describe('filters', () => {

--- a/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSystemsToGroupModal.js
@@ -1,9 +1,6 @@
 import {
-  Alert,
   AlertActionLink,
   Button,
-  Flex,
-  FlexItem,
   Modal,
   ModalHeader,
   ModalBody,
@@ -12,7 +9,7 @@ import {
 import { TableVariant } from '@patternfly/react-table';
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { fetchGroupDetail } from '../../../store/inventory-actions';
 import InventoryTable from '../../InventoryTable/InventoryTable';
 import { addHostsToGroupById } from '../utils/api';
@@ -29,6 +26,7 @@ const AddSystemsToGroupModal = ({
   groupName,
 }) => {
   const apiWithToast = useApiWithToast();
+  const dispatch = useDispatch();
 
   const selected = useSelector(
     (state) => state?.entities?.selected || new Map(),
@@ -48,12 +46,6 @@ const AddSystemsToGroupModal = ({
     true,
     pageSelected,
   );
-
-  const alreadyHasGroup = [...selected].filter((entry) => {
-    return (
-      !entry[1]?.groups?.[0]?.ungrouped && entry[1]?.groups?.[0]?.name !== ''
-    );
-  });
 
   const handleSystemAddition = useCallback(
     (hostIds) => {
@@ -102,8 +94,6 @@ const AddSystemsToGroupModal = ({
   const overallSelectedKeys = [...selected.keys()];
   // noneSelected a boolean showing that no system is selected
   const noneSelected = overallSelectedKeys.length === 0;
-  // showWarning when systems had groups
-  const showWarning = alreadyHasGroup.length > 0;
 
   const ConventionalInventoryTable = (
     <InventoryTable
@@ -139,34 +129,21 @@ const AddSystemsToGroupModal = ({
           <ModalHeader title="Add systems" />
           <ModalBody>{ConventionalInventoryTable}</ModalBody>
           <ModalFooter>
-            <Flex direction={{ default: 'column' }} style={{ width: '100%' }}>
-              {showWarning && (
-                <FlexItem fullWidth={{ default: 'fullWidth' }}>
-                  <Alert
-                    variant="warning"
-                    isInline
-                    title="One or more of the selected systems already belong to a workspace. Only systems not already belonging to a workspace can be added. Unselect these systems to move forward."
-                  />
-                </FlexItem>
-              )}
-              <FlexItem>
-                <Button
-                  key="confirm"
-                  variant="primary"
-                  onClick={handleAddSystemsButton}
-                  isDisabled={noneSelected || showWarning}
-                >
-                  Add systems
-                </Button>
-                <Button
-                  key="cancel"
-                  variant="link"
-                  onClick={() => setIsModalOpen(false)}
-                >
-                  Cancel
-                </Button>
-              </FlexItem>
-            </Flex>
+            <Button
+              key="confirm"
+              variant="primary"
+              onClick={handleAddSystemsButton}
+              isDisabled={noneSelected}
+            >
+              Add systems
+            </Button>
+            <Button
+              key="cancel"
+              variant="link"
+              onClick={() => setIsModalOpen(false)}
+            >
+              Cancel
+            </Button>
           </ModalFooter>
         </Modal>
       </>


### PR DESCRIPTION
## Jira
[RHINENG-25664](https://redhat.atlassian.net/browse/RHINENG-25664)

## What
A user should be able to move a system from another workspace into the current workspace in workspace details via the Add system modal.

Currently, a user with view permissions can select and attempt to add, but the api will block them. This is a known interaction and will be fixed in RHINENG-24481.

## How
To test:
- go to workspace details
- click Add System button in toolbar
- test in modal that you can select a system in another workspace and the alert doesn't appear, and the Add system button in the modal isn't disabled.


[RHINENG-25664]: https://redhat.atlassian.net/browse/RHINENG-25664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Allow adding systems that already belong to another workspace from the workspace details "Add systems" modal.

New Features:
- Permit adding systems that already belong to another workspace via the Add systems modal in workspace details.

Enhancements:
- Simplify Add systems modal footer by removing the inline warning message and its dependency on system group membership.

Tests:
- Update Cypress test expectation to verify that systems already in another workspace no longer trigger a warning or disable the Add systems button.