### PR TITLE
fix(RHINENG-27054): useGroupFilter is returning object instead of array

### DIFF
--- a/src/components/InventoryTable/helpers.test.js
+++ b/src/components/InventoryTable/helpers.test.js
@@ -151,16 +151,13 @@ describe('onDeleteFilter', () => {
     expect(data).toMatchObject(filter);
   });
 
-  it('should delete workspace filter selected by id', () => {
-    const workspaceFilter = [
-      { id: 'ws-1', name: 'Workspace One' },
-      { id: 'ws-2', name: 'Workspace Two' },
-    ];
+  it('should delete workspace filter selected by name', () => {
+    const workspaceFilter = ['Workspace One', 'Workspace Two'];
     const data = onDeleteFilter(
-      { chips: [{ value: 'ws-1' }] },
+      { chips: [{ value: 'Workspace One' }] },
       workspaceFilter,
     );
-    expect(data).toEqual([{ id: 'ws-2', name: 'Workspace Two' }]);
+    expect(data).toEqual(['Workspace Two']);
   });
 });
 

--- a/src/components/InventoryTabs/ConventionalSystems/Utilities.test.js
+++ b/src/components/InventoryTabs/ConventionalSystems/Utilities.test.js
@@ -62,4 +62,20 @@ describe('calculateFilters', () => {
       calculateFilters(searchParams, filters).getAll(WORKLOAD_FILTER_KEY),
     ).toEqual(['sap', 'ansible']);
   });
+
+  it('should append group_name params from workspace object selections', () => {
+    const searchParams = new URLSearchParams();
+    const filters = [
+      {
+        hostGroupFilter: [
+          { id: 'g1', name: 'group-1' },
+          { id: 'ungrouped-id', name: 'Ungrouped hosts', ungrouped: true },
+        ],
+      },
+    ];
+
+    expect(
+      calculateFilters(searchParams, filters).getAll('group_name'),
+    ).toEqual(['group-1', '']);
+  });
 });

--- a/src/components/filters/useGroupFilter.js
+++ b/src/components/filters/useGroupFilter.js
@@ -21,10 +21,16 @@ export const groupFilterReducer = (_state, { type, payload }) => ({
   }),
 });
 
-/**
- * Toolbar chips: `name` is shown in the UI; `value` is workspace id (chip delete / keys).
- *  @param selectedGroups
- */
+export const hostGroupFilterToApiValues = (selectedGroups = []) =>
+  selectedGroups.map((group) => {
+    if (typeof group === 'string') {
+      return group === UNGROUPED_HOSTS_LABEL ? '' : group;
+    }
+    if (typeof group === 'object' && group !== null) {
+      return group.ungrouped ? '' : group.name;
+    }
+    return group;
+  });
 
 export const buildHostGroupChips = (selectedGroups = []) => {
   const chips = selectedGroups.map((group) => {
@@ -32,12 +38,12 @@ export const buildHostGroupChips = (selectedGroups = []) => {
       const isUngrouped = group === '' || group === UNGROUPED_HOSTS_LABEL;
       return {
         name: isUngrouped ? UNGROUPED_HOSTS_LABEL : group,
-        value: group,
+        value: isUngrouped ? '' : group,
       };
     }
     return {
       name: group.ungrouped ? UNGROUPED_HOSTS_LABEL : group.name,
-      value: group.id,
+      value: group.ungrouped ? '' : group.name,
     };
   });
 
@@ -227,6 +233,11 @@ const useGroupFilter = (showNoGroupOption = true) => {
     [selectedGroupNames],
   );
 
+  const hostGroupFilterValue = useMemo(
+    () => hostGroupFilterToApiValues(selectedGroupNames),
+    [selectedGroupNames],
+  );
+
   const needsHostGroupResolution = useMemo(
     () =>
       selectedGroupNames.some((group) => {
@@ -303,7 +314,7 @@ const useGroupFilter = (showNoGroupOption = true) => {
       },
     },
     chips,
-    selectedGroupNames,
+    hostGroupFilterValue,
     (groupNames) => setSelectedGroupNames(groupNames || []),
   ];
 };

--- a/src/components/filters/useGroupFilter.test.js
+++ b/src/components/filters/useGroupFilter.test.js
@@ -13,7 +13,7 @@ import {
   createTestQueryClient,
   flushPromises,
 } from '../../Utilities/TestingUtilities';
-import useGroupFilter from './useGroupFilter';
+import useGroupFilter, { hostGroupFilterToApiValues } from './useGroupFilter';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { getGroups } from '../InventoryGroups/utils/api';
 
@@ -67,6 +67,24 @@ const waitForGroupsToBeLoaded = async (
       expect(getGroups).toHaveBeenCalledWith(searchParams, pageParams),
     ),
   );
