### PR TITLE
test(RHINENG-25381): add tests for utils from useSystemQuery and useInventoryViewsQuery

### DIFF
--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -26,9 +26,7 @@ import {
   HostGroupChipNode,
   useWorkspaceDisplayNames,
 } from '../hooks/useWorkspaceDisplayNames';
-import { ApiHostViewsGetHostViewsStalenessEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 
-type Test = ApiHostViewsGetHostViewsStalenessEnum[];
 export interface InventoryFilters {
   hostname_or_id: string;
   status: ApiHostGetHostListStalenessEnum[];

--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -26,7 +26,9 @@ import {
   HostGroupChipNode,
   useWorkspaceDisplayNames,
 } from '../hooks/useWorkspaceDisplayNames';
+import { ApiHostViewsGetHostViewsStalenessEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 
+type Test = ApiHostViewsGetHostViewsStalenessEnum[];
 export interface InventoryFilters {
   hostname_or_id: string;
   status: ApiHostGetHostListStalenessEnum[];

--- a/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
+++ b/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
@@ -1,38 +1,12 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getHostTags, getHostViews } from '../../../api/hostInventoryApiTyped';
 import { InventoryFilters } from '../filters/SystemsViewFilters';
-import {
-  ApiHostViewsGetHostViewsParams,
-  ApiHostViewsGetHostViewsOrderByEnum,
-  ApiHostViewsGetHostViewsRegisteredWithEnum,
-  ApiHostViewsGetHostViewsStalenessEnum,
-  ApiHostViewsGetHostViewsSystemTypeEnum,
-} from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import { SortDirection } from '../SystemsView';
-import { lastSeenKeysToApiParams } from '../utils/lastSeenKeysToApiParams';
 import type { LastSeenCustomRange } from '../DataViewFiltersContext';
-import qs from 'qs';
-import { buildSystemProfileFilters } from '../utils/buildSystemProfileFilters';
-import { Column } from '../columns/allColumnDefinitions';
+import { buildHostViewsParams } from '../utils/buildHostViewsParams';
 
 export const INVENTORY_VIEWS_QUERY_KEY = 'inventory-views' as const;
-
-const serializeSystemTypeForViews = (values: string[]) => {
-  const validValues = Object.values(ApiHostViewsGetHostViewsSystemTypeEnum);
-
-  return values
-    .map((val) => (val === 'image' ? ['bootc', 'edge'] : val))
-    .flat()
-    .filter((val): val is ApiHostViewsGetHostViewsSystemTypeEnum =>
-      validValues.includes(val as ApiHostViewsGetHostViewsSystemTypeEnum),
-    );
-};
-
-const COLUMN_SORT_BY_TO_API_ORDER_BY: Partial<
-  Record<NonNullable<Column['sortBy']>, ApiHostViewsGetHostViewsOrderByEnum>
-> = {
-  status: ApiHostViewsGetHostViewsOrderByEnum.LastCheckIn,
-};
 
 type FetchInventoryViewsReturnedValue = Awaited<
   ReturnType<typeof fetchInventoryViews>
@@ -62,60 +36,14 @@ const fetchInventoryViews = async ({
   sortBy,
   direction,
 }: FetchInventoryViewsParams) => {
-  const systemProfileFilters = buildSystemProfileFilters(filters);
-
-  const lastSeenParams = lastSeenKeysToApiParams(
-    filters.last_seen,
-    lastSeenCustomRange,
-  );
-
-  const params: ApiHostViewsGetHostViewsParams = {
+  const params = buildHostViewsParams({
     page,
     perPage,
-    ...(sortBy && {
-      orderBy: COLUMN_SORT_BY_TO_API_ORDER_BY[sortBy] ?? sortBy,
-    }),
-    ...(direction && { orderHow: direction.toUpperCase() }),
-    ...(filters?.hostname_or_id && { hostnameOrId: filters.hostname_or_id }),
-    ...(filters?.status?.length && {
-      staleness: filters.status as ApiHostViewsGetHostViewsStalenessEnum[],
-    }),
-    ...(filters?.source?.length && {
-      registeredWith:
-        filters.source as ApiHostViewsGetHostViewsRegisteredWithEnum[],
-    }),
-    ...(filters?.system_type?.length && {
-      systemType: serializeSystemTypeForViews(filters.system_type),
-    }),
-    ...(filters?.tags && { tags: filters.tags }),
-    ...(lastSeenParams ?? {}),
-    /* Override default dot notation from API client: backend requires bracket notation for nested params (fields, filter) */
-    options: {
-      paramsSerializer: (params) => {
-        return qs.stringify(params, {
-          arrayFormat: 'brackets',
-        });
-      },
-      params: {
-        fields: {
-          system_profile: [
-            'operating_system',
-            'system_update_method',
-            'bootc_status',
-            'host_type',
-            'infrastructure_type',
-            'infrastructure_vendor',
-            'workloads',
-          ],
-        },
-        ...(systemProfileFilters && {
-          filter: {
-            system_profile: systemProfileFilters,
-          },
-        }),
-      },
-    },
-  };
+    filters,
+    lastSeenCustomRange,
+    sortBy,
+    direction,
+  });
 
   const { results: hosts, total } = await getHostViews(params);
 
@@ -135,14 +63,7 @@ const fetchInventoryViews = async ({
   return { results, total };
 };
 
-/**
- * Arguments for `useInventoryViewsQuery`. Same shape as `useSystemsQuery` input.
- *
- * Uses `GET /beta/hosts-view` (`getHostViews`): no `system_profile` field or filter params; toolbar
- * keys `operating_system`, `workloads`, and `rhcStatus` do not affect the request.
- *
- * `InventoryFilters.group_id` is ignored until workspace filtering exists on this endpoint.
- */
+/* `InventoryFilters.group_id` is ignored until workspace filtering exists on this endpoint. */
 export interface UseInventoryViewsQueryParams {
   page: number;
   perPage: number;

--- a/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
+++ b/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
@@ -12,8 +12,7 @@ import { SortDirection } from '../SystemsView';
 import { lastSeenKeysToApiParams } from '../utils/lastSeenKeysToApiParams';
 import type { LastSeenCustomRange } from '../DataViewFiltersContext';
 import qs from 'qs';
-import { buildOperatingSystemProfileFilter } from '../utils/operatingSystemSelectOptions';
-import { buildWorkloadsFilter } from '../utils/workloadsFilter';
+import { buildSystemProfileFilters } from '../utils/buildSystemProfileFilters';
 import { Column } from '../columns/allColumnDefinitions';
 
 export const INVENTORY_VIEWS_QUERY_KEY = 'inventory-views' as const;
@@ -63,20 +62,7 @@ const fetchInventoryViews = async ({
   sortBy,
   direction,
 }: FetchInventoryViewsParams) => {
-  const operatingSystemFilter = buildOperatingSystemProfileFilter(
-    filters.operating_system,
-  );
-  const workloadsFilter = buildWorkloadsFilter(filters.workloads);
-
-  const systemProfileFilter: Record<string, unknown> = {
-    ...(filters?.rhcStatus?.length && {
-      rhc_client_id: filters.rhcStatus,
-    }),
-    ...(operatingSystemFilter && { operating_system: operatingSystemFilter }),
-    ...(workloadsFilter && { workloads: workloadsFilter }),
-  };
-
-  const hasSystemProfileFilter = Object.keys(systemProfileFilter).length > 0;
+  const systemProfileFilters = buildSystemProfileFilters(filters);
 
   const lastSeenParams = lastSeenKeysToApiParams(
     filters.last_seen,
@@ -122,9 +108,9 @@ const fetchInventoryViews = async ({
             'workloads',
           ],
         },
-        ...(hasSystemProfileFilter && {
+        ...(systemProfileFilters && {
           filter: {
-            system_profile: systemProfileFilter,
+            system_profile: systemProfileFilters,
           },
         }),
       },

--- a/src/components/SystemsView/hooks/useSystemsQuery.ts
+++ b/src/components/SystemsView/hooks/useSystemsQuery.ts
@@ -8,8 +8,7 @@ import {
 import qs from 'qs';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import { SortDirection } from '../SystemsView';
-import { buildOperatingSystemProfileFilter } from '../utils/operatingSystemSelectOptions';
-import { buildWorkloadsFilter } from '../utils/workloadsFilter';
+import { buildSystemProfileFilters } from '../utils/buildSystemProfileFilters';
 import { lastSeenKeysToApiParams } from '../utils/lastSeenKeysToApiParams';
 import type { LastSeenCustomRange } from '../DataViewFiltersContext';
 
@@ -45,20 +44,7 @@ const fetchSystems = async ({
   sortBy,
   direction,
 }: FetchSystemsParams) => {
-  const operatingSystemFilter = buildOperatingSystemProfileFilter(
-    filters.operating_system,
-  );
-  const workloadsFilter = buildWorkloadsFilter(filters.workloads);
-
-  const systemProfileFilter: Record<string, unknown> = {
-    ...(filters?.rhcStatus?.length && {
-      rhc_client_id: filters.rhcStatus,
-    }),
-    ...(operatingSystemFilter && { operating_system: operatingSystemFilter }),
-    ...(workloadsFilter && { workloads: workloadsFilter }),
-  };
-
-  const hasSystemProfileFilter = Object.keys(systemProfileFilter).length > 0;
+  const systemProfileFilters = buildSystemProfileFilters(filters);
 
   const lastSeenParams = lastSeenKeysToApiParams(
     filters.last_seen,
@@ -102,9 +88,9 @@ const fetchSystems = async ({
             'host_type',
           ],
         },
-        ...(hasSystemProfileFilter && {
+        ...(systemProfileFilters && {
           filter: {
-            system_profile: systemProfileFilter,
+            system_profile: systemProfileFilters,
           },
         }),
       },

--- a/src/components/SystemsView/hooks/useSystemsQuery.ts
+++ b/src/components/SystemsView/hooks/useSystemsQuery.ts
@@ -1,29 +1,12 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getHostList, getHostTags } from '../../../api/hostInventoryApiTyped';
 import { InventoryFilters } from '../filters/SystemsViewFilters';
-import {
-  ApiHostGetHostListSystemTypeEnum,
-  type ApiHostGetHostListParams,
-} from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
-import qs from 'qs';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import { SortDirection } from '../SystemsView';
-import { buildSystemProfileFilters } from '../utils/buildSystemProfileFilters';
-import { lastSeenKeysToApiParams } from '../utils/lastSeenKeysToApiParams';
+import { buildHostListParams } from '../utils/buildHostListParams';
 import type { LastSeenCustomRange } from '../DataViewFiltersContext';
 
 export const SYSTEMS_QUERY_KEY = 'systems' as const;
-
-const serializeSystemType = (values: string[]) => {
-  const validValues = Object.values(ApiHostGetHostListSystemTypeEnum);
-
-  return values
-    .map((val) => (val === 'image' ? ['bootc', 'edge'] : val))
-    .flat()
-    .filter((val): val is ApiHostGetHostListSystemTypeEnum =>
-      validValues.includes(val as ApiHostGetHostListSystemTypeEnum),
-    );
-};
 
 type FetchSystemsReturnedValue = Awaited<ReturnType<typeof fetchSystems>>;
 export type System = FetchSystemsReturnedValue['results'][number];
@@ -44,58 +27,14 @@ const fetchSystems = async ({
   sortBy,
   direction,
 }: FetchSystemsParams) => {
-  const systemProfileFilters = buildSystemProfileFilters(filters);
-
-  const lastSeenParams = lastSeenKeysToApiParams(
-    filters.last_seen,
-    lastSeenCustomRange,
-  );
-
-  const params: ApiHostGetHostListParams = {
+  const params = buildHostListParams({
     page,
     perPage,
-    ...(sortBy && { orderBy: sortBy }),
-    ...(direction && { orderHow: direction.toUpperCase() }),
-    ...(filters?.hostname_or_id && { hostnameOrId: filters.hostname_or_id }),
-    ...(filters?.status && { staleness: filters.status }),
-    ...(filters?.source && { registeredWith: filters.source }),
-    ...(filters?.system_type && {
-      systemType: serializeSystemType(filters.system_type),
-    }),
-    ...(() => {
-      const g = filters?.group_id ?? [];
-      const groupIdParam = [
-        ...g.filter((id) => id),
-        ...(g.includes('') ? [''] : []),
-      ];
-      return groupIdParam.length ? { groupId: groupIdParam } : {};
-    })(),
-    ...(filters?.tags && { tags: filters.tags }),
-    ...(lastSeenParams ?? {}),
-    /* Override default dot notation from API client: backend requires bracket notation for nested params (fields, filter) */
-    options: {
-      paramsSerializer: (params) => {
-        return qs.stringify(params, {
-          arrayFormat: 'brackets',
-        });
-      },
-      params: {
-        fields: {
-          system_profile: [
-            'operating_system',
-            'system_update_method',
-            'bootc_status',
-            'host_type',
-          ],
-        },
-        ...(systemProfileFilters && {
-          filter: {
-            system_profile: systemProfileFilters,
-          },
-        }),
-      },
-    },
-  };
+    filters,
+    lastSeenCustomRange,
+    sortBy,
+    direction,
+  });
 
   const { results: hosts, total } = await getHostList(params);
 

--- a/src/components/SystemsView/utils/buildHostListOptions.ts
+++ b/src/components/SystemsView/utils/buildHostListOptions.ts
@@ -1,0 +1,27 @@
+import qs from 'qs';
+import type { SystemProfileFilter } from './buildSystemProfileFilters';
+
+export const hostQueryParamsSerializer = (params: Record<string, unknown>) =>
+  qs.stringify(params, { arrayFormat: 'brackets' });
+
+/*
+ * Builds Axios `options` for host list and host-view API clients.
+ *
+ * Uses bracket notation because the backend requires it for `fields` and `filter`.
+ */
+export const buildHostQueryOptions = (
+  systemProfileFields: readonly string[],
+  systemProfileFilter: SystemProfileFilter | undefined,
+) => ({
+  paramsSerializer: hostQueryParamsSerializer,
+  params: {
+    fields: {
+      system_profile: [...systemProfileFields],
+    },
+    ...(systemProfileFilter && {
+      filter: {
+        system_profile: systemProfileFilter,
+      },
+    }),
+  },
+});

--- a/src/components/SystemsView/utils/buildHostListParams.test.ts
+++ b/src/components/SystemsView/utils/buildHostListParams.test.ts
@@ -1,0 +1,230 @@
+import { expect } from '@jest/globals';
+import {
+  ApiHostGetHostListOrderByEnum,
+  ApiHostGetHostListStalenessEnum,
+  ApiHostGetHostListSystemTypeEnum,
+} from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
+import { INITIAL_INVENTORY_FILTERS } from '../DataViewFiltersContext';
+import type { InventoryFilters } from '../filters/SystemsViewFilters';
+import type { BuildHostListParamsInput } from './buildHostListParams';
+import { buildHostListParams } from './buildHostListParams';
+import { hostQueryParamsSerializer } from './buildHostListOptions';
+
+const NOT_NIL = { is: 'not_nil' as const };
+
+const buildParams = (
+  overrides: Omit<Partial<BuildHostListParamsInput>, 'filters'> & {
+    filters?: Partial<InventoryFilters>;
+  } = {},
+) => {
+  const { filters: filterOverrides, ...rest } = overrides;
+
+  return buildHostListParams({
+    page: 1,
+    perPage: 20,
+    filters: {
+      ...INITIAL_INVENTORY_FILTERS,
+      ...filterOverrides,
+    },
+    lastSeenCustomRange: null,
+    ...rest,
+  });
+};
+
+describe('buildHostListParams', () => {
+  describe('pagination', () => {
+    it('sets page and perPage', () => {
+      const params = buildParams({ page: 2, perPage: 50 });
+
+      expect(params.page).toBe(2);
+      expect(params.perPage).toBe(50);
+    });
+  });
+
+  describe('sortBy', () => {
+    it('sets orderBy when sortBy is provided', () => {
+      const params = buildParams({
+        sortBy: ApiHostGetHostListOrderByEnum.DisplayName,
+      });
+
+      expect(params.orderBy).toBe('display_name');
+    });
+
+    it('omits orderBy when sortBy is undefined', () => {
+      const params = buildParams({ sortBy: undefined });
+
+      expect(params.orderBy).toBeUndefined();
+    });
+  });
+
+  describe('direction', () => {
+    it('sets orderHow from direction', () => {
+      const params = buildParams({ direction: 'desc' });
+
+      expect(params.orderHow).toBe('DESC');
+    });
+
+    it('omits orderHow when direction is undefined', () => {
+      const params = buildParams({ direction: undefined });
+
+      expect(params.orderHow).toBeUndefined();
+    });
+  });
+
+  describe('hostname_or_id', () => {
+    it('sets hostnameOrId when the filter value is non-empty', () => {
+      const params = buildParams({
+        filters: { hostname_or_id: 'my-host' },
+      });
+
+      expect(params.hostnameOrId).toBe('my-host');
+    });
+
+    it('omits hostnameOrId when the filter value is empty', () => {
+      const params = buildParams({
+        filters: { hostname_or_id: '' },
+      });
+
+      expect(params.hostnameOrId).toBeUndefined();
+    });
+  });
+
+  describe('status', () => {
+    it('sets staleness from the status filter', () => {
+      const params = buildParams({
+        filters: { status: [ApiHostGetHostListStalenessEnum.Fresh] },
+      });
+
+      expect(params.staleness).toEqual(['fresh']);
+    });
+  });
+
+  describe('source', () => {
+    it('sets registeredWith from the source filter', () => {
+      const params = buildParams({
+        filters: { source: ['insights'] },
+      });
+
+      expect(params.registeredWith).toEqual(['insights']);
+    });
+  });
+
+  describe('system_type', () => {
+    it('expands image to bootc and edge', () => {
+      const params = buildParams({
+        filters: { system_type: ['image', 'conventional'] },
+      });
+
+      expect(params.systemType).toEqual([
+        ApiHostGetHostListSystemTypeEnum.Bootc,
+        ApiHostGetHostListSystemTypeEnum.Edge,
+        ApiHostGetHostListSystemTypeEnum.Conventional,
+      ]);
+    });
+  });
+
+  describe('group_id', () => {
+    it('sets groupId and preserves empty string for ungrouped hosts', () => {
+      const params = buildParams({
+        filters: { group_id: ['workspace-1', '', 'workspace-2'] },
+      });
+
+      expect(params.groupId).toEqual(['workspace-1', 'workspace-2', '']);
+    });
+
+    it('omits groupId when group_id is empty', () => {
+      const params = buildParams({
+        filters: { group_id: [] },
+      });
+
+      expect(params.groupId).toBeUndefined();
+    });
+  });
+
+  describe('tags', () => {
+    it('sets tags from the tags filter', () => {
+      const params = buildParams({
+        filters: { tags: ['namespace/key=value'] },
+      });
+
+      expect(params.tags).toEqual(['namespace/key=value']);
+    });
+  });
+
+  describe('last_seen', () => {
+    it('sets lastCheckInStart and lastCheckInEnd for a custom range', () => {
+      const params = buildParams({
+        filters: { last_seen: 'custom' },
+        lastSeenCustomRange: {
+          start: '2024-01-01T00:00:00.000Z',
+          end: '2024-01-31T23:59:59.999Z',
+        },
+      });
+
+      expect(params.lastCheckInStart).toBe('2024-01-01T00:00:00.000Z');
+      expect(params.lastCheckInEnd).toBe('2024-01-31T23:59:59.999Z');
+    });
+  });
+
+  describe('options.params.fields', () => {
+    it('requests host list system profile fields', () => {
+      const params = buildParams();
+
+      expect(params.options?.params?.fields).toEqual({
+        system_profile: [
+          'operating_system',
+          'system_update_method',
+          'bootc_status',
+          'host_type',
+        ],
+      });
+    });
+  });
+
+  describe('options.params.filter', () => {
+    it('nests system profile filters when toolbar profile filters are set', () => {
+      const params = buildParams({
+        filters: {
+          rhcStatus: ['connected'],
+          operating_system: ['RHEL9.0'],
+          workloads: ['sap'],
+        },
+      });
+
+      expect(params.options?.params?.filter).toEqual({
+        system_profile: {
+          rhc_client_id: ['connected'],
+          operating_system: {
+            RHEL: { version: { eq: ['9.0'] } },
+          },
+          workloads: {
+            sap: NOT_NIL,
+          },
+        },
+      });
+    });
+
+    it('omits filter when no profile filters are set', () => {
+      const params = buildParams();
+
+      expect(params.options?.params?.filter).toBeUndefined();
+    });
+  });
+
+  describe('options.paramsSerializer', () => {
+    it('uses bracket notation for nested params', () => {
+      const params = buildParams();
+
+      expect(params.options?.paramsSerializer).toBe(hostQueryParamsSerializer);
+      expect(
+        decodeURIComponent(
+          hostQueryParamsSerializer({
+            filter: {
+              system_profile: { workloads: { sap: { is: 'not_nil' } } },
+            },
+          }),
+        ),
+      ).toBe('filter[system_profile][workloads][sap][is]=not_nil');
+    });
+  });
+});

--- a/src/components/SystemsView/utils/buildHostListParams.ts
+++ b/src/components/SystemsView/utils/buildHostListParams.ts
@@ -30,12 +30,12 @@ export interface BuildHostListParamsInput {
 const buildGroupIdParam = (
   groupIds: string[] | undefined,
 ): Pick<ApiHostGetHostListParams, 'groupId'> | Record<string, never> => {
-  const groupIdParam = [
-    ...(groupIds ?? []).filter((id) => id),
-    ...((groupIds ?? []).includes('') ? [''] : []),
-  ];
+  if (!groupIds?.length) return {};
 
-  return groupIdParam.length ? { groupId: groupIdParam } : {};
+  const hasEmpty = groupIds.includes('');
+  const nonEmpty = groupIds.filter((id) => id !== '');
+
+  return { groupId: hasEmpty ? [...nonEmpty, ''] : nonEmpty };
 };
 
 export const buildHostListParams = ({

--- a/src/components/SystemsView/utils/buildHostListParams.ts
+++ b/src/components/SystemsView/utils/buildHostListParams.ts
@@ -1,0 +1,77 @@
+import {
+  ApiHostGetHostListSystemTypeEnum,
+  type ApiHostGetHostListParams,
+  ApiHostGetHostListOrderByEnum,
+} from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
+import type { InventoryFilters } from '../filters/SystemsViewFilters';
+import type { LastSeenCustomRange } from '../DataViewFiltersContext';
+import type { SortDirection } from '../SystemsView';
+import { buildSystemProfileFilters } from './buildSystemProfileFilters';
+import { buildHostQueryOptions } from './buildHostListOptions';
+import { lastSeenKeysToApiParams } from './lastSeenKeysToApiParams';
+import { buildSystemType } from './buildSystemType';
+
+const HOST_LIST_SYSTEM_PROFILE_FIELDS = [
+  'operating_system',
+  'system_update_method',
+  'bootc_status',
+  'host_type',
+] as const;
+
+export interface BuildHostListParamsInput {
+  page: number;
+  perPage: number;
+  filters: InventoryFilters;
+  lastSeenCustomRange: LastSeenCustomRange;
+  sortBy?: ApiHostGetHostListOrderByEnum;
+  direction?: SortDirection;
+}
+
+const buildGroupIdParam = (
+  groupIds: string[] | undefined,
+): Pick<ApiHostGetHostListParams, 'groupId'> | Record<string, never> => {
+  const groupIdParam = [
+    ...(groupIds ?? []).filter((id) => id),
+    ...((groupIds ?? []).includes('') ? [''] : []),
+  ];
+
+  return groupIdParam.length ? { groupId: groupIdParam } : {};
+};
+
+export const buildHostListParams = ({
+  page,
+  perPage,
+  filters,
+  lastSeenCustomRange,
+  sortBy,
+  direction,
+}: BuildHostListParamsInput): ApiHostGetHostListParams => {
+  const systemProfileFilters = buildSystemProfileFilters(filters);
+  const lastSeenParams = lastSeenKeysToApiParams(
+    filters.last_seen,
+    lastSeenCustomRange,
+  );
+
+  return {
+    page,
+    perPage,
+    ...(sortBy && { orderBy: sortBy }),
+    ...(direction && { orderHow: direction.toUpperCase() }),
+    ...(filters.hostname_or_id && { hostnameOrId: filters.hostname_or_id }),
+    ...(filters.status && { staleness: filters.status }),
+    ...(filters.source && { registeredWith: filters.source }),
+    ...(filters.system_type && {
+      systemType: buildSystemType(
+        filters.system_type,
+        Object.values(ApiHostGetHostListSystemTypeEnum),
+      ),
+    }),
+    ...buildGroupIdParam(filters.group_id),
+    ...(filters.tags && { tags: filters.tags }),
+    ...(lastSeenParams ?? {}),
+    options: buildHostQueryOptions(
+      HOST_LIST_SYSTEM_PROFILE_FIELDS,
+      systemProfileFilters,
+    ),
+  };
+};

--- a/src/components/SystemsView/utils/buildHostListParams.ts
+++ b/src/components/SystemsView/utils/buildHostListParams.ts
@@ -58,8 +58,8 @@ export const buildHostListParams = ({
     ...(sortBy && { orderBy: sortBy }),
     ...(direction && { orderHow: direction.toUpperCase() }),
     ...(filters.hostname_or_id && { hostnameOrId: filters.hostname_or_id }),
-    ...(filters.status && { staleness: filters.status }),
-    ...(filters.source && { registeredWith: filters.source }),
+    ...(filters.status.length > 0 && { staleness: filters.status }),
+    ...(filters.source.length > 0 && { registeredWith: filters.source }),
     ...(filters.system_type && {
       systemType: buildSystemType(
         filters.system_type,

--- a/src/components/SystemsView/utils/buildHostViewsParams.test.ts
+++ b/src/components/SystemsView/utils/buildHostViewsParams.test.ts
@@ -1,0 +1,252 @@
+import { expect } from '@jest/globals';
+import {
+  ApiHostViewsGetHostViewsOrderByEnum,
+  ApiHostViewsGetHostViewsStalenessEnum,
+  ApiHostViewsGetHostViewsSystemTypeEnum,
+} from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import { INITIAL_INVENTORY_FILTERS } from '../DataViewFiltersContext';
+import type { InventoryFilters } from '../filters/SystemsViewFilters';
+import type { BuildHostViewsParamsInput } from './buildHostViewsParams';
+import { buildHostViewsParams } from './buildHostViewsParams';
+import { hostQueryParamsSerializer } from './buildHostListOptions';
+
+const NOT_NIL = { is: 'not_nil' as const };
+
+const buildParams = (
+  overrides: Omit<Partial<BuildHostViewsParamsInput>, 'filters'> & {
+    filters?: Partial<InventoryFilters>;
+  } = {},
+) => {
+  const { filters: filterOverrides, ...rest } = overrides;
+
+  return buildHostViewsParams({
+    page: 1,
+    perPage: 20,
+    filters: {
+      ...INITIAL_INVENTORY_FILTERS,
+      ...filterOverrides,
+    },
+    lastSeenCustomRange: null,
+    sortBy: undefined,
+    direction: undefined,
+    ...rest,
+  });
+};
+
+describe('buildHostViewsParams', () => {
+  describe('pagination', () => {
+    it('sets page and perPage', () => {
+      const params = buildParams({ page: 3, perPage: 40 });
+
+      expect(params.page).toBe(3);
+      expect(params.perPage).toBe(40);
+    });
+  });
+
+  describe('sortBy', () => {
+    it('remaps status column sort to last_check_in', () => {
+      const params = buildParams({
+        sortBy: 'status' as ApiHostViewsGetHostViewsOrderByEnum,
+      });
+
+      expect(params.orderBy).toBe(
+        ApiHostViewsGetHostViewsOrderByEnum.LastCheckIn,
+      );
+    });
+
+    it('passes through API orderBy values that do not need remapping', () => {
+      const params = buildParams({
+        sortBy: ApiHostViewsGetHostViewsOrderByEnum.DisplayName,
+      });
+
+      expect(params.orderBy).toBe('display_name');
+    });
+
+    it('omits orderBy when sortBy is undefined', () => {
+      const params = buildParams({ sortBy: undefined });
+
+      expect(params.orderBy).toBeUndefined();
+    });
+  });
+
+  describe('direction', () => {
+    it('sets orderHow from direction', () => {
+      const params = buildParams({ direction: 'asc' });
+
+      expect(params.orderHow).toBe('ASC');
+    });
+
+    it('omits orderHow when direction is undefined', () => {
+      const params = buildParams({ direction: undefined });
+
+      expect(params.orderHow).toBeUndefined();
+    });
+  });
+
+  describe('hostname_or_id', () => {
+    it('sets hostnameOrId when the filter value is non-empty', () => {
+      const params = buildParams({
+        filters: { hostname_or_id: 'my-host' },
+      });
+
+      expect(params.hostnameOrId).toBe('my-host');
+    });
+
+    it('omits hostnameOrId when the filter value is empty', () => {
+      const params = buildParams({
+        filters: { hostname_or_id: '' },
+      });
+
+      expect(params.hostnameOrId).toBeUndefined();
+    });
+  });
+
+  describe('status', () => {
+    it('sets staleness from the status filter', () => {
+      const params = buildParams({
+        filters: { status: [ApiHostViewsGetHostViewsStalenessEnum.Stale] },
+      });
+
+      expect(params.staleness).toEqual(['stale']);
+    });
+
+    it('omits staleness when the status filter is empty', () => {
+      const params = buildParams({
+        filters: { status: [] },
+      });
+
+      expect(params.staleness).toBeUndefined();
+    });
+  });
+
+  describe('source', () => {
+    it('sets registeredWith from the source filter', () => {
+      const params = buildParams({
+        filters: { source: ['insights'] },
+      });
+
+      expect(params.registeredWith).toEqual(['insights']);
+    });
+
+    it('omits registeredWith when the source filter is empty', () => {
+      const params = buildParams({
+        filters: { source: [] },
+      });
+
+      expect(params.registeredWith).toBeUndefined();
+    });
+  });
+
+  describe('system_type', () => {
+    it('expands image to bootc and edge', () => {
+      const params = buildParams({
+        filters: { system_type: ['image'] },
+      });
+
+      expect(params.systemType).toEqual([
+        ApiHostViewsGetHostViewsSystemTypeEnum.Bootc,
+        ApiHostViewsGetHostViewsSystemTypeEnum.Edge,
+      ]);
+    });
+
+    it('omits systemType when the system_type filter is empty', () => {
+      const params = buildParams({
+        filters: { system_type: [] },
+      });
+
+      expect(params.systemType).toBeUndefined();
+    });
+  });
+
+  describe('tags', () => {
+    it('sets tags from the tags filter', () => {
+      const params = buildParams({
+        filters: { tags: ['env/prod'] },
+      });
+
+      expect(params.tags).toEqual(['env/prod']);
+    });
+  });
+
+  describe('group_id', () => {
+    it('does not set groupId', () => {
+      const params = buildParams({
+        filters: { group_id: ['workspace-1'] },
+      });
+
+      expect(params).not.toHaveProperty('groupId');
+    });
+  });
+
+  describe('last_seen', () => {
+    it('sets lastCheckInStart and lastCheckInEnd for a custom range', () => {
+      const params = buildParams({
+        filters: { last_seen: 'custom' },
+        lastSeenCustomRange: {
+          start: '2024-01-01T00:00:00.000Z',
+          end: '2024-01-31T23:59:59.999Z',
+        },
+      });
+
+      expect(params.lastCheckInStart).toBe('2024-01-01T00:00:00.000Z');
+      expect(params.lastCheckInEnd).toBe('2024-01-31T23:59:59.999Z');
+    });
+  });
+
+  describe('options.params.fields', () => {
+    it('requests host-view system profile fields', () => {
+      const params = buildParams();
+
+      expect(params.options?.params?.fields).toEqual({
+        system_profile: [
+          'operating_system',
+          'system_update_method',
+          'bootc_status',
+          'host_type',
+          'infrastructure_type',
+          'infrastructure_vendor',
+          'workloads',
+        ],
+      });
+    });
+  });
+
+  describe('options.params.filter', () => {
+    it('nests system profile filters when toolbar profile filters are set', () => {
+      const params = buildParams({
+        filters: {
+          workloads: ['ansible'],
+        },
+      });
+
+      expect(params.options?.params?.filter).toEqual({
+        system_profile: {
+          workloads: {
+            ansible: NOT_NIL,
+          },
+        },
+      });
+    });
+
+    it('omits filter when no profile filters are set', () => {
+      const params = buildParams();
+
+      expect(params.options?.params?.filter).toBeUndefined();
+    });
+  });
+
+  describe('options.paramsSerializer', () => {
+    it('uses bracket notation for nested params', () => {
+      const params = buildParams();
+
+      expect(params.options?.paramsSerializer).toBe(hostQueryParamsSerializer);
+      expect(
+        decodeURIComponent(
+          hostQueryParamsSerializer({
+            fields: { system_profile: ['host_type'] },
+          }),
+        ),
+      ).toBe('fields[system_profile][]=host_type');
+    });
+  });
+});

--- a/src/components/SystemsView/utils/buildHostViewsParams.ts
+++ b/src/components/SystemsView/utils/buildHostViewsParams.ts
@@ -1,0 +1,84 @@
+import {
+  ApiHostViewsGetHostViewsOrderByEnum,
+  ApiHostViewsGetHostViewsRegisteredWithEnum,
+  ApiHostViewsGetHostViewsStalenessEnum,
+  ApiHostViewsGetHostViewsSystemTypeEnum,
+  type ApiHostViewsGetHostViewsParams,
+} from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import type { Column } from '../columns/allColumnDefinitions';
+import type { InventoryFilters } from '../filters/SystemsViewFilters';
+import type { LastSeenCustomRange } from '../DataViewFiltersContext';
+import type { SortDirection } from '../SystemsView';
+import { buildSystemProfileFilters } from './buildSystemProfileFilters';
+import { buildHostQueryOptions } from './buildHostListOptions';
+import { lastSeenKeysToApiParams } from './lastSeenKeysToApiParams';
+import { buildSystemType } from './buildSystemType';
+
+const HOST_VIEWS_SYSTEM_PROFILE_FIELDS = [
+  'operating_system',
+  'system_update_method',
+  'bootc_status',
+  'host_type',
+  'infrastructure_type',
+  'infrastructure_vendor',
+  'workloads',
+] as const;
+
+const COLUMN_SORT_BY_TO_API_ORDER_BY: Partial<
+  Record<NonNullable<Column['sortBy']>, ApiHostViewsGetHostViewsOrderByEnum>
+> = {
+  status: ApiHostViewsGetHostViewsOrderByEnum.LastCheckIn,
+};
+
+export interface BuildHostViewsParamsInput {
+  page: number;
+  perPage: number;
+  filters: InventoryFilters;
+  lastSeenCustomRange: LastSeenCustomRange;
+  sortBy: ApiHostViewsGetHostViewsOrderByEnum | undefined;
+  direction: SortDirection | undefined;
+}
+
+export const buildHostViewsParams = ({
+  page,
+  perPage,
+  filters,
+  lastSeenCustomRange,
+  sortBy,
+  direction,
+}: BuildHostViewsParamsInput): ApiHostViewsGetHostViewsParams => {
+  const systemProfileFilters = buildSystemProfileFilters(filters);
+  const lastSeenParams = lastSeenKeysToApiParams(
+    filters.last_seen,
+    lastSeenCustomRange,
+  );
+
+  return {
+    page,
+    perPage,
+    ...(sortBy && {
+      orderBy: COLUMN_SORT_BY_TO_API_ORDER_BY[sortBy] ?? sortBy,
+    }),
+    ...(direction && { orderHow: direction.toUpperCase() }),
+    ...(filters.hostname_or_id && { hostnameOrId: filters.hostname_or_id }),
+    ...(filters.status?.length && {
+      staleness: filters.status as ApiHostViewsGetHostViewsStalenessEnum[],
+    }),
+    ...(filters.source?.length && {
+      registeredWith:
+        filters.source as ApiHostViewsGetHostViewsRegisteredWithEnum[],
+    }),
+    ...(filters.system_type?.length && {
+      systemType: buildSystemType(
+        filters.system_type,
+        Object.values(ApiHostViewsGetHostViewsSystemTypeEnum),
+      ),
+    }),
+    ...(filters.tags && { tags: filters.tags }),
+    ...(lastSeenParams ?? {}),
+    options: buildHostQueryOptions(
+      HOST_VIEWS_SYSTEM_PROFILE_FIELDS,
+      systemProfileFilters,
+    ),
+  };
+};

--- a/src/components/SystemsView/utils/buildHostViewsParams.ts
+++ b/src/components/SystemsView/utils/buildHostViewsParams.ts
@@ -62,7 +62,7 @@ export const buildHostViewsParams = ({
     ...(direction && { orderHow: direction.toUpperCase() }),
     ...(filters.hostname_or_id && { hostnameOrId: filters.hostname_or_id }),
     ...(filters.status?.length && {
-      staleness: filters.status as ApiHostViewsGetHostViewsStalenessEnum[],
+      staleness: filters.status,
     }),
     ...(filters.source?.length && {
       registeredWith:

--- a/src/components/SystemsView/utils/buildHostViewsParams.ts
+++ b/src/components/SystemsView/utils/buildHostViewsParams.ts
@@ -35,8 +35,8 @@ export interface BuildHostViewsParamsInput {
   perPage: number;
   filters: InventoryFilters;
   lastSeenCustomRange: LastSeenCustomRange;
-  sortBy: ApiHostViewsGetHostViewsOrderByEnum | undefined;
-  direction: SortDirection | undefined;
+  sortBy?: ApiHostViewsGetHostViewsOrderByEnum;
+  direction?: SortDirection;
 }
 
 export const buildHostViewsParams = ({

--- a/src/components/SystemsView/utils/buildSystemProfileFilters.test.ts
+++ b/src/components/SystemsView/utils/buildSystemProfileFilters.test.ts
@@ -1,0 +1,75 @@
+import { expect } from '@jest/globals';
+import { buildSystemProfileFilters } from './buildSystemProfileFilters';
+
+const NOT_NIL = { is: 'not_nil' as const };
+
+describe('buildSystemProfileFilters', () => {
+  it('returns undefined when no profile filters are set', () => {
+    expect(
+      buildSystemProfileFilters({
+        rhcStatus: [],
+        operating_system: [],
+        workloads: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('includes rhc_client_id when rhcStatus is selected', () => {
+    expect(
+      buildSystemProfileFilters({
+        rhcStatus: ['connected'],
+        operating_system: [],
+        workloads: [],
+      }),
+    ).toEqual({
+      rhc_client_id: ['connected'],
+    });
+  });
+
+  it('includes operating_system when OS tokens are selected', () => {
+    expect(
+      buildSystemProfileFilters({
+        rhcStatus: [],
+        operating_system: ['RHEL9.0'],
+        workloads: [],
+      }),
+    ).toEqual({
+      operating_system: {
+        RHEL: { version: { eq: ['9.0'] } },
+      },
+    });
+  });
+
+  it('includes workloads when workload keys are selected', () => {
+    expect(
+      buildSystemProfileFilters({
+        rhcStatus: [],
+        operating_system: [],
+        workloads: ['sap', 'ansible'],
+      }),
+    ).toEqual({
+      workloads: {
+        sap: NOT_NIL,
+        ansible: NOT_NIL,
+      },
+    });
+  });
+
+  it('includes all filters when all are selected', () => {
+    expect(
+      buildSystemProfileFilters({
+        rhcStatus: ['connected'],
+        operating_system: ['RHEL9.0'],
+        workloads: ['sap'],
+      }),
+    ).toEqual({
+      rhc_client_id: ['connected'],
+      operating_system: {
+        RHEL: { version: { eq: ['9.0'] } },
+      },
+      workloads: {
+        sap: NOT_NIL,
+      },
+    });
+  });
+});

--- a/src/components/SystemsView/utils/buildSystemProfileFilters.ts
+++ b/src/components/SystemsView/utils/buildSystemProfileFilters.ts
@@ -1,0 +1,48 @@
+import type { InventoryFilters } from '../filters/SystemsViewFilters';
+import {
+  buildOperatingSystemProfileFilter,
+  type OperatingSystemProfileFilter,
+} from './operatingSystemSelectOptions';
+import {
+  buildWorkloadsFilter,
+  type WorkloadsPresenceFilter,
+} from './workloadsFilter';
+
+export type SystemProfileFilterInput = Pick<
+  InventoryFilters,
+  'rhcStatus' | 'operating_system' | 'workloads'
+>;
+
+/** Nested `filter.system_profile` fragment for host list and host-view APIs. */
+export type SystemProfileFilter = {
+  rhc_client_id?: string[];
+  operating_system?: OperatingSystemProfileFilter;
+  workloads?: WorkloadsPresenceFilter;
+};
+
+/**
+ * Maps toolbar RHC, OS, and workload filters to `filter.system_profile` for host APIs.
+ *
+ *  @param filters - Toolbar filter state for RHC status, operating system, and workloads.
+ *  @returns       Profile filter or `undefined` when there is nothing to filter.
+ */
+export const buildSystemProfileFilters = (
+  filters: SystemProfileFilterInput,
+): SystemProfileFilter | undefined => {
+  const operatingSystemFilter = buildOperatingSystemProfileFilter(
+    filters.operating_system,
+  );
+  const workloadsFilter = buildWorkloadsFilter(filters.workloads);
+
+  const systemProfileFilter: SystemProfileFilter = {
+    ...(filters.rhcStatus?.length && {
+      rhc_client_id: filters.rhcStatus,
+    }),
+    ...(operatingSystemFilter && { operating_system: operatingSystemFilter }),
+    ...(workloadsFilter && { workloads: workloadsFilter }),
+  };
+
+  return Object.keys(systemProfileFilter).length > 0
+    ? systemProfileFilter
+    : undefined;
+};

--- a/src/components/SystemsView/utils/buildSystemType.test.ts
+++ b/src/components/SystemsView/utils/buildSystemType.test.ts
@@ -1,0 +1,30 @@
+import { expect } from '@jest/globals';
+import { buildSystemType } from './buildSystemType';
+
+enum TestSystemType {
+  Conventional = 'conventional',
+  Bootc = 'bootc',
+  Edge = 'edge',
+}
+
+describe('buildSystemType', () => {
+  it('expands image to bootc and edge', () => {
+    expect(buildSystemType(['image'], Object.values(TestSystemType))).toEqual([
+      TestSystemType.Bootc,
+      TestSystemType.Edge,
+    ]);
+  });
+
+  it('filters out invalid values', () => {
+    expect(
+      buildSystemType(
+        ['conventional', 'invalid', 'image'],
+        Object.values(TestSystemType),
+      ),
+    ).toEqual([
+      TestSystemType.Conventional,
+      TestSystemType.Bootc,
+      TestSystemType.Edge,
+    ]);
+  });
+});

--- a/src/components/SystemsView/utils/buildSystemType.ts
+++ b/src/components/SystemsView/utils/buildSystemType.ts
@@ -1,0 +1,9 @@
+/* Maps toolbar system-type values to API `systemType` params. */
+export const buildSystemType = <T extends string>(
+  values: string[],
+  validValues: readonly T[],
+): T[] =>
+  values
+    .map((val) => (val === 'image' ? ['bootc', 'edge'] : val))
+    .flat()
+    .filter((val): val is T => validValues.includes(val as T));


### PR DESCRIPTION
RHINENG-25381

## What
Refactors and tests parts of useSystemsQuery and useInventoryViewsQuery.

## Why
In order to increase test coverage of logic related to Queries.

## How
Considering Queries themselves are just thin wrappers they are not good target for tests themselves. But they did contain lots of serialization logic for Axios calls. This logic is refactored to seperate files and tested. 
 
## Testing
Make sure UI for Inventory / Systems works correctly. Especially filtering.
Make sure to test with both Preview ON and OFF as each uses different Query.

IMPORTANT: on SystemsView table (Preview ON), workspace filter doesn't work currently. It doesn't because of lagging implementation of group_id for /hosts-view endpoint. This feature will be enabled in subsequent PR.

## Summary by Sourcery

Extract query parameter construction for systems and inventory views into shared utilities and add targeted test coverage for these helpers.

Enhancements:
- Refactor host list and host-views query parameter assembly into reusable utility functions, including shared handling of system profile filters, system types, and Axios options.

Tests:
- Add comprehensive unit tests for host list and host-views parameter builders, system profile filter mapping, and system type mapping utilities.