### PR TITLE
ci: Update PR reminder bot to match back-end

### DIFF
--- a/.github/workflows/pr-review-reminder.yaml
+++ b/.github/workflows/pr-review-reminder.yaml
@@ -30,15 +30,15 @@ jobs:
             --json number,title,author,createdAt,url,isDraft,reviewDecision,reviews,comments \
             --limit 100)
 
-          # Filter: not draft, older than 1 day, no human reviews or comments
+          # Filter: not draft, older than 1 day, no human reviews or comments in the last 24 hours
           # Bot interactions (logins matching "bot", "sourcery", or "github-actions") are ignored
           # Sort: oldest first (highest priority)
           FILTERED=$(echo "$PRS" | jq --argjson now "$NOW" --argjson day "$ONE_DAY" '
             [ .[]
               | select(.isDraft == false)
               | .author.login as $pr_author
-              | select(([.reviews[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not))] | length) == 0)
-              | select(([.comments[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not))] | length) == 0)
+              | select(([.reviews[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not)) | select(.submittedAt != null and ($now - (.submittedAt | fromdateiso8601)) <= $day)] | length) == 0)
+              | select(([.comments[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not)) | select(($now - (.createdAt | fromdateiso8601)) <= $day)] | length) == 0)
               | select(.reviewDecision != "APPROVED")
               | (.createdAt | fromdateiso8601) as $created
               | select(($now - $created) > $day)


### PR DESCRIPTION
## Jira
(None)

## What
Updates the front-end PR reminder bot to match the back-end bot's logic

## Why
So that the front- and back-ends have consistent logic for these bots

## How

## Testing

## Screenshots/Videos (if applicable)

## Summary by Sourcery

Align PR review reminder workflow logic with back-end bot behavior for detecting stale front-end PRs.

New Features:
- Update PR reminder filtering to only ignore PRs with human reviews or comments made within the last 24 hours.

Enhancements:
- Tighten PR reminder criteria by considering recent human review and comment activity instead of any historical activity.