### PR TITLE
fix(CI): combine --grep-invert markers into a single regex pattern

### DIFF
--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -75,7 +75,7 @@ jobs:
         run: npx playwright install chromium
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert @integration --grep-invert @rbac
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert "@integration|@rbac"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1


### PR DESCRIPTION
## What
Fix-up - combine --grep-invert markers into a single regex pattern

## Why
Playwright's `--grep-invert` only accepts one value. When you pass it twice, the second` --grep-invert @rbac` overrides the first `--grep-invert @integration`. So only `@rbac` tests are being excluded - `@integration` tests are still running.

## Summary by Sourcery

CI:
- Update Playwright test invocation in the production post-release workflow to use a single regex grep-invert pattern that filters out both @integration and @rbac tests.