### PR TITLE
fix(RBAC): avoid calling v1 when kessel enabled

### DIFF
--- a/src/modules/AsyncInventory.js
+++ b/src/modules/AsyncInventory.js
@@ -1,8 +1,11 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Bullseye } from '@patternfly/react-core/dist/dynamic/layouts/Bullseye';
+import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
 import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACProvider';
+import { useKesselMigrationFeatureFlag } from '../Utilities/hooks/useKesselMigrationFeatureFlag';
 
 import * as storeMod from '../store/redux';
 import * as utils from '../Utilities/index';
@@ -14,6 +17,9 @@ const { mergeWithDetail, ...rest } = storeMod;
 const queryClient = new QueryClient();
 
 const AsyncInventory = ({ component, onLoad, store, innerRef, ...props }) => {
+  const isKesselMigrationEnabled = useKesselMigrationFeatureFlag();
+  const [isStoreReady, setIsStoreReady] = useState(false);
+
   useEffect(() => {
     onLoad?.({
       ...rest,
@@ -21,6 +27,7 @@ const AsyncInventory = ({ component, onLoad, store, innerRef, ...props }) => {
       api: apiMod,
       mergeWithDetail,
     });
+    setIsStoreReady(true);
   }, []);
 
   const content = (
@@ -37,15 +44,26 @@ const AsyncInventory = ({ component, onLoad, store, innerRef, ...props }) => {
     </Provider>
   );
 
-  // Skipping RBACProvider caused InventoryTable not to load in other apps
+  const loadingFallback = (
+    <Bullseye>
+      <Spinner size="xl" />
+    </Bullseye>
+  );
+
   return (
     <AccessCheck.Provider
       baseUrl={typeof window !== 'undefined' ? window.location.origin : ''}
       apiPath={KESSEL_API_PATH}
     >
-      <RBACProvider appName="inventory" checkResourceDefinitions>
-        {content}
-      </RBACProvider>
+      {!isStoreReady ? (
+        loadingFallback
+      ) : isKesselMigrationEnabled ? (
+        content
+      ) : (
+        <RBACProvider appName="inventory" checkResourceDefinitions>
+          {content}
+        </RBACProvider>
+      )}
     </AccessCheck.Provider>
   );
 };


### PR DESCRIPTION
## What
Wrapping components into RBAC provider only when Kessel is disabled + also fixing the issue when Table was crashing with
```
installHook.js:1 TypeError: Cannot read properties of undefined (reading 'rows')
    at InventoryTable.js:101:28
```
Problem was that other apps are registering entities in onLoad from AsyncInventory, for example, `onLoad?.({ mergeWithEntities, ... })`  in compliance. That used to run in useEffect, which runs after the first render.
With RBACProvider children are hidden behind a spinner until RBAC finishes, so onLoad usually runs before InventoryTable mounts. So if we remove RBAC provider - inventory table mounts immediately and with not registered entities yet page crashes.

## Testing

1. Have Kessel feature flag enabled
2. Run inventory locally and open any app with systems page
3. See that table loads without any issues


## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->

## Summary by Sourcery

Gate RBAC provider usage on the Kessel migration feature flag and ensure the inventory store is initialized before rendering consumers to prevent crashes.

New Features:
- Add conditional rendering of the RBAC provider based on the Kessel migration feature flag in AsyncInventory.
- Introduce a loading spinner fallback while the inventory store initializes before rendering child content.

Bug Fixes:
- Prevent InventoryTable and other consumers from crashing due to uninitialized entities by delaying rendering until the inventory store is ready.