### PR TITLE
fix(RHINENG-25325): show Ungrouped Hosts filter option by default

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -845,7 +845,7 @@ EntityTableToolbar.defaultProps = {
   hasAccess: true,
   activeFiltersConfig: {},
   hideFilters: {},
-  showNoGroupOption: false,
+  showNoGroupOption: true,
 };
 
 export default EntityTableToolbar;

--- a/src/components/InventoryTable/InventoryTable.cy.js
+++ b/src/components/InventoryTable/InventoryTable.cy.js
@@ -226,6 +226,10 @@ describe('with default parameters', () => {
     });
 
     describe('groups filter', () => {
+      const UNGROUPED_HOSTS_LABEL = 'Ungrouped hosts';
+      const firstGroupName = shorterGroupsFixtures.results[0].name;
+      const firstGroupId = shorterGroupsFixtures.results[0].id;
+
       it('options are populated correctly', () => {
         cy.get('[aria-label="Conditional filter toggle"]').click(); // TODO: return to OUIA-based selectors
         cy.get(DROPDOWN_ITEM).contains('Workspace').click();
@@ -235,21 +239,21 @@ describe('with default parameters', () => {
         );
         cy.ouiaId('FilterByGroupOption').should(
           'have.length',
-          expectedNames.length,
+          expectedNames.length + 1,
         );
+        cy.ouiaId('FilterByGroupOption')
+          .contains(UNGROUPED_HOSTS_LABEL)
+          .should('exist');
         expectedNames.forEach((name) => {
           cy.ouiaId('FilterByGroupOption').contains(name).should('exist');
         });
       });
 
-      const firstGroupName = shorterGroupsFixtures.results[0].name;
-      const firstGroupId = shorterGroupsFixtures.results[0].id;
-
       it('creates a chip', () => {
         cy.get('[aria-label="Conditional filter toggle"]').click(); // TODO: return to OUIA-based selectors
         cy.get(DROPDOWN_ITEM).contains('Workspace').click();
         cy.ouiaId('FilterByGroup').click();
-        cy.ouiaId('FilterByGroupOption').eq(0).click();
+        cy.ouiaId('FilterByGroupOption').contains(firstGroupName).click();
         // Custom implementation for PatternFly v6 chips
         cy.get(CHIP_GROUP).should('exist');
         cy.get(CHIP).should('contain', firstGroupName);
@@ -259,7 +263,7 @@ describe('with default parameters', () => {
         cy.get('[aria-label="Conditional filter toggle"]').click(); // TODO: return to OUIA-based selectors
         cy.get(DROPDOWN_ITEM).contains('Workspace').click();
         cy.ouiaId('FilterByGroup').click();
-        cy.ouiaId('FilterByGroupOption').eq(0).click();
+        cy.ouiaId('FilterByGroupOption').contains(firstGroupName).click();
         cy.wait('@getHosts')
           .its('request.url')
           .should('include', `group_id=${firstGroupId}`);

--- a/src/components/InventoryTable/InventoryTable.paginationReset.cy.js
+++ b/src/components/InventoryTable/InventoryTable.paginationReset.cy.js
@@ -40,6 +40,8 @@ const shorterGroupsFixtures = {
   results: groupsFixtures.results.slice(0, 10),
 };
 
+const firstWorkspaceName = shorterGroupsFixtures.results[0].name;
+
 const setTableInterceptors = () => {
   featureFlagsInterceptors.successful();
   systemProfileInterceptors['operating system, successful empty']();
@@ -127,7 +129,7 @@ describe('InventoryTable - Pagination Reset on Filter Application', () => {
       cy.get('[aria-label="Conditional filter toggle"]').click();
       cy.get(DROPDOWN_ITEM).contains('Workspace').click();
       cy.ouiaId('FilterByGroup').click();
-      cy.ouiaId('FilterByGroupOption').eq(0).click();
+      cy.ouiaId('FilterByGroupOption').contains(firstWorkspaceName).click();
 
       // Verify pagination reset to page 1
       verifyPageInUrl(1);
@@ -176,7 +178,7 @@ describe('InventoryTable - Pagination Reset on Filter Application', () => {
       cy.get('[aria-label="Conditional filter toggle"]').click();
       cy.get(DROPDOWN_ITEM).contains('Workspace').click();
       cy.ouiaId('FilterByGroup').click();
-      cy.ouiaId('FilterByGroupOption').eq(0).click();
+      cy.ouiaId('FilterByGroupOption').contains(firstWorkspaceName).click();
 
       // Verify pagination reset to page 1 again
       verifyPageInUrl(1);

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -194,7 +194,7 @@ const useGroupsQueryWithFilter = ({
   };
 };
 
-const useGroupFilter = (showNoGroupOption = false) => {
+const useGroupFilter = (showNoGroupOption = true) => {
   const [selectedGroupIds, setSelectedGroupIds] = useState([]);
 
   const { hasAccess } = useConditionalRBAC(


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-25325

## What
show Ungrouped Hosts filter option by default

## Why
<!-- Reason for change / linked ticket -->

## How
<!-- Brief explanation of approach -->

## Testing

1. Login as a user who has access to multiple workspaces (Workspace-A, Workspace-B, and Ungrouped Hosts).
2. Navigate to the Vulnerability > CVEs section and click on any CVE that affects systems in all three areas.
3. Go to the "Affected Systems" tab.
4. Click on the "Filter by Workspace" (or Workspace filter) dropdown menu at the top of the table.
5. Observe the options "Ungrouped Hosts" available in the list

## Screenshots/Videos (if applicable)
<img width="3222" height="1660" alt="image" src="https://github.com/user-attachments/assets/e2adfeaa-8262-40c5-b6ed-34707e2eef7a" />

## Summary by Sourcery

New Features:
- Always display the Ungrouped Hosts option in the workspace/group filter dropdowns.