### PR TITLE
fix(RHINENG-14129): No access Staleness and Deletion

### DIFF
--- a/src/components/InventoryHostStaleness/InventoryHostStaleness.rbac.test.js
+++ b/src/components/InventoryHostStaleness/InventoryHostStaleness.rbac.test.js
@@ -11,6 +11,7 @@ import {
   GENERAL_HOST_STALENESS_WRITE_PERMISSION,
 } from './constants';
 import {
+  asPermissionList,
   GENERAL_HOSTS_READ_PERMISSIONS,
   GENERAL_HOSTS_WRITE_PERMISSIONS,
 } from '../../constants';
@@ -29,11 +30,11 @@ jest.mock('./HostStalenessCard', () => ({
   ),
 }));
 
-const MODIFY_PERMISSIONS = [
+const REQUIRED_MODIFY_PERMISSIONS = [
   GENERAL_HOST_STALENESS_WRITE_PERMISSION,
   GENERAL_HOST_STALENESS_READ_PERMISSION,
-  GENERAL_HOSTS_READ_PERMISSIONS,
-  GENERAL_HOSTS_WRITE_PERMISSIONS,
+  ...asPermissionList(GENERAL_HOSTS_READ_PERMISSIONS),
+  ...asPermissionList(GENERAL_HOSTS_WRITE_PERMISSIONS),
 ];
 
 describe('InventoryHostStaleness RBAC v1', () => {
@@ -49,7 +50,10 @@ describe('InventoryHostStaleness RBAC v1', () => {
 
     render(<InventoryHostStaleness />);
 
-    expect(useConditionalRBAC).toHaveBeenCalledWith(MODIFY_PERMISSIONS, true);
+    expect(useConditionalRBAC).toHaveBeenCalledWith(
+      REQUIRED_MODIFY_PERMISSIONS,
+      true,
+    );
   });
 
   it('passes canModifyHostStaleness false when write permissions are missing', () => {

--- a/src/components/InventoryHostStaleness/InventoryHostStaleness.rbac.test.js
+++ b/src/components/InventoryHostStaleness/InventoryHostStaleness.rbac.test.js
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import InventoryHostStaleness from './InventoryHostStaleness';
+import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
+import {
+  GENERAL_HOST_STALENESS_READ_PERMISSION,
+  GENERAL_HOST_STALENESS_WRITE_PERMISSION,
+} from './constants';
+import {
+  GENERAL_HOSTS_READ_PERMISSIONS,
+  GENERAL_HOSTS_WRITE_PERMISSIONS,
+} from '../../constants';
+
+jest.mock('../../Utilities/hooks/useConditionalRBAC', () => ({
+  useConditionalRBAC: jest.fn(() => ({ hasAccess: false, isOrgAdmin: false })),
+}));
+
+jest.mock('./HostStalenessCard', () => ({
+  __esModule: true,
+  default: ({ canModifyHostStaleness }) => (
+    <div
+      data-testid="host-staleness-card"
+      data-can-modify={String(canModifyHostStaleness)}
+    />
+  ),
+}));
+
+const MODIFY_PERMISSIONS = [
+  GENERAL_HOST_STALENESS_WRITE_PERMISSION,
+  GENERAL_HOST_STALENESS_READ_PERMISSION,
+  GENERAL_HOSTS_READ_PERMISSIONS,
+  GENERAL_HOSTS_WRITE_PERMISSIONS,
+];
+
+describe('InventoryHostStaleness RBAC v1', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires all staleness and hosts read/write permissions to allow editing', () => {
+    useConditionalRBAC.mockReturnValue({
+      hasAccess: true,
+      isOrgAdmin: false,
+    });
+
+    render(<InventoryHostStaleness />);
+
+    expect(useConditionalRBAC).toHaveBeenCalledWith(MODIFY_PERMISSIONS, true);
+  });
+
+  it('passes canModifyHostStaleness false when write permissions are missing', () => {
+    useConditionalRBAC.mockReturnValue({
+      hasAccess: false,
+      isOrgAdmin: false,
+    });
+
+    render(<InventoryHostStaleness />);
+
+    expect(screen.getByTestId('host-staleness-card')).toHaveAttribute(
+      'data-can-modify',
+      'false',
+    );
+  });
+
+  it('passes canModifyHostStaleness true when all modify permissions are granted', () => {
+    useConditionalRBAC.mockReturnValue({
+      hasAccess: true,
+      isOrgAdmin: false,
+    });
+
+    render(<InventoryHostStaleness />);
+
+    expect(screen.getByTestId('host-staleness-card')).toHaveAttribute(
+      'data-can-modify',
+      'true',
+    );
+  });
+
+  it('uses Kessel edit override instead of RBAC when provided', () => {
+    useConditionalRBAC.mockReturnValue({
+      hasAccess: true,
+      isOrgAdmin: false,
+    });
+
+    render(
+      <InventoryHostStaleness
+        kesselCanModifyHostStaleness={false}
+        editDisabledTooltip="Kessel read-only"
+      />,
+    );
+
+    expect(screen.getByTestId('host-staleness-card')).toHaveAttribute(
+      'data-can-modify',
+      'false',
+    );
+  });
+});

--- a/src/components/InventoryHostStaleness/InventoryHostStaleness.test.tsx
+++ b/src/components/InventoryHostStaleness/InventoryHostStaleness.test.tsx
@@ -47,6 +47,19 @@ describe('Table Renders', () => {
     menuToggleButtons.forEach((button) => expect(button).toBeDisabled());
   });
 
+  it('disables Edit and dropdowns when the user cannot modify staleness', async () => {
+    renderHostStalenessCard(false);
+
+    await screen.findByRole('button', { name: 'Edit' });
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled();
+
+    const menuToggleButtons = screen
+      .getAllByRole('button')
+      .filter((button) => button.classList.contains('pf-v6-c-menu-toggle'));
+
+    menuToggleButtons.forEach((button) => expect(button).toBeDisabled());
+  });
+
   it('enables staleness editing when edit is clicked', async () => {
     renderHostStalenessCard();
 

--- a/src/components/InventoryHostStaleness/InventoryHostStaleness.tsx
+++ b/src/components/InventoryHostStaleness/InventoryHostStaleness.tsx
@@ -6,15 +6,16 @@ import {
   GENERAL_HOST_STALENESS_WRITE_PERMISSION,
 } from './constants';
 import {
+  asPermissionList,
   GENERAL_HOSTS_READ_PERMISSIONS,
   GENERAL_HOSTS_WRITE_PERMISSIONS,
 } from '../../constants';
 
-const REQUIRED_PERMISSIONS = [
+const REQUIRED_MODIFY_PERMISSIONS = [
   GENERAL_HOST_STALENESS_WRITE_PERMISSION,
   GENERAL_HOST_STALENESS_READ_PERMISSION,
-  GENERAL_HOSTS_READ_PERMISSIONS,
-  GENERAL_HOSTS_WRITE_PERMISSIONS,
+  ...asPermissionList(GENERAL_HOSTS_READ_PERMISSIONS),
+  ...asPermissionList(GENERAL_HOSTS_WRITE_PERMISSIONS),
 ];
 
 interface InventoryHostStalenessProps {
@@ -28,15 +29,15 @@ const InventoryHostStaleness = ({
   kesselCanModifyHostStaleness,
   editDisabledTooltip,
 }: InventoryHostStalenessProps) => {
-  const { hasAccess: canModifyHostStalenessRbac } = useConditionalRBAC(
-    REQUIRED_PERMISSIONS,
+  const { hasAccess: hasStalenessAndHostsWriteRbac } = useConditionalRBAC(
+    REQUIRED_MODIFY_PERMISSIONS,
     true,
   );
 
   const canModifyHostStaleness =
     kesselCanModifyHostStaleness !== undefined
       ? kesselCanModifyHostStaleness
-      : canModifyHostStalenessRbac;
+      : hasStalenessAndHostsWriteRbac;
 
   return (
     <section>

--- a/src/constants.js
+++ b/src/constants.js
@@ -316,6 +316,10 @@ export const GROUPS_ADMINISTRATOR_PERMISSIONS = [
 ];
 export const GENERAL_HOSTS_READ_PERMISSIONS = 'inventory:hosts:read';
 export const GENERAL_HOSTS_WRITE_PERMISSIONS = 'inventory:hosts:write';
+
+/** Normalize permission exports that may be a string or array (e.g. plural-named constants). */
+export const asPermissionList = (permissions) =>
+  Array.isArray(permissions) ? permissions : [permissions];
 export const USER_ACCESS_ADMIN_PERMISSIONS = ['rbac:*:*'];
 export const PAGINATION_DEFAULT = { perPage: 10, page: 1 };
 export const NO_ACCESS_STATE = 'noAccess';

--- a/src/routes/InventoryHostStaleness.test.js
+++ b/src/routes/InventoryHostStaleness.test.js
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import HostStaleness from './InventoryHostStaleness';
+import { useConditionalRBAC } from '../Utilities/hooks/useConditionalRBAC';
+import { useHostStalenessKesselAccess } from '../Utilities/hooks/useHostStalenessKesselAccess';
+import { GENERAL_HOST_STALENESS_READ_PERMISSION } from '../components/InventoryHostStaleness/constants';
+import { GENERAL_HOSTS_READ_PERMISSIONS } from '../constants';
+
+jest.mock('../Utilities/hooks/useConditionalRBAC', () => ({
+  useConditionalRBAC: jest.fn(() => ({ hasAccess: false, isOrgAdmin: false })),
+}));
+
+jest.mock('../Utilities/hooks/useHostStalenessKesselAccess', () => ({
+  useHostStalenessKesselAccess: jest.fn(() => ({ mode: 'rbac' })),
+}));
+
+jest.mock('../components/InventoryHostStaleness', () => ({
+  __esModule: true,
+  default: () => (
+    <div data-testid="inventory-host-staleness-content">Staleness settings</div>
+  ),
+}));
+
+jest.mock('../components/OutageAlert', () => ({
+  OutageAlert: () => null,
+}));
+
+describe('HostStaleness route (RBAC v1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useHostStalenessKesselAccess.mockReturnValue({ mode: 'rbac' });
+  });
+
+  it('requests staleness read and inventory hosts read with checkAll', () => {
+    useConditionalRBAC.mockReturnValue({
+      hasAccess: true,
+      isOrgAdmin: false,
+    });
+
+    render(<HostStaleness />);
+
+    expect(useConditionalRBAC).toHaveBeenCalledWith(
+      [GENERAL_HOST_STALENESS_READ_PERMISSION, GENERAL_HOSTS_READ_PERMISSIONS],
+      true,
+    );
+  });
+
+  it('shows no access when RBAC read permissions are missing', () => {
+    useConditionalRBAC.mockReturnValue({
+      hasAccess: false,
+      isOrgAdmin: false,
+    });
+
+    render(<HostStaleness />);
+
+    expect(
+      screen.getByRole('heading', { name: /access permissions needed/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('inventory-host-staleness-content'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders staleness content when RBAC read permissions are granted', () => {
+    useConditionalRBAC.mockReturnValue({
+      hasAccess: true,
+      isOrgAdmin: false,
+    });
+
+    render(<HostStaleness />);
+
+    expect(
+      screen.getByTestId('inventory-host-staleness-content'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /access permissions needed/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('HostStaleness route (Kessel)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useConditionalRBAC.mockReturnValue({
+      hasAccess: true,
+      isOrgAdmin: false,
+    });
+  });
+
+  it('shows a permission spinner while Kessel access is loading', () => {
+    useHostStalenessKesselAccess.mockReturnValue({
+      mode: 'kessel',
+      isLoading: true,
+      canViewPage: false,
+      canEditStaleness: false,
+    });
+
+    render(<HostStaleness />);
+
+    expect(screen.getByLabelText('Loading permissions')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('inventory-host-staleness-content'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows no access when Kessel denies page view', () => {
+    useHostStalenessKesselAccess.mockReturnValue({
+      mode: 'kessel',
+      isLoading: false,
+      canViewPage: false,
+      canEditStaleness: false,
+    });
+
+    render(<HostStaleness />);
+
+    expect(
+      screen.getByRole('heading', { name: /access permissions needed/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/routes/InventoryHostStaleness.test.js
+++ b/src/routes/InventoryHostStaleness.test.js
@@ -8,7 +8,7 @@ import HostStaleness from './InventoryHostStaleness';
 import { useConditionalRBAC } from '../Utilities/hooks/useConditionalRBAC';
 import { useHostStalenessKesselAccess } from '../Utilities/hooks/useHostStalenessKesselAccess';
 import { GENERAL_HOST_STALENESS_READ_PERMISSION } from '../components/InventoryHostStaleness/constants';
-import { GENERAL_HOSTS_READ_PERMISSIONS } from '../constants';
+import { asPermissionList, GENERAL_HOSTS_READ_PERMISSIONS } from '../constants';
 
 jest.mock('../Utilities/hooks/useConditionalRBAC', () => ({
   useConditionalRBAC: jest.fn(() => ({ hasAccess: false, isOrgAdmin: false })),
@@ -44,7 +44,10 @@ describe('HostStaleness route (RBAC v1)', () => {
     render(<HostStaleness />);
 
     expect(useConditionalRBAC).toHaveBeenCalledWith(
-      [GENERAL_HOST_STALENESS_READ_PERMISSION, GENERAL_HOSTS_READ_PERMISSIONS],
+      [
+        GENERAL_HOST_STALENESS_READ_PERMISSION,
+        ...asPermissionList(GENERAL_HOSTS_READ_PERMISSIONS),
+      ],
       true,
     );
   });

--- a/src/routes/InventoryHostStaleness.tsx
+++ b/src/routes/InventoryHostStaleness.tsx
@@ -7,17 +7,21 @@ import {
 import InventoryHostStaleness from '../components/InventoryHostStaleness';
 import { useConditionalRBAC } from '../Utilities/hooks/useConditionalRBAC';
 import { GENERAL_HOST_STALENESS_READ_PERMISSION } from '../components/InventoryHostStaleness/constants';
+import { GENERAL_HOSTS_READ_PERMISSIONS } from '../constants';
 import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import HostStalenessNoAccess from '../components/InventoryHostStaleness/HostStalenessNoAccess';
 import { OutageAlert } from '../components/OutageAlert';
 import { useHostStalenessKesselAccess } from '../Utilities/hooks/useHostStalenessKesselAccess';
 
-const REQUIRED_PERMISSIONS = [GENERAL_HOST_STALENESS_READ_PERMISSION];
+const REQUIRED_READ_PERMISSIONS = [
+  GENERAL_HOST_STALENESS_READ_PERMISSION,
+  GENERAL_HOSTS_READ_PERMISSIONS,
+];
 
 const HostStaleness = () => {
   const chrome = useChrome();
   const { hasAccess: canReadHostStalenessRbac } = useConditionalRBAC(
-    REQUIRED_PERMISSIONS,
+    REQUIRED_READ_PERMISSIONS,
     true,
   );
   const kesselAccess = useHostStalenessKesselAccess();

--- a/src/routes/InventoryHostStaleness.tsx
+++ b/src/routes/InventoryHostStaleness.tsx
@@ -7,7 +7,7 @@ import {
 import InventoryHostStaleness from '../components/InventoryHostStaleness';
 import { useConditionalRBAC } from '../Utilities/hooks/useConditionalRBAC';
 import { GENERAL_HOST_STALENESS_READ_PERMISSION } from '../components/InventoryHostStaleness/constants';
-import { GENERAL_HOSTS_READ_PERMISSIONS } from '../constants';
+import { asPermissionList, GENERAL_HOSTS_READ_PERMISSIONS } from '../constants';
 import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import HostStalenessNoAccess from '../components/InventoryHostStaleness/HostStalenessNoAccess';
 import { OutageAlert } from '../components/OutageAlert';
@@ -15,12 +15,12 @@ import { useHostStalenessKesselAccess } from '../Utilities/hooks/useHostStalenes
 
 const REQUIRED_READ_PERMISSIONS = [
   GENERAL_HOST_STALENESS_READ_PERMISSION,
-  GENERAL_HOSTS_READ_PERMISSIONS,
+  ...asPermissionList(GENERAL_HOSTS_READ_PERMISSIONS),
 ];
 
 const HostStaleness = () => {
   const chrome = useChrome();
-  const { hasAccess: canReadHostStalenessRbac } = useConditionalRBAC(
+  const { hasAccess: hasStalenessAndHostsReadRbac } = useConditionalRBAC(
     REQUIRED_READ_PERMISSIONS,
     true,
   );
@@ -33,10 +33,10 @@ const HostStaleness = () => {
     chrome.hideGlobalFilter(true);
   }, [chrome]);
 
-  const canReadHostStaleness =
+  const canViewStalenessPage =
     kesselAccess.mode === 'kessel'
       ? kesselAccess.canViewPage
-      : canReadHostStalenessRbac;
+      : hasStalenessAndHostsReadRbac;
 
   const kesselEditOverride =
     kesselAccess.mode === 'kessel' ? kesselAccess.canEditStaleness : undefined;
@@ -57,7 +57,7 @@ const HostStaleness = () => {
           <Bullseye>
             <Spinner aria-label="Loading permissions" />
           </Bullseye>
-        ) : canReadHostStaleness ? (
+        ) : canViewStalenessPage ? (
           <InventoryHostStaleness
             kesselCanModifyHostStaleness={kesselEditOverride}
             editDisabledTooltip={editDisabledTooltip}


### PR DESCRIPTION
## Jira
[RHINENG-14129](https://redhat.atlassian.net/browse/RHINENG-14129)

## What
Custom staleness page displays spinner sign instead of page with disabled actions

## How
Visit staleness and Deletion page with user with staleness read role and without host viewer role

[RHINENG-14129]: https://redhat.atlassian.net/browse/RHINENG-14129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure the host staleness page enforces appropriate read and write permissions and reflects them in the UI state.

Bug Fixes:
- Prevent the staleness page from showing a loading spinner for users lacking host viewer access by correctly gating access on both staleness and host read permissions.

Enhancements:
- Tighten RBAC checks for modifying host staleness by requiring both staleness and host read/write permissions and wiring this through to the host staleness card.
- Add RBAC-focused tests to verify edit controls are disabled without modify permissions, and that Kessel access overrides RBAC when provided.
- Add UI tests to confirm Edit and related dropdown controls are disabled when the user cannot modify host staleness.

Tests:
- Introduce dedicated RBAC tests for the InventoryHostStaleness component and update UI tests to cover disabled edit controls for users without modify permissions.