### PR TITLE
feat(RHINENG-26562): add fetching from /beta/hosts-view

### DIFF
--- a/src/api/hostInventoryApiTyped.ts
+++ b/src/api/hostInventoryApiTyped.ts
@@ -27,7 +27,11 @@ import type {
   ApiSystemProfileGetOperatingSystemParams,
   ApiSystemProfileGetOperatingSystemReturnType,
 } from '@redhat-cloud-services/host-inventory-client/ApiSystemProfileGetOperatingSystem';
-import type { ActiveTags } from '@redhat-cloud-services/host-inventory-client';
+import type {
+  ActiveTags,
+  ApiHostViewsGetHostViewsReturnType,
+} from '@redhat-cloud-services/host-inventory-client';
+import { ApiHostViewsGetHostViewsParams } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 
 export type {
   HostOut,
@@ -69,6 +73,14 @@ export const getHostList = async (
   return (await hostInventoryApi().apiHostGetHostList(
     params,
   )) as unknown as ApiHostGetHostListReturnType;
+};
+
+export const getHostViews = async (
+  params: ApiHostViewsGetHostViewsParams = {},
+): Promise<ApiHostViewsGetHostViewsReturnType> => {
+  return (await hostInventoryApi().apiHostViewsGetHostViews(
+    params,
+  )) as unknown as ApiHostViewsGetHostViewsReturnType;
 };
 
 export const getHostTags = async (

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -9,6 +9,10 @@ import { useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/H
 import { PageSection, Pagination } from '@patternfly/react-core';
 import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
 import { BulkSelect } from '../BulkSelect';
+import {
+  type InventoryViewsSortBy,
+  useInventoryViewsQuery,
+} from './hooks/useInventoryViewsQuery';
 import { useSystemsQuery } from './hooks/useSystemsQuery';
 import { useHostIdsWithKessel } from '../../Utilities/hooks/useHostIdsWithKessel';
 import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
@@ -124,14 +128,41 @@ const SystemsViewInner = ({
     isInventoryViewsEnabled,
   });
 
-  const { data, total, isLoading, isFetching, isError } = useSystemsQuery({
+  const sharedQueryArgs = {
     page: pagination.page,
     perPage: pagination.perPage,
     filters: queryFilters,
     lastSeenCustomRange,
-    sortBy: sortBy as ApiOrderByEnum | undefined,
     direction,
+  };
+
+  const systemsQueryResult = useSystemsQuery({
+    ...sharedQueryArgs,
+    sortBy: sortBy as ApiOrderByEnum | undefined,
+    enabled: !isInventoryViewsEnabled,
   });
+
+  const inventoryViewsQueryResult = useInventoryViewsQuery({
+    ...sharedQueryArgs,
+    sortBy: sortBy as InventoryViewsSortBy | undefined,
+    enabled: isInventoryViewsEnabled,
+  });
+
+  const data = isInventoryViewsEnabled
+    ? inventoryViewsQueryResult.data
+    : systemsQueryResult.data;
+  const total = isInventoryViewsEnabled
+    ? inventoryViewsQueryResult.total
+    : systemsQueryResult.total;
+  const isLoading = isInventoryViewsEnabled
+    ? inventoryViewsQueryResult.isLoading
+    : systemsQueryResult.isLoading;
+  const isFetching = isInventoryViewsEnabled
+    ? inventoryViewsQueryResult.isFetching
+    : systemsQueryResult.isFetching;
+  const isError = isInventoryViewsEnabled
+    ? inventoryViewsQueryResult.isError
+    : systemsQueryResult.isError;
 
   const { hostsWithPermissions } = useHostIdsWithKessel(data);
 

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -148,21 +148,11 @@ const SystemsViewInner = ({
     enabled: isInventoryViewsEnabled,
   });
 
-  const data = isInventoryViewsEnabled
-    ? inventoryViewsQueryResult.data
-    : systemsQueryResult.data;
-  const total = isInventoryViewsEnabled
-    ? inventoryViewsQueryResult.total
-    : systemsQueryResult.total;
-  const isLoading = isInventoryViewsEnabled
-    ? inventoryViewsQueryResult.isLoading
-    : systemsQueryResult.isLoading;
-  const isFetching = isInventoryViewsEnabled
-    ? inventoryViewsQueryResult.isFetching
-    : systemsQueryResult.isFetching;
-  const isError = isInventoryViewsEnabled
-    ? inventoryViewsQueryResult.isError
-    : systemsQueryResult.isError;
+  const activeResult = isInventoryViewsEnabled
+    ? inventoryViewsQueryResult
+    : systemsQueryResult;
+
+  const { data, total, isLoading, isFetching, isError } = activeResult;
 
   const { hostsWithPermissions } = useHostIdsWithKessel(data);
 

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -9,10 +9,7 @@ import { useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/H
 import { PageSection, Pagination } from '@patternfly/react-core';
 import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
 import { BulkSelect } from '../BulkSelect';
-import {
-  type InventoryViewsSortBy,
-  useInventoryViewsQuery,
-} from './hooks/useInventoryViewsQuery';
+import { useInventoryViewsQuery } from './hooks/useInventoryViewsQuery';
 import { useSystemsQuery } from './hooks/useSystemsQuery';
 import { useHostIdsWithKessel } from '../../Utilities/hooks/useHostIdsWithKessel';
 import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
@@ -50,6 +47,7 @@ import { SORT_DIR_URL_PARAM, SORT_URL_PARAM } from './constants';
 import useInventoryViewsFeatureFlag from '../../Utilities/useInventoryViewsFeatureFlag';
 import type { Column } from './columns/allColumnDefinitions';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
+import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 
 export type SortDirection = ISortBy['direction'];
 export type OnSort = (
@@ -144,7 +142,7 @@ const SystemsViewInner = ({
 
   const inventoryViewsQueryResult = useInventoryViewsQuery({
     ...sharedQueryArgs,
-    sortBy: sortBy as InventoryViewsSortBy | undefined,
+    sortBy: sortBy as ApiHostViewsGetHostViewsOrderByEnum | undefined,
     enabled: isInventoryViewsEnabled,
   });
 

--- a/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
+++ b/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
@@ -1,0 +1,170 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { getHostTags, getHostViews } from '../../../api/hostInventoryApiTyped';
+import { InventoryFilters } from '../filters/SystemsViewFilters';
+import type { ApiHostViewsGetHostViewsParams } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import {
+  ApiHostViewsGetHostViewsOrderByEnum,
+  ApiHostViewsGetHostViewsRegisteredWithEnum,
+  ApiHostViewsGetHostViewsStalenessEnum,
+  ApiHostViewsGetHostViewsSystemTypeEnum,
+} from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import { ApiHostGetHostListOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
+import { SortDirection } from '../SystemsView';
+import { lastSeenKeysToApiParams } from '../utils/lastSeenKeysToApiParams';
+import type { LastSeenCustomRange } from '../DataViewFiltersContext';
+
+/**
+ * Sort field for `/beta/hosts-view` (`getHostViews`). Combines host-views order enums with
+ * host-list order enums so callers can reuse Systems View column `sortBy` where values overlap
+ * (e.g. `display_name`, `group_name`, `operating_system`, `last_check_in`).
+ */
+export type InventoryViewsSortBy =
+  | ApiHostViewsGetHostViewsOrderByEnum
+  | ApiHostGetHostListOrderByEnum;
+
+const serializeSystemTypeForViews = (values: string[]) => {
+  const validValues = Object.values(ApiHostViewsGetHostViewsSystemTypeEnum);
+
+  return values
+    .map((val) => (val === 'image' ? ['bootc', 'edge'] : val))
+    .flat()
+    .filter((val): val is ApiHostViewsGetHostViewsSystemTypeEnum =>
+      validValues.includes(val as ApiHostViewsGetHostViewsSystemTypeEnum),
+    );
+};
+
+type FetchInventoryViewsReturnedValue = Awaited<
+  ReturnType<typeof fetchInventoryViews>
+>;
+
+/**
+ * Host row from `fetchInventoryViews`: host-view API shape plus optional `tags` from
+ * `getHostTags`. Not the same as the classic host list `HostOut` type.
+ */
+export type InventoryViewHost =
+  FetchInventoryViewsReturnedValue['results'][number];
+
+interface FetchInventoryViewsParams {
+  page: number;
+  perPage: number;
+  filters: InventoryFilters;
+  lastSeenCustomRange: LastSeenCustomRange;
+  sortBy: InventoryViewsSortBy | undefined;
+  direction: SortDirection | undefined;
+}
+
+const fetchInventoryViews = async ({
+  page,
+  perPage,
+  filters,
+  lastSeenCustomRange,
+  sortBy,
+  direction,
+}: FetchInventoryViewsParams) => {
+  const lastSeenParams = lastSeenKeysToApiParams(
+    filters.last_seen,
+    lastSeenCustomRange,
+  );
+
+  const params: ApiHostViewsGetHostViewsParams = {
+    page,
+    perPage,
+    ...(sortBy && {
+      orderBy: sortBy as NonNullable<ApiHostViewsGetHostViewsParams['orderBy']>,
+    }),
+    ...(direction && { orderHow: direction.toUpperCase() }),
+    ...(filters?.hostname_or_id && { hostnameOrId: filters.hostname_or_id }),
+    ...(filters?.status?.length && {
+      staleness: filters.status as ApiHostViewsGetHostViewsStalenessEnum[],
+    }),
+    ...(filters?.source?.length && {
+      registeredWith:
+        filters.source as ApiHostViewsGetHostViewsRegisteredWithEnum[],
+    }),
+    ...(filters?.system_type?.length && {
+      systemType: serializeSystemTypeForViews(filters.system_type),
+    }),
+    ...(filters?.tags && { tags: filters.tags }),
+    ...(lastSeenParams ?? {}),
+  };
+
+  const { results: hosts, total } = await getHostViews(params);
+
+  if (total === 0) return { results: [], total };
+
+  const { results: hostsTags = {} } = await getHostTags({
+    hostIdList: hosts
+      .map(({ id }) => id)
+      .filter((id): id is string => id !== undefined),
+  });
+
+  const results = hosts.map((host) => ({
+    ...host,
+    ...(host.id && hostsTags[host.id] ? { tags: hostsTags[host.id] } : {}),
+  }));
+
+  return { results, total };
+};
+
+/**
+ * Arguments for `useInventoryViewsQuery`. Same shape as `useSystemsQuery` input.
+ *
+ * Uses `GET /beta/hosts-view` (`getHostViews`): no `system_profile` field or filter params; toolbar
+ * keys `operating_system`, `workloads`, and `rhcStatus` do not affect the request.
+ *
+ * `InventoryFilters.group_id` is ignored until workspace filtering exists on this endpoint.
+ */
+export interface UseInventoryViewsQueryParams {
+  page: number;
+  perPage: number;
+  filters: InventoryFilters;
+  lastSeenCustomRange: LastSeenCustomRange;
+  sortBy: InventoryViewsSortBy | undefined;
+  direction: SortDirection | undefined;
+  /** When false, the query is not run (e.g. when user has no access). Default true. */
+  enabled?: boolean;
+}
+
+export const useInventoryViewsQuery = ({
+  page,
+  perPage,
+  filters,
+  lastSeenCustomRange,
+  sortBy,
+  direction,
+  enabled = true,
+}: UseInventoryViewsQueryParams) => {
+  const { data, isLoading, isFetching, isError, error } = useQuery({
+    queryKey: [
+      'inventory-views',
+      page,
+      perPage,
+      filters,
+      lastSeenCustomRange,
+      sortBy,
+      direction,
+    ],
+    queryFn: async () => {
+      return await fetchInventoryViews({
+        page,
+        perPage,
+        filters,
+        lastSeenCustomRange,
+        sortBy,
+        direction,
+      });
+    },
+    placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
+    enabled,
+  });
+
+  return {
+    data: data?.results,
+    total: data?.total,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+  };
+};

--- a/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
+++ b/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
@@ -8,19 +8,9 @@ import {
   ApiHostViewsGetHostViewsStalenessEnum,
   ApiHostViewsGetHostViewsSystemTypeEnum,
 } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
-import { ApiHostGetHostListOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import { SortDirection } from '../SystemsView';
 import { lastSeenKeysToApiParams } from '../utils/lastSeenKeysToApiParams';
 import type { LastSeenCustomRange } from '../DataViewFiltersContext';
-
-/**
- * Sort field for `/beta/hosts-view` (`getHostViews`). Combines host-views order enums with
- * host-list order enums so callers can reuse Systems View column `sortBy` where values overlap
- * (e.g. `display_name`, `group_name`, `operating_system`, `last_check_in`).
- */
-export type InventoryViewsSortBy =
-  | ApiHostViewsGetHostViewsOrderByEnum
-  | ApiHostGetHostListOrderByEnum;
 
 const serializeSystemTypeForViews = (values: string[]) => {
   const validValues = Object.values(ApiHostViewsGetHostViewsSystemTypeEnum);
@@ -49,7 +39,7 @@ interface FetchInventoryViewsParams {
   perPage: number;
   filters: InventoryFilters;
   lastSeenCustomRange: LastSeenCustomRange;
-  sortBy: InventoryViewsSortBy | undefined;
+  sortBy: ApiHostViewsGetHostViewsOrderByEnum | undefined;
   direction: SortDirection | undefined;
 }
 
@@ -69,9 +59,7 @@ const fetchInventoryViews = async ({
   const params: ApiHostViewsGetHostViewsParams = {
     page,
     perPage,
-    ...(sortBy && {
-      orderBy: sortBy as NonNullable<ApiHostViewsGetHostViewsParams['orderBy']>,
-    }),
+    ...(sortBy && { orderBy: sortBy }),
     ...(direction && { orderHow: direction.toUpperCase() }),
     ...(filters?.hostname_or_id && { hostnameOrId: filters.hostname_or_id }),
     ...(filters?.status?.length && {
@@ -119,7 +107,7 @@ export interface UseInventoryViewsQueryParams {
   perPage: number;
   filters: InventoryFilters;
   lastSeenCustomRange: LastSeenCustomRange;
-  sortBy: InventoryViewsSortBy | undefined;
+  sortBy: ApiHostViewsGetHostViewsOrderByEnum | undefined;
   direction: SortDirection | undefined;
   /** When false, the query is not run (e.g. when user has no access). Default true. */
   enabled?: boolean;


### PR DESCRIPTION
## Jira
RHINENG-26562

## What
Adds useQuery for /beta/hosts-view endpoint. Temporary removes any usage of system_profile as it's not implemented yet for this endpoint. Missing system_profile has UI implications read below.

IMPORTANT! 

Some columns (displayName and OperatingSystem) and some filters (rhcStatus, workloads, operatingSystems) depends on system_profile data & filtering. Hence these columns might display wrong/unexpected data and mentioned filters won't work at all. This hook is mainly to unblock development process on InventoryViews columns. Once system_profile is implemented in the endpoints we get functionality for those filters and columns back.

## How
This introduces separate useInventoryViewsQuery which is copy of useSystemsQuery but is using different endpoint and stripping system_profile dependent params. 

New hook is used only when useInventoryViewsFeature is true. If flag is turned off we useSystemsQuery as before with all filters and inventory columns working.

## Testing UI
1. turn on preview mode
2. turn on InventoryViews by running in browser's console localStorage.setItem("ui.inventory-views", "true")
3. Go to Inventory / Systems
4. Observe in devtools we fetch from new endpoint and SystemsView works normally except affected parts mentioned earlier

<img width="1892" height="534" alt="image" src="https://github.com/user-attachments/assets/82de3900-34f0-4e43-ab2e-4979e7396bca" />

## Summary by Sourcery

Gate a new inventory views data source behind a feature flag and integrate it into SystemsView while preserving the existing systems query as a fallback.

New Features:
- Add a useInventoryViewsQuery hook that fetches hosts data from the hosts-view endpoint and decorates it with tags.
- Expose a getHostViews helper in the typed host inventory API wrapper for accessing the hosts-view endpoint.

Enhancements:
- Update SystemsView to switch between the classic systems query and the new inventory views query based on the inventory views feature flag, sharing common query arguments between them.