### PR TITLE
fix(RHINENG-26284): bulk delete workspaces with pagination

### DIFF
--- a/src/components/GroupsTable/useGroupsTableWorkspaceActionPermissions.test.ts
+++ b/src/components/GroupsTable/useGroupsTableWorkspaceActionPermissions.test.ts
@@ -269,6 +269,50 @@ describe('useGroupsTableWorkspaceActionPermissions', () => {
       ).toBeUndefined();
     });
 
+    it('bulk delete checks permissions for selected workspaces not on current page (RHINENG-26284)', () => {
+      // Mock the permission hook to verify it receives augmented groups including selected IDs
+      let receivedGroups: MockWorkspaceRowKesselGroup[] = [];
+      mockUseWorkspaceTableRowKesselPermissions.mockImplementation((groups) => {
+        receivedGroups = groups;
+        return {
+          workspacePermissionById: {
+            page1: { canEdit: true, canDelete: true },
+            page2a: { canEdit: true, canDelete: true },
+            page2b: { canEdit: true, canDelete: true },
+          },
+          permissionsLoading: false,
+        };
+      });
+
+      // Scenario: User is on page 2 (groups page2a, page2b) but has selected
+      // workspace 'page1' from page 1. The hook should augment groups to include page1.
+      const { result } = renderHook(() =>
+        useGroupsTableWorkspaceActionPermissions({
+          groups: [
+            { id: 'page2a', ungrouped: false },
+            { id: 'page2b', ungrouped: false },
+          ],
+          selectedIds: ['page1', 'page2a'],
+        }),
+      );
+
+      // Verify the permission hook received augmented groups including the selected ID from page 1
+      expect(receivedGroups).toEqual(
+        expect.arrayContaining([
+          { id: 'page2a', ungrouped: false },
+          { id: 'page2b', ungrouped: false },
+          { id: 'page1', ungrouped: false }, // synthetic entry for cross-page selection
+        ]),
+      );
+      expect(receivedGroups).toHaveLength(3);
+
+      // Bulk delete should be enabled since both selected workspaces are deletable
+      expect(result.current.bulkDeleteMenuItemProps.override).toBe(true);
+      expect(result.current.bulkDeleteMenuItemProps.isKesselGateBusy).toBe(
+        false,
+      );
+    });
+
     it('create workspace button reflects Kessel create permission', () => {
       mockUseKesselCanCreateWorkspace.mockReturnValue({
         canCreateWorkspace: true,

--- a/src/components/GroupsTable/useGroupsTableWorkspaceActionPermissions.ts
+++ b/src/components/GroupsTable/useGroupsTableWorkspaceActionPermissions.ts
@@ -67,10 +67,25 @@ export const useGroupsTableWorkspaceActionPermissions = ({
   selectedIds,
 }: UseGroupsTableWorkspaceActionPermissionsParams) => {
   const isKesselMigrationEnabled = useKesselMigrationFeatureFlag();
+
+  // Augment groups with selected IDs not on current page to ensure
+  // bulk delete permission checks work across pagination (RHINENG-26284)
+  const groupsWithSelectedIds = useMemo(() => {
+    const currentPageIds = new Set(groups.map((g) => g.id).filter(Boolean));
+    const missingSelectedIds = selectedIds.filter(
+      (id) => !currentPageIds.has(id),
+    );
+    const syntheticGroups = missingSelectedIds.map((id) => ({
+      id,
+      ungrouped: false,
+    }));
+    return [...groups, ...syntheticGroups];
+  }, [groups, selectedIds]);
+
   const {
     workspacePermissionById,
     permissionsLoading: workspacePermissionsLoading,
-  } = useWorkspaceTableRowKesselPermissions(groups);
+  } = useWorkspaceTableRowKesselPermissions(groupsWithSelectedIds);
   const { canCreateWorkspace, createPermissionLoading } =
     useKesselCanCreateWorkspace();
 


### PR DESCRIPTION
## Jira
[RHINENG-26284](https://redhat.atlassian.net/browse/RHINENG-26284)

## What
Bulk delete Workspace doesn't work with pagination - it works only on page where workspace is selected. Bulk delete Workspace is disabled on page where workspace is not selected.

## How
The issue is that the code checks permissions for all selected workspaces before it determines whether the bulk delete should be enabled; but it only has permissions data for the current page. This change handles that gap.

## Testing
- Visit Workspace page
- select Workspace with 0 systems
- Check bulk delete workspace is enabled
- go to second page
- check bulk delete Workspace

## Screenshots/Videos (if applicable)
<img width="743" height="222" alt="image" src="https://github.com/user-attachments/assets/45aad186-ac98-4488-993a-387fd9318dfb" />

[RHINENG-26284]: https://redhat.atlassian.net/browse/RHINENG-26284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Handle bulk workspace deletion permissions across paginated workspace lists so selections on non-current pages are respected.

Bug Fixes:
- Ensure bulk delete workspace action remains enabled when deletable workspaces are selected across multiple pages, not just the current page.

Tests:
- Add a unit test verifying that permission checks for bulk workspace deletion include selected workspaces that are not on the current page.