### PR TITLE
test(RHINENG-26768): Enable CI with systems table tests for Inventory Views

### DIFF
--- a/.github/workflows/playwright-inventory-views.yml
+++ b/.github/workflows/playwright-inventory-views.yml
@@ -1,0 +1,111 @@
+name: 'E2E: Inventory Views'
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  inventory_views-tests:
+    timeout-minutes: 30
+    runs-on:
+      - codebuild-host-inventory-frontend-${{ github.run_id }}-${{ github.run_attempt }}
+      - instance-size:large
+      - buildspec-override:true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Create front-end .env file
+        run: |
+          # Check if the secrets are set
+          if [ -z "$PLAYWRIGHT_USER" ]; then
+            echo "Error: PLAYWRIGHT_USER secret is not set."
+            exit 1
+          fi
+
+          if [ -z "$PLAYWRIGHT_PASSWORD" ]; then
+            echo "Error: PLAYWRIGHT_PASSWORD secret is not set."
+            exit 1
+          fi
+
+          # Create the .env file and write the secrets and other variables to it
+          {
+            echo "PLAYWRIGHT_USER=$PLAYWRIGHT_USER"
+            echo "PLAYWRIGHT_PASSWORD=$PLAYWRIGHT_PASSWORD"
+            echo "BASE_URL=https://stage.foo.redhat.com:1337"
+            echo "CI=true"
+            echo "PROXY=$PROXY"
+            echo "INVENTORY_VIEWS=true"
+            echo "STAGE_OFFLINE_TOKEN=$STAGE_OFFLINE_TOKEN"
+          } >> .env
+
+          echo ".env file created successfully."
+
+      - name: Get current PR URL
+        id: get-pr-url
+        run: |
+          # Extract the pull request URL from the event payload
+          pr_url=$(jq -r '.pull_request.html_url' < "$GITHUB_EVENT_PATH")
+          echo "Pull Request URL: $pr_url"
+          # Set the PR URL as an output using the environment file
+          echo "pr_url=$pr_url" >> $GITHUB_ENV
+      
+      - name: Cache - node_modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            node_modules
+            dist
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-frontend-node-modules-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install front-end dependencies
+        run: npm ci
+
+      - name: Install Playwright
+        run: npx playwright install chromium
+
+      - name: Increase file watchers limit
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
+      - name: Update /etc/hosts
+        run: sudo npm run patch:hosts
+
+      - name: Run testing proxy
+        run: docker run -d --network=host -e HTTPS_PROXY=$RH_PROXY_URL -e ROUTES_JSON_PATH=/config/routes-ci.json  -v "$(pwd)/config:/config:ro,Z" --name frontend-development-proxy quay.io/redhat-user-workloads/hcc-platex-services-tenant/frontend-development-proxy
+
+      - name: Start front-end server
+        run: |
+          npm run static &
+          npx wait-on http://localhost:8003/apps/inventory/
+
+      - name: Run front-end Playwright tests
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
+
+      - name: Publish front-end Test Report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: './playwright-ctrf/playwright-ctrf.json'
+        if: ${{ !cancelled() }}
+
+      - name: Store front-end Test report
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 10

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ npx playwright install  --with-deps
 * `npx playwright test --grep-invert @integration` - run tests except integration tests
 * `npx playwright test --grep @rbac` - run only E2E RBAC tests
 * `SYSTEMS_VIEW=true npx playwright test` - run the complete playwright test suite with enabled `SystemsView` and `Kessel` components
