### PR TITLE
feat(RHINENG-26759): Add test suite for InventoryViews to validate the default columns

### DIFF
--- a/.github/workflows/playwright-inventory-views.yml
+++ b/.github/workflows/playwright-inventory-views.yml
@@ -94,7 +94,7 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_inventory_views.test.ts _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
+        run: USE_CTRF=1 npx playwright test _playwright-tests/test_inventory_views.test.ts _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright-inventory-views.yml
+++ b/.github/workflows/playwright-inventory-views.yml
@@ -94,7 +94,7 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_inventory_views.test.ts _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright-inventory-views.yml
+++ b/.github/workflows/playwright-inventory-views.yml
@@ -94,7 +94,7 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 npx playwright test _playwright-tests/test_inventory_views.test.ts _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_inventory_views.test.ts _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright-systems-view.yml
+++ b/.github/workflows/playwright-systems-view.yml
@@ -94,7 +94,7 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@inventory-views"
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-systems-view-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@inventory-views"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright-systems-view.yml
+++ b/.github/workflows/playwright-systems-view.yml
@@ -94,7 +94,7 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-systems-view-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert @integration
+        run: USE_CTRF=1 npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@inventory-views"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -93,7 +93,7 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-full-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert @integration
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-full-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert "@integration|@inventory-views"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -75,7 +75,7 @@ jobs:
         run: npx playwright install chromium
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert "@integration|@rbac"
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert "@integration|@rbac|@inventory-views"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -1,0 +1,32 @@
+import { expect } from '@playwright/test';
+import { createSystem } from './helpers/uploadArchive';
+import { navigateToInventorySystemsFunc } from './helpers/navHelpers';
+import { test } from './helpers/fixtures';
+import { searchByName, waitForTableKebabReady } from './helpers/filterHelpers';
+import { isSystemsViewEnabled } from './helpers/constants';
+
+test.describe('Inventory Views default columns', () => {
+  test('User should see default columns when navigating to Systems page', async ({
+    page,
+  }) => {
+    /**Requirement for Inventory Views Phase 1*/
+
+    await test.step('Navigate to Inventory → Systems', async () => {
+      await navigateToInventorySystemsFunc(page);
+    });
+
+    await test.step(`Verify only default columns are displayed`, async () => {
+      // Default columns from inventory/columnDefinitions.tsx
+      const defaultColumns = ['Name', 'Workspace', 'Tags', 'OS', 'Last seen'];
+      // Get all visible table headers (excluding checkbox/per-row action columns)
+      const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
+
+      await expect(visibleHeaders).toHaveCount(defaultColumns.length);
+      for (const columnName of defaultColumns) {
+        await expect(
+          page.locator('th').filter({ hasText: new RegExp(columnName) }),
+        ).toBeVisible({ timeout: 10000 });
+      }
+    });
+  });
+});

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -3,32 +3,34 @@ import { navigateToInventorySystemsFunc } from './helpers/navHelpers';
 import { test } from './helpers/fixtures';
 
 test.describe('Inventory Views default columns', () => {
-  test('User should see only default columns when navigating to Systems page', async ({
-    page,
-  }) => {
-    await test.step('Navigate to Inventory → Systems', async () => {
-      await navigateToInventorySystemsFunc(page);
-    });
+  test(
+    'User should see only default columns when navigating to Systems page',
+    { tag: ['@inventory-views'] },
+    async ({ page }) => {
+      await test.step('Navigate to Inventory → Systems', async () => {
+        await navigateToInventorySystemsFunc(page);
+      });
 
-    await test.step(`Verify only default columns are displayed`, async () => {
-      // Default columns from inventory/columnDefinitions.tsx
-      const defaultContentColumns = [
-        'Name',
-        'Workspace',
-        'Tags',
-        'OS',
-        'Last seen',
-      ];
-      // Total columns includes checkbox (first) and per-row actions (last)
-      const totalExpectedColumns = defaultContentColumns.length + 2;
-      const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
-      await expect(visibleHeaders).toHaveCount(totalExpectedColumns);
+      await test.step(`Verify only default columns are displayed`, async () => {
+        // Default columns from inventory/columnDefinitions.tsx
+        const defaultContentColumns = [
+          'Name',
+          'Workspace',
+          'Tags',
+          'OS',
+          'Last seen',
+        ];
+        // Total columns includes checkbox (first) and per-row actions (last)
+        const totalExpectedColumns = defaultContentColumns.length + 2;
+        const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
+        await expect(visibleHeaders).toHaveCount(totalExpectedColumns);
 
-      for (const columnName of defaultContentColumns) {
-        await expect(
-          page.locator('th').filter({ hasText: new RegExp(columnName) }),
-        ).toBeVisible({ timeout: 10000 });
-      }
-    });
-  });
+        for (const columnName of defaultContentColumns) {
+          await expect(
+            page.locator('th').filter({ hasText: new RegExp(columnName) }),
+          ).toBeVisible({ timeout: 10000 });
+        }
+      });
+    },
+  );
 });

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -1,28 +1,30 @@
 import { expect } from '@playwright/test';
-import { createSystem } from './helpers/uploadArchive';
 import { navigateToInventorySystemsFunc } from './helpers/navHelpers';
 import { test } from './helpers/fixtures';
-import { searchByName, waitForTableKebabReady } from './helpers/filterHelpers';
-import { isSystemsViewEnabled } from './helpers/constants';
 
 test.describe('Inventory Views default columns', () => {
-  test('User should see default columns when navigating to Systems page', async ({
+  test('User should see only default columns when navigating to Systems page', async ({
     page,
   }) => {
-    /**Requirement for Inventory Views Phase 1*/
-
     await test.step('Navigate to Inventory → Systems', async () => {
       await navigateToInventorySystemsFunc(page);
     });
 
     await test.step(`Verify only default columns are displayed`, async () => {
       // Default columns from inventory/columnDefinitions.tsx
-      const defaultColumns = ['Name', 'Workspace', 'Tags', 'OS', 'Last seen'];
-      // Get all visible table headers (excluding checkbox/per-row action columns)
+      const defaultContentColumns = [
+        'Name',
+        'Workspace',
+        'Tags',
+        'OS',
+        'Last seen',
+      ];
+      // Total columns includes checkbox (first) and per-row actions (last)
+      const totalExpectedColumns = defaultContentColumns.length + 2;
       const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
+      await expect(visibleHeaders).toHaveCount(totalExpectedColumns);
 
-      await expect(visibleHeaders).toHaveCount(defaultColumns.length);
-      for (const columnName of defaultColumns) {
+      for (const columnName of defaultContentColumns) {
         await expect(
           page.locator('th').filter({ hasText: new RegExp(columnName) }),
         ).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-26759

## What
Test for Inventory Views default systems table columns
<img width="1328" height="154" alt="image" src="https://github.com/user-attachments/assets/8956e067-a09f-458d-b5d2-9dc421bbfcf2" />


## Why

- Requirement: Display by default inventory columns when loading/refresh the Systems page
- Feature for Inventory Views Phase 1

## How
via playwright tests

## Testing
- tests in Inventory Views CI should pass

## Summary by Sourcery

Add Playwright coverage for Inventory Views and integrate the new test into the Inventory Views CI workflow.

Tests:
- Add a new Playwright test suite for Inventory Views to validate the default systems table columns.
- Update the Playwright Inventory Views GitHub Actions workflow to execute the new Inventory Views test alongside existing system tests.