### PR TITLE
refactor(workspace): remove 'No workspace' placeholder

### DIFF
--- a/src/__factories__/hosts.js
+++ b/src/__factories__/hosts.js
@@ -17,15 +17,12 @@ export const buildHosts = (length) =>
         minor: faker.number.int(50),
       },
     },
-    groups:
-      Math.random() > 0.5
-        ? [
-            {
-              id: faker.string.uuid(),
-              name: faker.lorem.words({ min: 1, max: 3 }),
-            },
-          ]
-        : [],
+    groups: [
+      {
+        id: faker.string.uuid(),
+        name: faker.lorem.words({ min: 1, max: 3 }),
+      },
+    ],
   }));
 
 export const buildHostsPayload = (page = 1, per_page = 50, total = 20) => {

--- a/src/components/InventoryTable/InventoryTable.test.js
+++ b/src/components/InventoryTable/InventoryTable.test.js
@@ -113,9 +113,7 @@ const checkRowsContent = (hostsData) => {
     .forEach((row, index) => {
       try {
         expect(row).toHaveTextContent(hostsData[index].display_name);
-        expect(row).toHaveTextContent(
-          hostsData[index].groups?.[0]?.name || 'No workspace',
-        );
+        expect(row).toHaveTextContent(hostsData[index].groups?.[0]?.name);
         const os = hostsData[index].system_profile.operating_system;
         expect(row).toHaveTextContent(`${os.name} ${os.major}.${os.minor}`);
       } catch (error) {

--- a/src/routes/Systems/components/SystemsTable/components/columns/Workspace.js
+++ b/src/routes/Systems/components/SystemsTable/components/columns/Workspace.js
@@ -1,13 +1,6 @@
-import React from 'react';
-import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 
-const Workspace = ({ groups }) =>
-  isEmpty(groups) ? (
-    <div className="pf-v5-u-disabled-color-200">No workspace</div>
-  ) : (
-    groups[0].name
-  );
+const Workspace = ({ groups }) => groups?.[0]?.name;
 
 Workspace.propTypes = {
   groups: PropTypes.arrayOf(

--- a/src/store/constants.js
+++ b/src/store/constants.js
@@ -26,7 +26,7 @@ export const INVENTORY_COLUMNS = [
     title: 'Workspace',
     props: { width: 10 },
 
-    renderFunc: (groups) => groups[0].name,
+    renderFunc: (groups) => groups?.[0]?.name,
     transforms: [fitContent],
   },
   {

--- a/src/store/constants.js
+++ b/src/store/constants.js
@@ -9,7 +9,6 @@ import OperatingSystemFormatter from '../Utilities/OperatingSystemFormatter';
 import { Tooltip } from '@patternfly/react-core';
 import { verifyCulledReporter } from '../Utilities/sharedFunctions';
 import { fitContent } from '@patternfly/react-table';
-import isEmpty from 'lodash/isEmpty';
 import { LastSeenColumnHeader } from '../Utilities/LastSeenColumnHeader';
 
 export const INVENTORY_COLUMNS = [
@@ -27,12 +26,7 @@ export const INVENTORY_COLUMNS = [
     title: 'Workspace',
     props: { width: 10 },
 
-    renderFunc: (groups) =>
-      isEmpty(groups) ? (
-        <div className="pf-v6-u-disabled-color-200">No workspace</div>
-      ) : (
-        groups[0].name
-      ), // currently, one group at maximum is supported
+    renderFunc: (groups) => groups[0].name,
     transforms: [fitContent],
   },
   {

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -53,7 +53,7 @@ export const DEFAULT_COLUMNS = [
     title: 'Workspace',
     props: { width: 10 },
 
-    renderFunc: (groups) => groups[0].name,
+    renderFunc: (groups) => groups?.[0]?.name,
     transforms: [fitContent],
   },
   {

--- a/src/store/entities.js
+++ b/src/store/entities.js
@@ -24,7 +24,6 @@ import OperatingSystemFormatter from '../Utilities/OperatingSystemFormatter';
 import { Tooltip } from '@patternfly/react-core';
 import { verifyCulledReporter } from '../Utilities/sharedFunctions';
 import { fitContent } from '@patternfly/react-table';
-import isEmpty from 'lodash/isEmpty';
 import { LastSeenColumnHeader } from '../Utilities/LastSeenColumnHeader';
 
 export const defaultState = {
@@ -54,12 +53,7 @@ export const DEFAULT_COLUMNS = [
     title: 'Workspace',
     props: { width: 10 },
 
-    renderFunc: (groups) =>
-      isEmpty(groups) ? (
-        <div className="pf-v6-u-disabled-color-200">No workspace</div>
-      ) : (
-        groups[0].name
-      ), // currently, one group at maximum is supported
+    renderFunc: (groups) => groups[0].name,
     transforms: [fitContent],
   },
   {


### PR DESCRIPTION
## What
Remove 'No workspace' placeholder, this fallback causes intermittent issues in Advisor and Malware to display  'No workspace'  for Ungrouped Hosts workspace

## Why
After Kessel Phase 0 every host now in the workspace

## How
drop condition for  'No workspace' 

## Testing
All apps with Workspace column should not display 'No workspace'


## Screenshots/Videos (if applicable)
<img width="1312" height="476" alt="image" src="https://github.com/user-attachments/assets/aae0fc5a-e7e7-4fe1-b395-e0a7beb994dd" />
