### PR TITLE
fix(InventoryViews): Update Malware columns

### DIFF
--- a/src/components/SystemsView/columns/malware/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/malware/columnDefinitions.tsx
@@ -26,23 +26,6 @@ const lastMalwareStatusColumn = {
   },
 };
 
-const lastMalwareMatchesColumn = {
-  title: 'Last malware matches',
-  key: 'last_malware_matches',
-  minWidth: '12rem',
-  isShownByDefault: false,
-  isShown: false,
-  sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastMatches,
-  renderCell: (system: InventoryViewSystem) => {
-    const lastMatches = system?.app_data?.malware?.last_matches;
-    return lastMatches !== null && lastMatches !== undefined ? (
-      <DateFormat date={lastMatches} />
-    ) : (
-      'N/A'
-    );
-  },
-};
-
 const totalMalwareMatchesColumn = {
   title: 'Total malware matches',
   key: 'total_malware_matches',
@@ -78,7 +61,6 @@ const lastMalwareScanColumn = {
 
 export default [
   lastMalwareStatusColumn,
-  lastMalwareMatchesColumn,
   totalMalwareMatchesColumn,
   lastMalwareScanColumn,
 ] as const satisfies readonly Column[];


### PR DESCRIPTION
## What
Update Malware columns - display only Total malware matches, similar to Malware page

## Why
UX review

## Summary by Sourcery

Enhancements:
- Remove the Last malware matches column from the systems inventory malware table so only total malware matches are displayed for each system.