### PR TITLE
fix(RHINENG-25966): Modals backdrop doesn't span whole screen

### DIFF
--- a/src/components/InventoryGroups/Modals/Modal.js
+++ b/src/components/InventoryGroups/Modals/Modal.js
@@ -24,9 +24,6 @@ const RepoModal = ({
   return (
     <Modal
       ouiaId="group-modal"
-      appendTo={() =>
-        document.body.querySelector('.inventory') || document.body
-      } // required to support the app's stylesheets
       variant={size ?? 'small'}
       isOpen={isModalOpen}
       onClose={closeModal}


### PR DESCRIPTION
## Jira

RHINENG-25966

## What
Modals didn't span the whole screen just the Inventory div

## Testing
Open InventoryTable or SystemsView or Workspaces and try the Modal's behavior.

## Screenshots/Videos (if applicable)

After:
<img width="1684" height="1237" alt="image" src="https://github.com/user-attachments/assets/ce9a8213-d84d-41d0-b1cd-a2813a35353e" />

## Summary by Sourcery

Bug Fixes:
- Fix modal backdrops not spanning the entire screen by allowing them to render against the default document body.