### PR TITLE
Update the description for dry-run checkbox to match the actual behaviour

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/configure-pages@v6
       - name: Build with JSDoc
         run: npm run docs
+      - name: Restore metrics dashboard
+        run: git checkout -- docs/metrics/ 2>/dev/null || true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run (validate setup without running tests)'
+        description: 'Dry run: Run tests without notifying Slack'
         required: false
         type: boolean
         default: false

--- a/.github/workflows/stage-daily-pw-tests.yml
+++ b/.github/workflows/stage-daily-pw-tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run (validate setup without running tests)'
+        description: 'Dry run: Run tests without notifying Slack'
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
Follow up - https://github.com/RedHatInsights/insights-inventory-frontend/pull/3134

## Summary by Sourcery

CI:
- Update the dry_run input description in prod and stage Playwright workflow_dispatch triggers to indicate tests still run but Slack is not notified.