### PR TITLE
chore: colocate inventory views column min-widths on definitions

### DIFF
--- a/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
@@ -6,6 +6,7 @@ import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host
 const recommendationsColumn = {
   title: 'Recommendations',
   key: 'recommendations',
+  minWidth: '10rem',
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.Advisorrecommendations,
@@ -16,6 +17,7 @@ const recommendationsColumn = {
 const incidentsColumn = {
   title: 'Incidents',
   key: 'incidents',
+  minWidth: '7rem',
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.Advisorincidents,
@@ -26,6 +28,7 @@ const incidentsColumn = {
 const criticalColumn = {
   title: 'Critical',
   key: 'critical',
+  minWidth: '7rem',
   isShownByDefault: false,
   isShown: false,
   renderCell: (system: InventoryViewSystem) =>
@@ -35,6 +38,7 @@ const criticalColumn = {
 const importantColumn = {
   title: 'Important',
   key: 'important',
+  minWidth: '7rem',
   isShownByDefault: false,
   isShown: false,
   renderCell: (system: InventoryViewSystem) =>
@@ -44,6 +48,7 @@ const importantColumn = {
 const moderateColumn = {
   title: 'Moderate',
   key: 'moderate',
+  minWidth: '7rem',
   isShownByDefault: false,
   isShown: false,
   renderCell: (system: InventoryViewSystem) =>
@@ -53,6 +58,7 @@ const moderateColumn = {
 const lowColumn = {
   title: 'Low',
   key: 'low',
+  minWidth: '6rem',
   isShownByDefault: false,
   isShown: false,
   renderCell: (system: InventoryViewSystem) =>

--- a/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
+++ b/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
@@ -1,12 +1,22 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import allColumns from './allColumnDefinitions';
+import allColumns, { type Column } from './allColumnDefinitions';
 import { InventoryViewSystem } from '../hooks/useInventoryViewsQuery';
+import {
+  DEFAULT_NAME_COLUMN_MIN_WIDTH,
+  getColumnMinWidthStyle,
+  getNameColumnMinWidth,
+  resolveColumnMinWidth,
+} from '../utils/columnMinWidths';
 
 const inventoryKeys = ['name', 'workspace', 'tags', 'os', 'last_seen'];
 const nonInventoryColumns = allColumns.filter(
   (col) => !inventoryKeys.includes(col.key),
+);
+
+const columnsWithMinWidth = (allColumns as readonly Column[]).filter(
+  (col): col is Column & { minWidth: string } => col.minWidth !== undefined,
 );
 
 describe('allColumnDefinitions', () => {
@@ -43,6 +53,36 @@ describe('allColumnDefinitions', () => {
       expect(typeof column.renderCell).toBe('function');
     },
   );
+
+  it.each(columnsWithMinWidth)(
+    'should use a valid minWidth format when minWidth is defined on "$key"',
+    (column) => {
+      expect(column.minWidth).toMatch(/^\d+(\.\d+)?rem$/);
+    },
+  );
+
+  describe('optional minWidth', () => {
+    it('returns undefined for non-name columns without minWidth', () => {
+      expect(resolveColumnMinWidth({ key: 'tags' })).toBeUndefined();
+      expect(getColumnMinWidthStyle({ key: 'tags' })).toBeUndefined();
+    });
+
+    it('uses the provided minWidth when set', () => {
+      expect(resolveColumnMinWidth({ key: 'tags', minWidth: '6rem' })).toBe(
+        '6rem',
+      );
+      expect(getColumnMinWidthStyle({ key: 'tags', minWidth: '6rem' })).toEqual(
+        { style: { minWidth: '6rem' } },
+      );
+    });
+
+    it('falls back for the Name column when minWidth is omitted', () => {
+      expect(resolveColumnMinWidth({ key: 'name' })).toBe(
+        DEFAULT_NAME_COLUMN_MIN_WIDTH,
+      );
+      expect(getNameColumnMinWidth({})).toBe(DEFAULT_NAME_COLUMN_MIN_WIDTH);
+    });
+  });
 
   it.each(nonInventoryColumns)(
     'should render N/A when app data is missing for "$key"',

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -22,11 +22,17 @@ type ConsumerAppColumn = {
   appName?: 'patch' | 'vulnerability' | 'advisor';
 };
 
+type LayoutColumn = {
+  /** CSS min-width when inventory views scroll layout is enabled (e.g. '9rem'). */
+  readonly minWidth?: string;
+};
+
 export type Column = Resolve<
   ColumnManagementModalColumn &
     RenderableColumn &
     SortableColumn &
-    ConsumerAppColumn
+    ConsumerAppColumn &
+    LayoutColumn
 >;
 
 /**
@@ -34,6 +40,10 @@ export type Column = Resolve<
  *
  * To add an app: import its `./<appId>/columnDefinitions` default export and append
  * with `...thatAppsColumns` (or insert where the column order should appear).
+ *
+ * `minWidth` is optional on the type. Omitting it lets a column size to content;
+ * the sticky Name column falls back to {@link ../utils/columnMinWidths.DEFAULT_NAME_COLUMN_MIN_WIDTH}.
+ * Columns in `allColumns` should still define `minWidth` for inventory views scroll layout.
  */
 const allColumns = [
   ...inventoryColumns,

--- a/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom';
 const lastComplianceScanColumn = {
   title: 'Last compliance scan',
   key: 'last_compliance_scan',
+  minWidth: '12rem',
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.CompliancelastScan,
@@ -24,6 +25,7 @@ const lastComplianceScanColumn = {
 const policiesColumn = {
   title: 'Policies',
   key: 'policies',
+  minWidth: '7rem',
   isShownByDefault: false,
   isShown: false,
   renderCell: (system: InventoryViewSystem) => {

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -8,10 +8,12 @@ import Tags from './cells/Tags';
 import { LastSeenColumnHeader } from '../../../../Utilities/LastSeenColumnHeader';
 import { System } from '../../hooks/useSystemsQuery';
 import type { Column } from '../allColumnDefinitions';
+import { DEFAULT_NAME_COLUMN_MIN_WIDTH } from '../../utils/columnMinWidths';
 
 const nameColumn = {
   title: 'Name',
   key: 'name',
+  minWidth: DEFAULT_NAME_COLUMN_MIN_WIDTH,
   isShownByDefault: true,
   isShown: true,
   isUntoggleable: true,
@@ -24,6 +26,7 @@ const nameColumn = {
 const workspaceColumn = {
   title: 'Workspace',
   key: 'workspace',
+  minWidth: '10rem',
   isShownByDefault: true,
   isShown: true,
   sortBy: ApiOrderByEnum.GroupName,
@@ -35,6 +38,7 @@ const workspaceColumn = {
 const tagsColumn = {
   title: 'Tags',
   key: 'tags',
+  minWidth: '6rem',
   isShownByDefault: true,
   isShown: true,
   renderCell: (system: System) => (
@@ -45,6 +49,7 @@ const tagsColumn = {
 const operatingSystemColumn = {
   title: 'OS',
   key: 'os',
+  minWidth: '11rem',
   isShownByDefault: true,
   isShown: true,
   sortBy: ApiOrderByEnum.OperatingSystem,
@@ -56,6 +61,7 @@ const operatingSystemColumn = {
 const lastSeenColumn = {
   title: <LastSeenColumnHeader />,
   key: 'last_seen',
+  minWidth: '9rem',
   isShownByDefault: true,
   isShown: true,
   sortBy: ApiOrderByEnum.LastCheckIn,

--- a/src/components/SystemsView/columns/malware/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/malware/columnDefinitions.tsx
@@ -9,6 +9,7 @@ import { Label } from '@patternfly/react-core';
 const lastMalwareStatusColumn = {
   title: 'Last malware status',
   key: 'last_malware_status',
+  minWidth: '12rem',
   isShownByDefault: false,
   isShown: false,
   renderCell: (system: InventoryViewSystem) => {
@@ -28,6 +29,7 @@ const lastMalwareStatusColumn = {
 const lastMalwareMatchesColumn = {
   title: 'Last malware matches',
   key: 'last_malware_matches',
+  minWidth: '12rem',
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastMatches,
@@ -44,6 +46,7 @@ const lastMalwareMatchesColumn = {
 const totalMalwareMatchesColumn = {
   title: 'Total malware matches',
   key: 'total_malware_matches',
+  minWidth: '13rem',
   isShownByDefault: false,
   isShown: false,
   renderCell: (system: InventoryViewSystem) => {
@@ -59,6 +62,7 @@ const totalMalwareMatchesColumn = {
 const lastMalwareScanColumn = {
   title: 'Last malware scan',
   key: 'last_malware_scan',
+  minWidth: '12rem',
   isShownByDefault: false,
   isShown: false,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastScan,

--- a/src/components/SystemsView/columns/remediations/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/remediations/columnDefinitions.tsx
@@ -4,6 +4,7 @@ import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
 const remediationPlansColumn = {
   title: 'Remediation plans',
   key: 'remediations_plans',
+  minWidth: '12rem',
   isShownByDefault: false,
   isShown: false,
   sortBy: 'remediations:remediations_plans',

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import { DataViewTh } from '@patternfly/react-data-view';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { OnSort, SortDirection } from '../SystemsView';
-import { getSystemsViewColumnMinWidthStyle } from '../utils/columnMinWidths';
+import {
+  getColumnMinWidthStyle,
+  getNameColumnMinWidth,
+} from '../utils/columnMinWidths';
 import { STICKY_ACTIONS_HEADER_PROPS } from '../utils/stickyActionsColumn';
-import { STICKY_NAME_HEADER_PROPS } from '../utils/stickyNameColumn';
+import { getStickyNameHeaderProps } from '../utils/stickyNameColumn';
 import initialColumns, { type Column } from '../columns/allColumnDefinitions';
 
 export const INITIAL_SORT: {
@@ -67,10 +70,10 @@ export const useColumns = ({
             props: {
               ...(col.key === 'name'
                 ? isInventoryViewsEnabled
-                  ? STICKY_NAME_HEADER_PROPS
+                  ? getStickyNameHeaderProps(getNameColumnMinWidth(col))
                   : {}
                 : isInventoryViewsEnabled
-                  ? (getSystemsViewColumnMinWidthStyle(col.key) ?? {})
+                  ? (getColumnMinWidthStyle(col) ?? {})
                   : {}),
               ...(col.sortBy && {
                 sort: {

--- a/src/components/SystemsView/hooks/useRows.tsx
+++ b/src/components/SystemsView/hooks/useRows.tsx
@@ -1,9 +1,12 @@
 import { DataViewTrObject } from '@patternfly/react-data-view';
 import React from 'react';
 import SystemsViewRowActions from '../SystemsViewRowActions';
-import { getSystemsViewColumnMinWidthStyle } from '../utils/columnMinWidths';
+import {
+  getColumnMinWidthStyle,
+  getNameColumnMinWidth,
+} from '../utils/columnMinWidths';
 import { STICKY_ACTIONS_BODY_PROPS } from '../utils/stickyActionsColumn';
-import { STICKY_NAME_BODY_PROPS } from '../utils/stickyNameColumn';
+import { getStickyNameBodyProps } from '../utils/stickyNameColumn';
 import type { SystemWithPermissions } from '../../../Utilities/hooks/useHostIdsWithKessel';
 import type { System } from './useSystemsQuery';
 import { Column } from '../columns/allColumnDefinitions';
@@ -40,14 +43,17 @@ export const useRows = ({
         const cell = col.renderCell(system);
         if (col.key === 'name') {
           if (isInventoryViewsEnabled) {
-            return { cell, props: STICKY_NAME_BODY_PROPS };
+            return {
+              cell,
+              props: getStickyNameBodyProps(getNameColumnMinWidth(col)),
+            };
           }
           return cell;
         }
         if (!isInventoryViewsEnabled) {
           return cell;
         }
-        const minStyle = getSystemsViewColumnMinWidthStyle(col.key);
+        const minStyle = getColumnMinWidthStyle(col);
         return minStyle ? { cell, props: minStyle } : cell;
       });
 

--- a/src/components/SystemsView/utils/columnMinWidths.ts
+++ b/src/components/SystemsView/utils/columnMinWidths.ts
@@ -1,32 +1,36 @@
 import type { CSSProperties } from 'react';
-
-/**
- * Minimum widths for Systems View table columns (CSS lengths).
- * When the inventory views feature flag is on and combined minimum widths exceed the scroll
- * container, {@link ../SystemsView.tsx InnerScrollContainer} shows horizontal scroll.
- *
- * **Where to edit:** add or change entries keyed by `Column.key` for each column
- * listed in {@link ../columns/allColumnDefinitions.ts allColumnDefinitions.ts}
- * (and the per-app `columnDefinitions` modules it pulls in).
- * New columns should get an entry here once you know how wide they need to be.
- *
- * The Name column width is also read by {@link ./stickyNameColumn.ts} for
- * `stickyMinWidth` — keep a single value here for that key.
- */
-export const SYSTEMS_VIEW_COLUMN_MIN_WIDTHS: Record<string, string> = {
-  name: '11rem',
-  workspace: '10rem',
-  tags: '6rem',
-  os: '11rem',
-  last_seen: '9rem',
-};
+import type { Column } from '../columns/allColumnDefinitions';
 
 /** Last column (row actions kebab); not a managed inventory column key. */
 export const SYSTEMS_VIEW_ROW_ACTIONS_MIN_WIDTH = '2rem';
 
-export function getSystemsViewColumnMinWidthStyle(
-  key: string,
+/** Fallback when the Name column omits `minWidth` (sticky column requires a width). */
+export const DEFAULT_NAME_COLUMN_MIN_WIDTH = '11rem';
+
+export function resolveColumnMinWidth(
+  col: Pick<Column, 'key' | 'minWidth'>,
+): string | undefined {
+  if (col.minWidth) {
+    return col.minWidth;
+  }
+  if (col.key === 'name') {
+    return DEFAULT_NAME_COLUMN_MIN_WIDTH;
+  }
+  return undefined;
+}
+
+/**
+ * Resolved min-width for the sticky Name column (always returns a CSS length).
+ *  @param col - Column (or column-like object) with optional `minWidth`.
+ *  @returns   CSS min-width for the Name column.
+ */
+export function getNameColumnMinWidth(col: Pick<Column, 'minWidth'>): string {
+  return col.minWidth ?? DEFAULT_NAME_COLUMN_MIN_WIDTH;
+}
+
+export function getColumnMinWidthStyle(
+  col: Pick<Column, 'key' | 'minWidth'>,
 ): { style: CSSProperties } | undefined {
-  const minWidth = SYSTEMS_VIEW_COLUMN_MIN_WIDTHS[key];
+  const minWidth = resolveColumnMinWidth(col);
   return minWidth ? { style: { minWidth } } : undefined;
 }

--- a/src/components/SystemsView/utils/stickyNameColumn.ts
+++ b/src/components/SystemsView/utils/stickyNameColumn.ts
@@ -1,5 +1,4 @@
 import type { TdProps, ThProps } from '@patternfly/react-table';
-import { SYSTEMS_VIEW_COLUMN_MIN_WIDTHS } from './columnMinWidths';
 
 /**
  * Left inset for the Name column so it clears the bulk-select column when both stick.
@@ -7,31 +6,45 @@ import { SYSTEMS_VIEW_COLUMN_MIN_WIDTHS } from './columnMinWidths';
  */
 export const STICKY_NAME_LEFT_OFFSET = 'var(--pf-t--global--spacer--2xl)';
 
-const stickyNameShared: Pick<
+const getStickyNameShared = (
+  minWidth: string,
+): Pick<
   ThProps,
   'isStickyColumn' | 'hasRightBorder' | 'stickyMinWidth' | 'stickyLeftOffset'
-> = {
+> => ({
   isStickyColumn: true,
   hasRightBorder: true,
-  stickyMinWidth: SYSTEMS_VIEW_COLUMN_MIN_WIDTHS.name,
+  stickyMinWidth: minWidth,
   stickyLeftOffset: STICKY_NAME_LEFT_OFFSET,
-};
+});
 
-/** Forwarded through DataView column `props` → composable `Th` (via DataViewTh `thProps`). */
-export const STICKY_NAME_HEADER_PROPS: Pick<
+/**
+ * Forwarded through DataView column `props` → composable `Th` (via DataViewTh `thProps`).
+ *  @param minWidth - CSS min-width for the sticky Name column (from column `minWidth`).
+ *  @returns        Sticky header props for the Name column.
+ */
+export const getStickyNameHeaderProps = (
+  minWidth: string,
+): Pick<
   ThProps,
   'isStickyColumn' | 'hasRightBorder' | 'stickyMinWidth' | 'stickyLeftOffset'
-> = stickyNameShared;
+> => getStickyNameShared(minWidth);
 
-/** Forwarded through DataView body cell `{ props }` → composable `Td`. */
-export const STICKY_NAME_BODY_PROPS: Pick<
+/**
+ * Forwarded through DataView body cell `{ props }` → composable `Td`.
+ *  @param minWidth - CSS min-width for the sticky Name column (from column `minWidth`).
+ *  @returns        Sticky body cell props for the Name column.
+ */
+export const getStickyNameBodyProps = (
+  minWidth: string,
+): Pick<
   TdProps,
   | 'isStickyColumn'
   | 'hasRightBorder'
   | 'stickyMinWidth'
   | 'stickyLeftOffset'
   | 'modifier'
-> = {
-  ...stickyNameShared,
+> => ({
+  ...getStickyNameShared(minWidth),
   modifier: 'nowrap',
-};
+});


### PR DESCRIPTION
Move minWidth from the central columnMinWidths map onto each column definition so layout stays with column metadata. Optional minWidth keeps new columns compiling; the sticky Name column falls back to a default width.

## Summary by Sourcery

Co-locate Systems View inventory column min-width configuration with the column definitions and wire it through to header/body rendering and sticky name behavior.

Enhancements:
- Add an optional minWidth layout property to Systems View column definitions and use it to derive per-column min-width styles instead of a central mapping.
- Update sticky Name column helpers to accept the resolved min-width so sticky layout is driven by column metadata, with a default fallback for Name when omitted.

Tests:
- Add a test ensuring all inventory columns define a valid rem-based minWidth for the inventory views scroll layout.