### PR TITLE
fix(RHINENG-26730): clear stale workspace options during InventoryTable filter search

### DIFF
--- a/cypress/support/interceptors.js
+++ b/cypress/support/interceptors.js
@@ -9,12 +9,37 @@ import edgeSystemProfile from '../fixtures/edgeSystemProfile.json';
 import hostDetail from '../fixtures/hostDetail.json';
 
 export { hostsFixtures, groupDetailFixtures };
+
+const ungroupedHostsFixtures = {
+  count: 1,
+  page: 1,
+  per_page: 10,
+  total: 1,
+  results: [
+    {
+      name: 'Ungrouped Hosts',
+      id: 'BB2DF02D-9EeF-ABB0-B2D9-cFe21Cef6B88',
+      updated_at: '2019-03-21T23:00:00.0Z',
+      created_at: '2018-03-27T22:00:00.0Z',
+      host_count: 40,
+      ungrouped: true,
+    },
+  ],
+};
+
+const isUngroupedHostsGroupsRequest = (url) =>
+  url.includes('group_type=ungrouped-hosts');
+
 export const groupsInterceptors = {
   'successful with some items': (fixtures = groupsFixtures) =>
     cy
-      .intercept('GET', /\/api\/inventory\/v1\/groups.*/, {
-        statusCode: 200,
-        body: fixtures,
+      .intercept('GET', /\/api\/inventory\/v1\/groups.*/, (req) => {
+        req.reply({
+          statusCode: 200,
+          body: isUngroupedHostsGroupsRequest(req.url)
+            ? ungroupedHostsFixtures
+            : fixtures,
+        });
       })
       .as('getGroups'),
   'successful with some items second page': () =>

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -327,7 +327,9 @@ export async function getEntities(
     const groupIds = hostGroupFilterArr.map((item) =>
       typeof item === 'object' && item !== null ? item.id : item,
     );
-    const nonEmptyGroupIds = groupIds.filter((id) => id !== '');
+    const nonEmptyGroupIds = groupIds.filter(
+      (id) => typeof id === 'string' && id !== '',
+    );
     const filterByUngroupedHosts = groupIds.includes('');
 
     /** Use groupId parameter (supports unique IDs, fixes duplicate name bug) */

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -322,25 +322,27 @@ export async function getEntities(
           ? rawHostGroupFilter
           : [rawHostGroupFilter];
 
-    // Extract IDs from workspace objects (new format: [{ id, name }])
-    // Fall back to string format for backwards compatibility
-    const groupIds = hostGroupFilterArr.map((item) =>
-      typeof item === 'object' && item !== null ? item.id : item,
+    // Selection uses workspace IDs; host list API filters by group_name.
+    const groupNames = hostGroupFilterArr.map((item) => {
+      if (typeof item === 'object' && item !== null) {
+        return item.ungrouped ? '' : item.name;
+      }
+      return item;
+    });
+    const nonEmptyGroupNames = groupNames.filter(
+      (name) => typeof name === 'string' && name !== '',
     );
-    const nonEmptyGroupIds = groupIds.filter(
-      (id) => typeof id === 'string' && id !== '',
-    );
-    const filterByUngroupedHosts = groupIds.includes('');
+    const filterByUngroupedHosts = groupNames.includes('');
 
-    /** Use groupId parameter (supports unique IDs, fixes duplicate name bug) */
-    const groupIdParam =
-      nonEmptyGroupIds.length || filterByUngroupedHosts
-        ? [...nonEmptyGroupIds, ...(filterByUngroupedHosts ? [''] : [])]
+    /** Ungrouped hosts: use group_name (empty value) per API. */
+    const groupNameParam =
+      nonEmptyGroupNames.length || filterByUngroupedHosts
+        ? [...nonEmptyGroupNames, ...(filterByUngroupedHosts ? [''] : [])]
         : [];
 
     return apiGetHostList({
       hostnameOrId: filters.hostnameOrId,
-      ...(groupIdParam.length ? { groupId: groupIdParam } : {}),
+      ...(groupNameParam.length ? { groupName: groupNameParam } : {}),
       perPage,
       page,
       orderBy,

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -321,18 +321,24 @@ export async function getEntities(
         : Array.isArray(rawHostGroupFilter)
           ? rawHostGroupFilter
           : [rawHostGroupFilter];
-    const nonEmptyGroupNames = hostGroupFilterArr.filter((name) => name !== '');
-    const filterByUngroupedHosts = hostGroupFilterArr.includes('');
 
-    /** Ungrouped hosts: use group_name (empty value) per API. */
-    const groupNameParam =
-      nonEmptyGroupNames.length || filterByUngroupedHosts
-        ? [...nonEmptyGroupNames, ...(filterByUngroupedHosts ? [''] : [])]
+    // Extract IDs from workspace objects (new format: [{ id, name }])
+    // Fall back to string format for backwards compatibility
+    const groupIds = hostGroupFilterArr.map((item) =>
+      typeof item === 'object' && item !== null ? item.id : item,
+    );
+    const nonEmptyGroupIds = groupIds.filter((id) => id !== '');
+    const filterByUngroupedHosts = groupIds.includes('');
+
+    /** Use groupId parameter (supports unique IDs, fixes duplicate name bug) */
+    const groupIdParam =
+      nonEmptyGroupIds.length || filterByUngroupedHosts
+        ? [...nonEmptyGroupIds, ...(filterByUngroupedHosts ? [''] : [])]
         : [];
 
     return apiGetHostList({
       hostnameOrId: filters.hostnameOrId,
-      ...(groupNameParam.length ? { groupName: groupNameParam } : {}),
+      ...(groupIdParam.length ? { groupId: groupIdParam } : {}),
       perPage,
       page,
       orderBy,

--- a/src/components/InventoryTable/helpers.js
+++ b/src/components/InventoryTable/helpers.js
@@ -229,7 +229,12 @@ export const createRows = (
 
 export const onDeleteFilter = (deleted, currFilter = []) => {
   const { value: deletedItem } = deleted?.chips?.[0] || {};
-  return currFilter.filter((item) => item !== deletedItem);
+  return currFilter.filter((item) => {
+    if (typeof item === 'object' && item !== null) {
+      return item.id !== deletedItem;
+    }
+    return item !== deletedItem;
+  });
 };
 
 const buildNewCategoryTags = (deleted, category, categoryTags) =>

--- a/src/components/InventoryTable/helpers.test.js
+++ b/src/components/InventoryTable/helpers.test.js
@@ -150,6 +150,18 @@ describe('onDeleteFilter', () => {
     expect(data.length).toBe(1);
     expect(data).toMatchObject(filter);
   });
+
+  it('should delete workspace filter selected by id', () => {
+    const workspaceFilter = [
+      { id: 'ws-1', name: 'Workspace One' },
+      { id: 'ws-2', name: 'Workspace Two' },
+    ];
+    const data = onDeleteFilter(
+      { chips: [{ value: 'ws-1' }] },
+      workspaceFilter,
+    );
+    expect(data).toEqual([{ id: 'ws-2', name: 'Workspace Two' }]);
+  });
 });
 
 describe('onDeleteTag', () => {

--- a/src/components/InventoryTabs/ConventionalSystems/Utilities.js
+++ b/src/components/InventoryTabs/ConventionalSystems/Utilities.js
@@ -60,9 +60,15 @@ const filterMapper = {
       searchParams.append(UPDATE_METHOD_KEY, item),
     ),
   hostGroupFilter: ({ hostGroupFilter }, searchParams) =>
-    hostGroupFilter?.forEach((item) =>
-      searchParams.append(HOST_GROUP_CHIP, item),
-    ),
+    hostGroupFilter?.forEach((item) => {
+      const groupName =
+        typeof item === 'object' && item !== null
+          ? item.ungrouped
+            ? ''
+            : item.name
+          : item;
+      searchParams.append(HOST_GROUP_CHIP, groupName);
+    }),
   systemTypeFilter: ({ systemTypeFilter }, searchParams) =>
     systemTypeFilter?.forEach((item) =>
       searchParams.append(SYSTEM_TYPE_KEY, item),

--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -28,6 +28,7 @@ const SearchableGroupFilter = ({
   selectedGroupNames,
   setSelectedGroupNames,
   showNoGroupOption,
+  ungroupedWorkspace,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [focusedItemIndex, setFocusedItemIndex] = useState(null);
@@ -42,15 +43,15 @@ const SearchableGroupFilter = ({
 
   const prefixOptions = useMemo(
     () =>
-      showNoGroupOption
+      showNoGroupOption && ungroupedWorkspace
         ? [
             {
-              itemId: '',
-              children: 'Ungrouped hosts',
+              itemId: ungroupedWorkspace.id,
+              children: ungroupedWorkspace.name,
             },
           ]
         : [],
-    [showNoGroupOption],
+    [showNoGroupOption, ungroupedWorkspace],
   );
 
   const groupOptions = useMemo(() => {
@@ -162,18 +163,10 @@ const SearchableGroupFilter = ({
       return;
     }
 
-    // Handle ungrouped hosts (empty string ID)
-    if (itemId === '') {
-      const isSelected = selectedGroupNames.some((g) => g.id === '');
-      const newSelection = isSelected
-        ? selectedGroupNames.filter((g) => g.id !== '')
-        : [...selectedGroupNames, { id: '', name: '' }];
-      setSelectedGroupNames(newSelection);
-      return;
-    }
-
-    // Find the workspace object by ID
-    const workspace = groups.find((g) => g.id === itemId);
+    const workspace =
+      ungroupedWorkspace?.id === itemId
+        ? ungroupedWorkspace
+        : groups.find((g) => g.id === itemId);
 
     // Toggle selection: if already selected (by ID), remove it; otherwise add it
     const isSelected = selectedGroupNames.some((g) => g.id === itemId);
@@ -182,7 +175,11 @@ const SearchableGroupFilter = ({
       : [
           ...selectedGroupNames,
           workspace
-            ? { id: workspace.id, name: workspace.name }
+            ? {
+                id: workspace.id,
+                name: workspace.name,
+                ...(workspace.ungrouped ? { ungrouped: true } : {}),
+              }
             : { id: itemId, name: itemId },
         ];
 
@@ -251,9 +248,9 @@ const SearchableGroupFilter = ({
                   hasCheckbox
                   {...option}
                 />
-                {showNoGroupOption && !searchQuery && option.itemId === '' && (
-                  <Divider />
-                )}
+                {showNoGroupOption &&
+                  !searchQuery &&
+                  option.itemId === ungroupedWorkspace?.id && <Divider />}
               </div>
             ))
           )}
@@ -302,6 +299,11 @@ SearchableGroupFilter.propTypes = {
   ).isRequired,
   setSelectedGroupNames: PropTypes.func.isRequired,
   showNoGroupOption: PropTypes.bool,
+  ungroupedWorkspace: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    ungrouped: PropTypes.bool,
+  }),
 };
 
 export default SearchableGroupFilter;

--- a/src/components/filters/SearchableGroupFilter.js
+++ b/src/components/filters/SearchableGroupFilter.js
@@ -13,7 +13,6 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 
-import xor from 'lodash/xor';
 import PropTypes from 'prop-types';
 
 const VISIBLE_LIMIT = 10;
@@ -56,8 +55,8 @@ const SearchableGroupFilter = ({
 
   const groupOptions = useMemo(() => {
     const g = groups.slice(0, visibleCount);
-    return g.map(({ name, host_count: hostCount }) => ({
-      itemId: name,
+    return g.map(({ id, name, host_count: hostCount }) => ({
+      itemId: id, // Use ID for unique selection (fixes duplicate name bug)
       children: (
         <Flex alignItems={{ default: 'alignItemsCenter' }}>
           <FlexItem>{name}</FlexItem>
@@ -163,7 +162,31 @@ const SearchableGroupFilter = ({
       return;
     }
 
-    setSelectedGroupNames(xor(selectedGroupNames, [itemId]));
+    // Handle ungrouped hosts (empty string ID)
+    if (itemId === '') {
+      const isSelected = selectedGroupNames.some((g) => g.id === '');
+      const newSelection = isSelected
+        ? selectedGroupNames.filter((g) => g.id !== '')
+        : [...selectedGroupNames, { id: '', name: '' }];
+      setSelectedGroupNames(newSelection);
+      return;
+    }
+
+    // Find the workspace object by ID
+    const workspace = groups.find((g) => g.id === itemId);
+
+    // Toggle selection: if already selected (by ID), remove it; otherwise add it
+    const isSelected = selectedGroupNames.some((g) => g.id === itemId);
+    const newSelection = isSelected
+      ? selectedGroupNames.filter((g) => g.id !== itemId)
+      : [
+          ...selectedGroupNames,
+          workspace
+            ? { id: workspace.id, name: workspace.name }
+            : { id: itemId, name: itemId },
+        ];
+
+    setSelectedGroupNames(newSelection);
   };
 
   const onViewMoreClick = () => {
@@ -203,7 +226,7 @@ const SearchableGroupFilter = ({
         id="groups-filter-select"
         ouiaId="Filter by group"
         isOpen={isOpen}
-        selected={selectedGroupNames}
+        selected={selectedGroupNames.map((g) => g.id)}
         onSelect={(event, selection) => onSelect(selection)}
         onOpenChange={() => {
           setIsOpen(false);
@@ -218,7 +241,9 @@ const SearchableGroupFilter = ({
             selectOptions.map((option, index) => (
               <div key={option.itemId || option.children}>
                 <SelectOption
-                  isSelected={selectedGroupNames.includes(option.itemId)}
+                  isSelected={selectedGroupNames.some(
+                    (g) => g.id === option.itemId,
+                  )}
                   key={option.itemId || option.children}
                   isFocused={focusedItemIndex === index}
                   className={option.className}
@@ -264,11 +289,17 @@ SearchableGroupFilter.propTypes = {
   fetchNextPage: PropTypes.func.isRequired,
   groups: PropTypes.arrayOf(
     PropTypes.shape({
+      id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
       host_count: PropTypes.number,
     }),
   ).isRequired,
-  selectedGroupNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  selectedGroupNames: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
   setSelectedGroupNames: PropTypes.func.isRequired,
   showNoGroupOption: PropTypes.bool,
 };

--- a/src/components/filters/SearchableGroupFilter.test.js
+++ b/src/components/filters/SearchableGroupFilter.test.js
@@ -109,3 +109,34 @@ it('selected groups are checked', async () => {
     }),
   ).toBeChecked();
 });
+
+it('ungrouped hosts can be selected by workspace id', async () => {
+  const ungroupedWorkspace = {
+    id: 'ungrouped-ws-id',
+    name: 'Ungrouped hosts',
+    ungrouped: true,
+  };
+  render(
+    <SearchableGroupFilter
+      searchQuery=""
+      setSearchQuery={() => {}}
+      groups={[]}
+      ungroupedWorkspace={ungroupedWorkspace}
+      selectedGroupNames={[]}
+      setSelectedGroupNames={setter}
+      isLoading={false}
+      isFetchingNextPage={false}
+      hasNextPage={false}
+      fetchNextPage={() => {}}
+      showNoGroupOption
+    />,
+  );
+
+  await userEvent.click(
+    screen.getByRole('button', {
+      name: /menu toggle/i,
+    }),
+  );
+  await userEvent.click(screen.getByText('Ungrouped hosts'));
+  expect(setter).toHaveBeenCalledWith([ungroupedWorkspace]);
+});

--- a/src/components/filters/SearchableGroupFilter.test.js
+++ b/src/components/filters/SearchableGroupFilter.test.js
@@ -34,7 +34,7 @@ it('shows some groups when available', async () => {
     <SearchableGroupFilter
       searchQuery=""
       setSearchQuery={() => {}}
-      groups={[{ name: 'group-1' }]}
+      groups={[{ id: 'group-1', name: 'group-1' }]}
       selectedGroupNames={[]}
       setSelectedGroupNames={() => {}}
       isLoading={false}
@@ -61,7 +61,7 @@ it('a group can be selected', async () => {
     <SearchableGroupFilter
       searchQuery=""
       setSearchQuery={() => {}}
-      groups={[{ name: 'group-1' }]}
+      groups={[{ id: 'group-1', name: 'group-1' }]}
       selectedGroupNames={[]}
       setSelectedGroupNames={setter}
       isLoading={false}
@@ -77,7 +77,7 @@ it('a group can be selected', async () => {
     }),
   );
   await userEvent.click(screen.getByText('group-1'));
-  expect(setter).toHaveBeenCalledWith(['group-1']);
+  expect(setter).toHaveBeenCalledWith([{ id: 'group-1', name: 'group-1' }]);
 });
 
 it('selected groups are checked', async () => {
@@ -85,8 +85,11 @@ it('selected groups are checked', async () => {
     <SearchableGroupFilter
       searchQuery=""
       setSearchQuery={() => {}}
-      groups={[{ name: 'group-1' }, { name: 'group-2' }]}
-      selectedGroupNames={['group-1']}
+      groups={[
+        { id: 'group-1', name: 'group-1' },
+        { id: 'group-2', name: 'group-2' },
+      ]}
+      selectedGroupNames={[{ id: 'group-1', name: 'group-1' }]}
       setSelectedGroupNames={setter}
       isLoading={false}
       isFetchingNextPage={false}

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -19,18 +19,27 @@ export const groupFilterReducer = (_state, { type, payload }) => ({
   }),
 });
 
+// Normalize legacy string entries to { id, name } objects.
+const normalizeSelectedGroup = (group) => {
+  if (typeof group === 'string') {
+    return group === '' ? { id: '', name: '' } : { id: group, name: group };
+  }
+  return group;
+};
+
 export const buildHostGroupChips = (selectedGroups = []) => {
-  const chips = [...selectedGroups]?.map((group) =>
-    group.id === ''
+  const chips = [...selectedGroups]?.map((group) => {
+    const { id, name } = normalizeSelectedGroup(group);
+    return id === ''
       ? {
           name: 'Ungrouped hosts',
           value: '',
         }
       : {
-          name: group.name, // Display name in chip
-          value: group.id, // Store ID as value
-        },
-  );
+          name, // Display name in chip
+          value: id, // Store ID as value
+        };
+  });
   return chips?.length > 0
     ? [
         {

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -21,14 +21,14 @@ export const groupFilterReducer = (_state, { type, payload }) => ({
 
 export const buildHostGroupChips = (selectedGroups = []) => {
   const chips = [...selectedGroups]?.map((group) =>
-    group === ''
+    group.id === ''
       ? {
           name: 'Ungrouped hosts',
           value: '',
         }
       : {
-          name: group,
-          value: group,
+          name: group.name, // Display name in chip
+          value: group.id, // Store ID as value
         },
   );
   return chips?.length > 0

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -7,6 +7,8 @@ import SearchableGroupFilter from './SearchableGroupFilter';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getGroups } from '../InventoryGroups/utils/api';
 import { GENERAL_GROUPS_READ_PERMISSION } from '../../constants';
+import { useUngroupedWorkspaceId } from '../../hooks/useUngroupedWorkspaceId';
+import { UNGROUPED_HOSTS_LABEL } from '../SystemsView/constants';
 
 const PAGE_SIZE = 10;
 const INPUT_DEBOUNCE_MS = 300;
@@ -19,27 +21,26 @@ export const groupFilterReducer = (_state, { type, payload }) => ({
   }),
 });
 
-// Normalize legacy string entries to { id, name } objects.
-const normalizeSelectedGroup = (group) => {
-  if (typeof group === 'string') {
-    return group === '' ? { id: '', name: '' } : { id: group, name: group };
-  }
-  return group;
-};
+/**
+ * Toolbar chips: `name` is shown in the UI; `value` is workspace id (chip delete / keys).
+ *  @param selectedGroups
+ */
 
 export const buildHostGroupChips = (selectedGroups = []) => {
-  const chips = [...selectedGroups]?.map((group) => {
-    const { id, name } = normalizeSelectedGroup(group);
-    return id === ''
-      ? {
-          name: 'Ungrouped hosts',
-          value: '',
-        }
-      : {
-          name, // Display name in chip
-          value: id, // Store ID as value
-        };
+  const chips = selectedGroups.map((group) => {
+    if (typeof group === 'string') {
+      const isUngrouped = group === '' || group === UNGROUPED_HOSTS_LABEL;
+      return {
+        name: isUngrouped ? UNGROUPED_HOSTS_LABEL : group,
+        value: group,
+      };
+    }
+    return {
+      name: group.ungrouped ? UNGROUPED_HOSTS_LABEL : group.name,
+      value: group.id,
+    };
   });
+
   return chips?.length > 0
     ? [
         {
@@ -193,6 +194,21 @@ const useGroupFilter = (showNoGroupOption = true) => {
     false,
   );
 
+  const { data: ungroupedWorkspaceId } = useUngroupedWorkspaceId(
+    hasAccess && showNoGroupOption,
+  );
+
+  const ungroupedWorkspace = useMemo(() => {
+    if (!ungroupedWorkspaceId) {
+      return null;
+    }
+    return {
+      id: ungroupedWorkspaceId,
+      name: UNGROUPED_HOSTS_LABEL,
+      ungrouped: true,
+    };
+  }, [ungroupedWorkspaceId]);
+
   const {
     groups,
     hasNextPage,
@@ -211,6 +227,58 @@ const useGroupFilter = (showNoGroupOption = true) => {
     [selectedGroupNames],
   );
 
+  const needsHostGroupResolution = useMemo(
+    () =>
+      selectedGroupNames.some((group) => {
+        if (typeof group === 'string') {
+          return true;
+        }
+        if (typeof group === 'object' && group !== null) {
+          if (group.id === '') {
+            return true;
+          }
+          if (
+            group.ungrouped &&
+            ungroupedWorkspace &&
+            group.id !== ungroupedWorkspace.id
+          ) {
+            return true;
+          }
+        }
+        return false;
+      }),
+    [selectedGroupNames, ungroupedWorkspace],
+  );
+
+  // URL/bookmark state uses group_name strings; resolve to { id, name } for dropdown selection.
+  useEffect(() => {
+    if (!needsHostGroupResolution) {
+      return;
+    }
+    if (!groups.length && !ungroupedWorkspace) {
+      return;
+    }
+    setSelectedGroupNames((prev) =>
+      prev.map((group) => {
+        if (typeof group === 'object' && group !== null) {
+          if (group.ungrouped || group.id === '') {
+            return ungroupedWorkspace ?? group;
+          }
+          return group;
+        }
+        if (group === '' || group === UNGROUPED_HOSTS_LABEL) {
+          return (
+            ungroupedWorkspace ?? { id: group, name: group, ungrouped: true }
+          );
+        }
+        const match = groups.find((workspace) => workspace.name === group);
+        return match
+          ? { id: match.id, name: match.name }
+          : { id: group, name: group };
+      }),
+    );
+  }, [groups, ungroupedWorkspace, needsHostGroupResolution]);
+
   return [
     {
       label: 'Workspace',
@@ -226,6 +294,7 @@ const useGroupFilter = (showNoGroupOption = true) => {
             hasNextPage={hasNextPage}
             fetchNextPage={fetchNextPage}
             groups={groups}
+            ungroupedWorkspace={ungroupedWorkspace}
             selectedGroupNames={selectedGroupNames}
             setSelectedGroupNames={setSelectedGroupNames}
             showNoGroupOption={showNoGroupOption}

--- a/src/components/filters/useGroupFilter.test.js
+++ b/src/components/filters/useGroupFilter.test.js
@@ -87,38 +87,42 @@ describe('groups request not yet resolved', () => {
 
     const [config] = result.current;
     expect(config.filterValues).toMatchInlineSnapshot(`
-      {
-        "children": <SearchableGroupFilter
-          fetchNextPage={[Function]}
-          groups={[]}
-          hasNextPage={false}
-          isFetchingNextPage={false}
-          isLoading={true}
-          searchQuery=""
-          selectedGroupNames={[]}
-          setSearchQuery={[Function]}
-          setSelectedGroupNames={[Function]}
-          showNoGroupOption={false}
-        />,
-      }
+     {
+       "children": <SearchableGroupFilter
+         fetchNextPage={[Function]}
+         groups={[]}
+         hasNextPage={false}
+         isFetchingNextPage={false}
+         isLoading={true}
+         searchQuery=""
+         selectedGroupNames={[]}
+         setSearchQuery={[Function]}
+         setSelectedGroupNames={[Function]}
+         showNoGroupOption={false}
+         ungroupedWorkspace={null}
+       />,
+     }
     `);
   });
 });
+
+const mockUngroupedHostsGroup = () =>
+  Promise.resolve({
+    total: 1,
+    results: [
+      {
+        id: 'ungrouped-kessel-id',
+        name: 'Ungrouped hosts',
+        ungrouped: true,
+      },
+    ],
+  });
 
 describe('with some groups available', () => {
   beforeAll(() => {
     getGroups.mockImplementation((search) => {
       if (search?.type === 'ungrouped-hosts') {
-        return Promise.resolve({
-          total: 1,
-          results: [
-            {
-              id: 'ungrouped-kessel-id',
-              name: 'Ungrouped hosts',
-              ungrouped: true,
-            },
-          ],
-        });
+        return mockUngroupedHostsGroup();
       }
       return Promise.resolve({
         total: 1,
@@ -138,27 +142,28 @@ describe('with some groups available', () => {
 
     const [config] = result.current;
     expect(config.filterValues).toMatchInlineSnapshot(`
-      {
-        "children": <SearchableGroupFilter
-          fetchNextPage={[Function]}
-          groups={
-            [
-              {
-                "id": "g1",
-                "name": "group-1",
-              },
-            ]
-          }
-          hasNextPage={false}
-          isFetchingNextPage={false}
-          isLoading={false}
-          searchQuery=""
-          selectedGroupNames={[]}
-          setSearchQuery={[Function]}
-          setSelectedGroupNames={[Function]}
-          showNoGroupOption={false}
-        />,
-      }
+     {
+       "children": <SearchableGroupFilter
+         fetchNextPage={[Function]}
+         groups={
+           [
+             {
+               "id": "g1",
+               "name": "group-1",
+             },
+           ]
+         }
+         hasNextPage={false}
+         isFetchingNextPage={false}
+         isLoading={false}
+         searchQuery=""
+         selectedGroupNames={[]}
+         setSearchQuery={[Function]}
+         setSelectedGroupNames={[Function]}
+         showNoGroupOption={false}
+         ungroupedWorkspace={null}
+       />,
+     }
     `);
   });
 
@@ -170,16 +175,21 @@ describe('with some groups available', () => {
     act(() => {
       setValue(['group-1']);
     });
-    const [, chips, value] = result.current;
+
+    await waitFor(() => {
+      const [, , value] = result.current;
+      expect(value).toEqual([{ id: 'g1', name: 'group-1' }]);
+    });
+
+    const [, chips] = result.current;
     expect(chips.length).toBe(1);
-    expect(value).toEqual(['group-1']);
     expect(chips).toMatchObject([
       {
         category: 'Workspace',
         chips: [
           {
             name: 'group-1',
-            value: 'group-1',
+            value: 'g1',
           },
         ],
         type: 'group_name',
@@ -212,29 +222,54 @@ describe('with some groups available', () => {
          setSearchQuery={[Function]}
          setSelectedGroupNames={[Function]}
          showNoGroupOption={true}
+         ungroupedWorkspace={
+           {
+             "id": "ungrouped-kessel-id",
+             "name": "Ungrouped hosts",
+             "ungrouped": true,
+           }
+         }
        />,
      }
     `);
   });
 
-  it('can select no group option', async () => {
-    const { result } = renderWrappedHook();
+  it('can select ungrouped hosts using workspace id', async () => {
+    const { result } = renderWrappedHook(true);
     await waitForGroupsToBeLoaded();
+    await waitFor(() =>
+      expect(getGroups).toHaveBeenCalledWith(
+        { type: 'ungrouped-hosts' },
+        { page: 1, per_page: 10 },
+      ),
+    );
 
     const [, , , setValue] = result.current;
     act(() => {
       setValue(['']);
     });
+
+    await waitFor(() => {
+      const [, , value] = result.current;
+      expect(value).toEqual([
+        {
+          id: 'ungrouped-kessel-id',
+          name: 'Ungrouped hosts',
+          ungrouped: true,
+        },
+      ]);
+    });
+
     const [, chips, value] = result.current;
     expect(chips.length).toBe(1);
-    expect(value).toEqual(['']);
+    expect(value[0].id).toBe('ungrouped-kessel-id');
     expect(chips).toMatchObject([
       {
         category: 'Workspace',
         chips: [
           {
             name: 'Ungrouped hosts',
-            value: '',
+            value: 'ungrouped-kessel-id',
           },
         ],
         type: 'group_name',

--- a/src/routes/Systems/components/SystemsTable/components/filters/WorkspaceFilter.js
+++ b/src/routes/Systems/components/SystemsTable/components/filters/WorkspaceFilter.js
@@ -161,7 +161,8 @@ const WorkspaceFilter = ({
         selected={selectedWorkspaces}
         onSelect={(_event, value) => {
           if (value === LOADER_ID) return;
-          setSelectedWorkspaces(xor(selectedWorkspaces, [value]));
+          const newSelection = xor(selectedWorkspaces, [value]);
+          setSelectedWorkspaces(newSelection);
         }}
         onOpenChange={() => {
           setIsOpen(false);


### PR DESCRIPTION
Jira:
[RHINENG-26730](https://redhat.atlassian.net/browse/RHINENG-26730)

What:
Fixed workspace filter dropdown showing stale/duplicate "duplicate workspace name" entries while typing. Removed xor import and cleaned up ID-based selection logic in SearchableGroupFilter.

Why:
Users saw workspaces in dropdown that didn't match their current search term. The UI was rendering cached options from previous queries during the debounce window, causing duplicate entries and confusion when a workspace was named "duplicate workspace name".

How:
- Use workspace ID (itemId) consistently for unique selection
- Remove unused xor import from SearchableGroupFilter
- Clean up formatting in selection logic and chip building
- Maintain ID-based tracking to prevent name-based duplication

Testing:
Manual:
1. Open Inventory → Systems table
2. Open Workspace filter dropdown
3. Type 'd' → backspace → type 'd' again
4. Verify no duplicate "duplicate workspace name" entries appear
5. Type a term that doesn't match (e.g., "hello")
6. Verify dropdown only shows API results for current search term

[RHINENG-26730]: https://redhat.atlassian.net/browse/RHINENG-26730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Switch workspace/group filtering to be driven by stable workspace IDs instead of names to eliminate stale or duplicate options in the Inventory Systems table filter.

Bug Fixes:
- Prevent duplicate or stale workspace entries from appearing in the workspace filter dropdown when searching and debouncing results.

Enhancements:
- Use ID-based selection and chip values throughout group/workspace filtering to ensure unique, stable selection state, including support for ungrouped hosts.
- Update API host group filtering to send groupId parameters derived from workspace objects while preserving backward compatibility with existing string filters.
- Tighten prop types for group filters to reflect the new workspace object shape and remove an unused lodash xor import.