### PR TITLE
fix(e2e): Resolve the proxy url

### DIFF
--- a/_playwright-tests/helpers/apiHelpers.ts
+++ b/_playwright-tests/helpers/apiHelpers.ts
@@ -35,13 +35,13 @@ function resolvePlaywrightApiToken(): string {
   );
 }
 
-function isValidProxyUrl(url: string | undefined): url is string {
-  if (!url) return false;
+function resolveProxyUrl(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const url = raw.includes('://') ? raw : `http://${raw}`;
   try {
-    const parsed = new URL(url);
-    return !!parsed.hostname && !!parsed.port;
+    return new URL(url).hostname ? url : null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -53,10 +53,11 @@ function getPlaywrightApiClient(): AxiosInstance {
     throw new Error('BASE_URL must be set (run setup first).');
   }
 
-  const useProxy = isValidProxyUrl(proxyUrl);
-  const httpsAgent = useProxy
+  const needsProxy = process.env.INTEGRATION === 'true';
+  const resolvedProxy = needsProxy ? resolveProxyUrl(proxyUrl) : null;
+  const httpsAgent = resolvedProxy
     ? new HttpsProxyAgent({
-        proxy: proxyUrl,
+        proxy: resolvedProxy,
         rejectUnauthorized: false,
       })
     : new https.Agent({ rejectUnauthorized: false });


### PR DESCRIPTION
Follow up - https://github.com/RedHatInsights/insights-inventory-frontend/pull/3241

## Summary by Sourcery

Bug Fixes:
- Fix proxy handling in Playwright E2E API client by normalizing and validating the proxy URL, including adding a default scheme when missing.

## Summary by Sourcery

Bug Fixes:
- Ensure the Playwright E2E API client only configures an HTTPS proxy when running in integration mode and when a valid proxy URL is provided, adding a default scheme when missing.