### PR TITLE
fix(E2E): route API fixture calls through proxy to bypass preprod lockdown

### DIFF
--- a/_playwright-tests/helpers/apiHelpers.ts
+++ b/_playwright-tests/helpers/apiHelpers.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosInstance } from 'axios';
 import fs from 'fs';
 import https from 'https';
+import { HttpsProxyAgent } from 'hpagent';
 import path from 'path';
 import * as hostInventoryApi from '../../src/api/hostInventoryApi';
 export { INVENTORY_API_BASE } from '../../src/api/hostInventoryApi';
@@ -34,21 +35,40 @@ function resolvePlaywrightApiToken(): string {
   );
 }
 
+function isValidProxyUrl(url: string | undefined): url is string {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return !!parsed.hostname && !!parsed.port;
+  } catch {
+    return false;
+  }
+}
+
 function getPlaywrightApiClient(): AxiosInstance {
   const baseURL = process.env.BASE_URL;
+  const proxyUrl = process.env.PROXY;
   const token = resolvePlaywrightApiToken();
   if (!baseURL) {
     throw new Error('BASE_URL must be set (run setup first).');
   }
+
+  const useProxy = isValidProxyUrl(proxyUrl);
+  const httpsAgent = useProxy
+    ? new HttpsProxyAgent({
+        proxy: proxyUrl,
+        rejectUnauthorized: false,
+      })
+    : new https.Agent({ rejectUnauthorized: false });
+
   return axios.create({
     baseURL,
     headers: {
       Authorization: token,
       'Content-Type': 'application/json',
     },
-    httpsAgent: new https.Agent({
-      rejectUnauthorized: false,
-    }),
+    httpsAgent,
+    proxy: false,
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "eslint-plugin-playwright": "^2.10.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-testing-library": "^7.16.2",
+        "hpagent": "^1.2.0",
         "husky": "^8.0.3",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.3.0",
@@ -13014,9 +13015,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001763",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001763.tgz",
-      "integrity": "sha512-mh/dGtq56uN98LlNX9qdbKnzINhX0QzhiWBFEkFfsFO4QyCvL8YegrJAazCwXIeqkIob8BlZPGM3xdnY+sgmvQ==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "funding": [
         {
           "type": "opencollective",
@@ -18359,6 +18360,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "eslint-plugin-playwright": "^2.10.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-testing-library": "^7.16.2",
+    "hpagent": "^1.2.0",
     "husky": "^8.0.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.3.0",


### PR DESCRIPTION
What
Route E2E test fixture API calls through the proxy to fix 403 "Preprod Lockdown: Access Denied" errors in CI.

Why
Direct API calls from the CodeBuild runner to console.stage.redhat.com are blocked by the Akamai edge preprod IP allowlist. Browser-based tests work because they go through the proxy, but fixture API calls (workspace creation, host assignment) were not.

How
Added https-proxy-agent dependency
Updated getPlaywrightApiClient() in apiHelpers.ts to use the PROXY env var when set
Falls back to direct connection when no proxy is configured (local dev)

Testing
Verified locally without proxy (unchanged behavior)
CI run will confirm fixture API calls pass through the proxy without 403

Screenshots/Videos (if applicable)
NA

## Summary by Sourcery

Route Playwright E2E API client traffic through an optional HTTPS proxy to avoid preprod access restrictions while preserving local behavior.

Bug Fixes:
- Fix E2E fixture API calls failing with 403 errors in preprod by sending them through the configured proxy when available.

Enhancements:
- Add support in the Playwright API helper to detect and use a PROXY environment variable, falling back to direct HTTPS connections when unset.

Build:
- Add hpagent as a development dependency to support HTTPS proxying for E2E API calls.