### PR TITLE
fix(RHINENG-26177): Disable Move system button on system table

### DIFF
--- a/src/Utilities/hooks/useHostIdsWithKessel.test.ts
+++ b/src/Utilities/hooks/useHostIdsWithKessel.test.ts
@@ -1,0 +1,213 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { renderHook } from '@testing-library/react';
+import {
+  HOST_RESOURCE_TYPE,
+  HOST_RESOURCE_TYPE_DELETE,
+  HOST_RESOURCE_TYPE_UPDATE,
+  KESSEL_REPORTER,
+  KESSEL_WORKSPACE_REPORTER,
+  WORKSPACE_RELATION_EDIT,
+  WORKSPACE_RESOURCE_TYPE,
+} from '../../constants';
+import { useHostIdsWithKessel } from './useHostIdsWithKessel';
+
+const mockUseKesselMigrationFeatureFlag = jest.fn();
+const mockUseSelfAccessCheck = jest.fn();
+
+jest.mock('./useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
+}));
+
+jest.mock('@project-kessel/react-kessel-access-check', () => ({
+  useSelfAccessCheck: (opts: object) => mockUseSelfAccessCheck(opts),
+}));
+
+const testOrgId = 'test-org-id';
+
+describe('useHostIdsWithKessel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+    mockUseSelfAccessCheck.mockReturnValue({ data: undefined, loading: false });
+  });
+
+  it('when Kessel is off, leaves hostsWithPermissions.hasWorkspaceEdit permissive', () => {
+    const hosts = [
+      {
+        id: 'h1',
+        org_id: testOrgId,
+        groups: [
+          { id: 'ws-ungrouped', name: 'Ungrouped Hosts', ungrouped: true },
+        ],
+      },
+    ];
+
+    const { result } = renderHook(() => useHostIdsWithKessel(hosts));
+
+    expect(
+      result.current.hostsWithPermissions?.[0]?.permissions.hasWorkspaceEdit,
+    ).toBe(true);
+    expect(mockUseSelfAccessCheck).toHaveBeenCalledWith({ resources: [] });
+  });
+
+  it('when Kessel is on, requests workspace edit for Ungrouped Hosts workspace id', () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({ data: [], loading: false });
+
+    const ungroupedWorkspaceId = '00000000-0000-0000-0000-ungrouped-ws';
+    const hosts = [
+      {
+        id: 'h1',
+        org_id: testOrgId,
+        groups: [
+          {
+            id: ungroupedWorkspaceId,
+            name: 'Ungrouped Hosts',
+            ungrouped: true,
+          },
+        ],
+      },
+    ];
+
+    renderHook(() => useHostIdsWithKessel(hosts));
+
+    expect(mockUseSelfAccessCheck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resources: expect.arrayContaining([
+          {
+            id: ungroupedWorkspaceId,
+            type: WORKSPACE_RESOURCE_TYPE,
+            relation: WORKSPACE_RELATION_EDIT,
+            reporter: KESSEL_WORKSPACE_REPORTER,
+          },
+        ]),
+      }),
+    );
+  });
+
+  it('when Kessel is on, gates move (hasWorkspaceEdit) on workspace edit for ungrouped hosts', () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    const ungroupedWorkspaceId = 'ws-u1';
+
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [
+        {
+          resource: { id: 'h1' },
+          relation: HOST_RESOURCE_TYPE_UPDATE,
+          allowed: true,
+        },
+        {
+          resource: { id: 'h1' },
+          relation: HOST_RESOURCE_TYPE_DELETE,
+          allowed: true,
+        },
+        {
+          resource: { id: ungroupedWorkspaceId },
+          relation: WORKSPACE_RELATION_EDIT,
+          allowed: false,
+        },
+      ],
+      loading: false,
+    });
+
+    const hosts = [
+      {
+        id: 'h1',
+        org_id: testOrgId,
+        groups: [
+          {
+            id: ungroupedWorkspaceId,
+            name: 'Ungrouped Hosts',
+            ungrouped: true,
+          },
+        ],
+      },
+    ];
+
+    const { result } = renderHook(() => useHostIdsWithKessel(hosts));
+
+    expect(
+      result.current.hostsWithPermissions?.[0]?.permissions.hasWorkspaceEdit,
+    ).toBe(false);
+  });
+
+  it('when Kessel is on, groups workspace edit checks by host workspace id', () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    const wsId = 'ws-regular';
+
+    mockUseSelfAccessCheck.mockReturnValue({
+      data: [
+        {
+          resource: { id: 'h1' },
+          relation: HOST_RESOURCE_TYPE_UPDATE,
+          allowed: true,
+        },
+        {
+          resource: { id: 'h1' },
+          relation: HOST_RESOURCE_TYPE_DELETE,
+          allowed: false,
+        },
+        {
+          resource: { id: wsId },
+          relation: WORKSPACE_RELATION_EDIT,
+          allowed: true,
+        },
+      ],
+      loading: false,
+    });
+
+    const hosts = [
+      {
+        id: 'h1',
+        org_id: testOrgId,
+        groups: [{ id: wsId, name: 'Prod', ungrouped: false }],
+      },
+    ];
+
+    const { result } = renderHook(() => useHostIdsWithKessel(hosts));
+
+    expect(result.current.hostsWithPermissions?.[0]?.permissions).toEqual({
+      hasUpdate: true,
+      hasDelete: false,
+      hasWorkspaceEdit: true,
+    });
+  });
+
+  it('when Kessel is on, includes host update/delete resources in bulk check', () => {
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    mockUseSelfAccessCheck.mockReturnValue({ data: [], loading: false });
+
+    renderHook(() =>
+      useHostIdsWithKessel([
+        {
+          id: 'host-a',
+          org_id: testOrgId,
+          groups: [{ id: 'ws-1', ungrouped: false }],
+        },
+      ]),
+    );
+
+    expect(mockUseSelfAccessCheck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resources: expect.arrayContaining([
+          {
+            id: 'host-a',
+            type: HOST_RESOURCE_TYPE,
+            relation: HOST_RESOURCE_TYPE_UPDATE,
+            reporter: KESSEL_REPORTER,
+          },
+          {
+            id: 'host-a',
+            type: HOST_RESOURCE_TYPE,
+            relation: HOST_RESOURCE_TYPE_DELETE,
+            reporter: KESSEL_REPORTER,
+          },
+        ]),
+      }),
+    );
+  });
+});

