### PR TITLE
fix(Inventory Views): Update table Advisor columns to match mocks

### DIFF
--- a/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
@@ -23,47 +23,7 @@ const incidentsColumn = {
     system?.app_data?.advisor?.incidents ?? 'N/A',
 };
 
-const criticalColumn = {
-  title: 'Critical',
-  key: 'critical',
-  isShownByDefault: false,
-  isShown: false,
-  renderCell: (system: InventoryViewSystem) =>
-    system?.app_data?.advisor?.critical ?? 'N/A',
-};
-
-const importantColumn = {
-  title: 'Important',
-  key: 'important',
-  isShownByDefault: false,
-  isShown: false,
-  renderCell: (system: InventoryViewSystem) =>
-    system?.app_data?.advisor?.important ?? 'N/A',
-};
-
-const moderateColumn = {
-  title: 'Moderate',
-  key: 'moderate',
-  isShownByDefault: false,
-  isShown: false,
-  renderCell: (system: InventoryViewSystem) =>
-    system?.app_data?.advisor?.moderate ?? 'N/A',
-};
-
-const lowColumn = {
-  title: 'Low',
-  key: 'low',
-  isShownByDefault: false,
-  isShown: false,
-  renderCell: (system: InventoryViewSystem) =>
-    system?.app_data?.advisor?.low ?? 'N/A',
-};
-
 export default [
   recommendationsColumn,
   incidentsColumn,
-  criticalColumn,
-  importantColumn,
-  moderateColumn,
-  lowColumn,
 ] as const satisfies readonly Column[];


### PR DESCRIPTION
## What
Update table Advisor columns to match mocks

## Screenshots/Videos (if applicable)
<img width="660" height="318" alt="image" src="https://github.com/user-attachments/assets/b8043c36-336d-4d69-96df-f2baeba3014c" />

## Summary by Sourcery

Remove Advisor severity columns from the Systems view to align the Inventory table with the updated design mocks.