### PR TITLE
fix(E2E): Switch archive upload auth from Basic to SSO Bearer token

### DIFF
--- a/.github/workflows/playwright-systems-view.yml
+++ b/.github/workflows/playwright-systems-view.yml
@@ -43,6 +43,7 @@ jobs:
             echo "CI=true"
             echo "PROXY=$PROXY"
             echo "SYSTEMS_VIEW=true"
+            echo "STAGE_OFFLINE_TOKEN=$STAGE_OFFLINE_TOKEN"
           } >> .env
 
           echo ".env file created successfully."

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -42,6 +42,7 @@ jobs:
             echo "BASE_URL=https://stage.foo.redhat.com:1337"
             echo "CI=true"
             echo "PROXY=$PROXY"
+            echo "STAGE_OFFLINE_TOKEN=$STAGE_OFFLINE_TOKEN"
           } >> .env
 
           echo ".env file created successfully."

--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -57,6 +57,7 @@ jobs:
             echo "PROD=true"
             echo "BASE_URL=$PROD_BASE_URL"
             echo "PROXY=$RH_PROXY_URL"
+            echo "PROD_OFFLINE_TOKEN=$PROD_OFFLINE_TOKEN"
           } >> .env 2>/dev/null
 
           echo ".env file created successfully."

--- a/.github/workflows/stage-daily-pw-tests.yml
+++ b/.github/workflows/stage-daily-pw-tests.yml
@@ -58,6 +58,7 @@ jobs:
             echo "INTEGRATION=true"
             echo "BASE_URL=$STAGE_BASE_URL" 
             echo "PROXY=$RH_PROXY_URL"
+            echo "STAGE_OFFLINE_TOKEN=$STAGE_OFFLINE_TOKEN"
           } >> .env 2>/dev/null
 
           echo ".env file created successfully."

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ The E2E tests are located in the [_playwright-tests/](_playwright-tests/) direct
 #### First time setup
 
 1. Copy the example env file (`playwright_example.env`) and create a file named `.env`. For local development only the `BASE_URL` - `https://stage.foo.redhat.com:1337` is required, which is already set in the example config.
