### PR TITLE
feat(RHINENG-26074): InventoryViews add Patch columns

### DIFF
--- a/src/components/AdvisoryIcon/AdvisoryIcon.tsx
+++ b/src/components/AdvisoryIcon/AdvisoryIcon.tsx
@@ -1,0 +1,34 @@
+import React, { type FC, type ComponentType } from 'react';
+import {
+  Flex,
+  FlexItem,
+  Tooltip,
+  Icon as PfIcon,
+} from '@patternfly/react-core';
+
+export type AdvisoriesIconProps = {
+  Icon: ComponentType;
+  count?: number;
+  tooltipText: string;
+};
+
+const AdvisoriesIcon: FC<AdvisoriesIconProps> = ({
+  count,
+  tooltipText,
+  Icon,
+}) => (
+  <Tooltip content={tooltipText}>
+    <Flex style={{ display: 'inline-flex', flexWrap: 'nowrap' }}>
+      <FlexItem spacer={{ default: 'spacerSm' }}>
+        <PfIcon>
+          <Icon />
+        </PfIcon>
+      </FlexItem>
+      <FlexItem spacer={{ default: 'spacerSm' }}>
+        {(count && count.toString()) || 0}
+      </FlexItem>
+    </Flex>
+  </Tooltip>
+);
+
+export default AdvisoriesIcon;

--- a/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
@@ -1,5 +1,5 @@
 import type { Column } from '../allColumnDefinitions';
-import { InventoryViewHost } from '../../hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
 
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 
@@ -9,7 +9,7 @@ const recommendationsColumn = {
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.Advisorrecommendations,
-  renderCell: (system: InventoryViewHost) =>
+  renderCell: (system: InventoryViewSystem) =>
     system?.app_data?.advisor?.recommendations ?? 'N/A',
 };
 
@@ -19,7 +19,7 @@ const incidentsColumn = {
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.Advisorincidents,
-  renderCell: (system: InventoryViewHost) =>
+  renderCell: (system: InventoryViewSystem) =>
     system?.app_data?.advisor?.incidents ?? 'N/A',
 };
 
@@ -28,7 +28,7 @@ const criticalColumn = {
   key: 'critical',
   isShownByDefault: false,
   isShown: false,
-  renderCell: (system: InventoryViewHost) =>
+  renderCell: (system: InventoryViewSystem) =>
     system?.app_data?.advisor?.critical ?? 'N/A',
 };
 
@@ -37,7 +37,7 @@ const importantColumn = {
   key: 'important',
   isShownByDefault: false,
   isShown: false,
-  renderCell: (system: InventoryViewHost) =>
+  renderCell: (system: InventoryViewSystem) =>
     system?.app_data?.advisor?.important ?? 'N/A',
 };
 
@@ -46,7 +46,7 @@ const moderateColumn = {
   key: 'moderate',
   isShownByDefault: false,
   isShown: false,
-  renderCell: (system: InventoryViewHost) =>
+  renderCell: (system: InventoryViewSystem) =>
     system?.app_data?.advisor?.moderate ?? 'N/A',
 };
 
@@ -55,7 +55,7 @@ const lowColumn = {
   key: 'low',
   isShownByDefault: false,
   isShown: false,
-  renderCell: (system: InventoryViewHost) =>
+  renderCell: (system: InventoryViewSystem) =>
     system?.app_data?.advisor?.low ?? 'N/A',
 };
 

