### PR TITLE
fix(RHINENG-26227): Add ouiaId prop for UUID

### DIFF
--- a/src/components/InventoryDetail/FactsInfo.js
+++ b/src/components/InventoryDetail/FactsInfo.js
@@ -49,7 +49,9 @@ const FactsInfo = ({
           <FlexItem grow={{ default: 'grow' }}>
             {loaded ? (
               id ? (
-                <ClipboardCopy variant="inline-compact">{id}</ClipboardCopy>
+                <ClipboardCopy variant="inline-compact" ouiaId="system-uuid">
+                  {id}
+                </ClipboardCopy>
               ) : (
                 ' '
               )

--- a/src/components/InventoryDetail/__snapshots__/DetailWrapper.test.js.snap
+++ b/src/components/InventoryDetail/__snapshots__/DetailWrapper.test.js.snap
@@ -208,6 +208,7 @@ exports[`DetailWrapper DOM should render with data 1`] = `
                     >
                       <div
                         class="pf-v6-c-clipboard-copy pf-m-inline"
+                        data-ouia-component-id="system-uuid"
                         data-ouia-component-type="PF6/ClipboardCopy"
                         data-ouia-safe="true"
                       >


### PR DESCRIPTION
## Jira
[RHINENG-26227](https://redhat.atlassian.net/browse/RHINENG-26227)

## What
Add ouiaId prop for UUID ClipboardCopy component

## Why
this aids in test automation and does not impact component behavior

## How
magic

## Testing
nah

## Screenshots/Videos (if applicable)

## Summary by Sourcery

Enhancements:
- Assign an `ouiaId` to the inline-compact ClipboardCopy displaying the system UUID without changing its behavior.

[RHINENG-26227]: https://redhat.atlassian.net/browse/RHINENG-26227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