### PR TITLE
fix(CI): deploy JSDoc to /api/ subdirectory on gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,35 +6,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Dependencies
         run: npm ci
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v6
       - name: Build with JSDoc
         run: npm run docs
-      - name: Restore metrics dashboard
-        run: git checkout -- docs/metrics/ 2>/dev/null || true
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Prepare deployment directory
+        run: |
+          mkdir -p deploy/api
+          cp -r docs/* deploy/api/
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
         with:
-          path: docs/
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{steps.deployment.outputs.page_url}}
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          ref: gh-pages
+          path: gh-pages-current
+      - name: Merge with existing gh-pages content
+        run: |
+          cp -rn gh-pages-current/* deploy/ 2>/dev/null || true
+          rm -rf gh-pages-current
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./deploy


### PR DESCRIPTION
JSDoc was overwriting the metrics dashboard on gh-pages. Now JSDoc deploys to /api/ and existing gh-pages content (dashboard) is preserved.

## Summary by Sourcery

CI:
- Replace the previous two-job Pages deployment with a single workflow that builds docs, merges them into a deployment directory alongside existing gh-pages content, and publishes via peaceiris/actions-gh-pages.