### PR TITLE
fix(RHINENG-26210): Add tooltip to inline name edit sys details

### DIFF
--- a/src/components/GeneralInfo/EditButton/EditButton.js
+++ b/src/components/GeneralInfo/EditButton/EditButton.js
@@ -7,7 +7,9 @@ import { PencilAltIcon } from '@patternfly/react-icons';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 import { useConditionalRBAC } from '../../../Utilities/hooks/useConditionalRBAC';
+import { useKesselMigrationFeatureFlag } from '../../../Utilities/hooks/useKesselMigrationFeatureFlag';
 import {
+  NO_MODIFY_HOST_KESSEL_TOOLTIP_MESSAGE,
   NO_MODIFY_HOST_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP,
 } from '../../../constants';
@@ -17,9 +19,11 @@ const EditButton = ({
   variant = 'plain',
   onClick,
   className,
+  noAccessTooltip,
   ...rest
 }) => {
   const { isProd } = useChrome();
+  const isKesselEnabled = useKesselMigrationFeatureFlag();
   const entity = useSelector(({ entityDetails }) => entityDetails?.entity);
 
   const { hasAccess: canEditFromRbac } = useConditionalRBAC([
@@ -33,6 +37,12 @@ const EditButton = ({
     writePermissions === true ||
     (typeof writePermissions !== 'boolean' && canEditFromRbac);
 
+  const permissionDeniedTooltip =
+    noAccessTooltip ??
+    (isKesselEnabled && writePermissions === false
+      ? NO_MODIFY_HOST_KESSEL_TOOLTIP_MESSAGE
+      : NO_MODIFY_HOST_TOOLTIP_MESSAGE);
+
   const button = (
     <Button
       {...rest}
@@ -42,13 +52,12 @@ const EditButton = ({
       aria-label="Edit"
       variant={variant}
       onClick={isEnabled ? onClick : undefined}
-      isDisabled={!isEnabled}
       isAriaDisabled={!isEnabled}
     />
   );
 
   if (!isEnabled) {
-    return <Tooltip content={NO_MODIFY_HOST_TOOLTIP_MESSAGE}>{button}</Tooltip>;
+    return <Tooltip content={permissionDeniedTooltip}>{button}</Tooltip>;
   }
 
   return button;
@@ -56,6 +65,7 @@ const EditButton = ({
 
 EditButton.propTypes = {
   writePermissions: PropTypes.bool,
+  noAccessTooltip: PropTypes.string,
   /** 'plain' for field-specific inline edit (default), 'link' for full-page edit */
   variant: PropTypes.oneOf(['plain', 'link']),
   onClick: PropTypes.func.isRequired,

--- a/src/components/GeneralInfo/EditButton/EditButtonWithNoAccess.test.js
+++ b/src/components/GeneralInfo/EditButton/EditButtonWithNoAccess.test.js
@@ -12,21 +12,30 @@ jest.mock(
   }),
 );
 
+jest.mock('../../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
+  __esModule: true,
+  useKesselMigrationFeatureFlag: jest.fn(() => false),
+}));
+
 jest.mock('react-redux', () => ({
   esModule: true,
   useSelector: () => ({}),
 }));
 
-const checkDisabledEditButton = async () => {
+const { useKesselMigrationFeatureFlag } = jest.requireMock(
+  '../../../Utilities/hooks/useKesselMigrationFeatureFlag',
+);
+
+const checkDisabledEditButton = async (expectedTooltipSubstring) => {
   const button = await screen.findByRole('button', { name: /edit/i });
   await userEvent.hover(button);
   await waitFor(() => {
     expect(screen.queryByRole('tooltip')).toBeVisible();
   });
   expect(screen.queryByRole('tooltip')).toHaveTextContent(
-    'You do not have the necessary permissions to modify this host.',
+    expectedTooltipSubstring,
   );
-  expect(screen.queryByRole('button')).toBeDisabled();
+  expect(button).toHaveAttribute('aria-disabled', 'true');
 };
 
 describe('EditButton with no access', () => {
@@ -34,16 +43,29 @@ describe('EditButton with no access', () => {
 
   beforeEach(() => {
     onClick = jest.fn();
+    useKesselMigrationFeatureFlag.mockReturnValue(false);
   });
 
   it('disables with no permission', async () => {
     render(<EditButton onClick={onClick} />);
-    await checkDisabledEditButton();
+    await checkDisabledEditButton(
+      'You do not have the necessary permissions to modify this host.',
+    );
   });
 
   it('disables with no permission - write permissions set to false', async () => {
     render(<EditButton onClick={onClick} writePermissions={false} />);
-    await checkDisabledEditButton();
+    await checkDisabledEditButton(
+      'You do not have the necessary permissions to modify this host.',
+    );
+  });
+
+  it('uses Kessel denial tooltip when Kessel migration is on and write permissions are false', async () => {
+    useKesselMigrationFeatureFlag.mockReturnValue(true);
+    render(<EditButton onClick={onClick} writePermissions={false} />);
+    await checkDisabledEditButton(
+      'You do not have permission to edit this host.',
+    );
   });
 
   it('enables when write permissions are set to true', () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -277,6 +277,8 @@ export const NO_MODIFY_HOSTS_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify hosts. Contact your organization administrator.';
 export const NO_MODIFY_HOST_TOOLTIP_MESSAGE =
   'You do not have the necessary permissions to modify this host. Contact your organization administrator.';
+export const NO_MODIFY_HOST_KESSEL_TOOLTIP_MESSAGE =
+  'You do not have permission to edit this host. Contact your organization administrator.';
 export const NO_MANAGE_USER_ACCESS_TOOLTIP_MESSAGE =
   'You must be an organization administrator to modify User Access configuration.';
 const REMEDIATIONS_DISPLAY = 'Automation Toolkit > Remediations';


### PR DESCRIPTION
## Jira
[RHINENG-26210](https://redhat.atlassian.net/browse/RHINENG-26210)

## What
In RBAC v2, when a user doesn’t have permissions to edit a system, the inline edit icon on the System details page does not show a tooltip telling the user why the button is disabled.

## Screenshots/Videos (if applicable)
<img width="545" height="385" alt="image" src="https://github.com/user-attachments/assets/c0262607-9afd-4f2b-980a-4c17590d5c88" />

[RHINENG-26210]: https://redhat.atlassian.net/browse/RHINENG-26210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add configurable permission-denied tooltips for the system name inline edit button and align behavior with Kessel migration state.

New Features:
- Allow EditButton to accept a custom no-access tooltip message via a new prop.
- Introduce a Kessel-specific tooltip message used when migration is enabled and write permissions are false.

Enhancements:
- Use aria-disabled instead of fully disabling the edit button to improve accessibility semantics for the disabled state.

Tests:
- Extend EditButton no-access tests to cover Kessel migration behavior and the new tooltip messaging variants.