### PR TITLE
refactor: adjust Column related types

### DIFF
--- a/src/components/SystemsView/ColumnManagementModalContext.tsx
+++ b/src/components/SystemsView/ColumnManagementModalContext.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react';
-import { RenderableColumn } from './hooks/useColumns';
 import { ColumnManagementModal } from '../ColumnManagementModal';
+import { Column } from './columns/allColumnDefinitions';
 
 interface SystemsViewColumnManagementContextValue {
   openColumnManagementModal: () => void;
@@ -21,8 +21,8 @@ export const useColumnManagementModalContext = () => {
 
 interface ColumnManagementModalProviderProps {
   children: React.ReactNode;
-  columns: RenderableColumn[];
-  setColumns: React.Dispatch<React.SetStateAction<RenderableColumn[]>>;
+  columns: Column[];
+  setColumns: React.Dispatch<React.SetStateAction<Column[]>>;
 }
 
 export const ColumnManagementModalProvider = ({

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -19,7 +19,7 @@ import {
   SystemsViewFilters,
 } from './filters/SystemsViewFilters';
 import { useColumns } from './hooks/useColumns';
-import { SetURLSearchParams, useSearchParams } from 'react-router-dom';
+import { SetURLSearchParams } from 'react-router-dom';
 import { SystemActionModalsProvider } from './SystemActionModalsContext';
 import { SystemsViewBulkActions } from './SystemsViewBulkActions';
 import {
@@ -29,7 +29,6 @@ import {
 import { useRows, type SystemsViewTableRow } from './hooks/useRows';
 import AccessDenied from '../../Utilities/AccessDenied';
 import './SystemsView.scss';
-import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import { InnerScrollContainer, ISortBy } from '@patternfly/react-table';
 import { ColumnManagementModalProvider } from './ColumnManagementModalContext';
 import {
@@ -45,10 +44,10 @@ import { DEBOUNCE_TIMEOUT_MS } from '../../constants';
 import { normalizeLegacySortSearchParams } from './utils/normalizeLegacySortSearchParams';
 import { SORT_DIR_URL_PARAM, SORT_URL_PARAM } from './constants';
 import useInventoryViewsFeatureFlag from '../../Utilities/useInventoryViewsFeatureFlag';
+import { SortBy } from './columns/allColumnDefinitions';
 
 export type SortDirection = ISortBy['direction'];
-export type SortBy = ApiOrderByEnum | undefined;
-export type onSort = (
+export type OnSort = (
   _event: React.MouseEvent | React.KeyboardEvent | MouseEvent | undefined,
   newSortBy: string,
   newSortDirection: SortDirection,
@@ -106,8 +105,8 @@ const SystemsViewInner = ({
   const sort = useDataViewSort({
     initialSort: {
       direction: 'desc',
-      sortBy: ApiOrderByEnum.LastCheckIn,
-    },
+      sortBy: 'last_check_in',
+    } satisfies { direction: SortDirection; sortBy: SortBy },
     defaultDirection: 'asc',
     searchParams: sortSearchParams,
     setSearchParams,

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -44,7 +44,8 @@ import { DEBOUNCE_TIMEOUT_MS } from '../../constants';
 import { normalizeLegacySortSearchParams } from './utils/normalizeLegacySortSearchParams';
 import { SORT_DIR_URL_PARAM, SORT_URL_PARAM } from './constants';
 import useInventoryViewsFeatureFlag from '../../Utilities/useInventoryViewsFeatureFlag';
-import { SortBy } from './columns/allColumnDefinitions';
+import type { Column } from './columns/allColumnDefinitions';
+import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 
 export type SortDirection = ISortBy['direction'];
 export type OnSort = (
@@ -111,7 +112,7 @@ const SystemsViewInner = ({
     directionParam: SORT_DIR_URL_PARAM,
   });
 
-  const sortBy = sort?.sortBy as SortBy;
+  const sortBy = sort?.sortBy as Column['sortBy'];
   const { direction, onSort } = sort;
 
   const isInventoryViewsEnabled = useInventoryViewsFeatureFlag();
@@ -128,7 +129,7 @@ const SystemsViewInner = ({
     perPage: pagination.perPage,
     filters: queryFilters,
     lastSeenCustomRange,
-    sortBy,
+    sortBy: sortBy as ApiOrderByEnum | undefined,
     direction,
   });
 

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -18,7 +18,7 @@ import {
   InventoryFilters,
   SystemsViewFilters,
 } from './filters/SystemsViewFilters';
-import { useColumns } from './hooks/useColumns';
+import { INITIAL_SORT, useColumns } from './hooks/useColumns';
 import { SetURLSearchParams } from 'react-router-dom';
 import { SystemActionModalsProvider } from './SystemActionModalsContext';
 import { SystemsViewBulkActions } from './SystemsViewBulkActions';
@@ -103,10 +103,7 @@ const SystemsViewInner = ({
   );
 
   const sort = useDataViewSort({
-    initialSort: {
-      direction: 'desc',
-      sortBy: 'last_check_in',
-    } satisfies { direction: SortDirection; sortBy: SortBy },
+    initialSort: INITIAL_SORT,
     defaultDirection: 'asc',
     searchParams: sortSearchParams,
     setSearchParams,

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -4,10 +4,12 @@ import { System } from '../hooks/useSystemsQuery';
 import { Resolve } from '../../../types/utility-types';
 
 type RenderableColumn = {
+  /** Cell content for a single system row in the Systems table. */
   readonly renderCell: (system: System) => React.ReactNode;
 };
 
 type SortableColumn = {
+  /** Used when this column is the active sort; omit for non-sortable columns. */
   readonly sortBy?: string;
 };
 

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -1,13 +1,8 @@
 import { ColumnManagementModalColumn } from '@patternfly/react-component-groups';
 import inventoryColumns from './inventory/columnDefinitions';
 import { System } from '../hooks/useSystemsQuery';
+import { Resolve } from '../../../types/utility-types';
 
-/**
- * Default Systems View columns, merged in order from each integrated app.
- *
- * To add an app: import its `./<appId>/columnDefinitions` default export and append
- * with `...thatAppsColumns` (or insert where the column order should appear).
- */
 type RenderableColumn = {
   readonly renderCell: (system: System) => React.ReactNode;
 };
@@ -16,10 +11,16 @@ type SortableColumn = {
   readonly sortBy?: string;
 };
 
-export type Column = ColumnManagementModalColumn &
-  RenderableColumn &
-  SortableColumn;
+export type Column = Resolve<
+  ColumnManagementModalColumn & RenderableColumn & SortableColumn
+>;
 
+/**
+ * Default Systems View columns, merged in order from each integrated app.
+ *
+ * To add an app: import its `./<appId>/columnDefinitions` default export and append
+ * with `...thatAppsColumns` (or insert where the column order should appear).
+ */
 const allColumns = [...inventoryColumns];
 
 export type SortBy = Extract<

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -1,4 +1,6 @@
+import { ColumnManagementModalColumn } from '@patternfly/react-component-groups';
 import inventoryColumns from './inventory/columnDefinitions';
+import { System } from '../hooks/useSystemsQuery';
 
 /**
  * Default Systems View columns, merged in order from each integrated app.
@@ -6,4 +8,23 @@ import inventoryColumns from './inventory/columnDefinitions';
  * To add an app: import its `./<appId>/columnDefinitions` default export and append
  * with `...thatAppsColumns` (or insert where the column order should appear).
  */
-export default [...inventoryColumns];
+type RenderableColumn = {
+  readonly renderCell: (system: System) => React.ReactNode;
+};
+
+type SortableColumn = {
+  readonly sortBy?: string;
+};
+
+export type Column = ColumnManagementModalColumn &
+  RenderableColumn &
+  SortableColumn;
+
+const allColumns = [...inventoryColumns];
+
+export type SortBy = Extract<
+  (typeof allColumns)[number],
+  { sortBy: string }
+>['sortBy'];
+
+export default allColumns;

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -21,11 +21,6 @@ export type Column = Resolve<
  * To add an app: import its `./<appId>/columnDefinitions` default export and append
  * with `...thatAppsColumns` (or insert where the column order should appear).
  */
-const allColumns = [...inventoryColumns];
-
-export type SortBy = Extract<
-  (typeof allColumns)[number],
-  { sortBy: string }
->['sortBy'];
+const allColumns = [...inventoryColumns] as const satisfies readonly Column[];
 
 export default allColumns;

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -19,7 +19,7 @@ const nameColumn = {
   renderCell: (system: System) => (
     <DisplayName key={`name-${system.id}`} system={system} />
   ),
-} satisfies Column;
+};
 
 const workspaceColumn = {
   title: 'Workspace',
@@ -30,7 +30,7 @@ const workspaceColumn = {
   renderCell: (system: System) => (
     <Workspace key={`workspace-${system.id}`} system={system} />
   ),
-} satisfies Column;
+};
 
 const tagsColumn = {
   title: 'Tags',
@@ -40,7 +40,7 @@ const tagsColumn = {
   renderCell: (system: System) => (
     <Tags key={`tags-${system.id}`} system={system} />
   ),
-} satisfies Column;
+};
 
 const operatingSystemColumn = {
   title: 'OS',
@@ -51,7 +51,7 @@ const operatingSystemColumn = {
   renderCell: (system: System) => (
     <OperatingSystem key={`os-${system.id}`} system={system} />
   ),
-} satisfies Column;
+};
 
 const lastSeenColumn = {
   title: <LastSeenColumnHeader />,
@@ -62,9 +62,8 @@ const lastSeenColumn = {
   renderCell: (system: System) => (
     <LastSeen key={`lastseen-${system.id}`} system={system} />
   ),
-} satisfies Column;
+};
 
-/** `as const satisfies` keeps a tuple of distinct column types. */
 export default [
   nameColumn,
   workspaceColumn,

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { type RenderableColumn } from '../../hooks/useColumns';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import DisplayName from './cells/DisplayName';
 import Workspace from './cells/Workspace';
@@ -8,8 +7,9 @@ import OperatingSystem from './cells/OperatingSystem';
 import Tags from './cells/Tags';
 import { LastSeenColumnHeader } from '../../../../Utilities/LastSeenColumnHeader';
 import { System } from '../../hooks/useSystemsQuery';
+import type { Column } from '../allColumnDefinitions';
 
-const nameColumn: RenderableColumn = {
+const nameColumn = {
   title: 'Name',
   key: 'name',
   isShownByDefault: true,
@@ -19,9 +19,9 @@ const nameColumn: RenderableColumn = {
   renderCell: (system: System) => (
     <DisplayName key={`name-${system.id}`} system={system} />
   ),
-};
+} satisfies Column;
 
-const workspaceColumn: RenderableColumn = {
+const workspaceColumn = {
   title: 'Workspace',
   key: 'workspace',
   isShownByDefault: true,
@@ -30,9 +30,9 @@ const workspaceColumn: RenderableColumn = {
   renderCell: (system: System) => (
     <Workspace key={`workspace-${system.id}`} system={system} />
   ),
-};
+} satisfies Column;
 
-const tagsColumn: RenderableColumn = {
+const tagsColumn = {
   title: 'Tags',
   key: 'tags',
   isShownByDefault: true,
@@ -40,9 +40,9 @@ const tagsColumn: RenderableColumn = {
   renderCell: (system: System) => (
     <Tags key={`tags-${system.id}`} system={system} />
   ),
-};
+} satisfies Column;
 
-const operatingSystemColumn: RenderableColumn = {
+const operatingSystemColumn = {
   title: 'OS',
   key: 'os',
   isShownByDefault: true,
@@ -51,9 +51,9 @@ const operatingSystemColumn: RenderableColumn = {
   renderCell: (system: System) => (
     <OperatingSystem key={`os-${system.id}`} system={system} />
   ),
-};
+} satisfies Column;
 
-const lastSeenColumn: RenderableColumn = {
+const lastSeenColumn = {
   title: <LastSeenColumnHeader />,
   key: 'last_seen',
   isShownByDefault: true,
@@ -62,12 +62,13 @@ const lastSeenColumn: RenderableColumn = {
   renderCell: (system: System) => (
     <LastSeen key={`lastseen-${system.id}`} system={system} />
   ),
-};
+} satisfies Column;
 
+/** `as const satisfies` keeps a tuple of distinct column types. */
 export default [
   nameColumn,
   workspaceColumn,
   tagsColumn,
   operatingSystemColumn,
   lastSeenColumn,
-];
+] as const satisfies readonly Column[];

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -10,6 +10,11 @@ import initialColumns, {
   type Column,
 } from '../columns/allColumnDefinitions';
 
+export const INITIAL_SORT: { sortBy: SortBy; direction: SortDirection } = {
+  sortBy: 'last_check_in',
+  direction: 'desc',
+};
+
 const FALLBACK_SORT: { sortBy: SortBy; direction: SortDirection } = {
   sortBy: 'display_name',
   direction: 'asc',

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -5,23 +5,26 @@ import type { OnSort, SortDirection } from '../SystemsView';
 import { getSystemsViewColumnMinWidthStyle } from '../utils/columnMinWidths';
 import { STICKY_ACTIONS_HEADER_PROPS } from '../utils/stickyActionsColumn';
 import { STICKY_NAME_HEADER_PROPS } from '../utils/stickyNameColumn';
-import initialColumns, {
-  type SortBy,
-  type Column,
-} from '../columns/allColumnDefinitions';
+import initialColumns, { type Column } from '../columns/allColumnDefinitions';
 
-export const INITIAL_SORT: { sortBy: SortBy; direction: SortDirection } = {
+export const INITIAL_SORT: {
+  sortBy: Column['sortBy'];
+  direction: SortDirection;
+} = {
   sortBy: 'last_check_in',
   direction: 'desc',
 };
 
-const FALLBACK_SORT: { sortBy: SortBy; direction: SortDirection } = {
+const FALLBACK_SORT: {
+  sortBy: Column['sortBy'];
+  direction: SortDirection;
+} = {
   sortBy: 'display_name',
   direction: 'asc',
 };
 
 interface UseColumnParams {
-  sortBy: SortBy;
+  sortBy: Column['sortBy'];
   onSort: OnSort;
   direction: SortDirection;
   isInventoryViewsEnabled: boolean;
@@ -38,7 +41,7 @@ export const useColumns = ({
   );
 
   const fromSortByToIndex = useCallback(
-    (sortBy?: SortBy) =>
+    (sortBy?: Column['sortBy']) =>
       columns
         .filter((col) => col.isShown)
         .findIndex((col) => col.sortBy === sortBy),

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -1,28 +1,23 @@
 import React from 'react';
 import { DataViewTh } from '@patternfly/react-data-view';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
-import type { ColumnManagementModalColumn } from '../../ColumnManagementModal';
-import { System } from './useSystemsQuery';
-import type { onSort, SortBy, SortDirection } from '../SystemsView';
+import type { OnSort, SortDirection } from '../SystemsView';
 import { getSystemsViewColumnMinWidthStyle } from '../utils/columnMinWidths';
 import { STICKY_ACTIONS_HEADER_PROPS } from '../utils/stickyActionsColumn';
 import { STICKY_NAME_HEADER_PROPS } from '../utils/stickyNameColumn';
-import initialColumns from '../columns/allColumnDefinitions';
-
-export interface RenderableColumn extends ColumnManagementModalColumn {
-  renderCell: (system: System) => React.ReactNode;
-  sortBy?: ApiOrderByEnum;
-}
+import initialColumns, {
+  type SortBy,
+  type Column,
+} from '../columns/allColumnDefinitions';
 
 const FALLBACK_SORT: { sortBy: SortBy; direction: SortDirection } = {
-  sortBy: ApiOrderByEnum.DisplayName,
+  sortBy: 'display_name',
   direction: 'asc',
 };
 
 interface UseColumnParams {
   sortBy: SortBy;
-  onSort: onSort;
+  onSort: OnSort;
   direction: SortDirection;
   isInventoryViewsEnabled: boolean;
 }
@@ -33,12 +28,12 @@ export const useColumns = ({
   direction,
   isInventoryViewsEnabled,
 }: UseColumnParams) => {
-  const [columns, setColumns] = useState<RenderableColumn[]>(() =>
+  const [columns, setColumns] = useState<Column[]>(() =>
     initialColumns.map((col) => ({ ...col })),
   );
 
   const fromSortByToIndex = useCallback(
-    (sortBy?: ApiOrderByEnum) =>
+    (sortBy?: SortBy) =>
       columns
         .filter((col) => col.isShown)
         .findIndex((col) => col.sortBy === sortBy),

--- a/src/components/SystemsView/hooks/useRows.tsx
+++ b/src/components/SystemsView/hooks/useRows.tsx
@@ -1,12 +1,12 @@
 import { DataViewTrObject } from '@patternfly/react-data-view';
 import React from 'react';
 import SystemsViewRowActions from '../SystemsViewRowActions';
-import { RenderableColumn } from './useColumns';
 import { getSystemsViewColumnMinWidthStyle } from '../utils/columnMinWidths';
 import { STICKY_ACTIONS_BODY_PROPS } from '../utils/stickyActionsColumn';
 import { STICKY_NAME_BODY_PROPS } from '../utils/stickyNameColumn';
 import type { SystemWithPermissions } from '../../../Utilities/hooks/useHostIdsWithKessel';
 import type { System } from './useSystemsQuery';
+import { Column } from '../columns/allColumnDefinitions';
 
 /** DataViewTrObject Extension, `meta` points to associated system objects. */
 export type SystemsViewTableRow = DataViewTrObject & {
@@ -15,7 +15,7 @@ export type SystemsViewTableRow = DataViewTrObject & {
 
 interface UseRowsParams {
   data?: (System | SystemWithPermissions)[];
-  columns: RenderableColumn[];
+  columns: Column[];
   /**
    * When true (inventory views feature): sticky Name/actions cells and column min-widths.
    */

--- a/src/types/utility-types.ts
+++ b/src/types/utility-types.ts
@@ -1,0 +1,1 @@
+export type Resolve<T> = T extends Function ? T : { [K in keyof T]: T[K] };


### PR DESCRIPTION
This PR fixes one important incompatibility and introduces small QoL changes regarding Column type. 

- SortBy type became incompatible with our newly expected columns, I had to widen it to string | undefined.
- I've also refactored RenderableColumn into Column type which will be used onwards.
- Introduced Resolve<T> utility for improved Type display names (in IDE inspection tooling and such) 

### How to test
In UI make sure sortBy works as before for columns.

## Summary by Sourcery

Unify SystemsView column typing around a new Column definition and align sorting defaults and typing with the new column model.

Bug Fixes:
- Restore compatibility of SystemsView sorting by loosening the sort key type used with the host inventory API.

Enhancements:
- Introduce a shared Column type that combines column management, rendering, and sort metadata for SystemsView.
- Refactor SystemsView hooks and context to consume the new Column type instead of the previous RenderableColumn interface.
- Define initial and fallback sort configurations using the new Column sortBy type and reuse them in SystemsView.
- Tighten inventory column definitions and full column list using const assertions and a Resolve utility type for clearer inferred types.
- Add a Resolve utility type for normalizing composite types and improving type display.