### PR TITLE
feat(RHINENG-26475): InventoryViews add Vuln columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@redhat-cloud-services/frontend-components": "^7.4.2",
         "@redhat-cloud-services/frontend-components-notifications": "^6.6.2",
         "@redhat-cloud-services/frontend-components-utilities": "^7.3.1",
-        "@redhat-cloud-services/host-inventory-client": "^5.0.0",
+        "@redhat-cloud-services/host-inventory-client": "^5.0.2",
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.6",
         "@sentry/webpack-plugin": "^2.23.1",
         "@tanstack/react-query": "^5.90.21",
@@ -7533,9 +7533,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/host-inventory-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-5.0.0.tgz",
-      "integrity": "sha512-FsMPc22sH0mNplUVSxyJlBiXePnCRIiu7LlHDhvXGw+Fswhx5dchUG6pkpIw9f7WOFXivj8+kpeM1hNJRQivLA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-5.0.2.tgz",
+      "integrity": "sha512-8PlOowj1xKY+ZIrdiXW+ynTOQXeGZYmR2LxoiAAgSdhFtkoZpPLyHbQ5QojxzsGUXR788k/aSLPWkXmjXxCqNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@redhat-cloud-services/frontend-components": "^7.4.2",
     "@redhat-cloud-services/frontend-components-notifications": "^6.6.2",
     "@redhat-cloud-services/frontend-components-utilities": "^7.3.1",
-    "@redhat-cloud-services/host-inventory-client": "^5.0.0",
+    "@redhat-cloud-services/host-inventory-client": "^5.0.2",
     "@redhat-cloud-services/javascript-clients-shared": "^2.0.6",
     "@sentry/webpack-plugin": "^2.23.1",
     "@tanstack/react-query": "^5.90.21",

