### PR TITLE
ci(deps): Automerge minor Dependabot PRs in addition to Konflux

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - name: Metadata for PR
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:

--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -1,4 +1,4 @@
-name: Auto-Approve Konflux PRs
+name: Auto-Approve Dependency-Update PRs
 
 on:
   pull_request:
@@ -7,14 +7,25 @@ on:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'red-hat-konflux[bot]'
+    if: ${{ github.event.pull_request.user.login == 'red-hat-konflux[bot]' || github.event.pull_request.user.login == 'dependabot[bot]' }}
 
     permissions:
       pull-requests: write
 
     steps:
+      - name: Metadata for PR
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Auto-approve PR
+        if: ${{ github.event.pull_request.user.login == 'red-hat-konflux[bot]' ||
+                (github.event.pull_request.user.login == 'dependabot[bot]' &&
+                contains(github.event.pull_request.labels.*.name, 'dependencies') && (
+                  steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+                  steps.metadata.outputs.update-type == 'version-update:semver-patch'
+                ))}}
         uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7 # v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          review-message: "This PR from Konflux has been automatically approved."
+          review-message: "This dependency-update PR has been automatically approved."

--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Metadata for PR
         if: github.event.pull_request.user.login == 'dependabot[bot]'
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@dbb049abf0d677abbd7f7eee0375145b417fdd34 # v2.2.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Auto-approve PR


### PR DESCRIPTION
## Jira
(None)

## What
Updates the "automerge" GitHub action to automerge Dependabot minor-version updates (in addition to Konflux).
Replaces #3124.

## Why
To reduce manual review effort.

## How
Fetch PR metadata using `dependabot/fetch-metadata@v2`, which we then check if the PR was opened by Dependabot. The PR gets auto-approved if it was opened by Konflux, or if it was opened by Dependabot and is a minor-version update.

## Testing
None

## Screenshots/Videos (if applicable)
N/A

## Summary by Sourcery

CI:
- Update the auto-approve GitHub Actions workflow to also consider Dependabot PRs with dependency labels and minor/patch version bumps, using Dependabot metadata to gate approvals.

## Summary by Sourcery

CI:
- Update auto-approve GitHub Actions workflow to also approve Dependabot dependency PRs for minor and patch updates using Dependabot metadata.