### PR TITLE
feat(CI): add dry-run option to stage and prod pipelines with Slack notifications

### DIFF
--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -2,6 +2,12 @@ name: 'Prod Post-Release Sanity'
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (validate setup without running tests)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }} # target branch
@@ -84,3 +90,51 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 10
+
+      - name: Notify Slack on success
+        uses: slackapi/slack-github-action@v2.1.1
+        if: ${{ success() && inputs.dry_run != true }}
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#36a64f",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :test_tube: [CI/CD] Prod Post-Release Sanity>: *passed* :large_green_circle: <!subteam^${{ secrets.SLACK_USER_GROUP }}|@hbi-frontend>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v2.1.1
+        if: ${{ failure() && inputs.dry_run != true && !cancelled() }}
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#d72839",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :test_tube: [CI/CD] Prod Post-Release Sanity>: *failed* :red-stop: <!subteam^${{ secrets.SLACK_USER_GROUP }}|@hbi-frontend>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/stage-daily-pw-tests.yml
+++ b/.github/workflows/stage-daily-pw-tests.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 4 * * *' # This cron expression runs the action every 24 hours at 04:00 UTC
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (validate setup without running tests)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }} # target branch
@@ -88,7 +94,7 @@ jobs:
 
       - name: Notify Slack on failure
         uses: slackapi/slack-github-action@v2.1.1
-        if: ${{ failure() && github.event_name == 'schedule' && !cancelled() }}
+        if: ${{ failure() && inputs.dry_run != true && !cancelled() }}
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -102,7 +108,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :test_tube: [CI/CD] Daily Stage Inventory Frontend Test>: *failed* :red-stop: <!subteam^${{ secrets.SLACK_USER_GROUP }}|@hbi-frontend>"
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :test_tube: [CI/CD] Stage Inventory Frontend Test>: *failed* :red-stop: <!subteam^${{ secrets.SLACK_USER_GROUP }}|@hbi-frontend>"
                       }
                     }
                   ]


### PR DESCRIPTION
Jira
NA

What
Added a dry_run workflow_dispatch input to both stage and prod Playwright pipelines, and added Slack notifications for prod post-release sanity runs.

Why
Allow ad-hoc manual test runs for self-analysis without notifying the Slack channel, reducing noise for the team.

How
Added dry_run boolean input to workflow_dispatch in both workflows
Stage: notifies Slack on failure only (skipped when dry_run is checked)
Prod: notifies Slack on both success and failure (skipped when dry_run is checked)
Tests always execute regardless of the dry_run flag

Testing
Validated workflow YAML syntax; dry_run conditions are gated via inputs.dry_run != true on Slack steps only.

Screenshots/Videos (if applicable)
NA

## Summary by Sourcery

CI:
- Introduce a dry_run workflow_dispatch input for stage and prod Playwright test workflows and gate Slack notifications on it, including new success and failure alerts for prod and updated failure alerts for stage.