### PR TITLE
feat(SystemsView): revamp of columns

### DIFF
--- a/src/components/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/src/components/ColumnManagementModal/ColumnManagementModal.tsx
@@ -1,0 +1,196 @@
+/**
+ * Vendored from PatternFly `react-component-groups` (ColumnManagementModal).
+ * Source: https://github.com/patternfly/react-component-groups/blob/main/packages/module/src/ColumnManagementModal/ColumnManagementModal.tsx
+ * License: MIT (PatternFly / Red Hat)
+ *
+ * Copied locally for customization; keep in sync with upstream when upgrading PatternFly packages.
+ * ListManager remains imported from `@patternfly/react-component-groups`.
+ */
+import React, { useEffect, useState, type FunctionComponent } from 'react';
+import {
+  Button,
+  Content,
+  ContentVariants,
+  ButtonVariant,
+} from '@patternfly/react-core';
+import {
+  ModalProps,
+  Modal,
+  ModalVariant,
+} from '@patternfly/react-core/deprecated';
+import {
+  ListManager,
+  type ListManagerItem,
+} from '@patternfly/react-component-groups';
+
+export interface ColumnManagementModalColumn {
+  /** Internal identifier of a column by which table displayed columns are filtered. */
+  key: string;
+  /** The actual display name of the column possibly with a tooltip or icon. */
+  title: React.ReactNode;
+  /** If user changes checkboxes, the component will send back column array with this property altered. */
+  isShown?: boolean;
+  /** Set to false if the column should be hidden initially */
+  isShownByDefault: boolean;
+  /** The checkbox will be disabled, this is applicable to columns which should not be toggleable by user */
+  isUntoggleable?: boolean;
+}
+
+/** extends ModalProps */
+export interface ColumnManagementModalProps
+  extends Omit<ModalProps, 'ref' | 'children'> {
+  /** Flag to show the modal */
+  isOpen?: boolean;
+  /** Invoked when modal visibility is changed */
+  onClose?: (event: KeyboardEvent | React.MouseEvent) => void;
+  /** Current column state */
+  appliedColumns: ColumnManagementModalColumn[];
+  /** Invoked with new column state after save button is clicked */
+  applyColumns: (newColumns: ColumnManagementModalColumn[]) => void;
+  /* Modal description text */
+  description?: string;
+  /* Modal title text */
+  title?: string;
+  /** Custom OUIA ID */
+  ouiaId?: string | number;
+  /** Enable drag and drop functionality for reordering columns */
+  enableDragDrop?: boolean;
+}
+
+export const ColumnManagementModal: FunctionComponent<
+  ColumnManagementModalProps
+> = ({
+  title = 'Manage columns',
+  description = 'Selected categories will be displayed in the table.',
+  isOpen = false,
+  onClose = () => undefined,
+  appliedColumns,
+  applyColumns,
+  ouiaId = 'ColumnManagementModal',
+  enableDragDrop = false,
+  ...props
+}: ColumnManagementModalProps) => {
+  const [currentColumns, setCurrentColumns] = useState(() =>
+    appliedColumns.map((column) => ({
+      ...column,
+      isShown: column.isShown ?? column.isShownByDefault,
+    })),
+  );
+
+  // Sync with appliedColumns when they change
+  useEffect(() => {
+    setCurrentColumns(
+      appliedColumns.map((column) => ({
+        ...column,
+        isShown: column.isShown ?? column.isShownByDefault,
+      })),
+    );
+  }, [appliedColumns]);
+
+  // Convert ColumnManagementModalColumn to ListManagerItem
+  const listManagerItems: ListManagerItem[] = currentColumns.map((column) => ({
+    key: column.key,
+    title: column.title,
+    isSelected: column.isShown,
+    isShownByDefault: column.isShownByDefault,
+    isUntoggleable: column.isUntoggleable,
+  }));
+
+  const resetToDefault = () => {
+    setCurrentColumns(
+      currentColumns.map((column) => ({
+        ...column,
+        isShown: column.isShownByDefault ?? false,
+      })),
+    );
+  };
+
+  const updateColumns = (items: ListManagerItem[]) => {
+    const newColumns = currentColumns.map((column) => {
+      const matchingItem = items.find((item) => item.key === column.key);
+      return matchingItem
+        ? {
+            ...column,
+            isShown: matchingItem.isSelected ?? column.isShownByDefault,
+          }
+        : column;
+    });
+    setCurrentColumns(newColumns);
+  };
+
+  const handleSelect = (item: ListManagerItem) => {
+    updateColumns([item]);
+  };
+
+  const handleSelectAll = (items: ListManagerItem[]) => {
+    updateColumns(items);
+  };
+
+  const handleOrderChange = (items: ListManagerItem[]) => {
+    // Update the order of currentColumns based on the new order from ListManager
+    const newColumns = items.map((item) => {
+      const originalColumn = currentColumns.find((col) => col.key === item.key);
+      if (!originalColumn) {
+        throw new Error(`Column with key ${item.key} not found`);
+      }
+      return {
+        ...originalColumn,
+        isShown: item.isSelected ?? originalColumn.isShownByDefault,
+      };
+    });
+    setCurrentColumns(newColumns);
+  };
+
+  const handleSave = (items: ListManagerItem[]) => {
+    const updatedColumns = items.map((item) => ({
+      key: item.key,
+      title: item.title,
+      isShown: item.isSelected,
+      isShownByDefault: item.isShownByDefault,
+      isUntoggleable: item.isUntoggleable,
+    }));
+    applyColumns(updatedColumns);
+    onClose({} as KeyboardEvent);
+  };
+
+  const handleCancel = () => {
+    onClose({} as KeyboardEvent);
+  };
+
+  return (
+    <Modal
+      title={title}
+      onClose={onClose}
+      isOpen={isOpen}
+      variant={ModalVariant.small}
+      description={
+        <>
+          <Content component={ContentVariants.p}>{description}</Content>
+          <Button
+            isInline
+            onClick={resetToDefault}
+            variant={ButtonVariant.link}
+            ouiaId={`${ouiaId}-reset-button`}
+          >
+            Reset to default
+          </Button>
+        </>
+      }
+      ouiaId={ouiaId}
+      {...props}
+    >
+      <ListManager
+        columns={listManagerItems}
+        ouiaId={ouiaId}
+        onSelect={handleSelect}
+        onSelectAll={handleSelectAll}
+        onOrderChange={handleOrderChange}
+        onSave={handleSave}
+        onCancel={handleCancel}
+        enableDragDrop={enableDragDrop}
+      />
+    </Modal>
+  );
+};
+
+export default ColumnManagementModal;

--- a/src/components/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/src/components/ColumnManagementModal/ColumnManagementModal.tsx
@@ -6,7 +6,7 @@
  * Copied locally for customization; keep in sync with upstream when upgrading PatternFly packages.
  * ListManager remains imported from `@patternfly/react-component-groups`.
  */
-import React, { useEffect, useState, type FunctionComponent } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Button,
   Content,
@@ -37,16 +37,17 @@ export interface ColumnManagementModalColumn {
 }
 
 /** extends ModalProps */
