### PR TITLE
fix(RHINENG-21928): Partial revert: Restore group_name for InventoryTable

### DIFF
--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -12,8 +12,7 @@ export const UPDATE_METHOD_KEY = 'system_update_method';
 export const SYSTEM_TYPE_KEY = 'system_type';
 export const WORKLOAD_FILTER_KEY = 'workloads';
 export const LAST_SEEN_CHIP = 'last_seen';
-/** URL query and chip `type` for workspace filter; must match `GET /hosts?group_id=`. */
-export const HOST_GROUP_CHIP = 'group_id';
+export const HOST_GROUP_CHIP = 'group_name'; // use the same naming as for the back end parameter
 //REPORTERS
 export const REPORTER_PUPTOO = 'puptoo';
 export const REPORTER_RHSM_CONDUIT = 'rhsm-conduit';

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -321,18 +321,18 @@ export async function getEntities(
         : Array.isArray(rawHostGroupFilter)
           ? rawHostGroupFilter
           : [rawHostGroupFilter];
-    const nonEmptyGroupIds = hostGroupFilterArr.filter((id) => id !== '');
+    const nonEmptyGroupNames = hostGroupFilterArr.filter((name) => name !== '');
     const filterByUngroupedHosts = hostGroupFilterArr.includes('');
 
-    /** Ungrouped hosts: use group_id (empty value) per API, not group_name. */
-    const groupIdParam =
-      nonEmptyGroupIds.length || filterByUngroupedHosts
-        ? [...nonEmptyGroupIds, ...(filterByUngroupedHosts ? [''] : [])]
+    /** Ungrouped hosts: use group_name (empty value) per API. */
+    const groupNameParam =
+      nonEmptyGroupNames.length || filterByUngroupedHosts
+        ? [...nonEmptyGroupNames, ...(filterByUngroupedHosts ? [''] : [])]
         : [];
 
     return apiGetHostList({
       hostnameOrId: filters.hostnameOrId,
-      ...(groupIdParam.length ? { groupId: groupIdParam } : {}),
+      ...(groupNameParam.length ? { groupName: groupNameParam } : {}),
       perPage,
       page,
       orderBy,

--- a/src/components/GroupSystems/GroupSystems.js
+++ b/src/components/GroupSystems/GroupSystems.js
@@ -160,12 +160,12 @@ const GroupSystems = ({
           getEntities={async (items, config, showTags, defaultGetEntities) =>
             await defaultGetEntities(
               items,
-              // filter systems by workspace id (GET /hosts?group_id=)
+              // filter systems by the group name
               {
                 ...config,
                 filters: {
                   ...config.filters,
-                  hostGroupFilter: [groupId],
+                  hostGroupFilter: [groupName],
                 },
               },
               showTags,

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -67,7 +67,6 @@ import {
   workloadFilterState,
 } from '../filters';
 import useGroupFilter from '../filters/useGroupFilter';
-import FilterChipsWithChipValueKey from './FilterChipsWithChipValueKey';
 import {
   DatePicker,
   Split,
@@ -702,11 +701,7 @@ const EntityTableToolbar = ({
             })),
           },
         })}
-        {...(hasAccess && {
-          activeFiltersConfig: (
-            <FilterChipsWithChipValueKey {...constructFilters()} />
-          ),
-        })}
+        {...(hasAccess && { activeFiltersConfig: constructFilters() })}
         actionsConfig={loaded ? resolvedActionsConfig : null}
         pagination={
           loaded ? (

--- a/src/components/InventoryTable/InventoryTable.cy.js
+++ b/src/components/InventoryTable/InventoryTable.cy.js
@@ -228,7 +228,6 @@ describe('with default parameters', () => {
     describe('groups filter', () => {
       const UNGROUPED_HOSTS_LABEL = 'Ungrouped hosts';
       const firstGroupName = shorterGroupsFixtures.results[0].name;
-      const firstGroupId = shorterGroupsFixtures.results[0].id;
 
       it('options are populated correctly', () => {
         cy.get('[aria-label="Conditional filter toggle"]').click(); // TODO: return to OUIA-based selectors
@@ -266,7 +265,7 @@ describe('with default parameters', () => {
         cy.ouiaId('FilterByGroupOption').contains(firstGroupName).click();
         cy.wait('@getHosts')
           .its('request.url')
-          .should('include', `group_id=${firstGroupId}`);
+          .should('include', `group_name=${firstGroupName}`);
       });
     });
 

--- a/src/components/SystemsView/constants.ts
+++ b/src/components/SystemsView/constants.ts
@@ -1,8 +1,7 @@
 import moment from 'moment';
-import { HOST_GROUP_CHIP } from '../../Utilities/constants';
 
 /** URL query key / DataView `filterId` for workspace filter (`GET /hosts?group_id=`). */
-export const SYSTEMS_VIEW_WORKSPACE_FILTER_PARAM = HOST_GROUP_CHIP;
+export const SYSTEMS_VIEW_WORKSPACE_FILTER_PARAM = 'group_id';
 
 /** Display text for the ungrouped hosts workspace in filters and chips. */
 export const UNGROUPED_HOSTS_LABEL = 'Ungrouped hosts';

--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -26,10 +26,9 @@ const SearchableGroupFilter = ({
   hasNextPage,
   groups,
   fetchNextPage,
-  selectedGroupIds,
-  setSelectedGroupIds,
+  selectedGroupNames,
+  setSelectedGroupNames,
   showNoGroupOption,
-  ungroupedWorkspaceId,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [focusedItemIndex, setFocusedItemIndex] = useState(null);
@@ -42,31 +41,23 @@ const SearchableGroupFilter = ({
     setFocusedItemIndex(null);
   }, [searchQuery]);
 
-  const ungroupedRow = useMemo(
-    () => groups.find((row) => row.ungrouped === true),
-    [groups],
-  );
-
-  const ungroupedOptionId = ungroupedRow?.id ?? ungroupedWorkspaceId ?? '';
-
   const prefixOptions = useMemo(
     () =>
       showNoGroupOption
         ? [
             {
-              itemId: ungroupedOptionId,
+              itemId: '',
               children: 'Ungrouped hosts',
             },
           ]
         : [],
-    [showNoGroupOption, ungroupedOptionId],
+    [showNoGroupOption],
   );
 
   const groupOptions = useMemo(() => {
-    const visibleGroups = groups.filter((row) => !row.ungrouped);
-    const g = visibleGroups.slice(0, visibleCount);
-    return g.map(({ id, name, host_count: hostCount }) => ({
-      itemId: id,
+    const g = groups.slice(0, visibleCount);
+    return g.map(({ name, host_count: hostCount }) => ({
+      itemId: name,
       children: (
         <Flex alignItems={{ default: 'alignItemsCenter' }}>
           <FlexItem>{name}</FlexItem>
@@ -172,7 +163,7 @@ const SearchableGroupFilter = ({
       return;
     }
 
-    setSelectedGroupIds(xor(selectedGroupIds, [itemId]));
+    setSelectedGroupNames(xor(selectedGroupNames, [itemId]));
   };
 
   const onViewMoreClick = () => {
@@ -212,7 +203,7 @@ const SearchableGroupFilter = ({
         id="groups-filter-select"
         ouiaId="Filter by group"
         isOpen={isOpen}
-        selected={selectedGroupIds}
+        selected={selectedGroupNames}
         onSelect={(event, selection) => onSelect(selection)}
         onOpenChange={() => {
           setIsOpen(false);
@@ -227,7 +218,7 @@ const SearchableGroupFilter = ({
             selectOptions.map((option, index) => (
               <div key={option.itemId || option.children}>
                 <SelectOption
-                  isSelected={selectedGroupIds.includes(option.itemId)}
+                  isSelected={selectedGroupNames.includes(option.itemId)}
                   key={option.itemId || option.children}
                   isFocused={focusedItemIndex === index}
                   className={option.className}
@@ -235,9 +226,9 @@ const SearchableGroupFilter = ({
                   hasCheckbox
                   {...option}
                 />
-                {showNoGroupOption &&
-                  !searchQuery &&
-                  option.itemId === ungroupedOptionId && <Divider />}
+                {showNoGroupOption && !searchQuery && option.itemId === '' && (
+                  <Divider />
+                )}
               </div>
             ))
           )}
@@ -273,16 +264,13 @@ SearchableGroupFilter.propTypes = {
   fetchNextPage: PropTypes.func.isRequired,
   groups: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
       host_count: PropTypes.number,
-      ungrouped: PropTypes.bool,
     }),
   ).isRequired,
-  selectedGroupIds: PropTypes.arrayOf(PropTypes.string).isRequired,
-  setSelectedGroupIds: PropTypes.func.isRequired,
+  selectedGroupNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  setSelectedGroupNames: PropTypes.func.isRequired,
   showNoGroupOption: PropTypes.bool,
-  ungroupedWorkspaceId: PropTypes.string,
 };
 
 export default SearchableGroupFilter;

--- a/src/components/filters/SearchableGroupFilter.test.js
+++ b/src/components/filters/SearchableGroupFilter.test.js
@@ -12,8 +12,8 @@ it('shows no groups available message', async () => {
       searchQuery=""
       setSearchQuery={() => {}}
       groups={[]}
-      selectedGroupIds={[]}
-      setSelectedGroupIds={() => {}}
+      selectedGroupNames={[]}
+      setSelectedGroupNames={() => {}}
       isLoading={false}
       isFetchingNextPage={false}
       hasNextPage={false}
@@ -34,9 +34,9 @@ it('shows some groups when available', async () => {
     <SearchableGroupFilter
       searchQuery=""
       setSearchQuery={() => {}}
-      groups={[{ id: 'g1', name: 'group-1' }]}
-      selectedGroupIds={[]}
-      setSelectedGroupIds={() => {}}
+      groups={[{ name: 'group-1' }]}
+      selectedGroupNames={[]}
+      setSelectedGroupNames={() => {}}
       isLoading={false}
       isFetchingNextPage={false}
       hasNextPage={false}
@@ -61,9 +61,9 @@ it('a group can be selected', async () => {
     <SearchableGroupFilter
       searchQuery=""
       setSearchQuery={() => {}}
-      groups={[{ id: 'g1', name: 'group-1' }]}
-      selectedGroupIds={[]}
-      setSelectedGroupIds={setter}
+      groups={[{ name: 'group-1' }]}
+      selectedGroupNames={[]}
+      setSelectedGroupNames={setter}
       isLoading={false}
       isFetchingNextPage={false}
       hasNextPage={false}
@@ -77,7 +77,7 @@ it('a group can be selected', async () => {
     }),
   );
   await userEvent.click(screen.getByText('group-1'));
-  expect(setter).toHaveBeenCalledWith(['g1']);
+  expect(setter).toHaveBeenCalledWith(['group-1']);
 });
 
 it('selected groups are checked', async () => {
@@ -85,12 +85,9 @@ it('selected groups are checked', async () => {
     <SearchableGroupFilter
       searchQuery=""
       setSearchQuery={() => {}}
-      groups={[
-        { id: 'g1', name: 'group-1' },
-        { id: 'g2', name: 'group-2' },
-      ]}
-      selectedGroupIds={['g1']}
-      setSelectedGroupIds={setter}
+      groups={[{ name: 'group-1' }, { name: 'group-2' }]}
+      selectedGroupNames={['group-1']}
+      setSelectedGroupNames={setter}
       isLoading={false}
       isFetchingNextPage={false}
       hasNextPage={false}

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import debounce from 'lodash/debounce';
 import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
 
@@ -7,11 +7,6 @@ import SearchableGroupFilter from './SearchableGroupFilter';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getGroups } from '../InventoryGroups/utils/api';
 import { GENERAL_GROUPS_READ_PERMISSION } from '../../constants';
-import {
-  HostGroupChipNode,
-  useHostGroupNames,
-} from '../../hooks/useHostGroupChipDisplayNames';
-import { useUngroupedWorkspaceId } from '../../hooks/useUngroupedWorkspaceId';
 
 const PAGE_SIZE = 10;
 const INPUT_DEBOUNCE_MS = 300;
@@ -24,32 +19,18 @@ export const groupFilterReducer = (_state, { type, payload }) => ({
   }),
 });
 
-export const buildHostGroupChips = (
-  selectedIds = [],
-  groupsList = [],
-  resolveChipName,
-) => {
-  const idToName = Object.fromEntries(
-    (groupsList || []).map((g) => [g.id, g.name]),
+export const buildHostGroupChips = (selectedGroups = []) => {
+  const chips = [...selectedGroups]?.map((group) =>
+    group === ''
+      ? {
+          name: 'Ungrouped hosts',
+          value: '',
+        }
+      : {
+          name: group,
+          value: group,
+        },
   );
-  const chips = [...selectedIds]?.map((id) => {
-    if (id === '') {
-      return {
-        name: 'Ungrouped hosts',
-        value: '',
-      };
-    }
-    if (idToName[id]) {
-      return {
-        name: idToName[id],
-        value: id,
-      };
-    }
-    return {
-      name: resolveChipName ? resolveChipName(id) : id,
-      value: id,
-    };
-  });
   return chips?.length > 0
     ? [
         {
@@ -195,32 +176,12 @@ const useGroupsQueryWithFilter = ({
 };
 
 const useGroupFilter = (showNoGroupOption = true) => {
-  const [selectedGroupIds, setSelectedGroupIds] = useState([]);
+  const [selectedGroupNames, setSelectedGroupNames] = useState([]);
 
   const { hasAccess } = useConditionalRBAC(
     [GENERAL_GROUPS_READ_PERMISSION],
     true,
     false,
-  );
-
-  const { data: ungroupedWorkspaceId } = useUngroupedWorkspaceId(
-    Boolean(hasAccess && showNoGroupOption),
-  );
-
-  const { names, isFetching, ids, pendingLabelFetchIds } =
-    useHostGroupNames(selectedGroupIds);
-
-  const chipNodeForId = useCallback(
-    (id) => (
-      <HostGroupChipNode
-        id={id}
-        names={names}
-        isFetching={isFetching}
-        ids={ids}
-        pendingLabelFetchIds={pendingLabelFetchIds}
-      />
-    ),
-    [names, isFetching, ids, pendingLabelFetchIds],
   );
 
   const {
@@ -236,21 +197,9 @@ const useGroupFilter = (showNoGroupOption = true) => {
     debounceTime: INPUT_DEBOUNCE_MS,
   });
 
-  useEffect(() => {
-    if (!ungroupedWorkspaceId) {
-      return;
-    }
-    setSelectedGroupIds((prev) => {
-      if (!prev?.includes('')) {
-        return prev;
-      }
-      return prev.map((id) => (id === '' ? ungroupedWorkspaceId : id));
-    });
-  }, [ungroupedWorkspaceId]);
-
   const chips = useMemo(
-    () => buildHostGroupChips(selectedGroupIds, groups, chipNodeForId),
-    [selectedGroupIds, groups, chipNodeForId],
+    () => buildHostGroupChips(selectedGroupNames),
+    [selectedGroupNames],
   );
 
   return [
@@ -268,17 +217,16 @@ const useGroupFilter = (showNoGroupOption = true) => {
             hasNextPage={hasNextPage}
             fetchNextPage={fetchNextPage}
             groups={groups}
-            selectedGroupIds={selectedGroupIds}
-            setSelectedGroupIds={setSelectedGroupIds}
+            selectedGroupNames={selectedGroupNames}
+            setSelectedGroupNames={setSelectedGroupNames}
             showNoGroupOption={showNoGroupOption}
-            ungroupedWorkspaceId={ungroupedWorkspaceId}
           />
         ),
       },
     },
     chips,
-    selectedGroupIds,
-    (groupIds) => setSelectedGroupIds(groupIds || []),
+    selectedGroupNames,
+    (groupNames) => setSelectedGroupNames(groupNames || []),
   ];
 };
 

--- a/src/components/filters/useGroupFilter.test.js
+++ b/src/components/filters/useGroupFilter.test.js
@@ -95,9 +95,9 @@ describe('groups request not yet resolved', () => {
           isFetchingNextPage={false}
           isLoading={true}
           searchQuery=""
-          selectedGroupIds={[]}
+          selectedGroupNames={[]}
           setSearchQuery={[Function]}
-          setSelectedGroupIds={[Function]}
+          setSelectedGroupNames={[Function]}
           showNoGroupOption={false}
         />,
       }
@@ -153,9 +153,9 @@ describe('with some groups available', () => {
           isFetchingNextPage={false}
           isLoading={false}
           searchQuery=""
-          selectedGroupIds={[]}
+          selectedGroupNames={[]}
           setSearchQuery={[Function]}
-          setSelectedGroupIds={[Function]}
+          setSelectedGroupNames={[Function]}
           showNoGroupOption={false}
         />,
       }
@@ -168,21 +168,21 @@ describe('with some groups available', () => {
 
     const [, , , setValue] = result.current;
     act(() => {
-      setValue(['g1']);
+      setValue(['group-1']);
     });
     const [, chips, value] = result.current;
     expect(chips.length).toBe(1);
-    expect(value).toEqual(['g1']);
+    expect(value).toEqual(['group-1']);
     expect(chips).toMatchObject([
       {
         category: 'Workspace',
         chips: [
           {
             name: 'group-1',
-            value: 'g1',
+            value: 'group-1',
           },
         ],
-        type: 'group_id',
+        type: 'group_name',
       },
     ]);
   });
@@ -208,11 +208,10 @@ describe('with some groups available', () => {
          isFetchingNextPage={false}
          isLoading={false}
          searchQuery=""
-         selectedGroupIds={[]}
+         selectedGroupNames={[]}
          setSearchQuery={[Function]}
-         setSelectedGroupIds={[Function]}
+         setSelectedGroupNames={[Function]}
          showNoGroupOption={true}
-         ungroupedWorkspaceId="ungrouped-kessel-id"
        />,
      }
     `);
@@ -238,7 +237,7 @@ describe('with some groups available', () => {
             value: '',
           },
         ],
-        type: 'group_id',
+        type: 'group_name',
       },
     ]);
   });


### PR DESCRIPTION
## Jira
[RHINENG-21928](https://redhat.atlassian.net/browse/RHINENG-21928)

## What
This is a partial revert of commit d3f0813b1428059675ac2ce8d1461385e23c2820 to restore backward compatibility for apps importing InventoryTable as a federated module.

Changes:
- InventoryTable components now use group_name parameter (not group_id)
- SystemsView components continue using group_id (unchanged)
- Reverted HOST_GROUP_CHIP constant back to 'group_name'
- Reverted API calls in api.js to use groupName parameter
- Reverted useGroupFilter hook to use selectedGroupNames
- Reverted related test files

## Why
The group_id change broke other apps that import InventoryTable as a federated module because they cannot handle the group_id parameter yet. This change is currently in production and causing issues.

SystemsView can safely use group_id because it uses its own separate API call path (useSystemsQuery) and is not exported as a federated module.

## How
- Go to Inventory Table
- Select Workspaces from the filter dropdown
- Choose a workspace to filter on

What you should see with the InventoryTable is the group_name filter passing the group name as it used to (url and api calls). When you use a workspace filter in the new SystemsView table you should see the group_id passed in the url and api.

## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->


[RHINENG-21928]: https://redhat.atlassian.net/browse/RHINENG-21928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Restore InventoryTable workspace filtering to use group_name instead of group_id while keeping SystemsView on group_id, re-establishing backward-compatible URL/query behavior.

Bug Fixes:
- Fix InventoryTable host group filtering to pass group_name (including empty for ungrouped) to the hosts API to match existing consumers’ expectations.

Enhancements:
- Simplify group filter state to track selected group names rather than IDs and remove indirection for resolving chip display names.
- Align workspace filter constants so InventoryTable uses HOST_GROUP_CHIP=group_name while SystemsView uses its own group_id parameter name.
- Update group filter components and tests to operate on group names, including ungrouped hosts handling and chip rendering.

Tests:
- Adjust unit and Cypress tests for SearchableGroupFilter, useGroupFilter, and InventoryTable to assert group_name-based filtering and selection behavior.