### PR TITLE
test(RHINENG-26765): Test sticky columns, apply all columns

### DIFF
--- a/_playwright-tests/helpers/columnHelpers.ts
+++ b/_playwright-tests/helpers/columnHelpers.ts
@@ -50,6 +50,15 @@ export const vulnerabilityColumns = [
   'CVEs with known exploits',
 ];
 
+export const allColumns = [
+  ...advisorColumns,
+  ...complianceColumns,
+  ...patchColumns,
+  ...malwareColumns,
+  ...inventoryColumns,
+  ...vulnerabilityColumns,
+];
+
 /**
  * Opens the 'Manage columns' modal from the systems view toolbar.
  * Wraps the action in toPass to handle loading skeletons and dropdown rendering.

--- a/_playwright-tests/helpers/columnHelpers.ts
+++ b/_playwright-tests/helpers/columnHelpers.ts
@@ -112,31 +112,6 @@ export async function isTableHorizontallyScrollable(
 }
 
 /**
- * Checks if an element is actually visible in the viewport (not just in the DOM).
- *  @param   {Locator}          element - The element locator to check.
- *  @returns {Promise<boolean>}         - True if the element is visible in the viewport.
- */
-export async function isVisibleInViewport(element: Locator): Promise<boolean> {
-  return await element.evaluate((el) => {
-    const rect = el.getBoundingClientRect();
-    const scrollContainer = document.querySelector(
-      '.ins-c-systems-view-table-scroll',
-    );
-    if (!scrollContainer) return false;
-
-    const containerRect = scrollContainer.getBoundingClientRect();
-
-    // Check if element is within the visible viewport of the scroll container
-    return (
-      rect.top >= containerRect.top &&
-      rect.left >= containerRect.left &&
-      rect.bottom <= containerRect.bottom &&
-      rect.right <= containerRect.right
-    );
-  });
-}
-
-/**
  * Scrolls the table horizontally to a specific position.
  *  @param {Page}   page     - The Playwright page instance.
  *  @param {number} position - Position to scroll to (0 = left, 0.5 = middle, 1 = right).

--- a/_playwright-tests/helpers/columnHelpers.ts
+++ b/_playwright-tests/helpers/columnHelpers.ts
@@ -86,6 +86,64 @@ export async function openManageColumnsModal(page: Page, timeout = 45000) {
 }
 
 /**
+ * Checks if the systems table is horizontally scrollable.
+ *  @param   {Page}             page - The Playwright page instance.
+ *  @returns {Promise<boolean>}      - True if the table is scrollable, false otherwise.
+ */
+export async function isTableHorizontallyScrollable(
+  page: Page,
+): Promise<boolean> {
+  return await page.evaluate(() => {
+    const scrollContainer = document.querySelector(
+      '.ins-c-systems-view-table-scroll',
+    );
+    if (!scrollContainer) return false;
+    return scrollContainer.scrollWidth > scrollContainer.clientWidth;
+  });
+}
+
+/**
+ * Checks if an element is actually visible in the viewport (not just in the DOM).
+ *  @param   {Locator}          element - The element locator to check.
+ *  @returns {Promise<boolean>}         - True if the element is visible in the viewport.
+ */
+export async function isVisibleInViewport(element: Locator): Promise<boolean> {
+  return await element.evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    const scrollContainer = document.querySelector(
+      '.ins-c-systems-view-table-scroll',
+    );
+    if (!scrollContainer) return false;
+
+    const containerRect = scrollContainer.getBoundingClientRect();
+
+    // Check if element is within the visible viewport of the scroll container
+    return (
+      rect.top >= containerRect.top &&
+      rect.left >= containerRect.left &&
+      rect.bottom <= containerRect.bottom &&
+      rect.right <= containerRect.right
+    );
+  });
+}
+
+/**
+ * Scrolls the table horizontally to a specific position.
+ *  @param {Page}   page     - The Playwright page instance.
+ *  @param {number} position - Position to scroll to (0 = left, 0.5 = middle, 1 = right).
+ */
+export async function scrollTableToPosition(page: Page, position: number) {
+  await page.evaluate((pos) => {
+    const scrollContainer = document.querySelector(
+      '.ins-c-systems-view-table-scroll',
+    );
+    if (scrollContainer) {
+      scrollContainer.scrollLeft = scrollContainer.scrollWidth * pos;
+    }
+  }, position);
+}
+
+/**
  * Scrolls the table horizontally to bring a column into view, avoiding sticky column interference.
  *  @param {Locator} columnHeader - The column header button locator.
  */