-export interface ColumnManagementModalProps
-  extends Omit<ModalProps, 'ref' | 'children'> {
+export interface ColumnManagementModalProps<
+  T extends ColumnManagementModalColumn = ColumnManagementModalColumn,
+> extends Omit<ModalProps, 'ref' | 'children'> {
   /** Flag to show the modal */
   isOpen?: boolean;
   /** Invoked when modal visibility is changed */
   onClose?: (event: KeyboardEvent | React.MouseEvent) => void;
   /** Current column state */
-  appliedColumns: ColumnManagementModalColumn[];
+  appliedColumns: T[];
   /** Invoked with new column state after save button is clicked */
-  applyColumns: (newColumns: ColumnManagementModalColumn[]) => void;
+  applyColumns: (newColumns: T[]) => void;
   /* Modal description text */
   description?: string;
   /* Modal title text */
@@ -57,9 +58,9 @@ export interface ColumnManagementModalProps
   enableDragDrop?: boolean;
 }
 
-export const ColumnManagementModal: FunctionComponent<
-  ColumnManagementModalProps
-> = ({
+export function ColumnManagementModal<
+  T extends ColumnManagementModalColumn = ColumnManagementModalColumn,
+>({
   title = 'Manage columns',
   description = 'Selected categories will be displayed in the table.',
   isOpen = false,
@@ -69,8 +70,8 @@ export const ColumnManagementModal: FunctionComponent<
   ouiaId = 'ColumnManagementModal',
   enableDragDrop = false,
   ...props
-}: ColumnManagementModalProps) => {
-  const [currentColumns, setCurrentColumns] = useState(() =>
+}: ColumnManagementModalProps<T>) {
+  const [currentColumns, setCurrentColumns] = useState<T[]>(() =>
     appliedColumns.map((column) => ({
       ...column,
       isShown: column.isShown ?? column.isShownByDefault,
@@ -142,13 +143,16 @@ export const ColumnManagementModal: FunctionComponent<
   };
 
   const handleSave = (items: ListManagerItem[]) => {
-    const updatedColumns = items.map((item) => ({
-      key: item.key,
-      title: item.title,
-      isShown: item.isSelected,
-      isShownByDefault: item.isShownByDefault,
-      isUntoggleable: item.isUntoggleable,
-    }));
+    const updatedColumns = items.map((item) => {
+      const originalColumn = currentColumns.find((col) => col.key === item.key);
+      if (!originalColumn) {
+        throw new Error(`Column with key ${item.key} not found`);
+      }
+      return {
+        ...originalColumn,
+        isShown: item.isSelected,
+      };
+    });
     applyColumns(updatedColumns);
     onClose({} as KeyboardEvent);
   };
@@ -191,6 +195,6 @@ export const ColumnManagementModal: FunctionComponent<
       />
     </Modal>
   );
-};
+}
 
 export default ColumnManagementModal;

--- a/src/components/ColumnManagementModal/index.ts
+++ b/src/components/ColumnManagementModal/index.ts
@@ -1,0 +1,2 @@
+export * from './ColumnManagementModal';
+export { default } from './ColumnManagementModal';

--- a/src/components/SystemsView/ColumnManagementModalContext.tsx
+++ b/src/components/SystemsView/ColumnManagementModalContext.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react';
-import { Column } from './hooks/useColumns';
+import { RenderableColumn } from './hooks/useColumns';
 import { ColumnManagementModal } from '../ColumnManagementModal';
 
 interface SystemsViewColumnManagementContextValue {
@@ -21,8 +21,8 @@ export const useColumnManagementModalContext = () => {
 
 interface ColumnManagementModalProviderProps {
   children: React.ReactNode;
-  columns: Column[];
-  setColumns: React.Dispatch<React.SetStateAction<Column[]>>;
+  columns: RenderableColumn[];
+  setColumns: React.Dispatch<React.SetStateAction<RenderableColumn[]>>;
 }
 
 export const ColumnManagementModalProvider = ({

--- a/src/components/SystemsView/ColumnManagementModalContext.tsx
+++ b/src/components/SystemsView/ColumnManagementModalContext.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { Column } from './hooks/useColumns';
-import { ColumnManagementModal } from '@patternfly/react-component-groups';
+import { ColumnManagementModal } from '../ColumnManagementModal';
 
 interface SystemsViewColumnManagementContextValue {
   openColumnManagementModal: () => void;

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -120,13 +120,12 @@ const SystemsViewInner = ({
 
   const isInventoryViewsEnabled = useInventoryViewsFeatureFlag();
 
-  const { columns, setColumns, renderableColumns, tableHeaderNodes } =
-    useColumns({
-      sortBy,
-      onSort,
-      direction,
-      isInventoryViewsEnabled,
-    });
+  const { columns, setColumns, tableHeaderNodes } = useColumns({
+    sortBy,
+    onSort,
+    direction,
+    isInventoryViewsEnabled,
+  });
 
   const { data, total, isLoading, isFetching, isError } = useSystemsQuery({
     page: pagination.page,
@@ -141,7 +140,7 @@ const SystemsViewInner = ({
 
   const { rows } = useRows({
     data: hostsWithPermissions ?? data,
-    renderableColumns,
+    columns,
     isInventoryViewsEnabled,
   });
 

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -1,0 +1,9 @@
+import inventoryColumns from './inventory/columnDefinitions';
+
+/**
+ * Default Systems View columns, merged in order from each integrated app.
+ *
+ * To add an app: import its `./<appId>/columnDefinitions` default export and append
+ * with `...thatAppsColumns` (or insert where the column order should appear).
+ */
+export default [...inventoryColumns];

--- a/src/components/SystemsView/columns/inventory/cells/DisplayName.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/DisplayName.test.tsx
@@ -1,0 +1,143 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import DisplayName from './DisplayName';
+import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
+import type { System } from '../../../hooks/useSystemsQuery';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
+
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate',
+);
+
+const mockedUseInsightsNavigate = useInsightsNavigate as jest.MockedFunction<
+  typeof useInsightsNavigate
+>;
+
+const TEST_SYSTEM_ID = 'test-system-id';
+const TEST_DISPLAY_NAME = 'My test system';
+
+const packageBasedSystem = {
+  id: TEST_SYSTEM_ID,
+  display_name: TEST_DISPLAY_NAME,
+  system_profile: {},
+} as System;
+
+const imageBasedSystemBootcDigest = {
+  id: TEST_SYSTEM_ID,
+  display_name: TEST_DISPLAY_NAME,
+  system_profile: {
+    bootc_status: {
+      booted: { image_digest: 'sha256:abc123' },
+    },
+  },
+} as System;
+
+const imageBasedSystemEdge = {
+  id: TEST_SYSTEM_ID,
+  display_name: TEST_DISPLAY_NAME,
+  system_profile: {
+    host_type: 'edge',
+  },
+} as System;
+
+const centosSystem = {
+  id: TEST_SYSTEM_ID,
+  display_name: TEST_DISPLAY_NAME,
+  system_profile: {
+    operating_system: { name: 'CentOS Linux' },
+  },
+} as System;
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  return <span data-testid="current-pathname">{pathname}</span>;
+}
+
+describe('DisplayName cell', () => {
+  beforeEach(() => {
+    mockedUseInsightsNavigate.mockReturnValue(jest.fn());
+  });
+
+  it('should show the display name link', () => {
+    render(
+      <TestWrapper>
+        <DisplayName system={packageBasedSystem} />
+      </TestWrapper>,
+    );
+
+    expect(
+      screen.getByRole('link', { name: TEST_DISPLAY_NAME }),
+    ).toBeInTheDocument();
+  });
+
+  it('should show the package-based system icon', () => {
+    render(
+      <TestWrapper>
+        <DisplayName system={packageBasedSystem} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByLabelText(/package mode icon/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/image mode icon/i)).not.toBeInTheDocument();
+  });
+
+  it('should show the image-based system icon when booted with a bootc image digest', () => {
+    render(
+      <TestWrapper>
+        <DisplayName system={imageBasedSystemBootcDigest} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByLabelText(/image mode icon/i)).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/package mode icon/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show the image-based system icon when host type is edge', () => {
+    render(
+      <TestWrapper>
+        <DisplayName system={imageBasedSystemEdge} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByLabelText(/image mode icon/i)).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/package mode icon/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show ConversionPopover when operating system is CentOS Linux', () => {
+    render(
+      <TestWrapper>
+        <DisplayName system={centosSystem} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText(/convert system to rhel/i)).toBeVisible();
+  });
+
+  it('should navigate to system id when the display name link is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TestWrapper>
+        <>
+          <DisplayName system={packageBasedSystem} />
+          <LocationProbe />
+        </>
+      </TestWrapper>,
+    );
+
+    expect(screen.getByTestId('current-pathname')).toHaveTextContent('/');
+
+    await user.click(screen.getByRole('link', { name: TEST_DISPLAY_NAME }));
+
+    expect(screen.getByTestId('current-pathname')).toHaveTextContent(
+      `/${TEST_SYSTEM_ID}`,
+    );
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/DisplayName.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/DisplayName.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ConversionPopover } from '../../../../InventoryTable/ConversionPopover/ConversionPopover';
+import { Flex, FlexItem, Icon, Popover } from '@patternfly/react-core';
+import { BundleIcon } from '@patternfly/react-icons';
+import FontAwesomeImageIcon from '../../../../FontAwesomeImageIcon';
+import type { System } from '../../../hooks/useSystemsQuery';
+
+const isImageBasedSystem = (system: System) =>
+  system?.system_profile?.bootc_status?.booted?.image_digest ||
+  system?.system_profile?.host_type === 'edge';
+
+const isCentosLinuxSystem = (system: System) =>
+  system?.system_profile?.operating_system?.name === 'CentOS Linux';
+
+interface DisplayNameProps {
+  system: System;
+}
+
+const DisplayName = ({ system }: DisplayNameProps) => {
+  return (
+    <div className="ins-composed-col sentry-mask data-hj-suppress">
+      <div key="data">
+        <Flex gap={{ default: 'gapSm' }}>
+          <FlexItem>
+            {isImageBasedSystem(system) ? (
+              <Popover
+                triggerAction="hover"
+                headerContent="Image-based system"
+                bodyContent={
+                  <div>
+                    Image mode for Red Hat Enterprise Linux is a
+                    container-native approach that uses the same bits but
+                    delivers them as a container image. Updates are immutable
+                    and the experience is very close to running a containerized
+                    application.
+                  </div>
+                }
+              >
+                <Icon aria-label="Image mode icon">
+                  <FontAwesomeImageIcon
+                    fill="var(--pf-t--global--icon--color--subtle)"
+                    margin="0px"
+                  />
+                </Icon>
+              </Popover>
+            ) : (
+              <Popover
+                triggerAction="hover"
+                headerContent="Package-based system"
+                bodyContent={
+                  <div>
+                    Package mode is a familiar RHEL experience across any
+                    footprint where the OS is assembled and updated from rpm
+                    packages. This is traditionally how RHEL is deployed and
+                    will remain the preferred method for many.
+                  </div>
+                }
+              >
+                <Icon aria-label="Package mode icon">
+                  <BundleIcon color="var(--pf-t--global--icon--color--subtle)" />
+                </Icon>
+              </Popover>
+            )}
+          </FlexItem>
+          <FlexItem>
+            <Link to={system.id || ''}>{system.display_name}</Link>
+          </FlexItem>
+          <FlexItem>
+            {isCentosLinuxSystem(system) && <ConversionPopover />}
+          </FlexItem>
+        </Flex>
+      </div>
+    </div>
+  );
+};
+
+export default DisplayName;

--- a/src/components/SystemsView/columns/inventory/cells/LastSeen.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/LastSeen.test.tsx
@@ -1,0 +1,75 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import LastSeen from './LastSeen';
+import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
+import type { System } from '../../../hooks/useSystemsQuery';
+
+const LONG_AGO_LAST_SEEN = '2020-01-01T00:00:00.000Z';
+
+const SYSTEM_ID = 'test-system-id';
+
+const systemWithLongAgoLastCheckIn = {
+  id: SYSTEM_ID,
+  last_check_in: LONG_AGO_LAST_SEEN,
+} as unknown as System;
+
+const systemWithUndefinedLastCheckIn = {
+  id: SYSTEM_ID,
+  last_check_in: undefined,
+} as unknown as System;
+
+const systemWithNullLastCheckIn = {
+  id: SYSTEM_ID,
+  last_check_in: null,
+} as unknown as System;
+
+const systemWithEmptyPerReporterStaleness = {
+  id: SYSTEM_ID,
+  last_check_in: LONG_AGO_LAST_SEEN,
+  per_reporter_staleness: {},
+} as unknown as System;
+
+describe('LastSeen cell', () => {
+  it('should render a relative last seen label for last_check_in', () => {
+    render(
+      <TestWrapper>
+        <LastSeen system={systemWithLongAgoLastCheckIn} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getAllByText(/\d+ years ago/).length).toBeGreaterThan(0);
+  });
+
+  it('should show Invalid date when last_check_in is undefined', () => {
+    render(
+      <TestWrapper>
+        <LastSeen system={systemWithUndefinedLastCheckIn} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getAllByText('Invalid date').length).toBeGreaterThan(0);
+  });
+
+  it('should show Invalid date when last_check_in is null', () => {
+    render(
+      <TestWrapper>
+        <LastSeen system={systemWithNullLastCheckIn} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getAllByText('Invalid date').length).toBeGreaterThan(0);
+  });
+
+  it('should show the disconnected indicator when puptoo is missing from per_reporter_staleness', () => {
+    render(
+      <TestWrapper>
+        <LastSeen system={systemWithEmptyPerReporterStaleness} />
+      </TestWrapper>,
+    );
+
+    expect(
+      screen.getByLabelText(/disconnected indicator/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/LastSeen.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/LastSeen.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { CullingInformation } from '@redhat-cloud-services/frontend-components/CullingInfo';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { verifyCulledReporter } from '../../../../../Utilities/sharedFunctions';
+import InsightsDisconnected from '../../../../../Utilities/InsightsDisconnected';
+import { REPORTER_PUPTOO } from '../../../../../Utilities/constants';
+import { System } from '../../../hooks/useSystemsQuery';
+
+type CullingDate = string | number | Date;
+
+const DEFAULT_CULLING_DATE: CullingDate = new Date(0);
+
+interface LastSeenProps {
+  system: System;
+}
+
+const LastSeen = ({ system }: LastSeenProps) => {
+  const updated = system.last_check_in;
+  const culled = system.culled_timestamp;
+  const staleWarn = system.stale_warning_timestamp;
+  const stale = system.stale_timestamp;
+  const perReporterStaleness = system.per_reporter_staleness;
+
+  const displayDate: string | number | Date =
+    updated === undefined || updated === null ? '' : updated;
+
+  return (
+    <CullingInformation
+      className=""
+      content=""
+      culled={culled ?? DEFAULT_CULLING_DATE}
+      staleWarning={staleWarn ?? DEFAULT_CULLING_DATE}
+      stale={stale ?? DEFAULT_CULLING_DATE}
+      currDate={DEFAULT_CULLING_DATE}
+      render={({ msg }) => (
+        <React.Fragment>
+          <DateFormat
+            date={displayDate}
+            extraTitle={
+              <React.Fragment>
+                <div>{msg}</div>
+                Last seen:{` `}
+              </React.Fragment>
+            }
+          />
+          {verifyCulledReporter(perReporterStaleness, REPORTER_PUPTOO) && (
+            <InsightsDisconnected />
+          )}
+        </React.Fragment>
+      )}
+    >
+      <span>
+        <DateFormat date={displayDate} />
+      </span>
+    </CullingInformation>
+  );
+};
+
+export default LastSeen;

--- a/src/components/SystemsView/columns/inventory/cells/OperatingSystem.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/OperatingSystem.test.tsx
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import OperatingSystem from './OperatingSystem';
+import type { System } from '../../../hooks/useSystemsQuery';
+
+const SYSTEM_ID = 'test-system-id';
+
+const systemWithRhelOs = {
+  id: SYSTEM_ID,
+  system_profile: {
+    operating_system: {
+      name: 'RHEL',
+      major: 8,
+      minor: 10,
+    },
+  },
+} as unknown as System;
+
+const systemWithoutProfile = {
+  id: SYSTEM_ID,
+} as unknown as System;
+
+const systemWithProfileButNoOs = {
+  id: SYSTEM_ID,
+  system_profile: {},
+} as unknown as System;
+
+describe('OperatingSystem cell', () => {
+  it('should show OS version from system_profile.operating_system', () => {
+    render(<OperatingSystem system={systemWithRhelOs} />);
+
+    expect(screen.getByLabelText('Formatted OS version')).toHaveTextContent(
+      'RHEL 8.10',
+    );
+  });
+
+  it('should show Not available when operating system data is missing', () => {
+    const { rerender } = render(
+      <OperatingSystem system={systemWithoutProfile} />,
+    );
+
+    expect(screen.getByLabelText('Formatted OS version')).toHaveTextContent(
+      'Not available',
+    );
+
+    rerender(<OperatingSystem system={systemWithProfileButNoOs} />);
+
+    expect(screen.getByLabelText('Formatted OS version')).toHaveTextContent(
+      'Not available',
+    );
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/OperatingSystem.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/OperatingSystem.test.tsx
@@ -17,6 +17,17 @@ const systemWithRhelOs = {
   },
 } as unknown as System;
 
+const systemWithCentosOs = {
+  id: SYSTEM_ID,
+  system_profile: {
+    operating_system: {
+      name: 'CentOS Linux',
+      major: 7,
+      minor: 4,
+    },
+  },
+} as unknown as System;
+
 const systemWithoutProfile = {
   id: SYSTEM_ID,
 } as unknown as System;
@@ -32,6 +43,14 @@ describe('OperatingSystem cell', () => {
 
     expect(screen.getByLabelText('Formatted OS version')).toHaveTextContent(
       'RHEL 8.10',
+    );
+  });
+
+  it('should show CentOS Linux OS version from system_profile.operating_system', () => {
+    render(<OperatingSystem system={systemWithCentosOs} />);
+
+    expect(screen.getByLabelText('Formatted OS version')).toHaveTextContent(
+      'CentOS Linux 7.4',
     );
   });
 

--- a/src/components/SystemsView/columns/inventory/cells/OperatingSystem.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/OperatingSystem.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import OperatingSystemFormatter from '../../../../../Utilities/OperatingSystemFormatter';
+import { System } from '../../../hooks/useSystemsQuery';
+
+interface OperatingSystemProps {
+  system: System;
+}
+
+const OperatingSystem = ({ system }: OperatingSystemProps) => (
+  <OperatingSystemFormatter
+    operatingSystem={system.system_profile?.operating_system}
+  />
+);
+
+export default OperatingSystem;

--- a/src/components/SystemsView/columns/inventory/cells/Tags.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Tags.test.tsx
@@ -1,0 +1,83 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import Tags from './Tags';
+import { SystemActionModalsContext } from '../../../SystemActionModalsContext';
+import type { System } from '../../../hooks/useSystemsQuery';
+
+const SYSTEM_ID = 'test-system-id';
+
+const mockOpenTagsModal = jest.fn();
+
+const mockContextValue = {
+  openDeleteModal: jest.fn(),
+  openAddToWorkspaceModal: jest.fn(),
+  openRemoveFromWorkspaceModal: jest.fn(),
+  openEditModal: jest.fn(),
+  openTagsModal: mockOpenTagsModal,
+};
+
+function renderTags(system: System) {
+  return render(
+    <SystemActionModalsContext.Provider value={mockContextValue}>
+      <Tags system={system} />
+    </SystemActionModalsContext.Provider>,
+  );
+}
+
+const systemWithTags = {
+  id: SYSTEM_ID,
+  tags: [{ namespace: 'a', key: 'k', value: 'v' }],
+} as unknown as System;
+
+const systemWithoutTags = {
+  id: SYSTEM_ID,
+} as unknown as System;
+
+const systemWithEmptyTags = {
+  id: SYSTEM_ID,
+  tags: [],
+} as unknown as System;
+
+describe('Tags cell', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show tag count from system.tags length', () => {
+    renderTags(systemWithTags);
+
+    expect(
+      screen.getByRole('button', { name: /tag count/i }),
+    ).toHaveTextContent('1');
+  });
+
+  it('should show zero when tags are missing or empty', () => {
+    const { rerender } = renderTags(systemWithoutTags);
+
+    expect(
+      screen.getByRole('button', { name: /tag count/i }),
+    ).toHaveTextContent('0');
+
+    rerender(
+      <SystemActionModalsContext.Provider value={mockContextValue}>
+        <Tags system={systemWithEmptyTags} />
+      </SystemActionModalsContext.Provider>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /tag count/i }),
+    ).toHaveTextContent('0');
+  });
+
+  it('should call openTagsModal with the system when tag count is clicked', async () => {
+    const user = userEvent.setup();
+    renderTags(systemWithTags);
+
+    await user.click(screen.getByRole('button', { name: /tag count/i }));
+
+    expect(mockOpenTagsModal).toHaveBeenCalledTimes(1);
+    expect(mockOpenTagsModal).toHaveBeenCalledWith([systemWithTags]);
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/Tags.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Tags.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TagCount } from '@redhat-cloud-services/frontend-components/TagCount';
-import { useSystemActionModalsContext } from './SystemActionModalsContext';
-import { System } from './hooks/useSystemsQuery';
+import { useSystemActionModalsContext } from '../../../SystemActionModalsContext';
+import { System } from '../../../hooks/useSystemsQuery';
 
 interface TagsProps {
   system: System;

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.test.tsx
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Workspace from './Workspace';
+import { UNGROUPED_ID } from '../../../filters/WorkspaceFilter';
+import type { System } from '../../../hooks/useSystemsQuery';
+
+const SYSTEM_ID = 'test-system-id';
+
+const systemWithoutGroups = {
+  id: SYSTEM_ID,
+} as unknown as System;
+
+const systemWithEmptyGroups = {
+  id: SYSTEM_ID,
+  groups: [],
+} as unknown as System;
+
+const systemWithNamedWorkspace = {
+  id: SYSTEM_ID,
+  groups: [{ name: 'Production' }],
+} as unknown as System;
+
+const systemWithUngroupedFlag = {
+  id: SYSTEM_ID,
+  groups: [{ ungrouped: true }],
+} as unknown as System;
+
+describe('Workspace cell', () => {
+  it('should show the first workspace name when present', () => {
+    render(<Workspace system={systemWithNamedWorkspace} />);
+
+    expect(screen.getByText('Production')).toBeInTheDocument();
+  });
+
+  it('should show ungrouped label when system has no groups', () => {
+    const { rerender } = render(<Workspace system={systemWithoutGroups} />);
+
+    expect(screen.getByText(UNGROUPED_ID)).toBeInTheDocument();
+
+    rerender(<Workspace system={systemWithEmptyGroups} />);
+
+    expect(screen.getByText(UNGROUPED_ID)).toBeInTheDocument();
+  });
+
+  it('should show ungrouped label when first group is ungrouped', () => {
+    render(<Workspace system={systemWithUngroupedFlag} />);
+
+    expect(screen.getByText(UNGROUPED_ID)).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.test.tsx
@@ -7,23 +7,9 @@ import type { System } from '../../../hooks/useSystemsQuery';
 
 const SYSTEM_ID = 'test-system-id';
 
-const systemWithoutGroups = {
-  id: SYSTEM_ID,
-} as unknown as System;
-
-const systemWithEmptyGroups = {
-  id: SYSTEM_ID,
-  groups: [],
-} as unknown as System;
-
 const systemWithNamedWorkspace = {
   id: SYSTEM_ID,
   groups: [{ name: 'Production' }],
-} as unknown as System;
-
-const systemWithUngroupedFlag = {
-  id: SYSTEM_ID,
-  groups: [{ ungrouped: true }],
 } as unknown as System;
 
 describe('Workspace cell', () => {
@@ -31,21 +17,5 @@ describe('Workspace cell', () => {
     render(<Workspace system={systemWithNamedWorkspace} />);
 
     expect(screen.getByText('Production')).toBeInTheDocument();
-  });
-
-  it('should show ungrouped label when system has no groups', () => {
-    const { rerender } = render(<Workspace system={systemWithoutGroups} />);
-
-    expect(screen.getByText(UNGROUPED_ID)).toBeInTheDocument();
-
-    rerender(<Workspace system={systemWithEmptyGroups} />);
-
-    expect(screen.getByText(UNGROUPED_ID)).toBeInTheDocument();
-  });
-
-  it('should show ungrouped label when first group is ungrouped', () => {
-    render(<Workspace system={systemWithUngroupedFlag} />);
-
-    expect(screen.getByText(UNGROUPED_ID)).toBeInTheDocument();
   });
 });

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
@@ -1,0 +1,18 @@
+import { UNGROUPED_ID } from '../../../filters/WorkspaceFilter';
+import { System } from '../../../hooks/useSystemsQuery';
+
+interface WorkspaceProps {
+  system: System;
+}
+
+const Workspace = ({ system }: WorkspaceProps) => {
+  const [firstGroup] = system.groups ?? [];
+
+  if (firstGroup === undefined) {
+    return UNGROUPED_ID;
+  }
+
+  return firstGroup.name ?? (firstGroup.ungrouped ? UNGROUPED_ID : '');
+};
+
+export default Workspace;

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
@@ -1,3 +1,4 @@
+import { NOT_AVAILABLE } from '../../../../../constants';
 import { UNGROUPED_ID } from '../../../filters/WorkspaceFilter';
 import { System } from '../../../hooks/useSystemsQuery';
 
@@ -9,10 +10,12 @@ const Workspace = ({ system }: WorkspaceProps) => {
   const [firstGroup] = system.groups ?? [];
 
   if (firstGroup === undefined) {
-    return UNGROUPED_ID;
+    return NOT_AVAILABLE;
   }
 
-  return firstGroup.name ?? (firstGroup.ungrouped ? UNGROUPED_ID : '');
+  return (
+    firstGroup.name ?? (firstGroup.ungrouped ? UNGROUPED_ID : NOT_AVAILABLE)
+  );
 };
 
 export default Workspace;

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { type RenderableColumn } from '../../hooks/useColumns';
+import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
+import DisplayName from './cells/DisplayName';
+import Workspace from './cells/Workspace';
+import LastSeen from './cells/LastSeen';
+import OperatingSystem from './cells/OperatingSystem';
+import Tags from './cells/Tags';
+import { LastSeenColumnHeader } from '../../../../Utilities/LastSeenColumnHeader';
+import { System } from '../../hooks/useSystemsQuery';
+
+export const INITIAL_COLUMNS: RenderableColumn[] = [
+  {
+    title: 'Name',
+    key: 'name',
+    isShownByDefault: true,
+    isShown: true,
+    isUntoggleable: true,
+    sortBy: ApiOrderByEnum.DisplayName,
+    renderCell: (system: System) => (
+      <DisplayName key={`name-${system.id}`} system={system} />
+    ),
+  },
+  {
+    title: 'Workspace',
+    key: 'workspace',
+    isShownByDefault: true,
+    isShown: true,
+    sortBy: ApiOrderByEnum.GroupName,
+    renderCell: (system: System) => (
+      <Workspace key={`workspace-${system.id}`} system={system} />
+    ),
+  },
+  {
+    title: 'Tags',
+    key: 'tags',
+    isShownByDefault: true,
+    isShown: true,
+    renderCell: (system: System) => (
+      <Tags key={`tags-${system.id}`} system={system} />
+    ),
+  },
+  {
+    title: 'OS',
+    key: 'os',
+    isShownByDefault: true,
+    isShown: true,
+    sortBy: ApiOrderByEnum.OperatingSystem,
+    renderCell: (system: System) => (
+      <OperatingSystem key={`os-${system.id}`} system={system} />
+    ),
+  },
+  {
+    title: <LastSeenColumnHeader />,
+    key: 'last_seen',
+    isShownByDefault: true,
+    isShown: true,
+    sortBy: ApiOrderByEnum.LastCheckIn,
+    renderCell: (system: System) => (
+      <LastSeen key={`lastseen-${system.id}`} system={system} />
+    ),
+  },
+];

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -9,55 +9,65 @@ import Tags from './cells/Tags';
 import { LastSeenColumnHeader } from '../../../../Utilities/LastSeenColumnHeader';
 import { System } from '../../hooks/useSystemsQuery';
 
-export const INITIAL_COLUMNS: RenderableColumn[] = [
-  {
-    title: 'Name',
-    key: 'name',
-    isShownByDefault: true,
-    isShown: true,
-    isUntoggleable: true,
-    sortBy: ApiOrderByEnum.DisplayName,
-    renderCell: (system: System) => (
-      <DisplayName key={`name-${system.id}`} system={system} />
-    ),
-  },
-  {
-    title: 'Workspace',
-    key: 'workspace',
-    isShownByDefault: true,
-    isShown: true,
-    sortBy: ApiOrderByEnum.GroupName,
-    renderCell: (system: System) => (
-      <Workspace key={`workspace-${system.id}`} system={system} />
-    ),
-  },
-  {
-    title: 'Tags',
-    key: 'tags',
-    isShownByDefault: true,
-    isShown: true,
-    renderCell: (system: System) => (
-      <Tags key={`tags-${system.id}`} system={system} />
-    ),
-  },
-  {
-    title: 'OS',
-    key: 'os',
-    isShownByDefault: true,
-    isShown: true,
-    sortBy: ApiOrderByEnum.OperatingSystem,
-    renderCell: (system: System) => (
-      <OperatingSystem key={`os-${system.id}`} system={system} />
-    ),
-  },
-  {
-    title: <LastSeenColumnHeader />,
-    key: 'last_seen',
-    isShownByDefault: true,
-    isShown: true,
-    sortBy: ApiOrderByEnum.LastCheckIn,
-    renderCell: (system: System) => (
-      <LastSeen key={`lastseen-${system.id}`} system={system} />
-    ),
-  },
+const nameColumn: RenderableColumn = {
+  title: 'Name',
+  key: 'name',
+  isShownByDefault: true,
+  isShown: true,
+  isUntoggleable: true,
+  sortBy: ApiOrderByEnum.DisplayName,
+  renderCell: (system: System) => (
+    <DisplayName key={`name-${system.id}`} system={system} />
+  ),
+};
+
+const workspaceColumn: RenderableColumn = {
+  title: 'Workspace',
+  key: 'workspace',
+  isShownByDefault: true,
+  isShown: true,
+  sortBy: ApiOrderByEnum.GroupName,
+  renderCell: (system: System) => (
+    <Workspace key={`workspace-${system.id}`} system={system} />
+  ),
+};
+
+const tagsColumn: RenderableColumn = {
+  title: 'Tags',
+  key: 'tags',
+  isShownByDefault: true,
+  isShown: true,
+  renderCell: (system: System) => (
+    <Tags key={`tags-${system.id}`} system={system} />
+  ),
+};
+
+const operatingSystemColumn: RenderableColumn = {
+  title: 'OS',
+  key: 'os',
+  isShownByDefault: true,
+  isShown: true,
+  sortBy: ApiOrderByEnum.OperatingSystem,
+  renderCell: (system: System) => (
+    <OperatingSystem key={`os-${system.id}`} system={system} />
+  ),
+};
+
+const lastSeenColumn: RenderableColumn = {
+  title: <LastSeenColumnHeader />,
+  key: 'last_seen',
+  isShownByDefault: true,
+  isShown: true,
+  sortBy: ApiOrderByEnum.LastCheckIn,
+  renderCell: (system: System) => (
+    <LastSeen key={`lastseen-${system.id}`} system={system} />
+  ),
+};
+
+export default [
+  nameColumn,
+  workspaceColumn,
+  tagsColumn,
+  operatingSystemColumn,
+  lastSeenColumn,
 ];

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -1,19 +1,14 @@
+import React from 'react';
 import { DataViewTh } from '@patternfly/react-data-view';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import type { ColumnManagementModalColumn } from '../../ColumnManagementModal';
-import DisplayName from '../../../routes/Systems/components/SystemsTable/components/columns/DisplayName';
-import React from 'react';
-import Workspace from '../../../routes/Systems/components/SystemsTable/components/columns/Workspace';
-import LastSeen from '../../../routes/Systems/components/SystemsTable/components/columns/LastSeen';
-import OperatingSystem from '../../../routes/Systems/components/SystemsTable/components/columns/OperatingSystem';
 import { System } from './useSystemsQuery';
 import type { onSort, SortBy, SortDirection } from '../SystemsView';
-import Tags from '../Tags';
-import { LastSeenColumnHeader } from '../../../Utilities/LastSeenColumnHeader';
 import { getSystemsViewColumnMinWidthStyle } from '../utils/columnMinWidths';
 import { STICKY_ACTIONS_HEADER_PROPS } from '../utils/stickyActionsColumn';
 import { STICKY_NAME_HEADER_PROPS } from '../utils/stickyNameColumn';
+import { INITIAL_COLUMNS } from '../columns/inventory/columnDefinitions';
 
 export interface RenderableColumn extends ColumnManagementModalColumn {
   renderCell: (system: System) => React.ReactNode;
@@ -24,74 +19,6 @@ const FALLBACK_SORT: { sortBy: SortBy; direction: SortDirection } = {
   sortBy: ApiOrderByEnum.DisplayName,
   direction: 'asc',
 };
-
-const INITIAL_COLUMNS: RenderableColumn[] = [
-  {
-    title: 'Name',
-    key: 'name',
-    isShownByDefault: true,
-    isShown: true,
-    isUntoggleable: true,
-    sortBy: ApiOrderByEnum.DisplayName,
-    renderCell: (system: System) => (
-      <DisplayName
-        key={`name-${system.id}`}
-        id={system.id}
-        props={{}}
-        {...system}
-      />
-    ),
-  },
-  {
-    title: 'Workspace',
-    key: 'workspace',
-    isShownByDefault: true,
-    isShown: true,
-    sortBy: ApiOrderByEnum.GroupName,
-    renderCell: (system: System) => (
-      <Workspace key={`workspace-${system.id}`} groups={system.groups} />
-    ),
-  },
-  {
-    title: 'Tags',
-    key: 'tags',
-    isShownByDefault: true,
-    isShown: true,
-    renderCell: (system: System) => (
-      <Tags key={`tags-${system.id}`} system={system} />
-    ),
-  },
-  {
-    title: 'OS',
-    key: 'os',
-    isShownByDefault: true,
-    isShown: true,
-    sortBy: ApiOrderByEnum.OperatingSystem,
-    renderCell: (system: System) => (
-      <OperatingSystem
-        key={`os-${system.id}`}
-        system_profile={system.system_profile}
-      />
-    ),
-  },
-  {
-    title: <LastSeenColumnHeader />,
-    key: 'last_seen',
-    isShownByDefault: true,
-    isShown: true,
-    sortBy: ApiOrderByEnum.LastCheckIn,
-    renderCell: (system: System) => (
-      <LastSeen
-        key={`lastseen-${system.id}`}
-        updated={system.last_check_in}
-        culled_timestamp={system?.culled_timestamp}
-        stale_warning_timestamp={system?.stale_warning_timestamp}
-        stale_timestamp={system?.stale_timestamp}
-        per_reporter_staleness={system?.per_reporter_staleness}
-      />
-    ),
-  },
-];
 
 interface UseColumnParams {
   sortBy: SortBy;

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -8,7 +8,7 @@ import type { onSort, SortBy, SortDirection } from '../SystemsView';
 import { getSystemsViewColumnMinWidthStyle } from '../utils/columnMinWidths';
 import { STICKY_ACTIONS_HEADER_PROPS } from '../utils/stickyActionsColumn';
 import { STICKY_NAME_HEADER_PROPS } from '../utils/stickyNameColumn';
-import { INITIAL_COLUMNS } from '../columns/inventory/columnDefinitions';
+import initialColumns from '../columns/allColumnDefinitions';
 
 export interface RenderableColumn extends ColumnManagementModalColumn {
   renderCell: (system: System) => React.ReactNode;
@@ -33,7 +33,7 @@ export const useColumns = ({
   direction,
   isInventoryViewsEnabled,
 }: UseColumnParams) => {
-  const [columns, setColumns] = useState<RenderableColumn[]>(INITIAL_COLUMNS);
+  const [columns, setColumns] = useState<RenderableColumn[]>(initialColumns);
 
   const fromSortByToIndex = useCallback(
     (sortBy?: ApiOrderByEnum) =>

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -1,7 +1,7 @@
 import { DataViewTh } from '@patternfly/react-data-view';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
-import { ColumnManagementModalColumn } from '@patternfly/react-component-groups';
+import type { ColumnManagementModalColumn } from '../../ColumnManagementModal';
 import DisplayName from '../../../routes/Systems/components/SystemsTable/components/columns/DisplayName';
 import React from 'react';
 import Workspace from '../../../routes/Systems/components/SystemsTable/components/columns/Workspace';

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -26,43 +26,15 @@ const FALLBACK_SORT: { sortBy: SortBy; direction: SortDirection } = {
   direction: 'asc',
 };
 
-const INITIAL_COLUMNS: Column[] = [
+const INITIAL_COLUMNS: RenderableColumn[] = [
   {
     title: 'Name',
     key: 'name',
     isShownByDefault: true,
     isShown: true,
     isUntoggleable: true,
-  },
-  {
-    title: 'Workspace',
-    key: 'workspace',
-    isShownByDefault: true,
-    isShown: true,
-  },
-  {
-    title: 'Tags',
-    key: 'tags',
-    isShownByDefault: true,
-    isShown: true,
-  },
-  {
-    title: 'OS',
-    key: 'os',
-    isShownByDefault: true,
-    isShown: true,
-  },
-  {
-    title: <LastSeenColumnHeader />,
-    key: 'last_seen',
-    isShownByDefault: true,
-    isShown: true,
-  },
-];
-
-const COLUMN_RENDER_CELLS: Record<string, (system: System) => React.ReactNode> =
-  {
-    name: (system: System) => (
+    sortBy: ApiOrderByEnum.DisplayName,
+    renderCell: (system: System) => (
       <DisplayName
         key={`name-${system.id}`}
         id={system.id}
@@ -70,19 +42,46 @@ const COLUMN_RENDER_CELLS: Record<string, (system: System) => React.ReactNode> =
         {...system}
       />
     ),
-    workspace: (system: System) => (
+  },
+  {
+    title: 'Workspace',
+    key: 'workspace',
+    isShownByDefault: true,
+    isShown: true,
+    sortBy: ApiOrderByEnum.GroupName,
+    renderCell: (system: System) => (
       <Workspace key={`workspace-${system.id}`} groups={system.groups} />
     ),
-    tags: (system: System) => (
+  },
+  {
+    title: 'Tags',
+    key: 'tags',
+    isShownByDefault: true,
+    isShown: true,
+    renderCell: (system: System) => (
       <Tags key={`tags-${system.id}`} system={system} />
     ),
-    os: (system: System) => (
+  },
+  {
+    title: 'OS',
+    key: 'os',
+    isShownByDefault: true,
+    isShown: true,
+    sortBy: ApiOrderByEnum.OperatingSystem,
+    renderCell: (system: System) => (
       <OperatingSystem
         key={`os-${system.id}`}
         system_profile={system.system_profile}
       />
     ),
-    last_seen: (system: System) => (
+  },
+  {
+    title: <LastSeenColumnHeader />,
+    key: 'last_seen',
+    isShownByDefault: true,
+    isShown: true,
+    sortBy: ApiOrderByEnum.LastCheckIn,
+    renderCell: (system: System) => (
       <LastSeen
         key={`lastseen-${system.id}`}
         updated={system.last_check_in}
@@ -92,15 +91,13 @@ const COLUMN_RENDER_CELLS: Record<string, (system: System) => React.ReactNode> =
         per_reporter_staleness={system?.per_reporter_staleness}
       />
     ),
-  };
+  },
+];
 
-const COLUMN_SORT_BY: Record<string, ApiOrderByEnum | undefined> = {
-  name: ApiOrderByEnum.DisplayName,
-  workspace: ApiOrderByEnum.GroupName,
-  tags: undefined,
-  os: ApiOrderByEnum.OperatingSystem,
-  last_seen: ApiOrderByEnum.LastCheckIn,
-};
+function toManagementColumn(col: RenderableColumn): Column {
+  const { renderCell: _renderCell, sortBy: _sortBy, ...rest } = col;
+  return rest;
+}
 
 interface UseColumnParams {
   sortBy: SortBy;
@@ -119,15 +116,22 @@ export const useColumns = ({
   direction,
   isInventoryViewsEnabled,
 }: UseColumnParams) => {
-  const [columns, setColumns] = useState<Column[]>(INITIAL_COLUMNS);
+  const [columns, setColumns] = useState<Column[]>(() =>
+    INITIAL_COLUMNS.map(toManagementColumn),
+  );
 
-  const renderableColumns: RenderableColumn[] = useMemo(() => {
-    return columns.map((col) => ({
-      ...col,
-      renderCell: COLUMN_RENDER_CELLS[col.key] || (() => null),
-      sortBy: COLUMN_SORT_BY[col.key],
-    }));
-  }, [columns]);
+  const renderableColumns: RenderableColumn[] = useMemo(
+    () =>
+      columns.map((col) => {
+        const template = INITIAL_COLUMNS.find((c) => c.key === col.key);
+        return {
+          ...col,
+          renderCell: template?.renderCell ?? (() => null),
+          sortBy: template?.sortBy,
+        };
+      }),
+    [columns],
+  );
 
   const fromSortByToIndex = useCallback(
     (sortBy?: ApiOrderByEnum) =>

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -33,7 +33,9 @@ export const useColumns = ({
   direction,
   isInventoryViewsEnabled,
 }: UseColumnParams) => {
-  const [columns, setColumns] = useState<RenderableColumn[]>(initialColumns);
+  const [columns, setColumns] = useState<RenderableColumn[]>(() =>
+    initialColumns.map((col) => ({ ...col })),
+  );
 
   const fromSortByToIndex = useCallback(
     (sortBy?: ApiOrderByEnum) =>

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -15,8 +15,7 @@ import { getSystemsViewColumnMinWidthStyle } from '../utils/columnMinWidths';
 import { STICKY_ACTIONS_HEADER_PROPS } from '../utils/stickyActionsColumn';
 import { STICKY_NAME_HEADER_PROPS } from '../utils/stickyNameColumn';
 
-export interface Column extends ColumnManagementModalColumn {}
-export interface RenderableColumn extends Column {
+export interface RenderableColumn extends ColumnManagementModalColumn {
   renderCell: (system: System) => React.ReactNode;
   sortBy?: ApiOrderByEnum;
 }
@@ -94,19 +93,10 @@ const INITIAL_COLUMNS: RenderableColumn[] = [
   },
 ];
 
-function toManagementColumn(col: RenderableColumn): Column {
-  const { renderCell: _renderCell, sortBy: _sortBy, ...rest } = col;
-  return rest;
-}
-
 interface UseColumnParams {
   sortBy: SortBy;
   onSort: onSort;
   direction: SortDirection;
-  /**
-   * When true (inventory views feature): sticky Name/actions columns, column min-widths,
-   * and horizontal scroll layout (see SystemsView).
-   */
   isInventoryViewsEnabled: boolean;
 }
 
@@ -116,34 +106,19 @@ export const useColumns = ({
   direction,
   isInventoryViewsEnabled,
 }: UseColumnParams) => {
-  const [columns, setColumns] = useState<Column[]>(() =>
-    INITIAL_COLUMNS.map(toManagementColumn),
-  );
-
-  const renderableColumns: RenderableColumn[] = useMemo(
-    () =>
-      columns.map((col) => {
-        const template = INITIAL_COLUMNS.find((c) => c.key === col.key);
-        return {
-          ...col,
-          renderCell: template?.renderCell ?? (() => null),
-          sortBy: template?.sortBy,
-        };
-      }),
-    [columns],
-  );
+  const [columns, setColumns] = useState<RenderableColumn[]>(INITIAL_COLUMNS);
 
   const fromSortByToIndex = useCallback(
     (sortBy?: ApiOrderByEnum) =>
-      renderableColumns
+      columns
         .filter((col) => col.isShown)
         .findIndex((col) => col.sortBy === sortBy),
-    [renderableColumns],
+    [columns],
   );
 
   const tableHeaderNodes: DataViewTh[] = useMemo(
     () => [
-      ...renderableColumns
+      ...columns
         .filter((col) => col.isShown)
         .map((col, index) => {
           return {
@@ -184,7 +159,7 @@ export const useColumns = ({
       },
     ],
     [
-      renderableColumns,
+      columns,
       fromSortByToIndex,
       sortBy,
       direction,
@@ -195,7 +170,7 @@ export const useColumns = ({
 
   useEffect(() => {
     if (sortBy) {
-      const isSortColumnVisible = renderableColumns.some(
+      const isSortColumnVisible = columns.some(
         (col) => col.sortBy === sortBy && col.isShown,
       );
 
@@ -208,7 +183,6 @@ export const useColumns = ({
   return {
     columns,
     setColumns,
-    renderableColumns,
     tableHeaderNodes,
   };
 };

--- a/src/components/SystemsView/hooks/useRows.tsx
+++ b/src/components/SystemsView/hooks/useRows.tsx
@@ -15,7 +15,7 @@ export type SystemsViewTableRow = DataViewTrObject & {
 
 interface UseRowsParams {
   data?: (System | SystemWithPermissions)[];
-  renderableColumns: RenderableColumn[];
+  columns: RenderableColumn[];
   /**
    * When true (inventory views feature): sticky Name/actions cells and column min-widths.
    */
@@ -28,13 +28,13 @@ interface UseRowsReturnValue {
 
 export const useRows = ({
   data,
-  renderableColumns,
+  columns,
   isInventoryViewsEnabled,
 }: UseRowsParams): UseRowsReturnValue => {
   const mapSystemToRow = (
     system: System | SystemWithPermissions,
   ): SystemsViewTableRow => {
-    const selectableColumnCells = renderableColumns
+    const selectableColumnCells = columns
       .filter((col) => col.isShown)
       .map((col) => {
         const cell = col.renderCell(system);

--- a/src/components/SystemsView/utils/columnMinWidths.ts
+++ b/src/components/SystemsView/utils/columnMinWidths.ts
@@ -5,8 +5,9 @@ import type { CSSProperties } from 'react';
  * When the inventory views feature flag is on and combined minimum widths exceed the scroll
  * container, {@link ../SystemsView.tsx InnerScrollContainer} shows horizontal scroll.
  *
- * **Where to edit:** add or change entries keyed by `Column.key` from
- * `INITIAL_COLUMNS` in {@link ../hooks/useColumns.tsx useColumns.tsx}.
+ * **Where to edit:** add or change entries keyed by `Column.key` for each column
+ * listed in {@link ../columns/allColumnDefinitions.ts allColumnDefinitions.ts}
+ * (and the per-app `columnDefinitions` modules it pulls in).
  * New columns should get an entry here once you know how wide they need to be.
  *
  * The Name column width is also read by {@link ./stickyNameColumn.ts} for

--- a/src/constants.js
+++ b/src/constants.js
@@ -371,3 +371,4 @@ export const HOST_WORKSPACE_RELATION_VIEW = 'inventory_host_view';
 export const HOST_WORKSPACE_RELATION_UPDATE = 'inventory_host_update';
 export const DEFAULT_DELETE_ERROR_MESSAGE =
   'There was an error processing the request. Please try again.';
+export const NOT_AVAILABLE = 'N/A';


### PR DESCRIPTION
## Jira
first part of RHINENG-26074

## What
This PR does few things:

#### Simplifies useColumns by consolidating column structures into one
- This was achieved by patching Patternfly ColumnManagementModal which can now work with our RenderableColumn type by default

#### Major refactor of Inventory Column Cells
- we use our own copies of column cells, this help us remove SystemsTable later on
- every Cell componets was cleaned & transformed to Typescript
- every Cell component was covered by unit tests
- fixes Bug in Name column where we didn't suggest upgrade from CentOS

#### Creates wiring for adding App based columns
- established pattern and folder structure allow us adding column simultaneously

## Why
This is to prepare SystemsView column for major extension. It should be posibble introduce columns in paralel without unnecessary merge conflicts. It was also needed because since POC we didn't really address tech debt on table cells.

## Testing
1. localStorage.setItem("ui.inventory-views","true") in console (in order to see column management modal)
2. Visit SystemsView in Inventory, try to paginate and observe whether old table cells behave the same. 
3. Open column management modal and make sure it works

## Summary by Sourcery

Revamp SystemsView table column handling to use a unified, renderable column definition model and prepare for per-app column extensions.

New Features:
- Introduce a local, customizable ColumnManagementModal compatible with SystemsView renderable columns.
- Define inventory-specific column definitions for SystemsView as a composable list to enable future app-based column sets.

Enhancements:
- Refactor SystemsView to consume a single RenderableColumn model for both rendering and management instead of separate base and derived column structures.
- Extract inventory table cell renderers (display name, workspace, OS, last seen, tags) into dedicated TypeScript components under the SystemsView columns namespace.
- Adjust SystemsView hooks and utilities to use the new column definition registry and updated type contracts.

Tests:
- Add unit tests for DisplayName, Workspace, OperatingSystem, LastSeen, and Tags cell components in SystemsView.