-You also need to set the `PLAYWRIGHT_USER` and `PLAYWRIGHT_PASSWORD` for your Stage testing account in the `.env` file.
+You also need to set the following variables in the `.env` file:
+   - `PLAYWRIGHT_USER` and `PLAYWRIGHT_PASSWORD` — Stage testing account credentials (used for browser login).
+   - `STAGE_OFFLINE_TOKEN` — A shared offline token for the `qe-ui-inventory` stage account, used to authenticate archive uploads to the Ingress API.
+   - `PROXY` — Corporate proxy (e.g., `squid.corp.redhat.com:3128`) if running directly against stage.
 
 2. Install the test runner:
 ```bash

--- a/_playwright-tests/helpers/uploadArchive.ts
+++ b/_playwright-tests/helpers/uploadArchive.ts
@@ -14,35 +14,103 @@ export interface ModifiedArchive {
   archiveName: string;
 }
 
+let cachedAccessToken: string | null = null;
+
+/**
+ * Exchanges an offline (refresh) token for a short-lived access token via SSO.
+ * Caches the result for the lifetime of the process to avoid repeated exchanges.
+ */
+function getAccessToken(): string {
+  if (cachedAccessToken) {
+    return cachedAccessToken;
+  }
+
+  const offlineToken =
+    process.env.PROD === 'true'
+      ? process.env.PROD_OFFLINE_TOKEN
+      : process.env.STAGE_OFFLINE_TOKEN;
+  const proxy = process.env.PROXY;
+
+  const tokenEnvName =
+    process.env.PROD === 'true' ? 'PROD_OFFLINE_TOKEN' : 'STAGE_OFFLINE_TOKEN';
+
+  if (!offlineToken) {
+    throw new Error(
+      `Missing ${tokenEnvName} environment variable. Generate one from SSO.`,
+    );
+  }
+
+  const ssoUrl =
+    process.env.PROD === 'true'
+      ? 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token'
+      : 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token';
+
+  const args = [
+    '-s',
+    '-d',
+    'grant_type=refresh_token',
+    '-d',
+    'client_id=rhsm-api',
+    '-d',
+    `refresh_token=${offlineToken}`,
+    ssoUrl,
+  ];
+
+  if (proxy && proxy !== 'undefined') args.unshift('-x', proxy);
+
+  const result = spawnSync('curl', args, { encoding: 'utf-8' });
+
+  if (result.error) {
+    throw new Error(`SSO token exchange failed: ${result.error.message}`);
+  }
+
+  let json: {
+    access_token?: string;
+    error?: string;
+    error_description?: string;
+  };
+  try {
+    json = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(
+      `SSO returned non-JSON response: ${result.stdout.slice(0, 200)}`,
+    );
+  }
+
+  if (json.access_token) {
+    cachedAccessToken = json.access_token;
+    return cachedAccessToken;
+  }
+
+  throw new Error(
+    `SSO token exchange failed: ${json.error_description || json.error || 'unknown error'}`,
+  );
+}
+
 /**
  * Uploads a .tar.gz archive to the Red Hat Ingress API via curl.
- * Requires: PROXY, PLAYWRIGHT_USER, and PLAYWRIGHT_PASSWORD env vars.
+ * Authenticates using a Bearer token obtained from SSO offline token exchange.
  *
  * Jira References: https://issues.redhat.com/browse/RHINENG-21146
  *
  *  @param   {string}                        archivePath - Relative path to the archive in host_archives/.
+ *  @param   {number}                        maxRetries  - Number of upload attempts (default 3).
  *  @returns {Promise<{ httpCode: number }>}             Object containing the HTTP response code.
  * @throws {Error} Missing credentials, curl failure, or non-201 response.
  */
-export async function uploadArchive(archivePath: string) {
+export async function uploadArchive(
+  archivePath: string,
+  maxRetries: number = 3,
+) {
   const fullPath = `host_archives/${archivePath}`;
   const proxy = process.env.PROXY;
-  const user = process.env.PLAYWRIGHT_USER;
-  const password =
-    process.env.PROD === 'true'
-      ? process.env.PROD_PLAYWRIGHT_PASSWORD
-      : process.env.PLAYWRIGHT_PASSWORD;
 
   const uploadUrl =
     process.env.PROD === 'true'
       ? 'https://console.redhat.com/api/ingress/v1/upload'
       : 'https://console.stage.redhat.com/api/ingress/v1/upload';
 
-  if (!user || !password) {
-    throw new Error(
-      'Missing PLAYWRIGHT_USER or PLAYWRIGHT_PASSWORD environment variables.',
-    );
-  }
+  const accessToken = getAccessToken();
 
   const args = [
     '--retry',
@@ -55,28 +123,54 @@ export async function uploadArchive(archivePath: string) {
     '/tmp/upload_output.txt',
     '-w',
     '%{http_code}',
+    '-H',
+    `Authorization: Bearer ${accessToken}`,
     '-F',
     `upload=@${fullPath};type=application/vnd.redhat.advisor.collection+tgz`,
     uploadUrl,
-    '-u',
-    `${user}:${password}`,
   ];
 
   if (proxy && proxy !== 'undefined') args.unshift('-x', proxy);
 
-  const result = spawnSync('curl', args, { encoding: 'utf-8' });
+  let lastError: Error | null = null;
 
-  if (result.error) throw new Error(`Curl failed: ${result.error.message}`);
-  const stdout = result.stdout.trim();
-  const httpCode = Number(stdout.slice(-3));
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const result = spawnSync('curl', args, { encoding: 'utf-8' });
 
-  if (httpCode !== 201) {
+    if (result.error) {
+      lastError = new Error(`Curl failed: ${result.error.message}`);
+      if (attempt < maxRetries) {
+        console.warn(
+          `Upload attempt ${attempt}/${maxRetries} failed (curl error), retrying in 5s...`,
+        );
+        await new Promise((r) => setTimeout(r, 5000));
+        continue;
+      }
+      throw lastError;
+    }
+
+    const stdout = result.stdout.trim();
+    const httpCode = Number(stdout.slice(-3));
+
+    if (httpCode === 201) {
+      return { httpCode };
+    }
+
     const stderrMsg = result.stderr?.toString().trim() || 'Unknown error';
-    throw new Error(
+    lastError = new Error(
       `Upload failed with HTTP code ${httpCode}. stderr: ${stderrMsg}`,
     );
+
+    if (attempt < maxRetries) {
+      console.warn(
+        `Upload attempt ${attempt}/${maxRetries} failed (HTTP ${httpCode}), retrying in 5s...`,
+      );
+      await new Promise((r) => setTimeout(r, 5000));
+      continue;
+    }
   }
-  return { httpCode };
+
+  throw lastError!;
 }
 
 /**

--- a/playwright_example.env
+++ b/playwright_example.env
@@ -3,6 +3,7 @@ PLAYWRIGHT_PASSWORD="" # Required
 BASE_URL="https://stage.foo.redhat.com:1337" # Required
 CI="" # This is set to true for CI jobs, if checking for CI do  !!process.env.CI
 TOKEN="" # This is handled programmatically.
+STAGE_OFFLINE_TOKEN="" # Required - shared offline token for qe-ui-inventory stage account (get from team vault)
 
 # Variable required for integration tests
 INTEGRATION="" # When this is true, playwright test will run integration tests directly against stage/prod.


### PR DESCRIPTION
**Jira**
[RHINENG-26262](https://redhat.atlassian.net/browse/RHINENG-26262)

**What**
Switch archive upload auth from Basic auth to SSO Bearer token in Playwright Global Setup.

**Why**
Stage gateway no longer accepts Basic auth for /api/ingress/v1/upload — returns HTTP 401.

**How**
Exchange offline token for access token via SSO refresh_token grant
Use Authorization: Bearer <token> instead of -u user:password
Added STAGE_OFFLINE_TOKEN / PROD_OFFLINE_TOKEN to CI workflows
Added retry logic (3 attempts)

**Testing**
Verified upload returns HTTP 201 locally
All 43 Playwright tests parse, lint passes with 0 errors

**Screenshots/Videos (if applicable)**
N/A

[RHINENG-26262]: https://redhat.atlassian.net/browse/RHINENG-26262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Switch E2E archive upload to use SSO-derived Bearer tokens with retry handling and align supporting configs and docs.

New Features:
- Introduce SSO offline-token exchange helper to obtain short-lived access tokens for archive uploads.

Bug Fixes:
- Replace deprecated Basic auth with Bearer token authentication for Ingress archive uploads in Playwright global setup.

Enhancements:
- Add configurable retry logic with backoff for archive upload failures in E2E tests.
- Document new authentication-related environment variables for running Playwright tests locally.
- Clarify component and hook parameter documentation for inventory application details and workspace edit-access logic.

CI:
- Propagate STAGE_OFFLINE_TOKEN and PROD_OFFLINE_TOKEN secrets into Playwright GitHub Actions workflows for stage and production test runs.