### PR TITLE
fix(InventoryViews): Do not display Remediations column in Phase 1

### DIFF
--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -5,7 +5,6 @@ import patchColumns from './patch/columnDefinitions';
 import { System } from '../hooks/useSystemsQuery';
 import { Resolve } from '../../../types/utility-types';
 import advisorColumns from './advisor/columnDefinitions';
-import remediationPlansColumns from './remediations/columnDefinitions';
 import malwareColumns from './malware/columnDefinitions';
 
 type RenderableColumn = {
@@ -51,7 +50,6 @@ const allColumns = [
   ...advisorColumns,
   ...malwareColumns,
   ...complianceColumns,
-  ...remediationPlansColumns,
 ] as const satisfies readonly Column[];
 
 export default allColumns;


### PR DESCRIPTION
## What
Do not display Remediations column in Phase 1

## Why
Requirements needs to be revisit with the Remediations team in Q3

## Summary by Sourcery

Bug Fixes:
- Remove the Remediations column from the systems view to align the UI with current phase requirements.