### PR TITLE
Add fixes for workspace tests

### DIFF
--- a/_playwright-tests/helpers/workspaceHelpers.ts
+++ b/_playwright-tests/helpers/workspaceHelpers.ts
@@ -52,6 +52,11 @@ export type WaitForWorkspaceDetailOptions = {
  * Waits until workspace details main UI is ready (Systems tab visible).
  * Optionally waits until the header Actions toggle is enabled.
  *
+ * When `waitForEditableHeader` is true, the function retries with page
+ * reloads because RBAC/Kessel permissions for a newly created workspace
+ * may not have propagated by the time the detail page first loads,
+ * leaving the Actions toggle disabled.
+ *
  *  @param page    - Playwright page on workspace details
  *  @param options - When `waitForEditableHeader` is true, waits for `#group-dropdown-toggle` to be enabled
  *  @returns       Resolves when ready conditions are met
@@ -64,9 +69,15 @@ export const waitForWorkspaceDetailPageReady = async (
     timeout: 120000,
   });
   if (options?.waitForEditableHeader) {
-    await expect(workspaceHeaderActionsToggle(page)).toBeEnabled({
-      timeout: 120000,
-    });
+    await expect(async () => {
+      await page.reload({ waitUntil: 'load' });
+      await expect(page.getByRole('tab', { name: 'Systems' })).toBeVisible({
+        timeout: 30000,
+      });
+      await expect(workspaceHeaderActionsToggle(page)).toBeEnabled({
+        timeout: 10000,
+      });
+    }).toPass({ timeout: 120000 });
   }
 };
 

