### PR TITLE
ci: Roll back node version to 22.x

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.x
+          node-version: 22.x
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.x
+          node-version: 22.x
           cache: 'npm'
       - run: npm ci
       - name: Build with JSDoc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.inputs.commit_hash || 'refs/heads/master' }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.x
+          node-version: 22.x
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/playwright-systems-view.yml
+++ b/.github/workflows/playwright-systems-view.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: "npm"
 
       - name: Install front-end dependencies

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: "npm"
       
       - name: Install front-end dependencies

--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: "npm"
 
       - name: Create front-end .env file

--- a/.github/workflows/stage-daily-pw-tests.yml
+++ b/.github/workflows/stage-daily-pw-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: "npm"
 
       - name: Create front-end .env file


### PR DESCRIPTION
CI:
- Update all GitHub Actions workflows to run on Node.js 22.x rather than Node.js 24.x for linting, building, and Playwright test jobs.