### PR TITLE
fix(RHINENG-26014): Disable Runtime service card - no Kessel support

### DIFF
--- a/src/components/SystemDetails/DetailsTab.js
+++ b/src/components/SystemDetails/DetailsTab.js
@@ -2,10 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Details from './Details';
 import { useKesselMigrationFeatureFlag } from '../../Utilities/hooks/useKesselMigrationFeatureFlag';
+import useFeatureFlag from '../../Utilities/useFeatureFlag';
 
 const DetailsTab = ({ entity, ...props }) => {
+  const enableRuntimesInventoryCard = useFeatureFlag(
+    'runtimes.inventory-card.enabled',
+  );
   const isKesselMigrationEnabled = useKesselMigrationFeatureFlag();
-  const showRuntimesProcesses = !isKesselMigrationEnabled;
+  const showRuntimesProcesses =
+    enableRuntimesInventoryCard && !isKesselMigrationEnabled;
 
   if (!entity) {
     console.error('DetailsTab: entity data is missing. Rendering aborted.', {

--- a/src/components/SystemDetails/DetailsTab.js
+++ b/src/components/SystemDetails/DetailsTab.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Details from './Details';
-import useFeatureFlag from '../../Utilities/useFeatureFlag';
+import { useKesselMigrationFeatureFlag } from '../../Utilities/hooks/useKesselMigrationFeatureFlag';
 
 const DetailsTab = ({ entity, ...props }) => {
-  const enableRuntimesInventoryCard = useFeatureFlag(
-    'runtimes.inventory-card.enabled',
-  );
+  const isKesselMigrationEnabled = useKesselMigrationFeatureFlag();
+  const showRuntimesProcesses = !isKesselMigrationEnabled;
 
   if (!entity) {
     console.error('DetailsTab: entity data is missing. Rendering aborted.', {
@@ -19,7 +18,7 @@ const DetailsTab = ({ entity, ...props }) => {
     <Details
       {...props}
       isBootcHost={!!entity.system_profile?.bootc_status?.booted?.image_digest}
-      showRuntimesProcesses={enableRuntimesInventoryCard}
+      showRuntimesProcesses={showRuntimesProcesses}
       entity={entity}
     />
   );


### PR DESCRIPTION
## Jira
(https://redhat.atlassian.net/browse/RHINENG-26014)

## What
Disabled Runtime service card from Details tab in Systems details page 

## Why
With Kessel V2 migration enabled, opening a system’s Details tab triggers a GET to `runtimes-inventory-service` (from the federated Runtimes processes card). That request returns 401 Unauthorized. The console shell then behaves like a session loss / re-login for the user.

## How
In accounts with enabled Kessel v2 runtime card is disabled

## Testing

1. In account with enabled Kessel V2 flag (same flag used by inventory: platform.rbac.workspaces).
2. Open Inventory → Systems → any system with an FQDN.
3. Open the Details tab (where the Runtime card loads).
4. No force re-login / in Network tab no` runtimes-inventory-service` request

