### PR TITLE
docs(RHINENG-26311): Update release process docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,11 @@ The **Standard Release** method uses the `app-interface-bot`. This is the prefer
 * Configure the following variables:
   * HMS_SERVICE: `host-inventory`
   * HOST_INVENTORY_FRONTEND: `master`
-  * FORCE: Use `--force` only if GitHub CI is failing for an unrelated/known flake.
+  * FORCE: Use `--force`. This will skip validation of GitHub check runs on the commit.
+    We are not running any tests in these checks and they can fail intermittently, for example
+    because of some unrelated Konflux issue. If any relevant check fails and a new image is
+    not built or pushed to Quay, the app-interface MR checks won't pass and it won't allow us
+    to merge the release MR anyway.
 * Click Run Pipeline.
 * Result: The bot will create a MR and post the link in the `#insights-release` Slack channel.
 


### PR DESCRIPTION
## Jira
[RHINENG-26311](https://redhat.atlassian.net/browse/RHINENG-26311)

## What
Update release bot docs

## Why
We should be using `--force` when triggering release bot pipelines.

## How
Update README

## Testing
Not needed, docs change

## Screenshots/Videos (if applicable)
Not applicable


[RHINENG-26311]: https://redhat.atlassian.net/browse/RHINENG-26311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Documentation:
- Clarify that the release pipeline should always be triggered with the --force flag and explain why GitHub check validations can be skipped.