--- a/src/components/SystemsView/columns/AppDataCount.test.tsx
+++ b/src/components/SystemsView/columns/AppDataCount.test.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import AppDataCount, { buildSystemLink } from './AppDataCount';
+import { TestWrapper } from '../../../Utilities/TestingUtilities';
+import { NOT_AVAILABLE } from '../../../constants';
+
+const SYSTEM_ID = 'test-system-id';
+
+describe('buildSystemLink', () => {
+  it('builds per-app system links with optional search', () => {
+    expect(buildSystemLink('vulnerability', SYSTEM_ID, 'impact=7')).toBe(
+      `/insights/vulnerability/systems/${SYSTEM_ID}?impact=7`,
+    );
+  });
+});
+
+describe('AppDataCount', () => {
+  it('renders N/A when count is not a number', () => {
+    render(
+      <TestWrapper>
+        <AppDataCount
+          count={null}
+          appName="vulnerability"
+          systemId={SYSTEM_ID}
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
+
+  it('renders plain 0 without a link when linked', () => {
+    render(
+      <TestWrapper>
+        <AppDataCount count={0} appName="vulnerability" systemId={SYSTEM_ID} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders a per-app system link when appName and systemId are provided', () => {
+    render(
+      <TestWrapper>
+        <AppDataCount
+          count={12}
+          appName="vulnerability"
+          systemId={SYSTEM_ID}
+          search="impact=7"
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByRole('link', { name: '12' })).toHaveAttribute(
+      'href',
+      `/insights/vulnerability/systems/${SYSTEM_ID}?impact=7`,
+    );
+  });
+
+  it('renders an explicit to link for non-system targets', () => {
+    render(
+      <TestWrapper>
+        <AppDataCount count={3} to="/insights/compliance/reports" />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByRole('link', { name: '3' })).toHaveAttribute(
+      'href',
+      '/insights/compliance/reports',
+    );
+  });
+
+  it('renders plain count when linked is false', () => {
+    render(
+      <TestWrapper>
+        <AppDataCount count={5} linked={false} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders N/A for linked counts without a resolvable link target', () => {
+    render(
+      <TestWrapper>
+        <AppDataCount count={4} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
+
+  it('renders N/A when systemId is missing for per-app links', () => {
+    render(
+      <TestWrapper>
+        <AppDataCount count={4} appName="malware" />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/columns/AppDataCount.tsx
+++ b/src/components/SystemsView/columns/AppDataCount.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { NOT_AVAILABLE } from '../../../constants';
+
+export function buildSystemLink(
+  appName: string,
+  systemId: string,
+  search = '',
+): string {
+  const query = search.startsWith('?') ? search.slice(1) : search;
+  return `/insights/${appName}/systems/${systemId}${query ? `?${query}` : ''}`;
+}
+
+interface AppDataCountProps {
+  count: unknown;
+  /** When false, renders the count as plain text (no link). Defaults to true. */
+  linked?: boolean;
+  /** Explicit link target; overrides appName/systemId/search when linked. */
+  to?: string;
+  systemId?: string | null;
+  appName?: string;
+  search?: string;
+}
+
+const AppDataCount = ({
+  count,
+  linked = true,
+  to,
+  systemId,
+  appName,
+  search = '',
+}: AppDataCountProps) => {
+  if (typeof count !== 'number') {
+    return NOT_AVAILABLE;
+  }
+
+  if (!linked) {
+    return count;
+  }
+
+  if (count === 0) {
+    return 0;
+  }
+
+  const linkTo =
+    to ??
+    (appName && systemId
+      ? buildSystemLink(appName, systemId, search)
+      : undefined);
+
+  if (!linkTo) {
+    return NOT_AVAILABLE;
+  }
+
+  return <Link to={linkTo}>{count}</Link>;
+};
+
+export default AppDataCount;

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -5,6 +5,7 @@ import patchColumns from './patch/columnDefinitions';
 import { System } from '../hooks/useSystemsQuery';
 import { Resolve } from '../../../types/utility-types';
 import advisorColumns from './advisor/columnDefinitions';
+import vulnerabilityColumns from './vulnerability/columnDefinitions';
 import malwareColumns from './malware/columnDefinitions';
 
 type RenderableColumn = {
@@ -48,6 +49,7 @@ const allColumns = [
   ...inventoryColumns,
   ...patchColumns,
   ...advisorColumns,
+  ...vulnerabilityColumns,
   ...malwareColumns,
   ...complianceColumns,
 ] as const satisfies readonly Column[];

--- a/src/components/SystemsView/columns/types.ts
+++ b/src/components/SystemsView/columns/types.ts
@@ -1,0 +1,24 @@
+import type { ConsumerApplicationsData } from '@redhat-cloud-services/host-inventory-client';
+
+/**
+ * Column app types for Systems View. Add per-app sections here as columns
+ * adopt shared count/link cell patterns (e.g. AppDataCount).
+ */
+
+/** Keys on vulnerability `app_data` from host-inventory-client. */
+export type VulnerabilityField = keyof NonNullable<
+  ConsumerApplicationsData['vulnerability']
+>;
+
+/** Fields rendered as linked count columns in vulnerability columnDefinitions. */
+export type VulnerabilityCountField = VulnerabilityField | 'important_cves';
+
+/**
+ * Extended until important_cves ships in host-inventory-client.
+ * TODO(host-inventory-client): remove when important_cves is on VulnerabilityAppData.
+ */
+export type VulnerabilityAppDataExtended = NonNullable<
+  ConsumerApplicationsData['vulnerability']
+> & {
+  important_cves?: number | null;
+};

--- a/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import type { Column } from '../allColumnDefinitions';
+import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
+import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import AppDataCount from '../AppDataCount';
+import type { VulnerabilityAppDataExtended } from '../types';
+import {
+  CVES_WITH_KNOWN_EXPLOITS_SORT_KEY,
+  CVES_WITH_SECURITY_RULES_SORT_KEY,
+  IMPORTANT_CVES_FIELD,
+  IMPORTANT_CVES_SORT_KEY,
+  VULNERABILITY_LINK_SEARCH,
+} from '../../constants';
+
+const APP_NAME = 'vulnerability' as const;
+
+const totalCVEsColumn = {
+  title: 'Total CVEs',
+  key: 'total_cves',
+  minWidth: '10rem',
+  isShownByDefault: false,
+  isShown: false,
+  sortBy: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitytotalCves,
+  renderCell: (system: InventoryViewSystem) => (
+    <AppDataCount
+      key={`total_cves-${system.id}`}
+      count={system.app_data?.vulnerability?.total_cves}
+      systemId={system.id}
+      appName={APP_NAME}
+      search={VULNERABILITY_LINK_SEARCH.totalCves}
+    />
+  ),
+};
+
+const criticalCVEsColumn = {
+  title: 'Critical CVEs',
+  key: 'critical_cves',
+  minWidth: '10rem',
+  isShownByDefault: false,
+  isShown: false,
+  sortBy: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitycriticalCves,
+  renderCell: (system: InventoryViewSystem) => (
+    <AppDataCount
+      key={`critical_cves-${system.id}`}
+      count={system.app_data?.vulnerability?.critical_cves}
+      systemId={system.id}
+      appName={APP_NAME}
+      search={VULNERABILITY_LINK_SEARCH.criticalCves}
+    />
+  ),
+};
+
+const importantCVEsColumn = {
+  title: 'Important CVEs',
+  key: 'important_cves',
+  minWidth: '10rem',
+  isShownByDefault: false,
+  isShown: false,
+  sortBy: IMPORTANT_CVES_SORT_KEY,
+  renderCell: (system: InventoryViewSystem) => (
+    <AppDataCount
+      key={`important_cves-${system.id}`}
+      count={
+        (
+          system.app_data?.vulnerability as
+            | VulnerabilityAppDataExtended
+            | undefined
+        )?.[IMPORTANT_CVES_FIELD]
+      }
+      systemId={system.id}
+      appName={APP_NAME}
+      search={VULNERABILITY_LINK_SEARCH.importantCves}
+    />
+  ),
+};
+
+const cvesWithSecurityRulesColumn = {
+  title: 'CVEs with security rules',
+  key: 'cves_with_security_rules',
+  minWidth: '10rem',
+  isShownByDefault: false,
+  isShown: false,
+  sortBy: CVES_WITH_SECURITY_RULES_SORT_KEY,
+  renderCell: (system: InventoryViewSystem) => (
+    <AppDataCount
+      key={`cves_with_security_rules-${system.id}`}
+      count={system.app_data?.vulnerability?.cves_with_security_rules}
+      systemId={system.id}
+      appName={APP_NAME}
+      search={VULNERABILITY_LINK_SEARCH.cvesWithSecurityRules}
+    />
+  ),
+};
+
+const cvesWithKnownExploitsColumn = {
+  title: 'CVEs with known exploits',
+  key: 'cves_with_known_exploits',
+  minWidth: '10rem',
+  isShownByDefault: false,
+  isShown: false,
+  sortBy: CVES_WITH_KNOWN_EXPLOITS_SORT_KEY,
+  renderCell: (system: InventoryViewSystem) => (
+    <AppDataCount
+      key={`cves_with_known_exploits-${system.id}`}
+      count={system.app_data?.vulnerability?.cves_with_known_exploits}
+      systemId={system.id}
+      appName={APP_NAME}
+      search={VULNERABILITY_LINK_SEARCH.cvesWithKnownExploits}
+    />
+  ),
+};
+
+export default [
+  totalCVEsColumn,
+  criticalCVEsColumn,
+  importantCVEsColumn,
+  cvesWithSecurityRulesColumn,
+  cvesWithKnownExploitsColumn,
+] as readonly Column[];

--- a/src/components/SystemsView/constants.ts
+++ b/src/components/SystemsView/constants.ts
@@ -1,4 +1,6 @@
 import moment from 'moment';
+import type { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import type { VulnerabilityCountField } from './columns/types';
 
 /** URL query key / DataView `filterId` for workspace filter (`GET /hosts?group_id=`). */
 export const SYSTEMS_VIEW_WORKSPACE_FILTER_PARAM = 'group_id';
@@ -78,3 +80,51 @@ export const LAST_SEEN_OPTIONS: { label: string; key: LastSeenKey }[] = [
 export const SORT_URL_PARAM = 'sort';
 
 export const SORT_DIR_URL_PARAM = 'sort_dir';
+
+/**
+ * TODO(host-inventory-client): pass field="important_cves" directly once
+ * important_cves is added to VulnerabilityAppData.
+ */
+export const IMPORTANT_CVES_FIELD = 'important_cves' as VulnerabilityCountField;
+
+/**
+ * TODO(host-inventory-client): replace with
+ * ApiHostViewsGetHostViewsOrderByEnum.VulnerabilityimportantCves once the client
+ * enum supports this field.
+ */
+export const IMPORTANT_CVES_SORT_KEY = 'vulnerability:important_cves' as
+  | ApiHostViewsGetHostViewsOrderByEnum
+  | 'vulnerability:important_cves';
+
+/**
+ * TODO(host-inventory-client): replace with
+ * ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitycvesWithSecurityRules once the
+ * client enum supports this field.
+ */
+export const CVES_WITH_SECURITY_RULES_SORT_KEY =
+  'vulnerability:cves_with_security_rules' as
+    | ApiHostViewsGetHostViewsOrderByEnum
+    | 'vulnerability:cves_with_security_rules';
+
+/**
+ * TODO(host-inventory-client): replace with
+ * ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitycvesWithKnownExploits once the
+ * client enum supports this field.
+ */
+export const CVES_WITH_KNOWN_EXPLOITS_SORT_KEY =
+  'vulnerability:cves_with_known_exploits' as
+    | ApiHostViewsGetHostViewsOrderByEnum
+    | 'vulnerability:cves_with_known_exploits';
+
+const ADVISORY_AVAILABLE = 'advisory_available=true';
+const RULE_PRESENCE = 'rule_presence=true';
+const KNOWN_EXPLOIT = 'known_exploit=true';
+
+/** Vulnerability system link query strings keyed by column concern. */
+export const VULNERABILITY_LINK_SEARCH = {
+  totalCves: ADVISORY_AVAILABLE,
+  criticalCves: 'impact=7',
+  importantCves: 'impact=5',
+  cvesWithSecurityRules: `${ADVISORY_AVAILABLE}&${RULE_PRESENCE}`,
+  cvesWithKnownExploits: `${ADVISORY_AVAILABLE}&${KNOWN_EXPLOIT}`,
+} as const;


### PR DESCRIPTION
## Jira
[RHINENG-26475](https://redhat.atlassian.net/browse/RHINENG-26475)

## What
This PR adds Vulnerability columns to Inventory Views. We are waiting for this PR
https://github.com/RedHatInsights/insights-host-inventory/pull/4488 before we are able to uncomment the importantCVEsColumn column. This column replaces the High Severity CVEs column originally shown in the mock.

## Screenshots/Videos (if applicable)
<img width="1578" height="716" alt="image" src="https://github.com/user-attachments/assets/ba523a80-b647-4c55-8171-da0671fd5fae" />

[RHINENG-26475]: https://redhat.atlassian.net/browse/RHINENG-26475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add vulnerability application columns to inventory system views and support displaying per-application counts from host inventory app data.

New Features:
- Introduce reusable components to render per-application count cells and links to the corresponding insights app system pages.
- Add vulnerability-related inventory view columns for total, critical, important CVEs, and CVEs with security rules or known exploits.

Enhancements:
- Extend the aggregated systems view to include vulnerability columns alongside existing inventory, patch, advisor, malware, and compliance columns.

Build:
- Update host inventory client dependency to consume newer host-views API fields.