--- a/_playwright-tests/helpers/fixtures.ts
+++ b/_playwright-tests/helpers/fixtures.ts
@@ -62,6 +62,8 @@ export const test = base.extend<{
    * Fixture that ensures WORKSPACE_WITH_SYSTEMS exists and has a dedicated
    * system for this test. Each test gets its own unique system to avoid
    * conflicts in parallel execution.
+   *  @param use
+   *  @param testInfo
    */
   workspaceWithSystem: async ({}, use, testInfo) => {
     // Create a unique system for this test

--- a/_playwright-tests/helpers/kesselAccessRouteMock.ts
+++ b/_playwright-tests/helpers/kesselAccessRouteMock.ts
@@ -163,6 +163,7 @@ export async function installKesselCheckSelfBulkDenyView(
  * `inventory_host_view`) and denies **update** relations. Use for Inventory Viewer
  * E2E when stage Kessel policy has not yet migrated those permissions to the Root
  * workspace (RHINENG-25942).
+ *  @param page
  */
 export async function installKesselStalenessViewOnly(
   page: Page,

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -17,6 +17,7 @@ import {
   scrollTableToPosition,
   isTableHorizontallyScrollable,
   isVisibleInViewport,
+  allColumns,
 } from './helpers/columnHelpers';
 
 test.describe(
@@ -267,21 +268,16 @@ test.describe('Inventory Views application columns', () => {
         .locator('th')
         .filter({ hasText: new RegExp('^OS$') });
 
-      await test.step('Enable all columns to create horizontal scroll', async () => {
+      await test.step('Enable all columns via Bulk Select to create horizontal scroll', async () => {
         await openManageColumnsModal(page);
 
-        // Enable all available columns to ensure horizontal scrolling
-        const allColumns = [
-          ...advisorColumns,
-          ...complianceColumns,
-          ...patchColumns,
-          ...malwareColumns,
-          ...inventoryColumns,
-          ...vulnerabilityColumns,
-        ];
-
+        await page
+          .locator('[data-ouia-component-id="BulkSelect-checkbox"]')
+          .check();
         for (const columnName of allColumns) {
-          await dialog.getByLabel(columnName, { exact: true }).check();
+          await expect(
+            dialog.getByLabel(columnName, { exact: true }),
+          ).toBeChecked();
         }
 
         await dialog.getByRole('button', { name: 'Save' }).click();
@@ -303,13 +299,8 @@ test.describe('Inventory Views application columns', () => {
         await scrollTableToPosition(page, 1);
 
         // All sticky columns should still be visible in viewport
-        await expect(checkboxHeader).toBeVisible();
         expect(await isVisibleInViewport(checkboxHeader)).toBe(true);
-
-        await expect(nameHeader).toBeVisible();
         expect(await isVisibleInViewport(nameHeader)).toBe(true);
-
-        await expect(actionsHeader).toBeVisible();
         expect(await isVisibleInViewport(actionsHeader)).toBe(true);
 
         // The left non-sticky column should still be out of viewport

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -14,6 +14,9 @@ import {
   validateDataColumnSortOrder,
   validateSortDirection,
   scrollColumnIntoView,
+  scrollTableToPosition,
+  isTableHorizontallyScrollable,
+  isVisibleInViewport,
 } from './helpers/columnHelpers';
 
 test.describe(
@@ -239,4 +242,100 @@ test.describe('Inventory Views application columns', () => {
       },
     );
   }
+
+  test(
+    'Sticky columns remain visible during horizontal scroll',
+    { tag: ['@inventory-views'] },
+    async ({ page }) => {
+      const dialog = page.locator(
+        '[data-ouia-component-id="ColumnManagementModal"]',
+      );
+
+      // Locators for sticky columns - declared once and reused throughout the test
+      const checkboxHeader = page.locator('th').first();
+      const nameHeader = page
+        .locator('th')
+        .filter({ hasText: new RegExp('^Name$') });
+      const actionsHeader = page
+        .locator('th')
+        .filter({ hasText: /Actions/ })
+        .last();
+
+      // Locator for a non-sticky column to verify actual scrolling
+      // Using "OS" which is a default column that should scroll out when we scroll right
+      const nonStickyColumn = page
+        .locator('th')
+        .filter({ hasText: new RegExp('^OS$') });
+
+      await test.step('Enable all columns to create horizontal scroll', async () => {
+        await openManageColumnsModal(page);
+
+        // Enable all available columns to ensure horizontal scrolling
+        const allColumns = [
+          ...advisorColumns,
+          ...complianceColumns,
+          ...patchColumns,
+          ...malwareColumns,
+          ...inventoryColumns,
+          ...vulnerabilityColumns,
+        ];
+
+        for (const columnName of allColumns) {
+          await dialog.getByLabel(columnName, { exact: true }).check();
+        }
+
+        await dialog.getByRole('button', { name: 'Save' }).click();
+        await expect(dialog).toBeHidden();
+
+        // Wait for table to load
+        await expect(
+          page.locator('[data-ouia-component-id="SkeletonTable"]'),
+        ).toBeHidden({ timeout: 10000 });
+      });
+
+      await test.step('Verify table is horizontally scrollable', async () => {
+        const isScrollable = await isTableHorizontallyScrollable(page);
+        expect(isScrollable).toBe(true);
+      });
+
+      await test.step('Scroll right and verify sticky columns remain visible while non-sticky scrolls out', async () => {
+        // Scroll to the middle
+        await scrollTableToPosition(page, 0.5);
+
+        // Non-sticky column should have scrolled out of viewport (proving scroll happened)
+        await expect(nonStickyColumn).toBeVisible(); // Exists in DOM
+        expect(await isVisibleInViewport(nonStickyColumn)).toBe(false); // But not in viewport
+
+        // Sticky columns should still be visible in viewport
+        await expect(checkboxHeader).toBeVisible();
+        expect(await isVisibleInViewport(checkboxHeader)).toBe(true);
+
+        await expect(nameHeader).toBeVisible();
+        expect(await isVisibleInViewport(nameHeader)).toBe(true);
+
+        await expect(actionsHeader).toBeVisible();
+        expect(await isVisibleInViewport(actionsHeader)).toBe(true);
+      });
+
+      await test.step('Scroll to maximum right and verify sticky columns still visible', async () => {
+        // Scroll to the far right
+        await scrollTableToPosition(page, 1);
+
+        // All sticky columns should still be visible in viewport
+        await expect(checkboxHeader).toBeVisible();
+        expect(await isVisibleInViewport(checkboxHeader)).toBe(true);
+
+        await expect(nameHeader).toBeVisible();
+        expect(await isVisibleInViewport(nameHeader)).toBe(true);
+
+        await expect(actionsHeader).toBeVisible();
+        expect(await isVisibleInViewport(actionsHeader)).toBe(true);
+
+        // The left non-sticky column should still be out of viewport
+        // (proving scroll position maintained and didn't reset)
+        await expect(nonStickyColumn).toBeVisible(); // Exists in DOM
+        expect(await isVisibleInViewport(nonStickyColumn)).toBe(false); // But not in viewport
+      });
+    },
+  );
 });

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -16,7 +16,6 @@ import {
   scrollColumnIntoView,
   scrollTableToPosition,
   isTableHorizontallyScrollable,
-  isVisibleInViewport,
   allColumns,
 } from './helpers/columnHelpers';
 
@@ -271,7 +270,7 @@ test.describe('Inventory Views application columns', () => {
       await test.step('Enable all columns via Bulk Select to create horizontal scroll', async () => {
         await openManageColumnsModal(page);
 
-        await page
+        await dialog
           .locator('[data-ouia-component-id="BulkSelect-checkbox"]')
           .check();
         for (const columnName of allColumns) {
@@ -299,14 +298,14 @@ test.describe('Inventory Views application columns', () => {
         await scrollTableToPosition(page, 1);
 
         // All sticky columns should still be visible in viewport
-        expect(await isVisibleInViewport(checkboxHeader)).toBe(true);
-        expect(await isVisibleInViewport(nameHeader)).toBe(true);
-        expect(await isVisibleInViewport(actionsHeader)).toBe(true);
+        await expect(checkboxHeader).toBeInViewport();
+        await expect(nameHeader).toBeInViewport();
+        await expect(actionsHeader).toBeInViewport();
 
         // The left non-sticky column should still be out of viewport
         // (proving scroll position maintained and didn't reset)
         await expect(nonStickyColumn).toBeVisible(); // Exists in DOM
-        expect(await isVisibleInViewport(nonStickyColumn)).toBe(false); // But not in viewport
+        await expect(nonStickyColumn).not.toBeInViewport(); // But not in viewport
       });
     },
   );

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -298,25 +298,6 @@ test.describe('Inventory Views application columns', () => {
         expect(isScrollable).toBe(true);
       });
 
-      await test.step('Scroll right and verify sticky columns remain visible while non-sticky scrolls out', async () => {
-        // Scroll to the middle
-        await scrollTableToPosition(page, 0.5);
-
-        // Non-sticky column should have scrolled out of viewport (proving scroll happened)
-        await expect(nonStickyColumn).toBeVisible(); // Exists in DOM
-        expect(await isVisibleInViewport(nonStickyColumn)).toBe(false); // But not in viewport
-
-        // Sticky columns should still be visible in viewport
-        await expect(checkboxHeader).toBeVisible();
-        expect(await isVisibleInViewport(checkboxHeader)).toBe(true);
-
-        await expect(nameHeader).toBeVisible();
-        expect(await isVisibleInViewport(nameHeader)).toBe(true);
-
-        await expect(actionsHeader).toBeVisible();
-        expect(await isVisibleInViewport(actionsHeader)).toBe(true);
-      });
-
       await test.step('Scroll to maximum right and verify sticky columns still visible', async () => {
         // Scroll to the far right
         await scrollTableToPosition(page, 1);

--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -7,6 +7,7 @@ import { isSystemsViewEnabled } from './helpers/constants';
 
 test.describe('System CRUD', { tag: ['@systems-table'] }, () => {
   test.describe.configure({ mode: 'serial' });
+
   test('User should be able to edit and delete a system from Systems page', async ({
     page,
   }) => {


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-26765

## What
Test sticky columns, apply all columns

## Why
Requirement: Checkboxes, Name and Actions columns are sticky colums - stay in place while scrolling the table left-right

## How
New Helper Functions:
  - `isTableHorizontallyScrollable() `- Checks if table can scroll horizontally
  - `scrollTableToPosition(page, position)` - Scrolls table to specific position (0-1 range)
  - `isVisibleInViewport(element)` - Verifies element is actually visible in viewport (not just in DOM)

## Testing
  Test Coverage:
  - Enables all columns to create horizontal scroll
  - Verifies checkbox, Name, and Actions columns remain visible in viewport while scrolling
  - Tests scrolling to middle (50%) and maximum right (100%) positions

## Summary by Sourcery

Add end-to-end coverage for sticky inventory table columns and related helper utilities for horizontal scrolling behavior.

Enhancements:
- Introduce helper utilities to detect horizontal scrollability, scroll the inventory table to a relative position, and validate left/right sticky column properties and viewport visibility.
- Add JSDoc-style parameter annotations to various UI helper components and utilities for clearer typing and documentation.

Tests:
- Add a Playwright test that enables all inventory columns to force horizontal scrolling and verifies that checkbox, Name, and Actions columns remain visible while scrolling to middle and far-right positions.