--- a/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
+++ b/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
@@ -10,30 +10,6 @@ const nonInventoryColumns = allColumns.filter(
 );
 
 describe('allColumnDefinitions', () => {
-  it('should export columns in the correct order', () => {
-    const keys = allColumns.map((col) => col.key);
-    expect(keys).toEqual([
-      'name',
-      'workspace',
-      'tags',
-      'os',
-      'last_seen',
-      'recommendations',
-      'incidents',
-      'critical',
-      'important',
-      'moderate',
-      'low',
-      'last_malware_status',
-      'last_malware_matches',
-      'total_malware_matches',
-      'last_malware_scan',
-      'policies',
-      'last_compliance_scan',
-      'remediations_plans',
-    ]);
-  });
-
   it('should have no duplicate keys', () => {
     const keys = allColumns.map((col) => col.key);
     expect(new Set(keys).size).toBe(keys.length);

--- a/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
+++ b/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import allColumns from './allColumnDefinitions';
-import { InventoryViewHost } from '../hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../hooks/useInventoryViewsQuery';
 
 const inventoryKeys = ['name', 'workspace', 'tags', 'os', 'last_seen'];
 const nonInventoryColumns = allColumns.filter(
@@ -71,7 +71,7 @@ describe('allColumnDefinitions', () => {
   it.each(nonInventoryColumns)(
     'should render N/A when app data is missing for "$key"',
     (column) => {
-      const system = {} as unknown as InventoryViewHost;
+      const system = {} as unknown as InventoryViewSystem;
       render(<>{column.renderCell(system)}</>);
       expect(screen.getByText('N/A')).toBeInTheDocument();
     },

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -18,8 +18,15 @@ type SortableColumn = {
   readonly sortBy?: string;
 };
 
+type ConsumerAppColumn = {
+  appName?: 'patch' | 'vulnerability' | 'advisor';
+};
+
 export type Column = Resolve<
-  ColumnManagementModalColumn & RenderableColumn & SortableColumn
+  ColumnManagementModalColumn &
+    RenderableColumn &
+    SortableColumn &
+    ConsumerAppColumn
 >;
 
 /**

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -1,6 +1,7 @@
 import { ColumnManagementModalColumn } from '@patternfly/react-component-groups';
 import inventoryColumns from './inventory/columnDefinitions';
 import complianceColumns from './compliance/columnDefinitions';
+import patchColumns from './patch/columnDefinitions';
 import { System } from '../hooks/useSystemsQuery';
 import { Resolve } from '../../../types/utility-types';
 import advisorColumns from './advisor/columnDefinitions';
@@ -29,6 +30,7 @@ export type Column = Resolve<
  */
 const allColumns = [
   ...inventoryColumns,
+  ...patchColumns,
   ...advisorColumns,
   ...malwareColumns,
   ...complianceColumns,

--- a/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Column } from '../allColumnDefinitions';
-import { InventoryViewHost } from '../../hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import { Link } from 'react-router-dom';
@@ -11,7 +11,7 @@ const lastComplianceScanColumn = {
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.CompliancelastScan,
-  renderCell: (system: InventoryViewHost) => {
+  renderCell: (system: InventoryViewSystem) => {
     const lastScan = system?.app_data?.compliance?.last_scan;
     return lastScan !== null && lastScan !== undefined ? (
       <DateFormat date={lastScan} />
@@ -26,7 +26,7 @@ const policiesColumn = {
   key: 'policies',
   isShownByDefault: false,
   isShown: false,
-  renderCell: (system: InventoryViewHost) => {
+  renderCell: (system: InventoryViewSystem) => {
     const count = system?.app_data?.compliance?.policies?.length;
     return count !== null && count !== undefined ? (
       <Link to="/insights/compliance/reports">{count}</Link>

--- a/src/components/SystemsView/columns/malware/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/malware/columnDefinitions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Column } from '../allColumnDefinitions';
-import { InventoryViewHost } from '../../hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import { Link } from 'react-router-dom';
@@ -11,7 +11,7 @@ const lastMalwareStatusColumn = {
   key: 'last_malware_status',
   isShownByDefault: false,
   isShown: false,
-  renderCell: (system: InventoryViewHost) => {
+  renderCell: (system: InventoryViewSystem) => {
     const lastStatus = system?.app_data?.malware?.last_status;
     return lastStatus !== null && lastStatus !== undefined ? (
       lastStatus === 'Matched' ? (
@@ -31,7 +31,7 @@ const lastMalwareMatchesColumn = {
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastMatches,
-  renderCell: (system: InventoryViewHost) => {
+  renderCell: (system: InventoryViewSystem) => {
     const lastMatches = system?.app_data?.malware?.last_matches;
     return lastMatches !== null && lastMatches !== undefined ? (
       <DateFormat date={lastMatches} />
@@ -46,7 +46,7 @@ const totalMalwareMatchesColumn = {
   key: 'total_malware_matches',
   isShownByDefault: false,
   isShown: false,
-  renderCell: (system: InventoryViewHost) => {
+  renderCell: (system: InventoryViewSystem) => {
     const count = system?.app_data?.malware?.total_matches;
     return count !== null && count !== undefined ? (
       <Link to={`/insights/malware/systems/${system.id || ''}`}>{count}</Link>
@@ -62,7 +62,7 @@ const lastMalwareScanColumn = {
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastScan,
-  renderCell: (system: InventoryViewHost) => {
+  renderCell: (system: InventoryViewSystem) => {
     const lastScan = system?.app_data?.malware?.last_scan;
     return lastScan !== null && lastScan !== undefined ? (
       <DateFormat date={lastScan} />

--- a/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.test.tsx
+++ b/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.test.tsx
@@ -5,12 +5,13 @@ import InstallableAdvisories from './InstallableAdvisories';
 import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
 import type { PatchAppData } from '@redhat-cloud-services/host-inventory-client';
 
-const PATCH_ADVISORIES_PATH = '//patch/advisories';
+const SYSTEM_UUID = 'test-system-uuid';
+const PATCH_SYSTEM_PATH = `//patch/systems/${SYSTEM_UUID}`;
 
 function renderInstallableAdvisories(value: PatchAppData) {
   return render(
     <TestWrapper>
-      <InstallableAdvisories value={value} />
+      <InstallableAdvisories value={value} systemUUID={SYSTEM_UUID} />
     </TestWrapper>,
   );
 }
@@ -112,13 +113,13 @@ describe('InstallableAdvisories cell', () => {
     expect(screen.getByText('9')).toBeInTheDocument();
   });
 
-  it('should link each advisory type to patch advisories', () => {
+  it('should link each advisory type to the patch system page', () => {
     renderInstallableAdvisories(mixedCountsPatchAppData);
 
     ['5', '11', '3', '9'].forEach((count) => {
       expect(screen.getByRole('link', { name: count })).toHaveAttribute(
         'href',
-        PATCH_ADVISORIES_PATH,
+        PATCH_SYSTEM_PATH,
       );
     });
   });

--- a/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.test.tsx
+++ b/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.test.tsx
@@ -2,7 +2,18 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import InstallableAdvisories from './InstallableAdvisories';
+import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
 import type { PatchAppData } from '@redhat-cloud-services/host-inventory-client';
+
+const PATCH_ADVISORIES_PATH = '//patch/advisories';
+
+function renderInstallableAdvisories(value: PatchAppData) {
+  return render(
+    <TestWrapper>
+      <InstallableAdvisories value={value} />
+    </TestWrapper>,
+  );
+}
 
 const allZeroPatchAppData = {
   advisories_rhea_installable: 0,
@@ -48,13 +59,13 @@ const mixedCountsPatchAppData = {
 
 describe('InstallableAdvisories cell', () => {
   it('should show No installable advisories when all installable counts are zero', () => {
-    render(<InstallableAdvisories value={allZeroPatchAppData} />);
+    renderInstallableAdvisories(allZeroPatchAppData);
 
     expect(screen.getByText('No installable advisories')).toBeInTheDocument();
   });
 
   it('should render only the security advisory icon and count when rhsa is non-zero', () => {
-    render(<InstallableAdvisories value={securityOnlyPatchAppData} />);
+    renderInstallableAdvisories(securityOnlyPatchAppData);
 
     expect(
       screen.queryByText('No installable advisories'),
@@ -63,7 +74,7 @@ describe('InstallableAdvisories cell', () => {
   });
 
   it('should render only the bug fix advisory icon and count when rhba is non-zero', () => {
-    render(<InstallableAdvisories value={bugfixesOnlyPatchAppData} />);
+    renderInstallableAdvisories(bugfixesOnlyPatchAppData);
 
     expect(
       screen.queryByText('No installable advisories'),
@@ -72,7 +83,7 @@ describe('InstallableAdvisories cell', () => {
   });
 
   it('should render only the enhancement advisory icon and count when rhea is non-zero', () => {
-    render(<InstallableAdvisories value={enhancementsOnlyPatchAppData} />);
+    renderInstallableAdvisories(enhancementsOnlyPatchAppData);
 
     expect(
       screen.queryByText('No installable advisories'),
@@ -81,7 +92,7 @@ describe('InstallableAdvisories cell', () => {
   });
 
   it('should render only the other advisory icon and count when other is non-zero', () => {
-    render(<InstallableAdvisories value={otherOnlyPatchAppData} />);
+    renderInstallableAdvisories(otherOnlyPatchAppData);
 
     expect(
       screen.queryByText('No installable advisories'),
@@ -90,7 +101,7 @@ describe('InstallableAdvisories cell', () => {
   });
 
   it('should render all advisory type counts when each installable count is non-zero', () => {
-    render(<InstallableAdvisories value={mixedCountsPatchAppData} />);
+    renderInstallableAdvisories(mixedCountsPatchAppData);
 
     expect(
       screen.queryByText('No installable advisories'),
@@ -99,5 +110,16 @@ describe('InstallableAdvisories cell', () => {
     expect(screen.getByText('11')).toBeInTheDocument();
     expect(screen.getByText('3')).toBeInTheDocument();
     expect(screen.getByText('9')).toBeInTheDocument();
+  });
+
+  it('should link each advisory type to patch advisories', () => {
+    renderInstallableAdvisories(mixedCountsPatchAppData);
+
+    ['5', '11', '3', '9'].forEach((count) => {
+      expect(screen.getByRole('link', { name: count })).toHaveAttribute(
+        'href',
+        PATCH_ADVISORIES_PATH,
+      );
+    });
   });
 });

--- a/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.test.tsx
+++ b/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.test.tsx
@@ -59,7 +59,7 @@ const mixedCountsPatchAppData = {
 } as unknown as PatchAppData;
 
 describe('InstallableAdvisories cell', () => {
-  it('should show No installable advisories when all installable counts are zero', () => {
+  it('should show "No installable advisories" when all installable counts are zero', () => {
     renderInstallableAdvisories(allZeroPatchAppData);
 
     expect(screen.getByText('No installable advisories')).toBeInTheDocument();

--- a/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.test.tsx
+++ b/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.test.tsx
@@ -1,0 +1,103 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import InstallableAdvisories from './InstallableAdvisories';
+import type { PatchAppData } from '@redhat-cloud-services/host-inventory-client';
+
+const allZeroPatchAppData = {
+  advisories_rhea_installable: 0,
+  advisories_rhba_installable: 0,
+  advisories_rhsa_installable: 0,
+  advisories_other_installable: 0,
+} as unknown as PatchAppData;
+
+const securityOnlyPatchAppData = {
+  advisories_rhea_installable: 0,
+  advisories_rhba_installable: 0,
+  advisories_rhsa_installable: 7,
+  advisories_other_installable: 0,
+} as unknown as PatchAppData;
+
+const bugfixesOnlyPatchAppData = {
+  advisories_rhea_installable: 0,
+  advisories_rhba_installable: 4,
+  advisories_rhsa_installable: 0,
+  advisories_other_installable: 0,
+} as unknown as PatchAppData;
+
+const enhancementsOnlyPatchAppData = {
+  advisories_rhea_installable: 2,
+  advisories_rhba_installable: 0,
+  advisories_rhsa_installable: 0,
+  advisories_other_installable: 0,
+} as unknown as PatchAppData;
+
+const otherOnlyPatchAppData = {
+  advisories_rhea_installable: 0,
+  advisories_rhba_installable: 0,
+  advisories_rhsa_installable: 0,
+  advisories_other_installable: 1,
+} as unknown as PatchAppData;
+
+const mixedCountsPatchAppData = {
+  advisories_rhea_installable: 3,
+  advisories_rhba_installable: 11,
+  advisories_rhsa_installable: 5,
+  advisories_other_installable: 9,
+} as unknown as PatchAppData;
+
+describe('InstallableAdvisories cell', () => {
+  it('should show No installable advisories when all installable counts are zero', () => {
+    render(<InstallableAdvisories value={allZeroPatchAppData} />);
+
+    expect(screen.getByText('No installable advisories')).toBeInTheDocument();
+  });
+
+  it('should render only the security advisory icon and count when rhsa is non-zero', () => {
+    render(<InstallableAdvisories value={securityOnlyPatchAppData} />);
+
+    expect(
+      screen.queryByText('No installable advisories'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('should render only the bug fix advisory icon and count when rhba is non-zero', () => {
+    render(<InstallableAdvisories value={bugfixesOnlyPatchAppData} />);
+
+    expect(
+      screen.queryByText('No installable advisories'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('should render only the enhancement advisory icon and count when rhea is non-zero', () => {
+    render(<InstallableAdvisories value={enhancementsOnlyPatchAppData} />);
+
+    expect(
+      screen.queryByText('No installable advisories'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('should render only the other advisory icon and count when other is non-zero', () => {
+    render(<InstallableAdvisories value={otherOnlyPatchAppData} />);
+
+    expect(
+      screen.queryByText('No installable advisories'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('should render all advisory type counts when each installable count is non-zero', () => {
+    render(<InstallableAdvisories value={mixedCountsPatchAppData} />);
+
+    expect(
+      screen.queryByText('No installable advisories'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('11')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('9')).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.tsx
+++ b/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import AdvisoryIcon from '../../../../AdvisoryIcon/AdvisoryIcon';
+import {
+  BugIcon,
+  EnhancementIcon,
+  FlagIcon,
+  SecurityIcon,
+} from '@patternfly/react-icons';
+import { PatchAppData } from '@redhat-cloud-services/host-inventory-client';
+
+type AdvisoryCountsTuple = [
+  rhea: number,
+  rhba: number,
+  rhsa: number,
+  other: number,
+];
+
+/**
+ * Maps patch `app_data.patch` advisory fields into counts for installable advisories.
+ *
+ *  @param appData - Raw patch appData object from the API.
+ *  @returns       Tuple `[rhea, rhba, rhsa, other]` for advisory icons.
+ */
+function patchAppDataToInstallableCounts(
+  appData: PatchAppData,
+): AdvisoryCountsTuple {
+  const suffix = '_installable';
+  const getCount = (advisoryType: 'rhea' | 'rhba' | 'rhsa' | 'other') =>
+    appData?.[`advisories_${advisoryType}${suffix}`] as number;
+
+  return [
+    getCount('rhea'),
+    getCount('rhba'),
+    getCount('rhsa'),
+    getCount('other'),
+  ];
+}
+
+interface InstallableAdvisoriesProps {
+  value: PatchAppData;
+}
+
+const InstallableAdvisories = ({ value }: InstallableAdvisoriesProps) => {
+  const [rhea, rhba, rhsa, other] = patchAppDataToInstallableCounts(value);
+  const allZero = [rhea, rhba, rhsa, other].every((item) => item === 0);
+
+  return (
+    <Flex style={{ display: 'inline-flex', flexWrap: 'nowrap' }}>
+      {allZero && 'No installable advisories'}
+      {rhsa !== 0 && (
+        <FlexItem spacer={{ default: 'spacerXs' }}>
+          <AdvisoryIcon
+            tooltipText="Security advisories"
+            count={rhsa}
+            Icon={SecurityIcon}
+          />
+        </FlexItem>
+      )}
+      {rhba !== 0 && (
+        <FlexItem spacer={{ default: 'spacerXs' }}>
+          <AdvisoryIcon tooltipText="Bug fixes" count={rhba} Icon={BugIcon} />
+        </FlexItem>
+      )}
+      {rhea !== 0 && (
+        <FlexItem spacer={{ default: 'spacerXs' }}>
+          <AdvisoryIcon
+            tooltipText="Enhancements"
+            count={rhea}
+            Icon={EnhancementIcon}
+          />
+        </FlexItem>
+      )}
+      {other !== 0 && (
+        <FlexItem spacer={{ default: 'spacerXs' }}>
+          <AdvisoryIcon tooltipText="Other" count={other} Icon={FlagIcon} />
+        </FlexItem>
+      )}
+    </Flex>
+  );
+};
+
+export default InstallableAdvisories;

--- a/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.tsx
+++ b/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.tsx
@@ -40,24 +40,23 @@ function patchAppDataToInstallableCounts(
 
 interface InstallableAdvisoriesProps {
   value: PatchAppData;
+  systemUUID: string;
 }
 
-const InstallableAdvisories = ({ value }: InstallableAdvisoriesProps) => {
+const InstallableAdvisories = ({
+  value,
+  systemUUID,
+}: InstallableAdvisoriesProps) => {
   const [rhea, rhba, rhsa, other] = patchAppDataToInstallableCounts(value);
   const allZero = [rhea, rhba, rhsa, other].every((item) => item === 0);
+  const patchSystemLink = { pathname: `/systems/${systemUUID}` };
 
   return (
     <Flex style={{ display: 'inline-flex', flexWrap: 'nowrap' }}>
       {allZero && 'No installable advisories'}
       {rhsa !== 0 && (
         <FlexItem spacer={{ default: 'spacerXs' }}>
-          <InsightsLink
-            app="patch"
-            to={{
-              pathname: '/advisories',
-            }}
-            preview={false}
-          >
+          <InsightsLink app="patch" to={patchSystemLink} preview={false}>
             <AdvisoryIcon
               tooltipText="Security advisories"
               count={rhsa}
@@ -68,26 +67,14 @@ const InstallableAdvisories = ({ value }: InstallableAdvisoriesProps) => {
       )}
       {rhba !== 0 && (
         <FlexItem spacer={{ default: 'spacerXs' }}>
-          <InsightsLink
-            app="patch"
-            to={{
-              pathname: '/advisories',
-            }}
-            preview={false}
-          >
+          <InsightsLink app="patch" to={patchSystemLink} preview={false}>
             <AdvisoryIcon tooltipText="Bug fixes" count={rhba} Icon={BugIcon} />
           </InsightsLink>
         </FlexItem>
       )}
       {rhea !== 0 && (
         <FlexItem spacer={{ default: 'spacerXs' }}>
-          <InsightsLink
-            app="patch"
-            to={{
-              pathname: '/advisories',
-            }}
-            preview={false}
-          >
+          <InsightsLink app="patch" to={patchSystemLink} preview={false}>
             <AdvisoryIcon
               tooltipText="Enhancements"
               count={rhea}
@@ -98,13 +85,7 @@ const InstallableAdvisories = ({ value }: InstallableAdvisoriesProps) => {
       )}
       {other !== 0 && (
         <FlexItem spacer={{ default: 'spacerXs' }}>
-          <InsightsLink
-            app="patch"
-            to={{
-              pathname: '/advisories',
-            }}
-            preview={false}
-          >
+          <InsightsLink app="patch" to={patchSystemLink} preview={false}>
             <AdvisoryIcon tooltipText="Other" count={other} Icon={FlagIcon} />
           </InsightsLink>
         </FlexItem>

--- a/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.tsx
+++ b/src/components/SystemsView/columns/patch/cells/InstallableAdvisories.tsx
@@ -8,6 +8,7 @@ import {
   SecurityIcon,
 } from '@patternfly/react-icons';
 import { PatchAppData } from '@redhat-cloud-services/host-inventory-client';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 type AdvisoryCountsTuple = [
   rhea: number,
@@ -50,30 +51,62 @@ const InstallableAdvisories = ({ value }: InstallableAdvisoriesProps) => {
       {allZero && 'No installable advisories'}
       {rhsa !== 0 && (
         <FlexItem spacer={{ default: 'spacerXs' }}>
-          <AdvisoryIcon
-            tooltipText="Security advisories"
-            count={rhsa}
-            Icon={SecurityIcon}
-          />
+          <InsightsLink
+            app="patch"
+            to={{
+              pathname: '/advisories',
+            }}
+            preview={false}
+          >
+            <AdvisoryIcon
+              tooltipText="Security advisories"
+              count={rhsa}
+              Icon={SecurityIcon}
+            />
+          </InsightsLink>
         </FlexItem>
       )}
       {rhba !== 0 && (
         <FlexItem spacer={{ default: 'spacerXs' }}>
-          <AdvisoryIcon tooltipText="Bug fixes" count={rhba} Icon={BugIcon} />
+          <InsightsLink
+            app="patch"
+            to={{
+              pathname: '/advisories',
+            }}
+            preview={false}
+          >
+            <AdvisoryIcon tooltipText="Bug fixes" count={rhba} Icon={BugIcon} />
+          </InsightsLink>
         </FlexItem>
       )}
       {rhea !== 0 && (
         <FlexItem spacer={{ default: 'spacerXs' }}>
-          <AdvisoryIcon
-            tooltipText="Enhancements"
-            count={rhea}
-            Icon={EnhancementIcon}
-          />
+          <InsightsLink
+            app="patch"
+            to={{
+              pathname: '/advisories',
+            }}
+            preview={false}
+          >
+            <AdvisoryIcon
+              tooltipText="Enhancements"
+              count={rhea}
+              Icon={EnhancementIcon}
+            />
+          </InsightsLink>
         </FlexItem>
       )}
       {other !== 0 && (
         <FlexItem spacer={{ default: 'spacerXs' }}>
-          <AdvisoryIcon tooltipText="Other" count={other} Icon={FlagIcon} />
+          <InsightsLink
+            app="patch"
+            to={{
+              pathname: '/advisories',
+            }}
+            preview={false}
+          >
+            <AdvisoryIcon tooltipText="Other" count={other} Icon={FlagIcon} />
+          </InsightsLink>
         </FlexItem>
       )}
     </Flex>

--- a/src/components/SystemsView/columns/patch/cells/Template.test.tsx
+++ b/src/components/SystemsView/columns/patch/cells/Template.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import Template from './Template';
+import type { PatchAppData } from '@redhat-cloud-services/host-inventory-client';
+
+const noTemplatePatchAppData = {
+  template_name: null,
+  template_uuid: null,
+} as unknown as PatchAppData;
+
+const emptyTemplateNamePatchAppData = {
+  template_name: '',
+  template_uuid: '00000000-0000-0000-0000-000000000001',
+} as unknown as PatchAppData;
+
+const withTemplatePatchAppData = {
+  template_name: 'Production baseline',
+  template_uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+} as unknown as PatchAppData;
+
+describe('Template cell', () => {
+  it('should show No template when template_name is null', () => {
+    render(<Template value={noTemplatePatchAppData} />);
+
+    expect(screen.getByText('No template')).toBeInTheDocument();
+  });
+
+  it('should show No template when template_name is empty', () => {
+    render(<Template value={emptyTemplateNamePatchAppData} />);
+
+    expect(screen.getByText('No template')).toBeInTheDocument();
+  });
+
+  it('should render a link with the template name when template_name is set', () => {
+    render(
+      <MemoryRouter>
+        <Template value={withTemplatePatchAppData} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('No template')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Production baseline' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/columns/patch/cells/Template.tsx
+++ b/src/components/SystemsView/columns/patch/cells/Template.tsx
@@ -10,7 +10,7 @@ const Template = ({ value }: TemplateColumnProps) => {
   const templateName = value?.template_name;
   const templateUUID = value?.template_uuid;
 
-  return templateName ? (
+  return templateName && templateUUID ? (
     <InsightsLink
       app="content"
       to={{ pathname: `/templates/${templateUUID}` }}

--- a/src/components/SystemsView/columns/patch/cells/Template.tsx
+++ b/src/components/SystemsView/columns/patch/cells/Template.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { PatchAppData } from '@redhat-cloud-services/host-inventory-client';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+
+interface TemplateColumnProps {
+  value: PatchAppData;
+}
+
+const Template = ({ value }: TemplateColumnProps) => {
+  const templateName = value?.template_name;
+  const templateUUID = value?.template_uuid;
+
+  return templateName ? (
+    <InsightsLink
+      app="content"
+      to={{ pathname: `/templates/${templateUUID}` }}
+      preview={false}
+    >
+      {templateName}
+    </InsightsLink>
+  ) : (
+    'No template'
+  );
+};
+
+export default Template;

--- a/src/components/SystemsView/columns/patch/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/patch/columnDefinitions.tsx
@@ -1,6 +1,7 @@
 import { Column } from '../allColumnDefinitions';
 import React from 'react';
 import InstallableAdvisories from './cells/InstallableAdvisories';
+import Template from './cells/Template';
 import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
 
 const installableAdvisoriesColumn = {
@@ -18,6 +19,21 @@ const installableAdvisoriesColumn = {
   },
 } satisfies Column;
 
+const templateColumn = {
+  appName: 'patch',
+  title: 'Template',
+  key: 'template_name',
+  isShownByDefault: false,
+  isShown: false,
+  renderCell(system: InventoryViewSystem) {
+    const key = `${this.key}-${system.id}`;
+    const value = system?.app_data?.patch;
+
+    return value ? <Template key={key} value={value} /> : 'N/A';
+  },
+} satisfies Column;
+
 export default [
   installableAdvisoriesColumn,
+  templateColumn,
 ] as const satisfies readonly Column[];

--- a/src/components/SystemsView/columns/patch/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/patch/columnDefinitions.tsx
@@ -7,8 +7,8 @@ const installableAdvisoriesColumn = {
   appName: 'patch',
   title: 'Installable Advisories',
   key: 'installable-advisories',
-  isShownByDefault: true,
-  isShown: true,
+  isShownByDefault: false,
+  isShown: false,
   sortBy: 'patch:advisories_rhsa_installable',
   renderCell(system: InventoryViewSystem) {
     const key = `${this.key}-${system.id}`;
@@ -16,7 +16,7 @@ const installableAdvisoriesColumn = {
 
     return value ? <InstallableAdvisories key={key} value={value} /> : 'N/A';
   },
-};
+} satisfies Column;
 
 export default [
   installableAdvisoriesColumn,

--- a/src/components/SystemsView/columns/patch/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/patch/columnDefinitions.tsx
@@ -1,0 +1,23 @@
+import { Column } from '../allColumnDefinitions';
+import React from 'react';
+import InstallableAdvisories from './cells/InstallableAdvisories';
+import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
+
+const installableAdvisoriesColumn = {
+  appName: 'patch',
+  title: 'Installable Advisories',
+  key: 'installable-advisories',
+  isShownByDefault: true,
+  isShown: true,
+  sortBy: 'patch:advisories_rhsa_installable',
+  renderCell(system: InventoryViewSystem) {
+    const key = `${this.key}-${system.id}`;
+    const value = system?.app_data?.patch;
+
+    return value ? <InstallableAdvisories key={key} value={value} /> : 'N/A';
+  },
+};
+
+export default [
+  installableAdvisoriesColumn,
+] as const satisfies readonly Column[];

--- a/src/components/SystemsView/columns/patch/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/patch/columnDefinitions.tsx
@@ -15,7 +15,15 @@ const installableAdvisoriesColumn = {
     const key = `${this.key}-${system.id}`;
     const value = system?.app_data?.patch;
 
-    return value ? <InstallableAdvisories key={key} value={value} /> : 'N/A';
+    return value ? (
+      <InstallableAdvisories
+        key={key}
+        value={value}
+        systemUUID={system.id ?? ''}
+      />
+    ) : (
+      'N/A'
+    );
   },
 } satisfies Column;
 

--- a/src/components/SystemsView/columns/patch/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/patch/columnDefinitions.tsx
@@ -6,7 +6,7 @@ import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
 
 const installableAdvisoriesColumn = {
   appName: 'patch',
-  title: 'Installable Advisories',
+  title: 'Installable advisories',
   key: 'installable-advisories',
   isShownByDefault: false,
   isShown: false,

--- a/src/components/SystemsView/columns/remediations/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/remediations/columnDefinitions.tsx
@@ -1,5 +1,5 @@
 import type { Column } from '../allColumnDefinitions';
-import { InventoryViewHost } from '../../hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
 
 const remediationPlansColumn = {
   title: 'Remediation plans',
@@ -7,7 +7,7 @@ const remediationPlansColumn = {
   isShownByDefault: false,
   isShown: false,
   sortBy: 'remediations:remediations_plans',
-  renderCell: (system: InventoryViewHost) => {
+  renderCell: (system: InventoryViewSystem) => {
     return system?.app_data?.remediations?.remediations_plans ?? 'N/A';
   },
 };

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -43,10 +43,9 @@ export const useColumns = ({
         if (isInventoryViewsEnabled) {
           return true;
         }
-        // disable thirdParty columns
-        return !(
-          'appName' in col && Boolean((col as { appName?: string }).appName)
-        );
+
+        const isConsumerAppColumn = 'appName' in col && col.appName;
+        return !isConsumerAppColumn;
       }),
   );
 

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -37,7 +37,17 @@ export const useColumns = ({
   isInventoryViewsEnabled,
 }: UseColumnParams) => {
   const [columns, setColumns] = useState<Column[]>(() =>
-    initialColumns.map((col) => ({ ...col })),
+    initialColumns
+      .map((col) => ({ ...col }))
+      .filter((col) => {
+        if (isInventoryViewsEnabled) {
+          return true;
+        }
+        // disable thirdParty columns
+        return !(
+          'appName' in col && Boolean((col as { appName?: string }).appName)
+        );
+      }),
   );
 
   const fromSortByToIndex = useCallback(
@@ -110,7 +120,7 @@ export const useColumns = ({
         onSort(undefined, FALLBACK_SORT.sortBy!, FALLBACK_SORT.direction);
       }
     }
-  });
+  }, [sortBy, columns, onSort]);
 
   return {
     columns,

--- a/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
+++ b/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
@@ -34,7 +34,7 @@ type FetchInventoryViewsReturnedValue = Awaited<
  * Host row from `fetchInventoryViews`: host-view API shape plus optional `tags` from
  * `getHostTags`. Not the same as the classic host list `HostOut` type.
  */
-export type InventoryViewHost =
+export type InventoryViewSystem =
   FetchInventoryViewsReturnedValue['results'][number];
 
 interface FetchInventoryViewsParams {


### PR DESCRIPTION
## Jira
RHINENG-26074

## What
Implements Two patch columns: Installable Advisories and Template

Links in Installable Advisories point ALL to /patch/advisories. This is workaround because if we navigate with filtering by type, the toolbar in patch breaks.  

## Testing UI
1. enable InventoryViews locally by running in console localStorage.setItem("ui.inventory-views", "true")
2. open column management modal, check new Installable Advisories and Template column, click save
3. Observe correct column behavior

## Summary by Sourcery

Add patch application columns to SystemsView and align inventory view typing for advisor and patch data.

New Features:
- Introduce an Installable Advisories column showing counts of installable patch advisories with links to the advisories view.
- Introduce a Template column displaying and linking to the associated patch template when available.

Enhancements:
- Extend column definitions with an optional appName field and filter out consumer-app columns when inventory views are disabled.
- Unify SystemsView inventory row typing under the InventoryViewSystem type across advisor and patch columns.
- Add a reusable AdvisoryIcon component for rendering advisory icons with tooltips and counts.
- Initialize SystemsView columns based on inventory views feature flag and update column sorting effect dependencies for more predictable behavior.

Tests:
- Add unit tests for the Installable Advisories cell covering various advisory count combinations and link targets.
- Add unit tests for the Template cell covering missing and present template data.
- Update column definition tests to use the new InventoryViewSystem type and verify N/A rendering when app data is missing.