--- a/_playwright-tests/test_navigation.test.ts
+++ b/_playwright-tests/test_navigation.test.ts
@@ -4,7 +4,9 @@ import { test } from './helpers/fixtures';
 test.describe('Navigate to Inventory pages via side Navigation bar', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/insights/inventory/');
-    await page.locator('[data-quickstart-id="Inventory"]').isVisible();
+    await expect(page.locator('[data-quickstart-id="Inventory"]')).toBeVisible({
+      timeout: 30000,
+    });
   });
 
   test('Use can navigate to Staleness and Deletion page', async ({ page }) => {
@@ -13,8 +15,9 @@ test.describe('Navigate to Inventory pages via side Navigation bar', () => {
     const stalenessLink = page.locator(
       '[data-quickstart-id="insights_inventory_staleness-and-deletion"]',
     );
+    await expect(stalenessLink).toBeVisible({ timeout: 10000 });
     await stalenessLink.click();
-    await expect(page).toHaveURL(new RegExp(expectedURL));
+    await expect(page).toHaveURL(new RegExp(expectedURL), { timeout: 15000 });
   });
 
   test('Use can navigate to Inventory Systems page', async ({ page }) => {

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -234,7 +234,7 @@ test('User can create, rename and delete a workspace from Workspaces page', asyn
    */
   const workspaceName = await generateUniqueWorkspaceName();
   const renamedWorkspace = `${workspaceName}_Renamed`;
-  const dialogModal = page.locator('[data-ouia-component-id="group-modal"]');
+  const dialogModal = page.locator('[role="dialog"]');
   const nameCell = page.locator('td[data-label="Name"]');
 
   await test.step('Test setup: navigate to Workspaces page, create workspace to work with', async () => {
@@ -247,22 +247,24 @@ test('User can create, rename and delete a workspace from Workspaces page', asyn
   });
 
   await test.step('Rename workspace via per-row action from Workspaces page and verify renaming via search', async () => {
-    const kebab = await waitForTableKebabReady(
-      page,
-      new RegExp(workspaceName, 'i'),
-    );
-    await kebab.click();
-    await expect(kebab).toHaveAttribute('aria-expanded', 'true');
+    await expect(async () => {
+      await page.reload({ waitUntil: 'load' });
+      await searchByName(page, workspaceName);
+      const kebab = await waitForTableKebabReady(
+        page,
+        new RegExp(workspaceName, 'i'),
+      );
+      await kebab.click();
+      await expect(kebab).toHaveAttribute('aria-expanded', 'true');
 
-    const renameWorkspaceButton = page
-      .getByRole('menuitem', { name: 'Rename workspace' })
-      .first();
-    await expect(renameWorkspaceButton).toBeEnabled({
-      timeout: 50000,
-    });
-    await renameWorkspaceButton.click();
+      const renameWorkspaceButton = page
+        .getByRole('menuitem', { name: 'Rename workspace' })
+        .first();
+      await expect(renameWorkspaceButton).toBeEnabled();
+      await renameWorkspaceButton.click();
 
-    await expect(dialogModal).toBeVisible();
+      await expect(dialogModal).toBeVisible();
+    }).toPass({ timeout: 60000 });
     await dialogModal.locator('input').first().fill(renamedWorkspace);
     await dialogModal.getByRole('button', { name: 'Save' }).click();
 
@@ -273,23 +275,24 @@ test('User can create, rename and delete a workspace from Workspaces page', asyn
   });
 
   await test.step('Delete workspace via per-row action from Workspaces page and verify deletion via search', async () => {
-    await searchByName(page, renamedWorkspace);
-    const kebab = await waitForTableKebabReady(
-      page,
-      new RegExp(renamedWorkspace, 'i'),
-    );
-    await kebab.click();
-    await expect(kebab).toHaveAttribute('aria-expanded', 'true');
+    await expect(async () => {
+      await page.reload({ waitUntil: 'load' });
+      await searchByName(page, renamedWorkspace);
+      const kebab = await waitForTableKebabReady(
+        page,
+        new RegExp(renamedWorkspace, 'i'),
+      );
+      await kebab.click();
+      await expect(kebab).toHaveAttribute('aria-expanded', 'true');
 
-    const deleteWorkspaceButton = page
-      .getByRole('menuitem', { name: 'Delete workspace' })
-      .first();
-    await expect(deleteWorkspaceButton).toBeEnabled({
-      timeout: 50000,
-    });
-    await deleteWorkspaceButton.click();
+      const deleteWorkspaceButton = page
+        .getByRole('menuitem', { name: 'Delete workspace' })
+        .first();
+      await expect(deleteWorkspaceButton).toBeEnabled();
+      await deleteWorkspaceButton.click();
 
-    await expect(dialogModal).toBeVisible();
+      await expect(dialogModal).toBeVisible();
+    }).toPass({ timeout: 60000 });
     await dialogModal.getByRole('button', { name: 'Delete' }).click();
 
     // search for the workspace to confirm workspace is removed


### PR DESCRIPTION
## Jira
[RHINENG-26293](https://redhat.atlassian.net/browse/RHINENG-26293)

## What
Fix flaky workspace and navigation Playwright E2E tests on CI.

## Why
Tests pass locally but fail on CI due to RBAC permission propagation delay and unreliable kebab menu interactions in slower environments.

## How
- Added page reload in `waitForWorkspaceDetailPageReady` to pick up propagated RBAC permissions.
- Wrapped kebab menu → action → modal sequences in `expect().toPass()` retry loops.
- Increased modal visibility timeouts for rename/delete dialogs.
- Fixed `beforeEach` in navigation tests to properly await sidebar visibility before interacting.

## Testing
Ran affected tests locally in headed mode against stage.

## Screenshots/Videos (if applicable)
N/A – test-only changes.

## Summary by Sourcery

Improve reliability of workspace Playwright tests by handling slower UI loading and dialogs.

Tests:
- Ensure workspace detail page waits for the Systems tab to be visible and reloads the page before proceeding.
- Increase visibility timeouts for workspace rename and delete confirmation dialogs in Playwright tests.

[RHINENG-26293]: https://redhat.atlassian.net/browse/RHINENG-26293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Stabilize workspace and navigation Playwright E2E tests by making them resilient to slower UI updates and delayed permission propagation.

Tests:
- Wrap workspace row action menu interactions and dialogs in retryable expectations with page reloads and search refresh to handle flaky kebab/menu behavior.
- Relax and standardize dialog and navigation visibility/URL timeouts to accommodate slower CI environments.
- Update workspace detail readiness helper to reload and re-check Systems tab and header actions toggle until RBAC permissions propagate.
- Ensure navigation tests explicitly wait for sidebar inventory links to become visible before interacting.