--- a/src/Utilities/hooks/useHostIdsWithKessel.ts
+++ b/src/Utilities/hooks/useHostIdsWithKessel.ts
@@ -1,8 +1,5 @@
 import { useMemo } from 'react';
-import {
-  useSelfAccessCheck,
-  type SelfAccessCheckResourceWithRelation,
-} from '@project-kessel/react-kessel-access-check';
+import { useSelfAccessCheck } from '@project-kessel/react-kessel-access-check';
 import { type BulkSelfAccessCheckNestedRelationsParams } from '@project-kessel/react-kessel-access-check/types';
 import { useKesselMigrationFeatureFlag } from './useKesselMigrationFeatureFlag';
 import {
@@ -33,7 +30,7 @@ export interface SystemWithPermissions extends System {
  *
  * Use in both the legacy InventoryTable and the new SystemsView. Returned
  * `hostsWithPermissions` can replace the GET /hosts response so each host has
- * `permissions: { hasUpdate, hasDelete }`.
+ * `permissions: { hasUpdate, hasDelete, hasWorkspaceEdit }`.
  *
  *  @param hosts - Current page of host records (array of objects with at least an optional `id`)
  *  @returns     Object with hostIds, isKesselEnabled, hostsWithPermissions, permissionsLoading, permissionsError
@@ -50,7 +47,8 @@ export const useHostIdsWithKessel = (hosts: System[] | undefined) => {
       .filter((id): id is string => typeof id === 'string' && id.length > 0);
   }, [isKesselEnabled, hosts]);
 
-  // Unique workspace (group) IDs for hosts that are in a workspace (not ungrouped).
+  // Unique workspace (group) IDs on this page — includes Ungrouped Hosts (`ungrouped: true`),
+  // which still has an RBAC workspace id used for Kessel `workspace` + `edit` checks.
   const workspaceIds = useMemo(() => {
     if (!isKesselEnabled || !hosts?.length) return [];
     const ids = new Set<string>();
@@ -151,10 +149,11 @@ export const useHostIdsWithKessel = (hosts: System[] | undefined) => {
         hasDelete: false,
       };
       const group = host?.groups?.[0];
-      const hasWorkspaceEdit =
-        !group?.id || group?.ungrouped
-          ? true
-          : (workspaceEditByWorkspaceId.get(group.id) ?? false);
+      // Same `workspace` + `edit` self-access as other workspaces; Ungrouped Hosts must not bypass Kessel.
+      // Hosts with no group payload keep permissive default so legacy responses still allow move when unknown.
+      const hasWorkspaceEdit = group?.id
+        ? (workspaceEditByWorkspaceId.get(group.id) ?? false)
+        : true;
       return {
         ...host,
         permissions: isKesselEnabled

--- a/src/components/InventoryTabs/ConventionalSystems/useTableActions.js
+++ b/src/components/InventoryTabs/ConventionalSystems/useTableActions.js
@@ -4,6 +4,7 @@ import {
   NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE,
   NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
   NO_MODIFY_HOST_TOOLTIP_MESSAGE,
+  NO_MOVE_SYSTEM_KESSEL_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP,
 } from '../../../constants';
 import { ActionDropdownItem } from '../../InventoryTable/ActionWithRBAC';
@@ -89,8 +90,8 @@ const buildGroupActions = (row, { isKesselEnabled, onMove, onRemove }) => {
             key={`${row.id}-move-system`}
             onClick={onMove}
             requiredPermissions={[GENERAL_GROUPS_WRITE_PERMISSION]}
-            noAccessTooltip={NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE}
-            isAriaDisabled={!row.permissions?.hasWorkspaceEdit}
+            noAccessTooltip={NO_MOVE_SYSTEM_KESSEL_TOOLTIP_MESSAGE}
+            override={row.permissions?.hasWorkspaceEdit ?? false}
           >
             Move system
           </ActionDropdownItem>

--- a/src/components/SystemsView/SystemsViewRowActions.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.tsx
@@ -7,6 +7,7 @@ import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
 import {
   GENERAL_GROUPS_WRITE_PERMISSION,
   GENERAL_HOSTS_WRITE_PERMISSIONS,
+  NO_MOVE_SYSTEM_KESSEL_TOOLTIP_MESSAGE,
 } from '../../constants';
 import type { SystemWithPermissions } from '../../Utilities/hooks/useHostIdsWithKessel';
 import { hasWorkspace } from './utils/systemHelpers';
@@ -37,13 +38,17 @@ const SystemsViewRowActions = ({ system }: RowActionsProps) => {
   const permissions = 'permissions' in system ? system.permissions : undefined;
 
   const hasDelete = permissions?.hasDelete ?? false;
+  const canMoveSystem = permissions?.hasWorkspaceEdit ?? false;
 
   const rowActions = isKesselEnabled
     ? [
         {
           title: 'Move system',
           onClick: () => openAddToWorkspaceModal([system]),
-          isDisabled: !(permissions?.hasWorkspaceEdit ?? false),
+          isDisabled: !canMoveSystem,
+          ...(!canMoveSystem && {
+            tooltipProps: { content: NO_MOVE_SYSTEM_KESSEL_TOOLTIP_MESSAGE },
+          }),
         },
         {
           title: 'Edit',

--- a/src/constants.js
+++ b/src/constants.js
@@ -272,6 +272,8 @@ export const NO_RENAME_WORKSPACE_KESSEL_TOOLTIP_MESSAGE =
   'You do not have permission to rename this workspace. Contact your organization administrator.';
 export const NO_EDIT_WORKSPACE_KESSEL_TOOLTIP_MESSAGE =
   'You do not have permission to edit this workspace. Contact your organization administrator.';
+export const NO_MOVE_SYSTEM_KESSEL_TOOLTIP_MESSAGE =
+  'You do not have permission to move systems from this workspace. Contact your organization administrator.';
 export const NO_DELETE_WORKSPACE_KESSEL_TOOLTIP_MESSAGE =
   'You do not have permission to delete this workspace. Contact your organization administrator.';
 export const NO_DELETE_SELECTED_WORKSPACES_KESSEL_TOOLTIP_MESSAGE =


### PR DESCRIPTION
## Jira
[RHINENG-26177](https://redhat.atlassian.net/browse/RHINENG-26177)

## What
A user with no permissions to move a host in Ungrouped Hosts workspace doesn’t show a disabled “Move system” button in the row actions for a host in the systems table. The app should check for permissions to move the system and disable the button accordingly.

## Testing
- Use an account with a user that only has view permissions
- Go to systems page
- Click the row kebab action button


[RHINENG-26177]: https://redhat.atlassian.net/browse/RHINENG-26177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Gate system move actions on workspace-level edit permissions, including for Ungrouped Hosts, and surface appropriate tooltips when access is denied.

New Features:
- Expose per-host workspace edit permission (hasWorkspaceEdit) alongside existing update/delete permissions from the Kessel access check.
- Add a dedicated tooltip message explaining lack of permission to move systems from a workspace.

Bug Fixes:
- Ensure the Move system action is disabled and explains lack of access when users lack workspace edit permission, including for Ungrouped Hosts.

Enhancements:
- Unify workspace edit permission handling so Ungrouped Hosts respect Kessel RBAC instead of bypassing it.

Tests:
- Add unit tests for useHostIdsWithKessel to cover Kessel feature flag behavior, workspace edit checks (including Ungrouped Hosts), and bulk host permission requests.