### PR TITLE
fix(RHINENG-24840): SystemsView: column headers are misaligned

### DIFF
--- a/src/components/SystemsView/SystemsView.scss
+++ b/src/components/SystemsView/SystemsView.scss
@@ -6,7 +6,13 @@
 }
 
 .ins-c-systems-view-table {
-  .pf-v6-c-table__tr, .pf-v6-c-table__check {
+  // Align all thead cells the same way.
+  thead tr > th {
+    vertical-align: bottom;
+  }
+
+  // Center body cell content (including row-select checkboxes).
+  tbody .pf-v6-c-table__td {
     vertical-align: middle;
   }
 


### PR DESCRIPTION
RHINENG-24840

## What
Sortable and non-sortable column headers in SystemsView were vertically misaligned. This fixes it.

## How
I changed our custom SCSS rules for SystemsView table.

## Testing
Go to Inventory / Systems and observe alignment of headers with preview ON.

## Screenshots/Videos (if applicable)
<img width="3257" height="644" alt="image" src="https://github.com/user-attachments/assets/29f8abc0-2339-4844-ae9b-fc4b0efb9497" />

## Summary by Sourcery

Bug Fixes:
- Fix vertical misalignment between sortable and non-sortable column headers in SystemsView tables.