### PR TITLE
fix(RHINENG-26652): report to Currents only on test failures to reduce usage

### DIFF
--- a/.github/workflows/playwright-inventory-views.yml
+++ b/.github/workflows/playwright-inventory-views.yml
@@ -94,7 +94,17 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_inventory_views.test.ts _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
+        id: pw_run
+        continue-on-error: true
+        run: USE_CTRF=1 npx playwright test _playwright-tests/test_inventory_views.test.ts _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
+
+      - name: Report failures to Currents
+        if: steps.pw_run.outcome == 'failure'
+        run: CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_inventory_views.test.ts _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac" --last-failed
+
+      - name: Fail job if tests failed
+        if: steps.pw_run.outcome == 'failure'
+        run: exit 1
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright-systems-view.yml
+++ b/.github/workflows/playwright-systems-view.yml
@@ -94,7 +94,17 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-systems-view-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@inventory-views"
+        id: pw_run
+        continue-on-error: true
+        run: USE_CTRF=1 npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@inventory-views"
+
+      - name: Report failures to Currents
+        if: steps.pw_run.outcome == 'failure'
+        run: CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-systems-view-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@inventory-views" --last-failed
+
+      - name: Fail job if tests failed
+        if: steps.pw_run.outcome == 'failure'
+        run: exit 1
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -93,7 +93,17 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-full-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert "@integration|@inventory-views"
+        id: pw_run
+        continue-on-error: true
+        run: USE_CTRF=1 npx playwright test --grep-invert "@integration|@inventory-views"
+
+      - name: Report failures to Currents
+        if: steps.pw_run.outcome == 'failure'
+        run: CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-full-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert "@integration|@inventory-views" --last-failed
+
+      - name: Fail job if tests failed
+        if: steps.pw_run.outcome == 'failure'
+        run: exit 1
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -36,7 +36,7 @@ export default defineConfig({
               },
             ]
           : ['json', { outputFile: 'playwright-ctrf/playwright-ctrf.json' }],
-        ['@currents/playwright'],
+        ...(process.env.CURRENTS_PROJECT_ID ? [['@currents/playwright']] : []),
       ]
     : 'list',
   globalTimeout: 35 * 60 * 1000, // 35 min


### PR DESCRIPTION
Jira
[RHINENG-26652](https://redhat.atlassian.net/browse/RHINENG-26652)

What
Report to Currents only on test failures in PR pipelines to reduce monthly usage.

Why
Currents usage was at 80% (8,141/10,000 tests) with 11 days left in the billing cycle, predicted to reach ~13,283 tests and incur overage charges ($5 per 1,000 extra tests).

How
All 3 PR pipelines (playwright.yml, playwright-systems-view.yml, playwright-inventory-views.yml) now run tests without Currents first
On failure, only the failed tests are re-run with Currents reporting (--last-failed)
Stage daily and prod sanity pipelines unchanged always report to Currents

Testing
Passing PR runs: tests execute once, no Currents upload, job passes as before
Failing PR runs: tests execute, then failed tests re-run with Currents, job fails correctly
Stage/prod: unchanged behavior verified

Screenshots/Videos (if applicable)
NA

[RHINENG-26652]: https://redhat.atlassian.net/browse/RHINENG-26652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Gate Currents Playwright reporting in PR workflows so tests are only re-run with Currents on failure to reduce usage while preserving existing stage/prod reporting.

Enhancements:
- Run Playwright tests once without Currents in PR workflows and only re-run failed tests with Currents reporting when the initial run fails.
- Conditionally register the Currents Playwright reporter based on the presence of CURRENTS_PROJECT_ID to avoid unnecessary instrumentation in non-reporting runs.