### PR TITLE
test: Fixed Playwright test tags for proper workflow filtering

### DIFF
--- a/.github/workflows/playwright-inventory-views.yml
+++ b/.github/workflows/playwright-inventory-views.yml
@@ -94,7 +94,7 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_inventory_views.test.ts _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@rbac"
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep "@inventory_views|@systems-table"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/playwright-systems-view.yml
+++ b/.github/workflows/playwright-systems-view.yml
@@ -94,7 +94,7 @@ jobs:
           npx wait-on http://localhost:8003/apps/inventory/
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-systems-view-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test _playwright-tests/test_system.test.ts _playwright-tests/test_systems_filter.test.ts --grep-invert "@integration|@inventory-views"
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-systems-view-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep @systems-table
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -2,11 +2,13 @@ import { expect } from '@playwright/test';
 import { navigateToInventorySystemsFunc } from './helpers/navHelpers';
 import { test } from './helpers/fixtures';
 
-test.describe('Inventory Views default columns', () => {
-  test(
-    'User should see only default columns when navigating to Systems page',
-    { tag: ['@inventory-views'] },
-    async ({ page }) => {
+test.describe(
+  'Inventory Views default columns',
+  { tag: ['@inventory-views'] },
+  () => {
+    test('User should see only default columns when navigating to Systems page', async ({
+      page,
+    }) => {
       await test.step('Navigate to Inventory → Systems', async () => {
         await navigateToInventorySystemsFunc(page);
       });
@@ -31,6 +33,6 @@ test.describe('Inventory Views default columns', () => {
           ).toBeVisible({ timeout: 10000 });
         }
       });
-    },
-  );
-});
+    });
+  },
+);

--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -5,7 +5,7 @@ import { test } from './helpers/fixtures';
 import { searchByName, waitForTableKebabReady } from './helpers/filterHelpers';
 import { isSystemsViewEnabled } from './helpers/constants';
 
-test.describe('System CRUD', () => {
+test.describe('System CRUD', { tag: ['@systems-table'] }, () => {
   test('User should be able to edit and delete a system from Systems page', async ({
     page,
   }) => {
@@ -134,7 +134,7 @@ test.describe('System CRUD', () => {
   });
 });
 
-test.describe('System Export', () => {
+test.describe('System Export', { tag: ['@systems-table'] }, () => {
   test('User should be able to export systems to JSON', async ({ page }) => {
     await test.step('Navigate to Inventory → Systems', async () => {
       await navigateToInventorySystemsFunc(page);
@@ -225,7 +225,7 @@ test.describe('System Export', () => {
   });
 });
 
-test.describe('System Sorting', () => {
+test.describe('System Sorting', { tag: ['@systems-table'] }, () => {
   (['ascending', 'descending'] as const).forEach((order) => {
     test(`User can sort systems by Name column in ${order} order`, async ({
       page,

--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -13,7 +13,7 @@ import {
   isSystemsViewEnabled,
 } from './helpers/constants';
 
-test.describe('Filtering Systems Tests', () => {
+test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
   const operatingSystemTestCases = [
     { OS: 'RHEL 9.4' },
     { OS: 'CentOS Linux 7.6' },


### PR DESCRIPTION
## What
Changed from listing specific test files with `--grep-invert` to using positive tag matching (`--grep @inventory_views|@systems-table` and `--grep @systems-table`). This ensures each workflow runs only its intended tests:

-   `playwright-inventory-views.yml` - runs tests tagged with @inventory_views or @systems-table
-   `playwright-systems-view.yml` - runs tests tagged with @systems-table

  Also moved tags from individual tests to `test.describe()` blocks for cleaner organization.

## Summary by Sourcery

Align Playwright workflows with tag-based test selection for inventory and systems views.

Tests:
- Tag systems-related Playwright suites with @systems-table for targeted execution.
- Update Playwright CI workflows to run tests via positive tag matching instead of file lists and negative greps.