### PR TITLE
feat(RHINENG-26477): add Malware columns

### DIFF
--- a/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
+++ b/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
@@ -24,6 +24,10 @@ describe('allColumnDefinitions', () => {
       'important',
       'moderate',
       'low',
+      'last_malware_status',
+      'last_malware_matches',
+      'total_malware_matches',
+      'last_malware_scan',
     ]);
   });
 

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -3,6 +3,7 @@ import inventoryColumns from './inventory/columnDefinitions';
 import { System } from '../hooks/useSystemsQuery';
 import { Resolve } from '../../../types/utility-types';
 import advisorColumns from './advisor/columnDefinitions';
+import malwareColumns from './malware/columnDefinitions';
 
 type RenderableColumn = {
   /** Cell content for a single system row in the Systems table. */
@@ -27,6 +28,7 @@ export type Column = Resolve<
 const allColumns = [
   ...inventoryColumns,
   ...advisorColumns,
+  ...malwareColumns,
 ] as const satisfies readonly Column[];
 
 export default allColumns;

--- a/src/components/SystemsView/columns/malware/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/malware/columnDefinitions.tsx
@@ -3,6 +3,7 @@ import type { Column } from '../allColumnDefinitions';
 import { InventoryViewHost } from '../../hooks/useInventoryViewsQuery';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
 
 const lastMalwareStatusColumn = {
   title: 'Last malware status',
@@ -10,8 +11,16 @@ const lastMalwareStatusColumn = {
   isShownByDefault: false,
   isShown: false,
   renderCell: (system: InventoryViewHost) => {
-    const lastScan = system?.app_data?.malware?.last_status;
-    return lastScan != null ? <DateFormat date={lastScan} /> : 'N/A';
+    const lastStatus = system?.app_data?.malware?.last_status;
+    return lastStatus != null ? (
+      lastStatus === 'Matched' ? (
+        <Label color="red">{lastStatus}</Label>
+      ) : (
+        <Label color="teal">{lastStatus}</Label>
+      )
+    ) : (
+      'N/A'
+    );
   },
 };
 
@@ -22,7 +31,18 @@ const lastMalwareMatchesColumn = {
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastMatches,
   renderCell: (system: InventoryViewHost) => {
-    const count = system?.app_data?.malware?.last_matches;
+    const lastMatches = system?.app_data?.malware?.last_matches;
+    return lastMatches;
+  },
+};
+
+const totalMalwareMatchesColumn = {
+  title: 'Total malware matches',
+  key: 'total_malware_matches',
+  isShownByDefault: false,
+  isShown: false,
+  renderCell: (system: InventoryViewHost) => {
+    const count = system?.app_data?.malware?.total_matches;
     return count != null ? (
       <a href="./insights/compliance/reports">{count}</a>
     ) : (
@@ -38,17 +58,14 @@ const lastMalwareScanColumn = {
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastScan,
   renderCell: (system: InventoryViewHost) => {
-    const count = system?.app_data?.malware?.last_scan;
-    return count != null ? (
-      <a href="./insights/compliance/reports">{count}</a>
-    ) : (
-      'N/A'
-    );
+    const lastScan = system?.app_data?.malware?.last_scan;
+    return lastScan != null ? <DateFormat date={lastScan} /> : 'N/A';
   },
 };
 
 export default [
   lastMalwareStatusColumn,
   lastMalwareMatchesColumn,
+  totalMalwareMatchesColumn,
   lastMalwareScanColumn,
 ] as const satisfies readonly Column[];

--- a/src/components/SystemsView/columns/malware/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/malware/columnDefinitions.tsx
@@ -3,8 +3,8 @@ import type { Column } from '../allColumnDefinitions';
 import { InventoryViewHost } from '../../hooks/useInventoryViewsQuery';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
 import { Link } from 'react-router-dom';
+import { Label } from '@patternfly/react-core';
 
 const lastMalwareStatusColumn = {
   title: 'Last malware status',

--- a/src/components/SystemsView/columns/malware/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/malware/columnDefinitions.tsx
@@ -4,6 +4,7 @@ import { InventoryViewHost } from '../../hooks/useInventoryViewsQuery';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
+import { Link } from 'react-router-dom';
 
 const lastMalwareStatusColumn = {
   title: 'Last malware status',
@@ -12,7 +13,7 @@ const lastMalwareStatusColumn = {
   isShown: false,
   renderCell: (system: InventoryViewHost) => {
     const lastStatus = system?.app_data?.malware?.last_status;
-    return lastStatus != null ? (
+    return lastStatus !== null && lastStatus !== undefined ? (
       lastStatus === 'Matched' ? (
         <Label color="red">{lastStatus}</Label>
       ) : (
@@ -32,7 +33,11 @@ const lastMalwareMatchesColumn = {
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastMatches,
   renderCell: (system: InventoryViewHost) => {
     const lastMatches = system?.app_data?.malware?.last_matches;
-    return lastMatches;
+    return lastMatches !== null && lastMatches !== undefined ? (
+      <DateFormat date={lastMatches} />
+    ) : (
+      'N/A'
+    );
   },
 };
 
@@ -43,8 +48,8 @@ const totalMalwareMatchesColumn = {
   isShown: false,
   renderCell: (system: InventoryViewHost) => {
     const count = system?.app_data?.malware?.total_matches;
-    return count != null ? (
-      <a href="./insights/compliance/reports">{count}</a>
+    return count !== null && count !== undefined ? (
+      <Link to={`/insights/malware/systems/${system.id || ''}`}>{count}</Link>
     ) : (
       'N/A'
     );
@@ -59,7 +64,11 @@ const lastMalwareScanColumn = {
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastScan,
   renderCell: (system: InventoryViewHost) => {
     const lastScan = system?.app_data?.malware?.last_scan;
-    return lastScan != null ? <DateFormat date={lastScan} /> : 'N/A';
+    return lastScan !== null && lastScan !== undefined ? (
+      <DateFormat date={lastScan} />
+    ) : (
+      'N/A'
+    );
   },
 };
 

--- a/src/components/SystemsView/columns/malware/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/malware/columnDefinitions.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import type { Column } from '../allColumnDefinitions';
+import { InventoryViewHost } from '../../hooks/useInventoryViewsQuery';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+
+const lastMalwareStatusColumn = {
+  title: 'Last malware status',
+  key: 'last_malware_status',
+  isShownByDefault: false,
+  isShown: false,
+  renderCell: (system: InventoryViewHost) => {
+    const lastScan = system?.app_data?.malware?.last_status;
+    return lastScan != null ? <DateFormat date={lastScan} /> : 'N/A';
+  },
+};
+
+const lastMalwareMatchesColumn = {
+  title: 'Last malware matches',
+  key: 'last_malware_matches',
+  isShownByDefault: false,
+  isShown: false,
+  sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastMatches,
+  renderCell: (system: InventoryViewHost) => {
+    const count = system?.app_data?.malware?.last_matches;
+    return count != null ? (
+      <a href="./insights/compliance/reports">{count}</a>
+    ) : (
+      'N/A'
+    );
+  },
+};
+
+const lastMalwareScanColumn = {
+  title: 'Last malware scan',
+  key: 'last_malware_scan',
+  isShownByDefault: false,
+  isShown: false,
+  sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastScan,
+  renderCell: (system: InventoryViewHost) => {
+    const count = system?.app_data?.malware?.last_scan;
+    return count != null ? (
+      <a href="./insights/compliance/reports">{count}</a>
+    ) : (
+      'N/A'
+    );
+  },
+};
+
+export default [
+  lastMalwareStatusColumn,
+  lastMalwareMatchesColumn,
+  lastMalwareScanColumn,
+] as const satisfies readonly Column[];


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-26477

## What
add Malware columns

## Why
Inventory Views Phase 1

## How

1. reads system.app_data.malware from the` InventoryViewHost` data
2. column is hidden by default
3. columns are registered via `allColumnDefinitions.ts`

## Testing

1. enable `localStorage.setItem("ui.inventory-views", "true")`
2. open Manage columns modal to select Malware columns
3. check System table now displays Malware columns

known issues: 
1. malware doesn't have all malware data https://redhat.atlassian.net/browse/RHINENG-26686
<img width="596" height="150" alt="image" src="https://github.com/user-attachments/assets/01b1e20f-0108-4101-8037-d3e02675c542" />

2.  required columns are under review with the Malware PM - column naming and data type (Last matched and Total matches i made it same as Malware for now) 

## Screenshots/Videos (if applicable)
<img width="1269" height="653" alt="image" src="https://github.com/user-attachments/assets/bbe63f4e-1799-4768-8dbc-5b9afcaa108e" />

## Summary by Sourcery

Add malware-related inventory columns to the Systems view and wire them into the unified column registry.

New Features:
- Introduce malware status, matches, and scan metadata columns based on InventoryViewHost.app_data.malware in the Systems table.
- Allow users to enable malware columns via the shared column definitions, with all malware columns hidden by default.