### PR TITLE
fix: Correct Modal path in Details tab

### DIFF
--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Card,
@@ -43,12 +43,15 @@ export const Clickable = ({
   workload,
   title,
 }) => {
-  const { pathname } = useLocation();
+  const { pathname, search, hash } = useLocation();
   // const { modalId } = useParams(); is causing regression when using LoadingCard derived components in Federated mode
   const modalId = pathname.split('/').pop();
+  const onClickRef = useRef(onClick);
+  onClickRef.current = onClick;
+
   useEffect(() => {
     if (target === modalId) {
-      onClick({ value, target });
+      onClickRef.current({ value, target });
     }
   }, [modalId, target, value]);
 
@@ -61,7 +64,13 @@ export const Clickable = ({
   }
 
   return (
-    <Link to={`${pathname}/${target}`}>
+    <Link
+      to={{
+        pathname: `${pathname}/${target}`,
+        search: search || '',
+        hash: hash || '',
+      }}
+    >
       {workload ? title : valueToText(value, singular, plural)}
     </Link>
   );

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.js
@@ -43,9 +43,9 @@ export const Clickable = ({
   workload,
   title,
 }) => {
-  const { pathname, search, hash } = useLocation();
+  const location = useLocation();
   // const { modalId } = useParams(); is causing regression when using LoadingCard derived components in Federated mode
-  const modalId = pathname.split('/').pop();
+  const modalId = location.pathname.split('/').pop();
   const onClickRef = useRef(onClick);
   onClickRef.current = onClick;
 
@@ -66,9 +66,8 @@ export const Clickable = ({
   return (
     <Link
       to={{
-        pathname: `${pathname}/${target}`,
-        search: search || '',
-        hash: hash || '',
+        ...location,
+        pathname: `${location.pathname}/${target}`,
       }}
     >
       {workload ? title : valueToText(value, singular, plural)}

--- a/src/components/GeneralInfo/LoadingCard/LoadingCard.test.js
+++ b/src/components/GeneralInfo/LoadingCard/LoadingCard.test.js
@@ -8,17 +8,27 @@ import LoadingCard, {
   getDefaultColumnModifier,
 } from './LoadingCard';
 
+const defaultUseLocation = () => ({
+  pathname: 'localhost:3000/example/path',
+  search: '',
+  hash: '',
+});
+
+const mockUseLocation = jest.fn(defaultUseLocation);
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useLocation: () => ({
-    pathname: 'localhost:3000/example/path',
-  }),
+  useLocation: () => mockUseLocation(),
   useParams: () => ({
     modalId: 'path',
   }),
 }));
 
 describe('LoadingCard', () => {
+  beforeEach(() => {
+    mockUseLocation.mockImplementation(defaultUseLocation);
+  });
+
   [true, false].map((isLoading) => {
     it(`Loading card render - isLoading: ${isLoading}`, () => {
       const view = render(
@@ -276,6 +286,25 @@ describe('LoadingCard', () => {
     expect(screen.getByRole('link', { name: /15/i })).toHaveAttribute(
       'href',
       'localhost:3000/example/path/some-target',
+    );
+  });
+
+  it('Clickable should preserve search params when building modal path', () => {
+    mockUseLocation.mockReturnValue({
+      pathname: '/insights/inventory/abc-123',
+      search: '?appName=details',
+      hash: '',
+    });
+
+    render(
+      <TestWrapper>
+        <Clickable onClick={jest.fn()} value="15" target="kernel_modules" />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByRole('link', { name: /15/i })).toHaveAttribute(
+      'href',
+      '/insights/inventory/abc-123/kernel_modules?appName=details',
     );
   });
 


### PR DESCRIPTION
## Jira
[RHINENG-xxxxx](https://redhat.atlassian.net/browse/RHINENG-xxxxx)

## What
Fix path when modal is opened in Details tab

## Why
Any time we open modal in Details tab we get redirected to Overview tab

## How
Keep `?appName=details` when the modal path is added

## Testing

1. Navigate to Systems detaisl page
2. click on Details tab
3. open any modals on Details tab - we should not be redirected to Overview tab

## Screenshots/Videos (if applicable)
[Bug_SystemDetails_Modals.webm](https://github.com/user-attachments/assets/fa21ce55-20f4-4395-9770-27f1ddeeec58)

## Summary by Sourcery

Preserve URL query and hash parameters when opening modal links from the General Info LoadingCard clickable elements.

Bug Fixes:
- Ensure modal links opened from the Details tab retain existing URL query parameters so navigation stays on the correct tab.

Enhancements:
- Make Clickable component use a stable onClick ref to avoid stale closures when handling modal activation from the current URL.

Tests:
- Add unit test coverage to verify that Clickable preserves search parameters when generating modal link URLs.