### PR TITLE
fix(RHINENG-26211): Add tooltip to action dropdown workspace details

### DIFF
--- a/src/components/GeneralInfo/EditButton/EditButton.js
+++ b/src/components/GeneralInfo/EditButton/EditButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
@@ -13,6 +13,7 @@ import {
   NO_MODIFY_HOST_TOOLTIP_MESSAGE,
   REQUIRED_PERMISSION_TO_MODIFY_HOST_IN_GROUP,
 } from '../../../constants';
+import NoAccessTooltipWrap from '../../NoAccessTooltipWrap';
 
 const EditButton = ({
   writePermissions,
@@ -56,11 +57,14 @@ const EditButton = ({
     />
   );
 
-  if (!isEnabled) {
-    return <Tooltip content={permissionDeniedTooltip}>{button}</Tooltip>;
-  }
-
-  return button;
+  return (
+    <NoAccessTooltipWrap
+      isEnabled={isEnabled}
+      tooltipContent={permissionDeniedTooltip}
+    >
+      {button}
+    </NoAccessTooltipWrap>
+  );
 };
 
 EditButton.propTypes = {

--- a/src/components/InventoryDetail/TopBar.js
+++ b/src/components/InventoryDetail/TopBar.js
@@ -16,12 +16,12 @@ import {
   Split,
   SplitItem,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import { redirectToInventoryList } from './helpers';
 import { useDispatch } from 'react-redux';
 import { toggleDrawer } from '../../store/actions';
 import { NO_MODIFY_HOST_TOOLTIP_MESSAGE } from '../../constants';
+import NoAccessTooltipWrap from '../NoAccessTooltipWrap';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 
 /**
@@ -114,20 +114,20 @@ const TopBar = ({
             <Flex>
               <FlexItem>
                 <DeleteWrapper>
-                  {showDelete ? (
+                  <NoAccessTooltipWrap
+                    isEnabled={showDelete}
+                    tooltipContent={NO_MODIFY_HOST_TOOLTIP_MESSAGE}
+                  >
                     <Button
-                      onClick={() => setIsModalOpen(true)}
+                      onClick={
+                        showDelete ? () => setIsModalOpen(true) : undefined
+                      }
                       variant="secondary"
+                      {...(!showDelete ? { isAriaDisabled: true } : {})}
                     >
                       Delete
                     </Button>
-                  ) : (
-                    <Tooltip content={NO_MODIFY_HOST_TOOLTIP_MESSAGE}>
-                      <Button isAriaDisabled variant="secondary">
-                        Delete
-                      </Button>
-                    </Tooltip>
-                  )}
+                  </NoAccessTooltipWrap>
                 </DeleteWrapper>
               </FlexItem>
               {inventoryActions?.length > 0 && (

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -6,6 +6,7 @@ import {
   FlexItem,
   MenuToggle,
   Skeleton,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   PageHeader,
@@ -123,21 +124,50 @@ const GroupDetailHeader = ({
             popperProps={{
               position: 'right',
             }}
-            toggle={(toggleRef) => (
-              <MenuToggle
-                ref={toggleRef}
-                isExpanded={dropdownOpen}
-                onClick={() => setDropdownOpen(!dropdownOpen)}
-                id="group-dropdown-toggle"
-                toggleVariant="secondary"
-                isDisabled={
-                  !canModifyWorkspaceForActions || uninitialized || loading
-                }
-                ouiaId="group-actions-dropdown-toggle"
-              >
-                Actions
-              </MenuToggle>
-            )}
+            toggle={(toggleRef) => {
+              const detailLoading = uninitialized || loading;
+              const actionsToggleDisabled =
+                !canModifyWorkspaceForActions || detailLoading;
+              const menuToggle = (
+                <MenuToggle
+                  ref={toggleRef}
+                  isExpanded={dropdownOpen}
+                  onClick={() => setDropdownOpen(!dropdownOpen)}
+                  id="group-dropdown-toggle"
+                  toggleVariant="secondary"
+                  isDisabled={actionsToggleDisabled}
+                  ouiaId="group-actions-dropdown-toggle"
+                >
+                  Actions
+                </MenuToggle>
+              );
+
+              // MenuToggle uses native `disabled`, which blocks hover; a transparent
+              // layer receives pointer events so the PatternFly tooltip can show.
+              if (!canModifyWorkspaceForActions) {
+                return (
+                  <Tooltip content={noAccessEditTooltip}>
+                    <span
+                      data-testid="group-detail-header-actions-tooltip-trigger"
+                      className="pf-v6-u-display-inline-block"
+                      style={{ position: 'relative', cursor: 'not-allowed' }}
+                    >
+                      <span
+                        aria-hidden
+                        style={{
+                          position: 'absolute',
+                          inset: 0,
+                          zIndex: 1,
+                        }}
+                      />
+                      {menuToggle}
+                    </span>
+                  </Tooltip>
+                );
+              }
+
+              return menuToggle;
+            }}
           >
             <DropdownList>
               <DropdownItem

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -8,6 +8,8 @@ import {
   Skeleton,
   Tooltip,
 } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import menuToggleStyles from '@patternfly/react-styles/css/components/MenuToggle/menu-toggle';
 import {
   PageHeader,
   PageHeaderTitle,
@@ -25,6 +27,7 @@ import {
   REQUIRED_PERMISSIONS_TO_READ_GROUP,
 } from '../../constants';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
+import './GroupDetailHeader.scss';
 
 const defaultWorkspaceAccess = {
   canEdit: undefined,
@@ -126,40 +129,44 @@ const GroupDetailHeader = ({
             }}
             toggle={(toggleRef) => {
               const detailLoading = uninitialized || loading;
-              const actionsToggleDisabled =
-                !canModifyWorkspaceForActions || detailLoading;
+              const actionsTogglePermissionDisabled =
+                !canModifyWorkspaceForActions;
+              const actionsToggleLoadingDisabled = detailLoading;
               const menuToggle = (
                 <MenuToggle
                   ref={toggleRef}
                   isExpanded={dropdownOpen}
-                  onClick={() => setDropdownOpen(!dropdownOpen)}
+                  onClick={() => {
+                    if (actionsTogglePermissionDisabled) {
+                      return;
+                    }
+                    setDropdownOpen(!dropdownOpen);
+                  }}
                   id="group-dropdown-toggle"
-                  toggleVariant="secondary"
-                  isDisabled={actionsToggleDisabled}
+                  isDisabled={actionsToggleLoadingDisabled}
+                  className={
+                    actionsTogglePermissionDisabled &&
+                    !actionsToggleLoadingDisabled
+                      ? css(menuToggleStyles.modifiers.disabled)
+                      : undefined
+                  }
+                  {...(actionsTogglePermissionDisabled &&
+                    !actionsToggleLoadingDisabled && {
+                      'aria-disabled': true,
+                    })}
                   ouiaId="group-actions-dropdown-toggle"
                 >
                   Actions
                 </MenuToggle>
               );
 
-              // MenuToggle uses native `disabled`, which blocks hover; a transparent
-              // layer receives pointer events so the PatternFly tooltip can show.
               if (!canModifyWorkspaceForActions) {
                 return (
                   <Tooltip content={noAccessEditTooltip}>
                     <span
                       data-testid="group-detail-header-actions-tooltip-trigger"
-                      className="pf-v6-u-display-inline-block"
-                      style={{ position: 'relative', cursor: 'not-allowed' }}
+                      className="pf-v6-u-display-inline-block ins-c-group-detail-header__actions-tooltip-anchor"
                     >
-                      <span
-                        aria-hidden
-                        style={{
-                          position: 'absolute',
-                          inset: 0,
-                          zIndex: 1,
-                        }}
-                      />
                       {menuToggle}
                     </span>
                   </Tooltip>

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.js
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.js
@@ -6,7 +6,6 @@ import {
   FlexItem,
   MenuToggle,
   Skeleton,
-  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import menuToggleStyles from '@patternfly/react-styles/css/components/MenuToggle/menu-toggle';
@@ -27,6 +26,7 @@ import {
   REQUIRED_PERMISSIONS_TO_READ_GROUP,
 } from '../../constants';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
+import NoAccessTooltipWrap from '../NoAccessTooltipWrap';
 import './GroupDetailHeader.scss';
 
 const defaultWorkspaceAccess = {
@@ -160,20 +160,21 @@ const GroupDetailHeader = ({
                 </MenuToggle>
               );
 
-              if (!canModifyWorkspaceForActions) {
-                return (
-                  <Tooltip content={noAccessEditTooltip}>
-                    <span
-                      data-testid="group-detail-header-actions-tooltip-trigger"
-                      className="pf-v6-u-display-inline-block ins-c-group-detail-header__actions-tooltip-anchor"
-                    >
-                      {menuToggle}
-                    </span>
-                  </Tooltip>
-                );
-              }
-
-              return menuToggle;
+              return (
+                <NoAccessTooltipWrap
+                  isEnabled={canModifyWorkspaceForActions}
+                  tooltipContent={noAccessEditTooltip}
+                  wrapTriggerInSpan
+                  triggerSpanProps={{
+                    'data-testid':
+                      'group-detail-header-actions-tooltip-trigger',
+                    className:
+                      'pf-v6-u-display-inline-block ins-c-group-detail-header__actions-tooltip-anchor',
+                  }}
+                >
+                  {menuToggle}
+                </NoAccessTooltipWrap>
+              );
             }}
           >
             <DropdownList>

--- a/src/components/InventoryGroupDetail/GroupDetailHeader.scss
+++ b/src/components/InventoryGroupDetail/GroupDetailHeader.scss
@@ -1,0 +1,4 @@
+.ins-c-group-detail-header__actions-tooltip-anchor {
+  position: relative;
+  cursor: not-allowed;
+}

--- a/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
+++ b/src/components/InventoryGroupDetail/InventoryGroupDetail.cy.js
@@ -197,7 +197,7 @@ describe('integration with rbac', () => {
     });
 
     it('actions are disabled', () => {
-      cy.get(MENU_TOGGLE).should('be.disabled');
+      cy.get(MENU_TOGGLE).shouldHaveAriaDisabled();
       cy.contains('button', 'Add systems').shouldHaveAriaDisabled();
     });
 

--- a/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
+++ b/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
@@ -1,11 +1,12 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import GroupDetailHeader from '../GroupDetailHeader';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import userEvent from '@testing-library/user-event';
 import { useKesselMigrationFeatureFlag } from '../../../Utilities/hooks/useKesselMigrationFeatureFlag';
+import { NO_EDIT_WORKSPACE_KESSEL_TOOLTIP_MESSAGE } from '../../../constants';
 
 jest.mock('../../../Utilities/useFeatureFlag');
 jest.mock('../../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
@@ -102,6 +103,29 @@ describe('group detail header', () => {
     });
 
     expect(screen.getByRole('button', { name: /actions/i })).toBeDisabled();
+  });
+
+  it('shows a tooltip on Actions when Kessel workspace edit is denied', async () => {
+    useKesselMigrationFeatureFlag.mockReturnValue(true);
+
+    renderHeader({
+      workspaceAccess: {
+        gateActive: true,
+        canEdit: false,
+        isLoading: false,
+      },
+    });
+
+    await userEvent.hover(
+      screen.getByTestId('group-detail-header-actions-tooltip-trigger'),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeVisible();
+    });
+    expect(screen.getByRole('tooltip')).toHaveTextContent(
+      NO_EDIT_WORKSPACE_KESSEL_TOOLTIP_MESSAGE,
+    );
   });
 
   it('disables the Actions toggle while Kessel workspace permissions are loading', () => {

--- a/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
+++ b/src/components/InventoryGroupDetail/__tests__/GroupDetailHeader.test.js
@@ -83,15 +83,18 @@ describe('group detail header', () => {
     ).toBeVisible();
   });
 
-  it('disables the Actions toggle when RBAC denies workspace modify (Kessel migration off)', () => {
+  it('marks the Actions toggle aria-disabled when RBAC denies workspace modify (Kessel migration off)', () => {
     usePermissionsWithContext.mockImplementation(() => ({ hasAccess: false }));
 
     renderHeader();
 
-    expect(screen.getByRole('button', { name: /actions/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /actions/i })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
   });
 
-  it('disables the Actions toggle when Kessel workspace edit is denied', () => {
+  it('marks the Actions toggle aria-disabled when Kessel workspace edit is denied', () => {
     useKesselMigrationFeatureFlag.mockReturnValue(true);
 
     renderHeader({
@@ -102,7 +105,10 @@ describe('group detail header', () => {
       },
     });
 
-    expect(screen.getByRole('button', { name: /actions/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /actions/i })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
   });
 
   it('shows a tooltip on Actions when Kessel workspace edit is denied', async () => {
@@ -128,7 +134,25 @@ describe('group detail header', () => {
     );
   });
 
-  it('disables the Actions toggle while Kessel workspace permissions are loading', () => {
+  it('does not show a tooltip on Actions when Kessel workspace edit is allowed', async () => {
+    useKesselMigrationFeatureFlag.mockReturnValue(true);
+
+    renderHeader({
+      workspaceAccess: {
+        gateActive: true,
+        canEdit: true,
+        isLoading: false,
+      },
+    });
+
+    await userEvent.hover(screen.getByRole('button', { name: /actions/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  it('marks the Actions toggle aria-disabled while Kessel workspace permissions are loading', () => {
     useKesselMigrationFeatureFlag.mockReturnValue(true);
 
     renderHeader({
@@ -139,7 +163,10 @@ describe('group detail header', () => {
       },
     });
 
-    expect(screen.getByRole('button', { name: /actions/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /actions/i })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
   });
 
   it('opens the actions menu when Kessel workspace edit is allowed', async () => {

--- a/src/components/InventoryGroups/NoGroupsEmptyState.js
+++ b/src/components/InventoryGroups/NoGroupsEmptyState.js
@@ -3,7 +3,6 @@ import {
   Button,
   EmptyState,
   EmptyStateBody,
-  Tooltip,
   EmptyStateFooter,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
@@ -11,6 +10,7 @@ import PropTypes from 'prop-types';
 
 import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
 import { GENERAL_GROUPS_WRITE_PERMISSION } from '../../constants';
+import NoAccessTooltipWrap from '../NoAccessTooltipWrap';
 
 const REQUIRED_PERMISSIONS = [GENERAL_GROUPS_WRITE_PERMISSION];
 
@@ -31,21 +31,19 @@ const NoGroupsEmptyState = ({ onCreateGroupClick }) => {
         Manage device operations efficiently by creating workspaces
       </EmptyStateBody>
       <EmptyStateFooter>
-        {canModifyGroups ? (
+        <NoAccessTooltipWrap
+          isEnabled={canModifyGroups}
+          tooltipContent="You do not have the necessary permissions to modify workspaces. Contact your organization administrator."
+        >
           <Button
             variant="primary"
-            onClick={onCreateGroupClick}
+            onClick={canModifyGroups ? onCreateGroupClick : undefined}
             ouiaId="CreateGroupButton"
+            {...(!canModifyGroups ? { isAriaDisabled: true } : {})}
           >
             Create workspace
           </Button>
-        ) : (
-          <Tooltip content="You do not have the necessary permissions to modify workspaces. Contact your organization administrator.">
-            <Button variant="primary" isAriaDisabled ouiaId="CreateGroupButton">
-              Create workspace
-            </Button>
-          </Tooltip>
-        )}
+        </NoAccessTooltipWrap>
       </EmptyStateFooter>
     </EmptyState>
   );

--- a/src/components/InventoryTable/ActionWithRBAC.js
+++ b/src/components/InventoryTable/ActionWithRBAC.js
@@ -6,8 +6,9 @@
  */
 import React from 'react';
 import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
-import { Button, MenuItem, Tooltip } from '@patternfly/react-core';
+import { Button, MenuItem } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
+import NoAccessTooltipWrap from '../NoAccessTooltipWrap';
 import './ActionWithRBAC.scss';
 
 export const ActionButton = ({
@@ -27,12 +28,10 @@ export const ActionButton = ({
           !ignoreResourceDefinitions
         );
 
-  return enabled ? (
-    <Button {...props} />
-  ) : (
-    <Tooltip content={noAccessTooltip}>
-      <Button {...props} isAriaDisabled />
-    </Tooltip>
+  return (
+    <NoAccessTooltipWrap isEnabled={enabled} tooltipContent={noAccessTooltip}>
+      <Button {...props} {...(!enabled ? { isAriaDisabled: true } : {})} />
+    </NoAccessTooltipWrap>
   );
 };
 

--- a/src/components/NoAccessTooltipWrap.js
+++ b/src/components/NoAccessTooltipWrap.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
+
+/**
+ * When `isEnabled` is false, wraps children in a Tooltip explaining missing access.
+ * When true, returns children unchanged.
+ *
+ * Use `wrapTriggerInSpan` for controls that need an inline wrapper so the tooltip
+ * can receive hover events (e.g. MenuToggle styled as disabled, or native-disabled buttons).
+ */
+const NoAccessTooltipWrap = ({
+  isEnabled,
+  tooltipContent,
+  children,
+  wrapTriggerInSpan,
+  triggerSpanProps,
+}) => {
+  if (isEnabled) {
+    return children;
+  }
+
+  const trigger = wrapTriggerInSpan ? (
+    <span {...triggerSpanProps}>{children}</span>
+  ) : (
+    children
+  );
+
+  return <Tooltip content={tooltipContent}>{trigger}</Tooltip>;
+};
+
+NoAccessTooltipWrap.propTypes = {
+  isEnabled: PropTypes.bool.isRequired,
+  tooltipContent: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+  wrapTriggerInSpan: PropTypes.bool,
+  triggerSpanProps: PropTypes.object,
+};
+
+NoAccessTooltipWrap.defaultProps = {
+  wrapTriggerInSpan: false,
+  triggerSpanProps: {},
+};
+
+export default NoAccessTooltipWrap;

--- a/src/components/NoAccessTooltipWrap.tsx
+++ b/src/components/NoAccessTooltipWrap.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Tooltip } from '@patternfly/react-core';
+
+interface NoAccessTooltipWrapProps {
+  isEnabled: boolean;
+  tooltipContent: React.ReactNode;
+  children: React.ReactElement;
+  wrapTriggerInSpan?: boolean;
+  triggerSpanProps?: React.HTMLAttributes<HTMLSpanElement>;
+}
 
 /**
  * When `isEnabled` is false, wraps children in a Tooltip explaining missing access.
@@ -13,9 +20,9 @@ const NoAccessTooltipWrap = ({
   isEnabled,
   tooltipContent,
   children,
-  wrapTriggerInSpan,
-  triggerSpanProps,
-}) => {
+  wrapTriggerInSpan = false,
+  triggerSpanProps = {},
+}: NoAccessTooltipWrapProps) => {
   if (isEnabled) {
     return children;
   }
@@ -27,19 +34,6 @@ const NoAccessTooltipWrap = ({
   );
 
   return <Tooltip content={tooltipContent}>{trigger}</Tooltip>;
-};
-
-NoAccessTooltipWrap.propTypes = {
-  isEnabled: PropTypes.bool.isRequired,
-  tooltipContent: PropTypes.node.isRequired,
-  children: PropTypes.node.isRequired,
-  wrapTriggerInSpan: PropTypes.bool,
-  triggerSpanProps: PropTypes.object,
-};
-
-NoAccessTooltipWrap.defaultProps = {
-  wrapTriggerInSpan: false,
-  triggerSpanProps: {},
 };
 
 export default NoAccessTooltipWrap;

--- a/src/components/SystemsView/SystemsViewRowActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.test.tsx
@@ -42,6 +42,10 @@ jest.mock('../../Utilities/hooks/useConditionalRBAC', () => ({
 describe('SystemsViewRowActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    const useFeatureFlag = require('../../Utilities/useFeatureFlag').default;
+    useFeatureFlag.mockImplementation(
+      (key: string) => key === 'platform.rbac.workspaces',
+    );
     const useConditionalRBACMock =
       require('../../Utilities/hooks/useConditionalRBAC')
         .useConditionalRBAC as jest.Mock;

--- a/src/components/SystemsView/SystemsViewRowActions.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.tsx
@@ -7,6 +7,9 @@ import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
 import {
   GENERAL_GROUPS_WRITE_PERMISSION,
   GENERAL_HOSTS_WRITE_PERMISSIONS,
+  NO_MODIFY_HOST_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
+  NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE,
   NO_MOVE_SYSTEM_KESSEL_TOOLTIP_MESSAGE,
 } from '../../constants';
 import type { SystemWithPermissions } from '../../Utilities/hooks/useHostIdsWithKessel';
@@ -38,22 +41,31 @@ const SystemsViewRowActions = ({ system }: RowActionsProps) => {
   const permissions = 'permissions' in system ? system.permissions : undefined;
 
   const hasDelete = permissions?.hasDelete ?? false;
-  const canMoveSystem = permissions?.hasWorkspaceEdit ?? false;
+  const canWorkspaceEdit = permissions?.hasWorkspaceEdit ?? false;
+  const canUpdate = permissions?.hasUpdate ?? false;
+
+  const addToWorkspaceDisabled = !hasGroupsWrite || hasWorkspace(system);
+  const removeFromWorkspaceDisabled = !hasGroupsWrite || !hasWorkspace(system);
 
   const rowActions = isKesselEnabled
     ? [
         {
           title: 'Move system',
           onClick: () => openAddToWorkspaceModal([system]),
-          isDisabled: !canMoveSystem,
-          ...(!canMoveSystem && {
-            tooltipProps: { content: NO_MOVE_SYSTEM_KESSEL_TOOLTIP_MESSAGE },
+          ...(!canWorkspaceEdit && {
+            isAriaDisabled: true,
+            tooltipProps: {
+              content: NO_MOVE_SYSTEM_KESSEL_TOOLTIP_MESSAGE,
+            },
           }),
         },
         {
           title: 'Edit',
           onClick: () => openEditModal([system]),
-          isDisabled: !(permissions?.hasUpdate ?? false),
+          ...(!canUpdate && {
+            isAriaDisabled: true,
+            tooltipProps: { content: NO_MODIFY_HOST_TOOLTIP_MESSAGE },
+          }),
         },
         { isSeparator: true, itemKey: `${system.id}-divider` },
         {
@@ -63,29 +75,60 @@ const SystemsViewRowActions = ({ system }: RowActionsProps) => {
             isDanger: true,
             className: 'pf-v6-u-danger-color-100',
           }),
-          isDisabled: !hasDelete,
+          ...(!hasDelete && {
+            isAriaDisabled: true,
+            tooltipProps: { content: NO_MODIFY_HOST_TOOLTIP_MESSAGE },
+          }),
         },
       ]
     : [
         {
           title: 'Add to workspace',
           onClick: () => openAddToWorkspaceModal([system]),
-          isDisabled: !hasGroupsWrite || hasWorkspace(system),
+          ...(!hasGroupsWrite
+            ? {
+                isAriaDisabled: true,
+                tooltipProps: {
+                  content: NO_MODIFY_WORKSPACES_TOOLTIP_MESSAGE,
+                },
+              }
+            : addToWorkspaceDisabled
+              ? { isDisabled: true }
+              : { isDisabled: false }),
         },
         {
           title: 'Remove from workspace',
           onClick: () => openRemoveFromWorkspaceModal([system]),
-          isDisabled: !hasGroupsWrite || !hasWorkspace(system),
+          ...(!hasGroupsWrite
+            ? {
+                isAriaDisabled: true,
+                tooltipProps: {
+                  content: NO_MODIFY_WORKSPACE_TOOLTIP_MESSAGE,
+                },
+              }
+            : removeFromWorkspaceDisabled
+              ? { isDisabled: true }
+              : { isDisabled: false }),
         },
         {
           title: 'Edit display name',
           onClick: () => openEditModal([system]),
-          isDisabled: !hasHostsWrite,
+          ...(!hasHostsWrite
+            ? {
+                isAriaDisabled: true,
+                tooltipProps: { content: NO_MODIFY_HOST_TOOLTIP_MESSAGE },
+              }
+            : { isDisabled: false }),
         },
         {
           title: 'Delete from inventory',
           onClick: () => openDeleteModal([system]),
-          isDisabled: !hasHostsWrite,
+          ...(!hasHostsWrite
+            ? {
+                isAriaDisabled: true,
+                tooltipProps: { content: NO_MODIFY_HOST_TOOLTIP_MESSAGE },
+              }
+            : { isDisabled: false }),
         },
       ];
 


### PR DESCRIPTION
## Jira
[RHINENG-26211](https://redhat.atlassian.net/browse/RHINENG-26211)

## What
If a user doesn’t have RBAC v2 permissions to edit a workspace, the Action dropdown in the top right of the page should show a tooltip when it’s disabled.

## Screenshots/Videos (if applicable)
<img width="547" height="434" alt="image" src="https://github.com/user-attachments/assets/62e7add0-dce0-4acd-8221-5fc30331592b" />

[RHINENG-26211]: https://redhat.atlassian.net/browse/RHINENG-26211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