+* `INVENTORY_VIEWS=true npx playwright test` - run the complete playwright test suite with enabled `Inventory Views` components
 
 For more examples on how to run and debug tests, visit the [official Playwright documentation](https://playwright.dev/docs/running-tests).
 

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -2,6 +2,7 @@ import { expect, test as setup, type Page } from '@playwright/test';
 import {
   ensureNotInPreview,
   enableSystemsView,
+  enableInventoryViews,
   logInAsRole,
   throwIfMissingAdminEnvVariables,
   throwIfMissingRbacEnvVariables,
@@ -11,11 +12,17 @@ import {
   getRbacUsersForSetup,
   type UserConfig,
 } from './helpers/loginHelpers';
-import { isSystemsViewEnabled } from './helpers/constants';
+import {
+  isSystemsViewEnabled,
+  isInventoryViewsEnabled,
+} from './helpers/constants';
 
 async function authenticateUser(page: Page, user: UserConfig) {
   if (isSystemsViewEnabled) {
     await enableSystemsView(page);
+  }
+  if (isInventoryViewsEnabled) {
+    await enableInventoryViews(page);
   }
   await closePopupsIfExist(page);
   await logInAsRole(page, user);

--- a/_playwright-tests/helpers/constants.ts
+++ b/_playwright-tests/helpers/constants.ts
@@ -13,6 +13,7 @@ export const GLOBAL_DATA_PATH = path.resolve(
 );
 
 export const isSystemsViewEnabled = process.env.SYSTEMS_VIEW === 'true';
+export const isInventoryViewsEnabled = process.env.INVENTORY_VIEWS === 'true';
 
 // Base archives
 export const CENTOS_ARCHIVE = 'centos79.tar.gz';

--- a/_playwright-tests/helpers/loginHelpers.ts
+++ b/_playwright-tests/helpers/loginHelpers.ts
@@ -163,6 +163,13 @@ export const disableSystemsView = async (page: Page) => {
   });
 };
 
+export const enableInventoryViews = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('ui.systems-view', 'true');
+    localStorage.setItem('ui.inventory-views', 'true');
+  });
+};
+
 export const storeStorageStateAndToken = async (
   /** Save state using the specific token variable name from config */
   page: Page,

--- a/_playwright-tests/rbac/test_granular_access.test.ts
+++ b/_playwright-tests/rbac/test_granular_access.test.ts
@@ -13,7 +13,7 @@ import {
 
 test.use({ storageState: '.auth/granular_user.json' });
 
-test.describe('@rbac Granular access:', () => {
+test.describe('Granular access:', { tag: ['@rbac'] }, () => {
   test('Systems page - only expected workpsaces are displayed', async ({
     page,
   }) => {

--- a/_playwright-tests/rbac/test_no_access.test.ts
+++ b/_playwright-tests/rbac/test_no_access.test.ts
@@ -4,7 +4,7 @@ import { NO_ACCESS_STALENESS, NO_ACCESS_INVENTORY } from './constants';
 
 test.use({ storageState: '.auth/no_access_user.json' });
 
-test.describe('@rbac No access:', () => {
+test.describe('No access:', { tag: ['@rbac'] }, () => {
   test('Systems page - no access is displayed', async ({ page }) => {
     await page.goto('/insights/inventory/', { timeout: 100000 });
 

--- a/_playwright-tests/rbac/test_viewer_role_access.test.ts
+++ b/_playwright-tests/rbac/test_viewer_role_access.test.ts
@@ -12,7 +12,7 @@ import {
 
 test.use({ storageState: '.auth/viewer_user.json' });
 
-test.describe('@rbac Viewer:', () => {
+test.describe('Viewer:', { tag: ['@rbac'] }, () => {
   test('Systems page - all actions are disabled', async ({ page }) => {
     await navigateToInventorySystemsFunc(page);
     const nameCell = page

--- a/_playwright-tests/test_integration.test.ts
+++ b/_playwright-tests/test_integration.test.ts
@@ -27,41 +27,45 @@ const typeError =
 const scalprumError =
   "Scalprum encountered an error! Cannot read properties of undefined (reading 'page')";
 
-test.describe('Inventory federated modules check @integration', () => {
-  for (const service of systemsPageUrls) {
-    test(`Verify Inventory Table in: ${service.name}`, async ({ page }) => {
-      const logs: string[] = [];
+test.describe(
+  'Inventory federated modules check',
+  { tag: ['@integration'] },
+  () => {
+    for (const service of systemsPageUrls) {
+      test(`Verify Inventory Table in: ${service.name}`, async ({ page }) => {
+        const logs: string[] = [];
 
-      // Setup Listener BEFORE navigation
-      page.on('console', (message: ConsoleMessage) => {
-        const text = message.text();
-        const isCriticalError =
-          text.includes(failedLoadComponent) ||
-          text.includes(typeError) ||
-          text.includes(scalprumError);
+        // Setup Listener BEFORE navigation
+        page.on('console', (message: ConsoleMessage) => {
+          const text = message.text();
+          const isCriticalError =
+            text.includes(failedLoadComponent) ||
+            text.includes(typeError) ||
+            text.includes(scalprumError);
 
-        if (message.type() === 'error' && isCriticalError) {
-          logs.push(text);
+          if (message.type() === 'error' && isCriticalError) {
+            logs.push(text);
+          }
+        });
+
+        await page.goto(service.url);
+        // eslint-disable-next-line playwright/no-networkidle
+        await page.waitForLoadState('networkidle');
+
+        expect(
+          logs,
+          `Found ${logs.length} critical console errors on ${service.name}`,
+        ).toHaveLength(0);
+
+        // eslint-disable-next-line playwright/no-conditional-in-test
+        if (service.name === 'Remediation Plan') {
+          const systemsTab = page.getByLabel('SystemsTab');
+          await systemsTab.click({ timeout: 1000 });
         }
+        await expect(
+          page.locator('[data-ouia-component-id="systems-table"]'),
+        ).toBeVisible({ timeout: 10000 });
       });
-
-      await page.goto(service.url);
-      // eslint-disable-next-line playwright/no-networkidle
-      await page.waitForLoadState('networkidle');
-
-      expect(
-        logs,
-        `Found ${logs.length} critical console errors on ${service.name}`,
-      ).toHaveLength(0);
-
-      // eslint-disable-next-line playwright/no-conditional-in-test
-      if (service.name === 'Remediation Plan') {
-        const systemsTab = page.getByLabel('SystemsTab');
-        await systemsTab.click({ timeout: 1000 });
-      }
-      await expect(
-        page.locator('[data-ouia-component-id="systems-table"]'),
-      ).toBeVisible({ timeout: 10000 });
-    });
-  }
-});
+    }
+  },
+);

--- a/playwright_example.env
+++ b/playwright_example.env
@@ -9,7 +9,7 @@ STAGE_OFFLINE_TOKEN="" # Required - shared offline token for qe-ui-inventory sta
 INTEGRATION="" # When this is true, playwright test will run integration tests directly against stage/prod.
 PROXY="" # Set this if running directly against stage (not using "npm local")
 PROD=""  # Determines the environment used for the tests.
-# Run tests with enabled 'SystemsView' and 'Kessel'
+
 SYSTEMS_VIEW="" # This is set to true for SystemsView CI job
 INVENTORY_VIEWS="" # This is set to true for Inventory Views CI job
 

--- a/playwright_example.env
+++ b/playwright_example.env
@@ -11,6 +11,7 @@ PROXY="" # Set this if running directly against stage (not using "npm local")
 PROD=""  # Determines the environment used for the tests.
 # Run tests with enabled 'SystemsView' and 'Kessel'
 SYSTEMS_VIEW="" # This is set to true for SystemsView CI job
+INVENTORY_VIEWS="" # This is set to true for Inventory Views CI job
 
 # RBAC
 RBAC_VIEWER_ROLE_ACCESS_USER="" # Required


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-26768

## What
Add CI for Inventory Views: all existing systems tests should work as expected when Inventory Views is enabled

## Why
PR check for Inventory Views components

## How
Enable via local storage `localStorage.setItem('ui.inventory-views', 'true');`
It enables Inventory Views - system table start to use API `/inventory/v1/beta/hosts-view ` instead of `/hosts`

## Testing
CI for Inventory Views should pass

## Screenshots/Videos (if applicable)
<img width="2218" height="933" alt="image" src="https://github.com/user-attachments/assets/6883ed69-4dc1-45ed-939a-33c0795dab46" />

## Summary by Sourcery

Add CI coverage and configuration to run systems table Playwright tests with Inventory Views enabled in Inventory.

New Features:
- Enable Inventory Views via local storage for authenticated Playwright sessions when INVENTORY_VIEWS is set.
- Add a dedicated GitHub Actions workflow to execute Inventory Views end-to-end Playwright tests on pull requests.

Enhancements:
- Introduce an INVENTORY_VIEWS environment flag and helper to toggle Inventory Views in Playwright tests.
- Document how to run the Playwright test suite with Inventory Views enabled via CLI.