### PR TITLE
test(E2E): Fix flaky workspaces tests, unblock system type tests

### DIFF
--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -28,6 +28,7 @@ export const filterSystemsWithConditionalFilter = async (
     .locator(
       '[data-ouia-component-id="DataViewFilters"] button.pf-v6-c-menu-toggle',
     )
+    .first()
     .or(page.getByRole('button', { name: 'Conditional filter toggle' }))
     .click();
   // Wait for the filter menu to be visible before proceeding
@@ -68,7 +69,14 @@ export const filterSystemsWithConditionalFilter = async (
     await expect(optionCheckbox).toBeVisible({ timeout: 100000 });
     await optionCheckbox.click();
   } else if (filterName === 'System type') {
-    await page.getByRole('button', { name: 'Options menu' }).click();
+    await page
+      .getByRole('button', { name: 'Options menu' })
+      .or(
+        page.locator(
+          'button[data-ouia-component-id="DataViewCheckboxFilter-toggle"]',
+        ),
+      )
+      .click();
     optionCheckbox = page.getByText(option, { exact: true });
     await expect(optionCheckbox).toBeVisible({ timeout: 100000 });
     await optionCheckbox.click();
@@ -147,7 +155,7 @@ export const searchByName = async (page: Page, name: string): Promise<void> => {
   await searchInput.fill(name);
 };
 
-export const waitForSystemsTableKebabReady = async (
+export const waitForTableKebabReady = async (
   page: Page,
   rowNameMatch: RegExp,
 ): Promise<Locator> => {

--- a/_playwright-tests/test_navigation.test.ts
+++ b/_playwright-tests/test_navigation.test.ts
@@ -29,7 +29,6 @@ test.describe('Navigate to Inventory pages via side Navigation bar', () => {
   test('User can switch to the Images view in Inventory page', async ({
     page,
   }) => {
-    test.fixme(true, 'https://redhat.atlassian.net/browse/RHINENG-25470');
     const systemsPageNav = page
       .locator('li[data-ouia-component-id="Systems"]')
       .locator('a[data-quickstart-id="insights_inventory"]');
@@ -45,7 +44,7 @@ test.describe('Navigate to Inventory pages via side Navigation bar', () => {
     await test.step('Verify Images view is visible', async () => {
       await expect(
         page.getByRole('columnheader', { name: 'Image name' }),
-      ).toBeVisible({ timeout: 10000 });
+      ).toBeVisible({ timeout: 50000 });
     });
   });
 

--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -34,7 +34,7 @@ test('User should be able to edit and delete a system from Systems page', async 
 
   await test.step(`Edit the system "${system.hostname}" display name and save`, async () => {
     await searchByName(page, system.hostname);
-    await expect(nameCell).toHaveCount(1);
+    await expect(nameCell).toHaveCount(1, { timeout: 10000 });
     const kebab = await waitForSystemsTableKebabReady(
       page,
       new RegExp(system.hostname, 'i'),
@@ -57,7 +57,7 @@ test('User should be able to edit and delete a system from Systems page', async 
 
   await test.step(`Delete the renamed system "${newDisplayName}" and verify it is removed`, async () => {
     await searchByName(page, newDisplayName);
-    await expect(nameCell).toHaveCount(1);
+    await expect(nameCell).toHaveCount(1, { timeout: 10000 });
     const kebab = await waitForSystemsTableKebabReady(
       page,
       new RegExp(newDisplayName, 'i'),

--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -2,10 +2,7 @@ import { expect, Locator } from '@playwright/test';
 import { createSystem } from './helpers/uploadArchive';
 import { navigateToInventorySystemsFunc } from './helpers/navHelpers';
 import { test } from './helpers/fixtures';
-import {
-  searchByName,
-  waitForSystemsTableKebabReady,
-} from './helpers/filterHelpers';
+import { searchByName, waitForTableKebabReady } from './helpers/filterHelpers';
 import { isSystemsViewEnabled } from './helpers/constants';
 
 test('User should be able to edit and delete a system from Systems page', async ({
@@ -35,7 +32,7 @@ test('User should be able to edit and delete a system from Systems page', async 
   await test.step(`Edit the system "${system.hostname}" display name and save`, async () => {
     await searchByName(page, system.hostname);
     await expect(nameCell).toHaveCount(1, { timeout: 10000 });
-    const kebab = await waitForSystemsTableKebabReady(
+    const kebab = await waitForTableKebabReady(
       page,
       new RegExp(system.hostname, 'i'),
     );
@@ -58,7 +55,7 @@ test('User should be able to edit and delete a system from Systems page', async 
   await test.step(`Delete the renamed system "${newDisplayName}" and verify it is removed`, async () => {
     await searchByName(page, newDisplayName);
     await expect(nameCell).toHaveCount(1, { timeout: 10000 });
-    const kebab = await waitForSystemsTableKebabReady(
+    const kebab = await waitForTableKebabReady(
       page,
       new RegExp(newDisplayName, 'i'),
     );

--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -31,7 +31,6 @@ test.describe('Filtering Systems Tests', () => {
   });
 
   test('User can filter systems by System type', async ({ page }) => {
-    test.fixme(true, 'https://redhat.atlassian.net/browse/RHINENG-25470');
     /**
      * Metadata:
        - requirements:

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -3,10 +3,7 @@ import {
   navigateToWorkspacesFunc,
   navigateToInventorySystemsFunc,
 } from './helpers/navHelpers';
-import {
-  searchByName,
-  waitForSystemsTableKebabReady,
-} from './helpers/filterHelpers';
+import { searchByName, waitForTableKebabReady } from './helpers/filterHelpers';
 import {
   generateUniqueWorkspaceName,
   createNewWorkspace,
@@ -237,7 +234,7 @@ test('User can create, rename and delete a workspace from Workspaces page', asyn
   });
 
   await test.step('Rename workspace via per-row action from Workspaces page and verify renaming via search', async () => {
-    const kebab = await waitForSystemsTableKebabReady(
+    const kebab = await waitForTableKebabReady(
       page,
       new RegExp(workspaceName, 'i'),
     );
@@ -264,7 +261,7 @@ test('User can create, rename and delete a workspace from Workspaces page', asyn
 
   await test.step('Delete workspace via per-row action from Workspaces page and verify deletion via search', async () => {
     await searchByName(page, renamedWorkspace);
-    const kebab = await waitForSystemsTableKebabReady(
+    const kebab = await waitForTableKebabReady(
       page,
       new RegExp(renamedWorkspace, 'i'),
     );

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -3,7 +3,10 @@ import {
   navigateToWorkspacesFunc,
   navigateToInventorySystemsFunc,
 } from './helpers/navHelpers';
-import { searchByName } from './helpers/filterHelpers';
+import {
+  searchByName,
+  waitForSystemsTableKebabReady,
+} from './helpers/filterHelpers';
 import {
   generateUniqueWorkspaceName,
   createNewWorkspace,
@@ -222,8 +225,6 @@ test('User can create, rename and delete a workspace from Workspaces page', asyn
   const workspaceName = await generateUniqueWorkspaceName();
   const renamedWorkspace = `${workspaceName}_Renamed`;
   const dialogModal = page.locator('[data-ouia-component-id="group-modal"]');
-  const perRowKebabButton = page.getByRole('button', { name: 'Kebab toggle' });
-  const perRowMenu = page.locator('[class="pf-v6-c-menu"]');
   const nameCell = page.locator('td[data-label="Name"]');
 
   await test.step('Test setup: navigate to Workspaces page, create workspace to work with', async () => {
@@ -231,16 +232,24 @@ test('User can create, rename and delete a workspace from Workspaces page', asyn
     await createNewWorkspace(page, workspaceName);
     // search for workspace and via 'Name' column make sure only 1 workspace is found
     await searchByName(page, workspaceName);
-    await expect(nameCell).toHaveCount(1);
+    await expect(nameCell).toHaveCount(1, { timeout: 10000 });
     await expect(nameCell).toHaveText(workspaceName);
   });
 
   await test.step('Rename workspace via per-row action from Workspaces page and verify renaming via search', async () => {
-    await perRowKebabButton.click();
-    await expect(perRowMenu).toBeVisible();
+    const kebab = await waitForSystemsTableKebabReady(
+      page,
+      new RegExp(workspaceName, 'i'),
+    );
+    await kebab.click();
+    await expect(kebab).toHaveAttribute('aria-expanded', 'true');
+
     const renameWorkspaceButton = page
       .getByRole('menuitem', { name: 'Rename workspace' })
       .first();
+    await expect(renameWorkspaceButton).toBeEnabled({
+      timeout: 50000,
+    });
     await renameWorkspaceButton.click();
 
     await expect(dialogModal).toBeVisible();
@@ -249,18 +258,26 @@ test('User can create, rename and delete a workspace from Workspaces page', asyn
 
     // search for the new name to confirm rename worked
     await searchByName(page, renamedWorkspace);
-    await expect(nameCell).toHaveCount(1);
+    await expect(nameCell).toHaveCount(1, { timeout: 10000 });
     await expect(nameCell).toHaveText(renamedWorkspace);
   });
 
   await test.step('Delete workspace via per-row action from Workspaces page and verify deletion via search', async () => {
     await searchByName(page, renamedWorkspace);
-    await perRowKebabButton.click();
-    await expect(perRowMenu).toBeVisible();
-    await page
+    const kebab = await waitForSystemsTableKebabReady(
+      page,
+      new RegExp(renamedWorkspace, 'i'),
+    );
+    await kebab.click();
+    await expect(kebab).toHaveAttribute('aria-expanded', 'true');
+
+    const deleteWorkspaceButton = page
       .getByRole('menuitem', { name: 'Delete workspace' })
-      .first()
-      .click();
+      .first();
+    await expect(deleteWorkspaceButton).toBeEnabled({
+      timeout: 50000,
+    });
+    await deleteWorkspaceButton.click();
 
     await expect(dialogModal).toBeVisible();
     await dialogModal.getByRole('button', { name: 'Delete' }).click();


### PR DESCRIPTION
## What
Fix flaky tests, unblock tests

## Summary by Sourcery

Stabilize Playwright UI tests for workspaces, systems, navigation, and filters by improving selectors, timing, and reusable helpers to eliminate flakiness.

Tests:
- Increase robustness of workspace and system table actions by reusing a shared kebab-locator helper and adding appropriate waits and assertions.
- Update filtering helpers and system type filter tests to support alternate toggle/button selectors used in the UI.
- Re-enable previously skipped navigation and system type filtering tests and relax timeouts where necessary to avoid flaky failures.