+
+describe('hostGroupFilterToApiValues', () => {
+  it('maps workspace objects to group_name strings', () => {
+    expect(
+      hostGroupFilterToApiValues([
+        { id: 'g1', name: 'group-1' },
+        { id: 'ungrouped-id', name: 'Ungrouped hosts', ungrouped: true },
+      ]),
+    ).toEqual(['group-1', '']);
+  });
+
+  it('passes through legacy string selections', () => {
+    expect(hostGroupFilterToApiValues(['group-1', ''])).toEqual([
+      'group-1',
+      '',
+    ]);
+  });
+});
 
 describe('groups request not yet resolved', () => {
   beforeEach(() => {
@@ -178,7 +196,7 @@ describe('with some groups available', () => {
 
     await waitFor(() => {
       const [, , value] = result.current;
-      expect(value).toEqual([{ id: 'g1', name: 'group-1' }]);
+      expect(value).toEqual(['group-1']);
     });
 
     const [, chips] = result.current;
@@ -189,7 +207,7 @@ describe('with some groups available', () => {
         chips: [
           {
             name: 'group-1',
-            value: 'g1',
+            value: 'group-1',
           },
         ],
         type: 'group_name',
@@ -251,25 +269,19 @@ describe('with some groups available', () => {
 
     await waitFor(() => {
       const [, , value] = result.current;
-      expect(value).toEqual([
-        {
-          id: 'ungrouped-kessel-id',
-          name: 'Ungrouped hosts',
-          ungrouped: true,
-        },
-      ]);
+      expect(value).toEqual(['']);
     });
 
     const [, chips, value] = result.current;
     expect(chips.length).toBe(1);
-    expect(value[0].id).toBe('ungrouped-kessel-id');
+    expect(value).toEqual(['']);
     expect(chips).toMatchObject([
       {
         category: 'Workspace',
         chips: [
           {
             name: 'Ungrouped hosts',
-            value: 'ungrouped-kessel-id',
+            value: '',
           },
         ],
         type: 'group_name',


### PR DESCRIPTION
RHINENG-27054

## What
Solves serialization problem for groupFilter.
Issue was introduced by latest workspace PR #3234 which introduced change to useGroupFilter api. It started returning Object instead of string[].

This PR maps over this internal selection and returns API compatible array.

## Testing

go to Inventory/Systems table and filter by workspace 
go to Malware/Systems and filter by workspace
go to Compliance/Systems and filter by workspace
go to Content/Systems and filter by workspace
go to Advisor and filter by workspace

## Summary by Sourcery

Normalize host group filter values to use group_name strings rather than workspace objects across filtering, chips, and URL parameters.

Bug Fixes:
- Fix useGroupFilter to return API-compatible string values for host group filters instead of workspace objects, including ungrouped hosts.

Enhancements:
- Introduce a helper to convert mixed workspace group selections (objects and strings) into group_name values for API and URL usage.
- Align toolbar chip values and workspace filter deletion logic to operate consistently on group_name strings rather than internal ids.

Tests:
- Extend unit tests for useGroupFilter, filter calculation, and onDeleteFilter to cover string-based group_name handling and workspace selection deletion.