### PR TITLE
test: Update stage daily CI

### DIFF
--- a/.github/workflows/stage-daily-pw-tests.yml
+++ b/.github/workflows/stage-daily-pw-tests.yml
@@ -76,7 +76,7 @@ jobs:
         run: npx playwright install chromium
 
       - name: Run front-end Playwright tests
-        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert @integration
+        run: USE_CTRF=1 CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert "@integration|@inventory-views"
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1


### PR DESCRIPTION
## What
Do not run @inventory-views tests in Daily stage pipeline

## Summary by Sourcery

CI:
- Update stage daily Playwright test job to skip tests tagged with @inventory-views.