### PR TITLE
fix(RHINENG-26715): disable manage columns while table loads

### DIFF
--- a/src/components/SystemsView/SystemsViewBulkActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.test.tsx
@@ -1,0 +1,194 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { expect, jest } from '@jest/globals';
+import { SystemsViewBulkActions } from './SystemsViewBulkActions';
+import { SystemActionModalsContext } from './SystemActionModalsContext';
+import { ColumnManagementModalProvider } from './ColumnManagementModalContext';
+import type { Column } from './columns/allColumnDefinitions';
+import type { System } from './hooks/useSystemsQuery';
+
+const mockOpenDeleteModal = jest.fn();
+const mockOpenAddToWorkspaceModal = jest.fn();
+const mockOpenRemoveFromWorkspaceModal = jest.fn();
+const mockOpenEditModal = jest.fn();
+const mockOpenTagsModal = jest.fn();
+
+const mockContextValue = {
+  openDeleteModal: mockOpenDeleteModal,
+  openAddToWorkspaceModal: mockOpenAddToWorkspaceModal,
+  openRemoveFromWorkspaceModal: mockOpenRemoveFromWorkspaceModal,
+  openEditModal: mockOpenEditModal,
+  openTagsModal: mockOpenTagsModal,
+};
+
+const mockColumns: Column[] = [
+  {
+    key: 'display_name',
+    title: 'Name',
+    isShownByDefault: true,
+    renderCell: () => null,
+  },
+];
+
+jest.mock('./SystemsViewExport', () => ({
+  SystemsViewExport: () => null,
+}));
+
+jest.mock('../ColumnManagementModal', () => ({
+  ColumnManagementModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="column-management-modal" /> : null,
+}));
+
+jest.mock('../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: jest.fn(() => false),
+}));
+
+jest.mock('../../Utilities/useFeatureFlag', () => ({
+  __esModule: true,
+  default: jest.fn((key: string) => key === 'ui.inventory-views'),
+}));
+
+jest.mock('../../Utilities/hooks/useConditionalRBAC', () => ({
+  useConditionalRBAC: jest.fn(() => ({ hasAccess: true })),
+}));
+
+function renderBulkActions(
+  activeState: string,
+  selectedSystems: System[] = [],
+) {
+  return render(
+    <SystemActionModalsContext.Provider value={mockContextValue}>
+      <ColumnManagementModalProvider
+        columns={mockColumns}
+        setColumns={jest.fn()}
+      >
+        <SystemsViewBulkActions
+          activeState={activeState}
+          selectedSystems={selectedSystems}
+        />
+      </ColumnManagementModalProvider>
+    </SystemActionModalsContext.Provider>,
+  );
+}
+
+const openActionsOverflowMenu = async () => {
+  await userEvent.click(
+    screen.getByRole('button', { name: 'Actions overflow menu' }),
+  );
+};
+
+const getManageColumnsAction = () =>
+  screen.getByRole('menuitem', { name: 'Manage columns' });
+
+const expectActionDisabled = (action: HTMLElement) => {
+  expect(
+    action.hasAttribute('disabled') ||
+      action.getAttribute('aria-disabled') === 'true' ||
+      action.className.includes('disabled'),
+  ).toBe(true);
+};
+
+const expectActionEnabled = (action: HTMLElement) => {
+  expect(action).toBeEnabled();
+  expect(action.getAttribute('aria-disabled')).not.toBe('true');
+};
+
+describe('SystemsViewBulkActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+
+    const useFeatureFlag = require('../../Utilities/useFeatureFlag')
+      .default as jest.Mock;
+    useFeatureFlag.mockImplementation(
+      (key: unknown) => key === 'ui.inventory-views',
+    );
+
+    const useKesselMigrationFeatureFlag =
+      require('../../Utilities/hooks/useKesselMigrationFeatureFlag')
+        .useKesselMigrationFeatureFlag as jest.Mock;
+    useKesselMigrationFeatureFlag.mockReturnValue(false);
+  });
+
+  describe('Manage columns button', () => {
+    it('is not rendered when inventory views feature flag is disabled', async () => {
+      const useFeatureFlag = require('../../Utilities/useFeatureFlag')
+        .default as jest.Mock;
+      useFeatureFlag.mockReturnValue(false);
+
+      renderBulkActions('active');
+      await openActionsOverflowMenu();
+
+      expect(
+        screen.queryByRole('menuitem', { name: 'Manage columns' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it.each(['loading', 'error', 'empty'])(
+      'is disabled when activeState is "%s"',
+      async (activeState) => {
+        renderBulkActions(activeState);
+        await openActionsOverflowMenu();
+
+        expectActionDisabled(getManageColumnsAction());
+      },
+    );
+
+    it('is enabled when activeState is "active"', async () => {
+      renderBulkActions('active');
+      await openActionsOverflowMenu();
+
+      expectActionEnabled(getManageColumnsAction());
+    });
+
+    it('opens the column management modal when enabled and clicked', async () => {
+      renderBulkActions('active');
+      await openActionsOverflowMenu();
+      await userEvent.click(getManageColumnsAction());
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('dialog', { name: 'Manage columns' }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('does not open the column management modal when disabled and clicked', async () => {
+      renderBulkActions('loading');
+      await openActionsOverflowMenu();
+      await userEvent.click(getManageColumnsAction());
+
+      expect(
+        screen.queryByRole('dialog', { name: 'Manage columns' }),
+      ).not.toBeInTheDocument();
+    });
+
+    describe('when Kessel migration is enabled', () => {
+      beforeEach(() => {
+        const useKesselMigrationFeatureFlag =
+          require('../../Utilities/hooks/useKesselMigrationFeatureFlag')
+            .useKesselMigrationFeatureFlag as jest.Mock;
+        useKesselMigrationFeatureFlag.mockReturnValue(true);
+      });
+
+      it.each(['loading', 'error', 'empty'])(
+        'is disabled when activeState is "%s"',
+        async (activeState) => {
+          renderBulkActions(activeState);
+          await openActionsOverflowMenu();
+
+          expectActionDisabled(getManageColumnsAction());
+        },
+      );
+
+      it('is enabled when activeState is "active"', async () => {
+        renderBulkActions('active');
+        await openActionsOverflowMenu();
+
+        expectActionEnabled(getManageColumnsAction());
+      });
+    });
+  });
+});

--- a/src/components/SystemsView/SystemsViewBulkActions.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.tsx
@@ -68,7 +68,10 @@ export const SystemsViewBulkActions = ({
             Delete
           </ResponsiveAction>
           {isInventoryViewsEnabled && (
-            <ResponsiveAction onClick={() => openColumnManagementModal()}>
+            <ResponsiveAction
+              isDisabled={activeState !== 'active'}
+              onClick={() => openColumnManagementModal()}
+            >
               Manage columns
             </ResponsiveAction>
           )}
@@ -104,7 +107,10 @@ export const SystemsViewBulkActions = ({
             Remove from workspace
           </ResponsiveAction>
           {isInventoryViewsEnabled && (
-            <ResponsiveAction onClick={() => openColumnManagementModal()}>
+            <ResponsiveAction
+              isDisabled={activeState !== 'active'}
+              onClick={() => openColumnManagementModal()}
+            >
               Manage columns
             </ResponsiveAction>
           )}


### PR DESCRIPTION
## Jira
[RHINENG-26715](https://redhat.atlassian.net/browse/RHINENG-26715)

## What
Steps to Reproduce

- visit systems page with enabled inventory views
- while table is loading open Manage columns modal
- observe the system table after load is finished

We now disable the manage columns button until the activeState === 'active'.

[RHINENG-26715]: https://redhat.atlassian.net/browse/RHINENG-26715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Gate the systems table “Manage columns” bulk action on the table’s active state to prevent interaction while data is loading or in error/empty states.

Bug Fixes:
- Disable the inventory views “Manage columns” action when the systems table is not in the active state to avoid opening column management during loading or error conditions.

Tests:
- Add unit tests covering visibility, enabled/disabled behavior, and modal opening for the “Manage columns” action across feature-flag and active state combinations.