### PR TITLE
feat(RHINENG-24124): pass default preselected filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@patternfly/react-table": "^6.5.1",
         "@patternfly/react-tokens": "^6.5.1",
         "@project-kessel/react-kessel-access-check": "^0.5.0",
-        "@redhat-cloud-services/frontend-components": "^7.7.1",
+        "@redhat-cloud-services/frontend-components": "^7.8.0",
         "@redhat-cloud-services/frontend-components-notifications": "^6.9.1",
         "@redhat-cloud-services/frontend-components-utilities": "^7.4.0",
         "@redhat-cloud-services/host-inventory-client": "^5.0.2",
@@ -7116,9 +7116,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-7.7.1.tgz",
-      "integrity": "sha512-KpmSAI1EdNWsE4ZMcVsKpGAsrAj1SnpUPLDRZOImygFAVeg6GvAvTqfmPYy3DrcGzT+IIgkJqC3Oy+hhyuZllA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-7.8.0.tgz",
+      "integrity": "sha512-1xv//2x43FL0jjvT5Guh5PnfvkrS4kTWeX5HsRtbA3fO1eG24NfCX/t83Y908Q3NNhU7O36LLkW3QstOON+D9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@patternfly/react-table": "^6.5.1",
     "@patternfly/react-tokens": "^6.5.1",
     "@project-kessel/react-kessel-access-check": "^0.5.0",
-    "@redhat-cloud-services/frontend-components": "^7.7.1",
+    "@redhat-cloud-services/frontend-components": "^7.8.0",
     "@redhat-cloud-services/frontend-components-notifications": "^6.9.1",
     "@redhat-cloud-services/frontend-components-utilities": "^7.4.0",
     "@redhat-cloud-services/host-inventory-client": "^5.0.2",

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -313,7 +313,7 @@ describe('EntityTableToolbar', () => {
         screen.getByRole('button', {
           name: /conditional filter/i,
         }),
-      ).toHaveTextContent('Filter by text');
+      ).toHaveTextContent('Name');
       expect(
         screen.getByRole('menuitem', {
           name: /filter by text/i,

--- a/src/components/filters/useTextFilter.js
+++ b/src/components/filters/useTextFilter.js
@@ -19,6 +19,7 @@ export const useTextFilter = ([state, dispatch] = [textFilterState]) => {
   const filter = {
     label: 'Name',
     value: 'name-filter',
+    default: true,
     type: 'text',
     filterValues: {
       placeholder: 'Filter by name',

--- a/src/components/filters/useTextFilter.test.js
+++ b/src/components/filters/useTextFilter.test.js
@@ -9,6 +9,7 @@ describe('useTextFilter', () => {
     expect(filter).toMatchObject({
       label: 'Name',
       value: 'name-filter',
+      default: true,
     });
     expect(filter.filterValues.value.length).toBe(0);
     expect(filter.filterValues.placeholder).toBe('Filter by name');


### PR DESCRIPTION
## Jira
[RHINENG-24124](https://redhat.atlassian.net/browse/RHINENG-24124)

## What
Set filter by Name as default filter that will be shown on table render. Nothing really changes for inventory, but it helps to other apps to have default filter set which pass other filter options and inventory merges it. It will fix compliance(and other apps) filter order and default selected filter

## Testing
Just run PR and see that nothing is changing for inventory, `Name` filter is preselected as default and it's on top of filter options

## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->


[RHINENG-24124]: https://redhat.atlassian.net/browse/RHINENG-24124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Set the Name text filter as the default table filter and align its test coverage.

New Features:
- Mark the Name text filter as the default filter shown on initial table render.

Tests:
- Extend the useTextFilter test to assert that the Name filter is marked as default.

## Summary by Sourcery

Set the Name text filter as the default preselected filter and update dependencies accordingly.

New Features:
- Make the Name text filter the default filter shown when the table is rendered.

Enhancements:
- Bump @redhat-cloud-services/frontend-components dependency to version 7.8.0.

Tests:
- Update the useTextFilter test to assert that the Name filter is marked as the default.