### PR TITLE
fix(RHINENG-26093): SystemsView actions have incomplete access control

### DIFF
--- a/src/components/SystemsView/SystemsViewBulkActions.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.tsx
@@ -14,6 +14,7 @@ import {
   GENERAL_GROUPS_WRITE_PERMISSION,
   GENERAL_HOSTS_WRITE_PERMISSIONS,
 } from '../../constants';
+import { hasWorkspace } from './utils/systemHelpers';
 
 interface SystemsViewBulkActionsProps {
   selectedSystems: System[];
@@ -84,13 +85,21 @@ export const SystemsViewBulkActions = ({
           </ResponsiveAction>
           <ResponsiveAction
             onClick={() => openAddToWorkspaceModal(selectedSystems)}
-            isDisabled={moveDisabled || !hasGroupsWrite}
+            isDisabled={
+              moveDisabled ||
+              !hasGroupsWrite ||
+              selectedSystems.some((s) => hasWorkspace(s))
+            }
           >
             Add to workspace
           </ResponsiveAction>
           <ResponsiveAction
             onClick={() => openRemoveFromWorkspaceModal(selectedSystems)}
-            isDisabled={moveDisabled || !hasGroupsWrite}
+            isDisabled={
+              moveDisabled ||
+              !hasGroupsWrite ||
+              selectedSystems.some((s) => !hasWorkspace(s))
+            }
           >
             Remove from workspace
           </ResponsiveAction>

--- a/src/components/SystemsView/SystemsViewRowActions.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.tsx
@@ -9,6 +9,7 @@ import {
   GENERAL_HOSTS_WRITE_PERMISSIONS,
 } from '../../constants';
 import type { SystemWithPermissions } from '../../Utilities/hooks/useHostIdsWithKessel';
+import { hasWorkspace } from './utils/systemHelpers';
 
 interface RowActionsProps {
   system: System | SystemWithPermissions;
@@ -64,12 +65,12 @@ const SystemsViewRowActions = ({ system }: RowActionsProps) => {
         {
           title: 'Add to workspace',
           onClick: () => openAddToWorkspaceModal([system]),
-          isDisabled: !hasGroupsWrite,
+          isDisabled: !hasGroupsWrite || hasWorkspace(system),
         },
         {
           title: 'Remove from workspace',
           onClick: () => openRemoveFromWorkspaceModal([system]),
-          isDisabled: !hasGroupsWrite,
+          isDisabled: !hasGroupsWrite || !hasWorkspace(system),
         },
         {
           title: 'Edit display name',


### PR DESCRIPTION
## Jira
RHINENG-26093

## What
When kessel UI is disabled, actions in SystemsView have incomplete access control. They are enabled at times when they should be disabled. For instance, `Add to workspace` is allowed on rows which clearly has workspace already, which is wrong.  

## Why
SystemsView must be able to work also without Kessel enabled. Hence this UI needs to have proper access control.


## Testing
1. Turn on SystemsView
2. observe BulkActions and RowActions correctly handle situations when system(s) have or doesn't have workspace assigned.

## Screenshots/Videos (if applicable)

## Summary by Sourcery

Tighten workspace-related access control in SystemsView actions to respect existing workspace assignments.

Bug Fixes:
- Disable bulk and row 'Add to workspace' actions when systems already belong to a workspace.
- Disable bulk and row 'Remove from workspace' actions when systems do not belong to any workspace.