### PR TITLE
feat(RHINENG-26910): Inventory Views add new Inventory columns

### DIFF
--- a/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
+++ b/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
@@ -9,8 +9,11 @@ import {
   getNameColumnMinWidth,
   resolveColumnMinWidth,
 } from '../utils/columnMinWidths';
+import { NOT_AVAILABLE } from '../../../constants';
+import inventoryColumns from './inventory/columnDefinitions';
 
-const inventoryKeys = ['name', 'workspace', 'tags', 'os', 'last_seen'];
+const inventoryKeys = inventoryColumns.map((col) => col.key);
+const defaultColumnsKeys = ['name', 'workspace', 'tags', 'os', 'last_seen'];
 const nonInventoryColumns = allColumns.filter(
   (col) => !inventoryKeys.includes(col.key),
 );
@@ -25,9 +28,9 @@ describe('allColumnDefinitions', () => {
     expect(new Set(keys).size).toBe(keys.length);
   });
 
-  it('should show inventory columns by default', () => {
+  it('should show default columns', () => {
     const inventoryColumns = allColumns.filter((col) =>
-      inventoryKeys.includes(col.key),
+      defaultColumnsKeys.includes(col.key),
     );
     inventoryColumns.forEach((col) => {
       expect(col.isShownByDefault).toBe(true);
@@ -41,18 +44,6 @@ describe('allColumnDefinitions', () => {
       expect(col.isShown).toBe(false);
     });
   });
-
-  it.each(allColumns)(
-    'should have required properties for "$key"',
-    (column) => {
-      expect(column).toHaveProperty('key');
-      expect(column).toHaveProperty('title');
-      expect(column).toHaveProperty('renderCell');
-      expect(column).toHaveProperty('isShownByDefault');
-      expect(column).toHaveProperty('isShown');
-      expect(typeof column.renderCell).toBe('function');
-    },
-  );
 
   it.each(columnsWithMinWidth)(
     'should use a valid minWidth format when minWidth is defined on "$key"',
@@ -85,11 +76,11 @@ describe('allColumnDefinitions', () => {
   });
 
   it.each(nonInventoryColumns)(
-    'should render N/A when app data is missing for "$key"',
+    `should render ${NOT_AVAILABLE} when app data is missing for "$key"`,
     (column) => {
       const system = {} as unknown as InventoryViewSystem;
       render(<>{column.renderCell(system)}</>);
-      expect(screen.getByText('N/A')).toBeInTheDocument();
+      expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
     },
   );
 });

--- a/src/components/SystemsView/columns/helpers.ts
+++ b/src/components/SystemsView/columns/helpers.ts
@@ -1,0 +1,4 @@
+import { NOT_AVAILABLE } from '../../../constants';
+
+export const valueOrNotAvailable = <T>(value: T) =>
+  value != null && value !== '' ? value : NOT_AVAILABLE;

--- a/src/components/SystemsView/columns/inventory/cells/Status.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Status.test.tsx
@@ -1,0 +1,113 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Status, { getHostStalenessStatus } from './Status';
+import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
+import type { System } from '../../../hooks/useSystemsQuery';
+import { NOT_AVAILABLE } from '../../../../../constants';
+
+const NOW = new Date('2024-06-15T12:00:00.000Z');
+
+const freshSystem = {
+  id: 'fresh-system',
+  stale_timestamp: '2024-07-01T00:00:00.000Z',
+  stale_warning_timestamp: '2024-08-01T00:00:00.000Z',
+  culled_timestamp: '2024-09-01T00:00:00.000Z',
+} as System;
+
+const staleSystem = {
+  id: 'stale-system',
+  stale_timestamp: '2024-06-01T00:00:00.000Z',
+  stale_warning_timestamp: '2024-07-01T00:00:00.000Z',
+  culled_timestamp: '2024-08-01T00:00:00.000Z',
+} as System;
+
+const staleWarningSystem = {
+  id: 'stale-warning-system',
+  stale_timestamp: '2024-05-01T00:00:00.000Z',
+  stale_warning_timestamp: '2024-06-01T00:00:00.000Z',
+  culled_timestamp: '2024-08-01T00:00:00.000Z',
+} as System;
+
+const unknownSystem = {
+  id: 'unknown-system',
+  stale_timestamp: null,
+} as System;
+
+describe('getHostStalenessStatus', () => {
+  it('returns Fresh when the current time is before stale_timestamp', () => {
+    expect(getHostStalenessStatus(freshSystem, NOW)).toBe('Fresh');
+  });
+
+  it('returns Stale when the current time is past stale_timestamp but before stale_warning_timestamp', () => {
+    expect(getHostStalenessStatus(staleSystem, NOW)).toBe('Stale');
+  });
+
+  it('returns Stale warning when the current time is past stale_warning_timestamp but before culled_timestamp', () => {
+    expect(getHostStalenessStatus(staleWarningSystem, NOW)).toBe(
+      'Stale warning',
+    );
+  });
+
+  it(`returns ${NOT_AVAILABLE} when stale_timestamp is missing`, () => {
+    expect(getHostStalenessStatus(unknownSystem, NOW)).toBe(NOT_AVAILABLE);
+  });
+});
+
+describe('Status cell', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders plain Fresh text without an icon', () => {
+    render(
+      <TestWrapper>
+        <Status system={freshSystem} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('Fresh')).toBeInTheDocument();
+    expect(screen.queryByRole('img', { hidden: true })).not.toBeInTheDocument();
+  });
+
+  it('renders Stale with a warning icon and warning text color', () => {
+    render(
+      <TestWrapper>
+        <Status system={staleSystem} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('Stale')).toHaveClass(
+      'pf-v6-u-text-color-status-warning',
+    );
+    expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument();
+  });
+
+  it('renders Stale warning with a danger icon and danger text color', () => {
+    render(
+      <TestWrapper>
+        <Status system={staleWarningSystem} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('Stale warning')).toHaveClass(
+      'pf-v6-u-text-color-status-danger',
+    );
+    expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument();
+  });
+
+  it('renders N/A when staleness cannot be determined', () => {
+    render(
+      <TestWrapper>
+        <Status system={unknownSystem} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/Status.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Status.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Icon } from '@patternfly/react-core';
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+} from '@patternfly/react-icons';
+import { NOT_AVAILABLE } from '../../../../../constants';
+import { System } from '../../../hooks/useSystemsQuery';
+
+export type HostStalenessStatus =
+  | 'Fresh'
+  | 'Stale'
+  | 'Stale warning'
+  | typeof NOT_AVAILABLE;
+
+export const getHostStalenessStatus = (
+  system: Pick<
+    System,
+    'stale_timestamp' | 'stale_warning_timestamp' | 'culled_timestamp'
+  >,
+  now: Date = new Date(),
+): HostStalenessStatus => {
+  const { stale_timestamp, stale_warning_timestamp, culled_timestamp } = system;
+
+  if (!stale_timestamp) {
+    return NOT_AVAILABLE;
+  }
+
+  const nowMs = now.getTime();
+  const staleMs = new Date(stale_timestamp).getTime();
+
+  if (nowMs < staleMs) {
+    return 'Fresh';
+  }
+
+  if (stale_warning_timestamp) {
+    const staleWarningMs = new Date(stale_warning_timestamp).getTime();
+    if (nowMs < staleWarningMs) {
+      return 'Stale';
+    }
+  } else {
+    return 'Stale';
+  }
+
+  if (culled_timestamp) {
+    const culledMs = new Date(culled_timestamp).getTime();
+    if (nowMs < culledMs) {
+      return 'Stale warning';
+    }
+  } else {
+    return 'Stale warning';
+  }
+
+  return NOT_AVAILABLE;
+};
+
+interface StatusProps {
+  system: System;
+}
+
+const Status = ({ system }: StatusProps) => {
+  const status = getHostStalenessStatus(system);
+
+  if (status === 'Stale') {
+    return (
+      <span className="pf-v6-u-display-inline-flex pf-v6-u-align-items-center">
+        <Icon status="warning" className="pf-v6-u-mr-xs">
+          <ExclamationTriangleIcon />
+        </Icon>
+        <span className="pf-v6-u-text-color-status-warning pf-v6-u-font-weight-bold">
+          Stale
+        </span>
+      </span>
+    );
+  }
+
+  if (status === 'Stale warning') {
+    return (
+      <span className="pf-v6-u-display-inline-flex pf-v6-u-align-items-center">
+        <Icon status="danger" className="pf-v6-u-mr-xs">
+          <ExclamationCircleIcon />
+        </Icon>
+        <span className="pf-v6-u-text-color-status-danger pf-v6-u-font-weight-bold">
+          Stale warning
+        </span>
+      </span>
+    );
+  }
+
+  return status;
+};
+
+export default Status;

--- a/src/components/SystemsView/columns/inventory/cells/Workload.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workload.test.tsx
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Workload from './Workload';
+import type { InventoryViewSystem } from '../../../hooks/useInventoryViewsQuery';
+
+const SYSTEM_ID = 'test-system-id';
+
+const systemWithWorkloads = {
+  id: SYSTEM_ID,
+  system_profile: {
+    workloads: {
+      sap: { sids: ['PRD'] },
+      ansible: { controller_version: '4.0' },
+    },
+  },
+} as unknown as InventoryViewSystem;
+
+const systemWithEmptyWorkloads = {
+  id: SYSTEM_ID,
+  system_profile: {
+    workloads: {},
+  },
+} as unknown as InventoryViewSystem;
+
+const systemWithoutWorkloads = {
+  id: SYSTEM_ID,
+  system_profile: {},
+} as unknown as InventoryViewSystem;
+
+describe('Workload cell', () => {
+  it('should show comma-separated workload acronyms for present keys', () => {
+    render(<Workload system={systemWithWorkloads} />);
+
+    expect(screen.getByText('AAP, SAP')).toBeInTheDocument();
+  });
+
+  it('should show N/A when no workloads are present', () => {
+    const { rerender } = render(<Workload system={systemWithEmptyWorkloads} />);
+
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+
+    rerender(<Workload system={systemWithoutWorkloads} />);
+
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/Workload.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workload.tsx
@@ -1,0 +1,31 @@
+import { NOT_AVAILABLE } from '../../../../../constants';
+import { InventoryViewSystem } from '../../../hooks/useInventoryViewsQuery';
+import { WORKLOAD_ACRONYMS } from '../../../utils/workloadsFilter';
+
+interface WorkloadProps {
+  system: InventoryViewSystem;
+}
+
+const Workload = ({ system }: WorkloadProps) => {
+  const workloads = system.system_profile?.workloads as
+    | Record<string, unknown>
+    | undefined;
+
+  if (!workloads) {
+    return NOT_AVAILABLE;
+  }
+
+  const acronyms = Object.keys(workloads)
+    .filter((key) => workloads[key] != null)
+    .map((key) => WORKLOAD_ACRONYMS[key as keyof typeof WORKLOAD_ACRONYMS])
+    .filter((acronym): acronym is string => acronym != null)
+    .sort();
+
+  if (acronyms.length === 0) {
+    return NOT_AVAILABLE;
+  }
+
+  return acronyms.join(', ');
+};
+
+export default Workload;

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
+import { ApiHostViewsGetHostViewsOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import DisplayName from './cells/DisplayName';
 import Workspace from './cells/Workspace';
 import LastSeen from './cells/LastSeen';
 import OperatingSystem from './cells/OperatingSystem';
+import Status from './cells/Status';
 import Tags from './cells/Tags';
+import Workload from './cells/Workload';
 import { LastSeenColumnHeader } from '../../../../Utilities/LastSeenColumnHeader';
 import { System } from '../../hooks/useSystemsQuery';
 import type { Column } from '../allColumnDefinitions';
 import { DEFAULT_NAME_COLUMN_MIN_WIDTH } from '../../utils/columnMinWidths';
+import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
+import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
+import { NOT_AVAILABLE } from '../../../../constants';
+import { valueOrNotAvailable } from '../helpers';
 
 const nameColumn = {
   title: 'Name',
@@ -70,10 +76,80 @@ const lastSeenColumn = {
   ),
 };
 
+const statusColumn = {
+  title: 'Status',
+  key: 'status',
+  minWidth: '9rem',
+  isShownByDefault: false,
+  isShown: false,
+  sortBy: 'status',
+  renderCell: (system: System) => (
+    <Status key={`status-${system.id}`} system={system} />
+  ),
+};
+
+const infrastructureColumn = {
+  title: 'Infrastructure',
+  key: 'infrastructure',
+  isShownByDefault: false,
+  isShown: false,
+  renderCell(system: InventoryViewSystem) {
+    return (
+      <span key={`${this.key}-${system.id}`}>
+        {valueOrNotAvailable(system?.system_profile?.infrastructure_type)}
+      </span>
+    );
+  },
+};
+
+const vendorColumn = {
+  title: 'Vendor',
+  key: 'vendor',
+  isShownByDefault: false,
+  isShown: false,
+  renderCell(system: InventoryViewSystem) {
+    return (
+      <span key={`${this.key}-${system.id}`}>
+        {valueOrNotAvailable(system?.system_profile?.infrastructure_vendor)}
+      </span>
+    );
+  },
+};
+
+const workloadColumn = {
+  title: 'Workload',
+  key: 'workload',
+  isShownByDefault: false,
+  isShown: false,
+  renderCell(system: InventoryViewSystem) {
+    return <Workload key={`${this.key}-${system.id}`} system={system} />;
+  },
+};
+
+const createdColumn = {
+  title: 'Created',
+  key: 'created',
+  isShownByDefault: false,
+  isShown: false,
+  renderCell(system: InventoryViewSystem) {
+    const value = system?.created;
+    return value ? (
+      <DateFormat key={`${this.key}-${system.id}`} date={value} />
+    ) : (
+      NOT_AVAILABLE
+    );
+  },
+};
+
 export default [
   nameColumn,
   workspaceColumn,
   tagsColumn,
   operatingSystemColumn,
   lastSeenColumn,
+  statusColumn,
+  infrastructureColumn,
+  vendorColumn,
+  workloadColumn,
+  createdColumn,
 ] as const satisfies readonly Column[];

--- a/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
+++ b/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
@@ -1,8 +1,8 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getHostTags, getHostViews } from '../../../api/hostInventoryApiTyped';
 import { InventoryFilters } from '../filters/SystemsViewFilters';
-import type { ApiHostViewsGetHostViewsParams } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import {
+  ApiHostViewsGetHostViewsParams,
   ApiHostViewsGetHostViewsOrderByEnum,
   ApiHostViewsGetHostViewsRegisteredWithEnum,
   ApiHostViewsGetHostViewsStalenessEnum,
@@ -14,6 +14,7 @@ import type { LastSeenCustomRange } from '../DataViewFiltersContext';
 import qs from 'qs';
 import { buildOperatingSystemProfileFilter } from '../utils/operatingSystemSelectOptions';
 import { buildWorkloadsFilter } from '../utils/workloadsFilter';
+import { Column } from '../columns/allColumnDefinitions';
 
 const serializeSystemTypeForViews = (values: string[]) => {
   const validValues = Object.values(ApiHostViewsGetHostViewsSystemTypeEnum);
@@ -24,6 +25,12 @@ const serializeSystemTypeForViews = (values: string[]) => {
     .filter((val): val is ApiHostViewsGetHostViewsSystemTypeEnum =>
       validValues.includes(val as ApiHostViewsGetHostViewsSystemTypeEnum),
     );
+};
+
+const COLUMN_SORT_BY_TO_API_ORDER_BY: Partial<
+  Record<NonNullable<Column['sortBy']>, ApiHostViewsGetHostViewsOrderByEnum>
+> = {
+  status: ApiHostViewsGetHostViewsOrderByEnum.LastCheckIn,
 };
 
 type FetchInventoryViewsReturnedValue = Awaited<
@@ -77,7 +84,9 @@ const fetchInventoryViews = async ({
   const params: ApiHostViewsGetHostViewsParams = {
     page,
     perPage,
-    ...(sortBy && { orderBy: sortBy }),
+    ...(sortBy && {
+      orderBy: COLUMN_SORT_BY_TO_API_ORDER_BY[sortBy] ?? sortBy,
+    }),
     ...(direction && { orderHow: direction.toUpperCase() }),
     ...(filters?.hostname_or_id && { hostnameOrId: filters.hostname_or_id }),
     ...(filters?.status?.length && {
@@ -106,6 +115,9 @@ const fetchInventoryViews = async ({
             'system_update_method',
             'bootc_status',
             'host_type',
+            'infrastructure_type',
+            'infrastructure_vendor',
+            'workloads',
           ],
         },
         ...(hasSystemProfileFilter && {

--- a/src/components/SystemsView/utils/workloadsFilter.ts
+++ b/src/components/SystemsView/utils/workloadsFilter.ts
@@ -13,6 +13,20 @@ export const WORKLOAD_FILTER_OPTIONS = [
   { label: 'SAP', value: 'sap' },
 ] as const;
 
+type WorkloadFilterValue = (typeof WORKLOAD_FILTER_OPTIONS)[number]['value'];
+
+/** Table column acronyms for keys under `system_profile.workloads`. */
+export const WORKLOAD_ACRONYMS: Record<WorkloadFilterValue, string> = {
+  ansible: 'AAP',
+  crowdstrike: 'CS',
+  ibm_db2: 'DB2',
+  intersystems: 'IS',
+  mssql: 'MSSQL',
+  oracle_db: 'ORACLE',
+  rhel_ai: 'RHEL AI',
+  sap: 'SAP',
+};
+
 /**
  * Nested `filter.system_profile.workloads` fragment for host list API.
  * Each key represents a workload name (e.g., 'sap', 'ansible') and uses a


### PR DESCRIPTION
## Jira
RHINENG-26910

## What
Adds 5 new Inventory Views columns

<img width="259" height="296" alt="image" src="https://github.com/user-attachments/assets/253ff272-994f-4dd0-822d-21f77e06a87c" />

Sorting for Status is same as for lastSeen. Backend doesn't server-side sorting for the other columns.

The design hasn't provided detailed mocks for values in Workload and Created columns. I've   
used what I thought are sane values. I'd leave it be until UX suggests otherwise.

## Testing
1. turn on preview
2. turn on inventoryViews by running localStorage.setItem("ui.inventory-views", "true") in browser console
3. Go to Inventory/Systems
4. Open management modal via actions and enable columns, observe their behavior

[figma](https://www.figma.com/design/t27sa9XsmHRjhtmRjP7qmC/Inventory-Views?node-id=320-5621&t=owmJdpnw5WnztwJT-0)

## Summary by Sourcery

Add new inventory view columns and supporting utilities for host status, infrastructure, vendor, workloads, and creation date, including sorting wiring and N/A handling.

New Features:
- Add Status, Infrastructure, Vendor, Workload, and Created columns to the Systems inventory view.

Enhancements:
- Switch inventory views sorting to use the host-views orderBy enum with a mapping for Status.
- Extend inventory views queries to retrieve infrastructure and workload profile fields.
- Introduce a reusable BaseCell component to standardize N/A rendering for inventory cells.
- Expand workload utilities to include acronyms for display in the Workload column.

Tests:
- Add unit tests for Status cell staleness logic and rendering.
- Add unit tests for Workload cell acronym display and N/A fallback.
- Add unit tests to ensure non-inventory columns render the NOT_AVAILABLE constant when data is missing.