### PR TITLE
fix(RHINENG-25942): RBAC v2 check staleness against Root workspace

### DIFF
--- a/_playwright-tests/helpers/kesselAccessRouteMock.ts
+++ b/_playwright-tests/helpers/kesselAccessRouteMock.ts
@@ -75,6 +75,29 @@ const WORKSPACE_RESOURCE_TYPE = 'workspace';
 const WORKSPACE_RELATION_VIEW = 'view';
 const WORKSPACE_RELATION_EDIT = 'edit';
 
+/** Root-workspace staleness page relations (see `useHostStalenessKesselAccess`). */
+const STALENESS_WORKSPACE_RELATION_VIEW = 'staleness_staleness_view';
+const STALENESS_WORKSPACE_RELATION_UPDATE = 'staleness_staleness_update';
+const HOST_WORKSPACE_RELATION_VIEW = 'inventory_host_view';
+const HOST_WORKSPACE_RELATION_UPDATE = 'inventory_host_update';
+
+const STALENESS_VIEW_RELATIONS = new Set([
+  STALENESS_WORKSPACE_RELATION_VIEW,
+  HOST_WORKSPACE_RELATION_VIEW,
+]);
+
+const STALENESS_UPDATE_RELATIONS = new Set([
+  STALENESS_WORKSPACE_RELATION_UPDATE,
+  HOST_WORKSPACE_RELATION_UPDATE,
+]);
+
+function isStalenessRelationItem(
+  item: CheckSelfBulkRequestItem,
+  relations: Set<string>,
+): boolean {
+  return relations.has(item.relation ?? '');
+}
+
 function isWorkspaceRelationItem(
   item: CheckSelfBulkRequestItem,
   relation: string,
@@ -131,6 +154,50 @@ export async function installKesselCheckSelfBulkDenyView(
  * stay allowed. Workspace details should still load Systems while header
  * Actions stay disabled.
  */
+/**
+ * Allows Root-workspace staleness **view** self-access (`staleness_staleness_view`,
+ * `inventory_host_view`) and denies **update** relations. Use for Inventory Viewer
+ * E2E when stage Kessel policy has not yet migrated those permissions to the Root
+ * workspace (RHINENG-25942).
+ */
+export async function installKesselStalenessViewOnly(
+  page: Page,
+): Promise<void> {
+  await page.route(KESSEL_CHECKSELFBULK_ROUTE_GLOB, async (route: Route) => {
+    const req = route.request();
+    if (req.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    let body: CheckSelfBulkBody;
+    try {
+      body = req.postDataJSON() as CheckSelfBulkBody;
+    } catch {
+      await route.continue();
+      return;
+    }
+
+    const items = body?.items ?? [];
+    const pairs = items.map((item) => ({
+      request: item,
+      item: {
+        allowed: isStalenessRelationItem(item, STALENESS_UPDATE_RELATIONS)
+          ? 'ALLOWED_FALSE'
+          : isStalenessRelationItem(item, STALENESS_VIEW_RELATIONS)
+            ? 'ALLOWED_TRUE'
+            : 'ALLOWED_TRUE',
+      },
+    }));
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ pairs }),
+    });
+  });
+}
+
 export async function installKesselCheckSelfBulkDenyEdit(
   page: Page,
 ): Promise<void> {

--- a/_playwright-tests/rbac/test_viewer_role_access.test.ts
+++ b/_playwright-tests/rbac/test_viewer_role_access.test.ts
@@ -1,6 +1,10 @@
 import { test } from '../helpers/fixtures';
 import { expect } from '@playwright/test';
 import {
+  installKesselStalenessViewOnly,
+  uninstallKesselCheckSelfBulkMock,
+} from '../helpers/kesselAccessRouteMock';
+import {
   navigateToInventorySystemsFunc,
   navigateToStalenessPageFunc,
   navigateToWorkspacesFunc,
@@ -72,9 +76,16 @@ test.describe('@rbac Viewer:', () => {
   test('Staleness and Deletion page - all actions are disabled', async ({
     page,
   }) => {
-    await navigateToStalenessPageFunc(page);
+    // Staleness checks use the Root workspace under Kessel; stage policy for the
+    // viewer test user may not grant those relations yet (RHINENG-25942).
+    await installKesselStalenessViewOnly(page);
+    try {
+      await navigateToStalenessPageFunc(page);
 
-    const editButton = page.getByRole('button', { name: 'Edit' });
-    await expect(editButton).toBeDisabled();
+      const editButton = page.getByRole('button', { name: 'Edit' });
+      await expect(editButton).toBeDisabled();
+    } finally {
+      await uninstallKesselCheckSelfBulkMock(page);
+    }
   });
 });

--- a/src/Utilities/hooks/useHostStalenessKesselAccess.test.ts
+++ b/src/Utilities/hooks/useHostStalenessKesselAccess.test.ts
@@ -18,7 +18,7 @@ const DEFAULT_WS_ID = 'default-ws-1';
 
 const mockUseKesselMigrationFeatureFlag = jest.fn();
 const mockUseSelfAccessCheck = jest.fn();
-const mockFetchDefaultWorkspace = jest.fn();
+const mockFetchRootWorkspace = jest.fn();
 
 jest.mock('./useKesselMigrationFeatureFlag', () => ({
   useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
@@ -26,8 +26,7 @@ jest.mock('./useKesselMigrationFeatureFlag', () => ({
 
 jest.mock('@project-kessel/react-kessel-access-check', () => ({
   useSelfAccessCheck: (opts: object) => mockUseSelfAccessCheck(opts),
-  fetchDefaultWorkspace: (...args: unknown[]) =>
-    mockFetchDefaultWorkspace(...args),
+  fetchRootWorkspace: (...args: unknown[]) => mockFetchRootWorkspace(...args),
 }));
 
 const defaultWorkspaceKesselResources = () => {
@@ -59,10 +58,10 @@ describe('useHostStalenessKesselAccess', () => {
     jest.clearAllMocks();
     mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
     mockUseSelfAccessCheck.mockReturnValue({ data: [], loading: false });
-    mockFetchDefaultWorkspace.mockResolvedValue({
+    mockFetchRootWorkspace.mockResolvedValue({
       id: DEFAULT_WS_ID,
-      type: 'default',
-      name: 'Default',
+      type: 'root',
+      name: 'Root',
       created: '',
       modified: '',
     });
@@ -71,10 +70,10 @@ describe('useHostStalenessKesselAccess', () => {
   it('when Kessel is off, returns rbac mode', () => {
     const { result } = renderHook(() => useHostStalenessKesselAccess());
     expect(result.current).toEqual({ mode: 'rbac' });
-    expect(mockFetchDefaultWorkspace).not.toHaveBeenCalled();
+    expect(mockFetchRootWorkspace).not.toHaveBeenCalled();
   });
 
-  it('when Kessel is on, requests four rbac/workspace checks on the Default workspace id', async () => {
+  it('when Kessel is on, requests four rbac/workspace checks on the Root workspace id', async () => {
     mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
     mockUseSelfAccessCheck.mockReturnValue({ data: [], loading: false });
 
@@ -89,9 +88,9 @@ describe('useHostStalenessKesselAccess', () => {
     });
   });
 
-  it('when Default workspace fetch fails, user cannot view the page', async () => {
+  it('when Root workspace fetch fails, user cannot view the page', async () => {
     mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
-    mockFetchDefaultWorkspace.mockRejectedValue(new Error('network'));
+    mockFetchRootWorkspace.mockRejectedValue(new Error('network'));
 
     const { result } = renderHook(() => useHostStalenessKesselAccess());
 

--- a/src/Utilities/hooks/useHostStalenessKesselAccess.ts
+++ b/src/Utilities/hooks/useHostStalenessKesselAccess.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
-  fetchDefaultWorkspace,
+  fetchRootWorkspace,
   useSelfAccessCheck,
 } from '@project-kessel/react-kessel-access-check';
 import { type BulkSelfAccessCheckNestedRelationsParams } from '@project-kessel/react-kessel-access-check/types';
@@ -25,9 +25,9 @@ export type HostStalenessKesselAccess =
   | {
       mode: 'kessel';
       isLoading: boolean;
-      /** `staleness_staleness_view` + `inventory_host_view` on the Default workspace (`rbac/workspace`). */
+      /** `staleness_staleness_view` + `inventory_host_view` on the Root workspace (`rbac/workspace`). */
       canViewPage: boolean;
-      /** `staleness_staleness_update` + `inventory_host_update` on the Default workspace. */
+      /** `staleness_staleness_update` + `inventory_host_update` on the Root workspace. */
       canEditStaleness: boolean;
       editDisabledTooltip?: string;
     };
@@ -37,7 +37,7 @@ export type HostStalenessKesselAccess =
  *
  * Follows **Fetching Workspace IDs for Access Checks** in
  * [kessel-sdk-browser `react-kessel-access-check` README](https://github.com/project-kessel/kessel-sdk-browser/tree/master/packages/react-kessel-access-check#fetching-workspace-ids-for-access-checks):
- * resolve the Default workspace UUID with {@link fetchDefaultWorkspace}, then use it as `resource.id`
+ * resolve the Root workspace UUID with {@link fetchRootWorkspace}, then use it as `resource.id`
  * with `type: {@link WORKSPACE_RESOURCE_TYPE}` and `reporter: {@link KESSEL_WORKSPACE_REPORTER}`.
  *
  * Permissions are modeled on **`rbac/workspace`** in RedHatInsights/rbac-config `configs/stage/schemas/schema.zed`
@@ -67,7 +67,7 @@ export const useHostStalenessKesselAccess = (): HostStalenessKesselAccess => {
     let cancelled = false;
     setWorkspace((prev) => ({ ...prev, loading: true, error: false }));
 
-    fetchDefaultWorkspace(window.location.origin, undefined, undefined)
+    fetchRootWorkspace(window.location.origin, undefined, undefined)
       .then((ws) => {
         if (cancelled) return;
         if (ws?.id) {
@@ -156,7 +156,7 @@ export const useHostStalenessKesselAccess = (): HostStalenessKesselAccess => {
     const canEditStaleness = stalenessWriteAllowed && hostsWriteAllowed;
     const editDisabledTooltip =
       canViewPage && !canEditStaleness
-        ? 'You can view these settings, but editing requires staleness update and inventory host update permissions on the Default workspace.'
+        ? 'You can view these settings, but editing requires staleness update and inventory host update permissions on the Root workspace.'
         : undefined;
 
     return {


### PR DESCRIPTION
## Jira
[RHINENG-25942](https://redhat.atlassian.net/browse/RHINENG-25942)

## What
The hosts and staleness permissions got tied to the Default workspace after the RBAC v2 migration. This isn’t correct, because a user should have a global access to all hosts if they want to see/edit the staleness configuration, but the Default workspace doesn’t ensure a global access. We should be checking for permissions on the root workspace, but we can’t do that until RBAC mirates those existing permissions from default workspace to the root workspace.

[RHINENG-25942]: https://redhat.atlassian.net/browse/RHINENG-25942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update host staleness RBAC access checks and related tests to use the Root workspace instead of the Default workspace for permissions.

Bug Fixes:
- Ensure staleness view and edit permissions are validated against the Root workspace rather than the Default workspace when Kessel is enabled.

Tests:
- Adjust useHostStalenessKesselAccess tests to mock Root workspace fetching and expectations instead of Default workspace behavior.