### PR TITLE
  feat(RHINENG-28009): add localStorage draft persistence for Inventory table state

### DIFF
--- a/_playwright-tests/test_system.test.ts
+++ b/_playwright-tests/test_system.test.ts
@@ -7,6 +7,7 @@ import { isSystemsViewEnabled } from './helpers/constants';
 
 test.describe('System CRUD', { tag: ['@systems-table'] }, () => {
   test.describe.configure({ mode: 'serial' });
+
   test('User should be able to edit and delete a system from Systems page', async ({
     page,
   }) => {

--- a/src/components/SystemsView/DataViewFiltersContext.tsx
+++ b/src/components/SystemsView/DataViewFiltersContext.tsx
@@ -12,24 +12,16 @@ import { normalizeLastSeenFilterValue } from './constants';
 import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
 import { GENERAL_GROUPS_READ_PERMISSION } from '../../constants';
 import { useUngroupedWorkspaceId } from '../../hooks/useUngroupedWorkspaceId';
+import { clearInventoryTableDraftFilters } from './utils/inventoryTableDraftStorage';
+import { INITIAL_INVENTORY_FILTERS } from './inventoryFilterDefaults';
+import { useHydrateDraftField } from './hooks/useHydrateDraftField';
 
 export type LastSeenCustomRange = {
   start?: string;
   end?: string;
 } | null;
 
-export const INITIAL_INVENTORY_FILTERS: InventoryFilters = {
-  hostname_or_id: '',
-  status: [],
-  source: [],
-  rhcStatus: [],
-  system_type: [],
-  group_id: [],
-  last_seen: '',
-  tags: [],
-  operating_system: [],
-  workloads: [],
-};
+export { INITIAL_INVENTORY_FILTERS };
 
 export interface DataViewFiltersContextValue {
   filters: InventoryFilters;
@@ -67,12 +59,16 @@ interface DataViewFiltersProviderProps {
   children: React.ReactNode;
   searchParams: SearchParamsTuple[0];
   setSearchParams: SearchParamsTuple[1];
+  orgId?: string;
+  isDraftReady?: boolean;
 }
 
 export const DataViewFiltersProvider = ({
   children,
   searchParams,
   setSearchParams,
+  orgId,
+  isDraftReady = true,
 }: DataViewFiltersProviderProps) => {
   const [lastSeenCustomRange, setLastSeenCustomRange] =
     useState<LastSeenCustomRange>(null);
@@ -111,6 +107,19 @@ export const DataViewFiltersProvider = ({
     }
   }, [rawFilters.last_seen]);
 
+  // Hydrate lastSeenCustomRange from draft storage when user selects 'custom' filter
+  useHydrateDraftField(
+    orgId,
+    isDraftReady,
+    'lastSeenCustomRange',
+    setLastSeenCustomRange,
+    {
+      shouldHydrate: () =>
+        normalizeLastSeenFilterValue(rawFilters.last_seen) === 'custom',
+      extraDeps: [rawFilters.last_seen],
+    },
+  );
+
   useEffect(() => {
     if (!ungroupedWorkspaceId) {
       return;
@@ -126,8 +135,11 @@ export const DataViewFiltersProvider = ({
 
   const clearAllFilters = useCallback(() => {
     setLastSeenCustomRange(null);
+    if (orgId !== undefined) {
+      clearInventoryTableDraftFilters(orgId);
+    }
     hookClearAll();
-  }, [hookClearAll]);
+  }, [hookClearAll, orgId]);
 
   const value = useMemo(
     () => ({

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   DataView,
   useDataViewPagination,
@@ -47,7 +47,9 @@ import { SORT_DIR_URL_PARAM, SORT_URL_PARAM } from './constants';
 import useInventoryViewsFeatureFlag from '../../Utilities/useInventoryViewsFeatureFlag';
 import type { Column } from './columns/allColumnDefinitions';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
-import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import { useBootstrapInventoryTableDraft } from './hooks/useBootstrapInventoryTableDraft';
+import { useInventoryOrgId } from './hooks/useInventoryOrgId';
+import { usePersistInventoryTableDraft } from './hooks/usePersistInventoryTableDraft';
 
 export type SortDirection = ISortBy['direction'];
 export type OnSort = (
@@ -56,14 +58,20 @@ export type OnSort = (
   newSortDirection: SortDirection,
 ) => void;
 export type Pagination = ReturnType<typeof useDataViewPagination>;
+import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+
 interface SystemsViewInnerProps {
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
+  orgId: string;
+  isDraftReady: boolean;
 }
 
 const SystemsViewInner = ({
   searchParams,
   setSearchParams,
+  orgId,
+  isDraftReady,
 }: SystemsViewInnerProps) => {
   const { filters, clearAllFilters, lastSeenCustomRange } =
     useDataViewFiltersContext();
@@ -124,6 +132,20 @@ const SystemsViewInner = ({
     onSort,
     direction,
     isInventoryViewsEnabled,
+    orgId,
+    isDraftReady,
+  });
+
+  usePersistInventoryTableDraft({
+    orgId,
+    columns,
+    filters,
+    lastSeenCustomRange,
+    sortBy,
+    direction,
+    page: pagination.page,
+    perPage: pagination.perPage,
+    isReady: isDraftReady,
   });
 
   const sharedQueryArgs = {
@@ -271,6 +293,30 @@ interface SystemsViewProps {
 
 export const SystemsView = ({ hasAccess = true }: SystemsViewProps) => {
   const [searchParams, setSearchParams] = useSearchParamsWithFragment();
+  const orgId = useInventoryOrgId();
+  const [isDraftReady, setIsDraftReady] = useState(false);
+  const handleDraftReady = useCallback(() => {
+    setIsDraftReady(true);
+  }, []);
+
+  useBootstrapInventoryTableDraft({
+    orgId,
+    searchParams,
+    setSearchParams,
+    onReady: handleDraftReady,
+  });
+
+  // Fix #1: Timeout fallback - degrade gracefully if bootstrap hangs
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (!isDraftReady) {
+        console.warn('Draft bootstrap timeout - rendering without draft state');
+        setIsDraftReady(true);
+      }
+    }, 5000);
+
+    return () => clearTimeout(timeout);
+  }, [isDraftReady]);
 
   if (!hasAccess) {
     return (
@@ -287,14 +333,22 @@ export const SystemsView = ({ hasAccess = true }: SystemsViewProps) => {
     );
   }
 
+  if (orgId === undefined || !isDraftReady) {
+    return null;
+  }
+
   return (
     <DataViewFiltersProvider
       searchParams={searchParams}
       setSearchParams={setSearchParams}
+      orgId={orgId}
+      isDraftReady={isDraftReady}
     >
       <SystemsViewInner
         searchParams={searchParams}
         setSearchParams={setSearchParams}
+        orgId={orgId}
+        isDraftReady={isDraftReady}
       />
     </DataViewFiltersProvider>
   );

--- a/src/components/SystemsView/hooks/useBootstrapInventoryTableDraft.test.ts
+++ b/src/components/SystemsView/hooks/useBootstrapInventoryTableDraft.test.ts
@@ -1,0 +1,79 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useBootstrapInventoryTableDraft } from './useBootstrapInventoryTableDraft';
+import {
+  getInventoryTableDraftStorageKey,
+  INVENTORY_TABLE_DRAFT_VERSION,
+} from '../utils/inventoryTableDraftStorage';
+import { INITIAL_INVENTORY_FILTERS } from '../inventoryFilterDefaults';
+
+const ORG_ID = 'org-bootstrap-test';
+
+describe('useBootstrapInventoryTableDraft', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('hydrates search params from draft when url has no filter state', async () => {
+    window.localStorage.setItem(
+      getInventoryTableDraftStorageKey(ORG_ID),
+      JSON.stringify({
+        version: INVENTORY_TABLE_DRAFT_VERSION,
+        filters: {
+          ...INITIAL_INVENTORY_FILTERS,
+          hostname_or_id: 'restored-host',
+        },
+      }),
+    );
+
+    const setSearchParams = jest.fn();
+    const onReady = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ searchParams }) =>
+        useBootstrapInventoryTableDraft({
+          orgId: ORG_ID,
+          searchParams,
+          setSearchParams,
+          onReady,
+        }),
+      {
+        initialProps: {
+          searchParams: new URLSearchParams(),
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(setSearchParams).toHaveBeenCalledWith(
+        expect.any(URLSearchParams),
+        { replace: true },
+      );
+    });
+
+    const hydratedParams = setSearchParams.mock.calls[0][0] as URLSearchParams;
+    expect(hydratedParams.get('hostname_or_id')).toBe('restored-host');
+
+    rerender({ searchParams: hydratedParams });
+
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalled();
+    });
+  });
+
+  it('marks ready immediately when url already has filters', async () => {
+    const onReady = jest.fn();
+
+    renderHook(() =>
+      useBootstrapInventoryTableDraft({
+        orgId: ORG_ID,
+        searchParams: new URLSearchParams('status=fresh'),
+        setSearchParams: jest.fn(),
+        onReady,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/SystemsView/hooks/useBootstrapInventoryTableDraft.ts
+++ b/src/components/SystemsView/hooks/useBootstrapInventoryTableDraft.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+import type { SetURLSearchParams } from 'react-router-dom';
+import {
+  applyDraftToSearchParams,
+  hasFilterOrSortInUrl,
+  hasPersistedTableState,
+  readInventoryTableDraft,
+} from '../utils/inventoryTableDraftStorage';
+
+interface UseBootstrapInventoryTableDraftParams {
+  orgId: string | undefined;
+  searchParams: URLSearchParams;
+  setSearchParams: SetURLSearchParams;
+  onReady: () => void;
+}
+
+export const useBootstrapInventoryTableDraft = ({
+  orgId,
+  searchParams,
+  setSearchParams,
+  onReady,
+}: UseBootstrapInventoryTableDraftParams) => {
+  const bootstrapPhaseRef = useRef<'idle' | 'done'>('idle');
+
+  useEffect(() => {
+    if (orgId === undefined) {
+      return;
+    }
+
+    if (bootstrapPhaseRef.current === 'done') {
+      return;
+    }
+
+    if (!hasFilterOrSortInUrl(searchParams)) {
+      const draft = readInventoryTableDraft(orgId);
+      if (draft && hasPersistedTableState(draft)) {
+        setSearchParams(applyDraftToSearchParams(searchParams, draft), {
+          replace: true,
+        });
+        // Call onReady asynchronously to allow URL update to complete
+        setTimeout(() => {
+          bootstrapPhaseRef.current = 'done';
+          onReady();
+        }, 0);
+        return;
+      }
+    }
+
+    bootstrapPhaseRef.current = 'done';
+    onReady();
+  }, [orgId, onReady, searchParams, setSearchParams]);
+};

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -8,6 +8,12 @@ import {
 import { STICKY_ACTIONS_HEADER_PROPS } from '../utils/stickyActionsColumn';
 import { getStickyNameHeaderProps } from '../utils/stickyNameColumn';
 import defaultColumns, { type Column } from '../columns/allColumnDefinitions';
+import {
+  mergeColumnsWithDraft,
+  toStoredColumnPreferences,
+  saveInventoryTableDraft,
+} from '../utils/inventoryTableDraftStorage';
+import { useHydrateDraftField } from './useHydrateDraftField';
 
 export const INITIAL_SORT: {
   sortBy: Column['sortBy'];
@@ -30,6 +36,8 @@ interface UseColumnParams {
   onSort: OnSort;
   direction: SortDirection;
   isInventoryViewsEnabled: boolean;
+  orgId?: string;
+  isDraftReady?: boolean;
 }
 
 export const useColumns = ({
@@ -37,8 +45,36 @@ export const useColumns = ({
   onSort,
   direction,
   isInventoryViewsEnabled,
+  orgId,
+  isDraftReady = true,
 }: UseColumnParams) => {
-  const [columns, setColumns] = useState<readonly Column[]>(defaultColumns);
+  const [columns, setColumnsState] =
+    useState<readonly Column[]>(defaultColumns);
+
+  // Hydrate columns from draft storage on mount
+  useHydrateDraftField(orgId, isDraftReady, 'columns', (draftColumns) => {
+    if (draftColumns.length) {
+      setColumnsState(mergeColumnsWithDraft(defaultColumns, draftColumns));
+    }
+  });
+
+  const setColumns = useCallback(
+    (value: React.SetStateAction<readonly Column[]>) => {
+      setColumnsState((previousColumns) => {
+        const nextColumns =
+          typeof value === 'function' ? value(previousColumns) : value;
+
+        if (orgId !== undefined) {
+          saveInventoryTableDraft(orgId, {
+            columns: toStoredColumnPreferences(nextColumns),
+          });
+        }
+
+        return nextColumns;
+      });
+    },
+    [orgId],
+  );
 
   const fromSortByToIndex = useCallback(
     (sortBy?: Column['sortBy']) =>

--- a/src/components/SystemsView/hooks/useHydrateDraftField.ts
+++ b/src/components/SystemsView/hooks/useHydrateDraftField.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from 'react';
+import type { DependencyList } from 'react';
+import { readInventoryTableDraft } from '../utils/inventoryTableDraftStorage';
+import type { InventoryTableDraft } from '../utils/inventoryTableDraftStorage';
+
+interface UseHydrateDraftFieldOptions {
+  /**
+   * Additional condition that must be true for hydration to occur.
+   * Checked after standard guards (isDraftReady, orgId, hydratedRef).
+   */
+  shouldHydrate?: () => boolean;
+  /**
+   * Extra dependencies to include in the useEffect dependency array.
+   * Use when shouldHydrate references reactive values.
+   */
+  extraDeps?: DependencyList;
+}
+
+/**
+ * Shared hook for hydrating a single field from localStorage draft.
+ *
+ * Handles common hydration pattern:
+ * - Guard against premature hydration (isDraftReady, orgId)
+ * - Ensure one-time hydration (useRef tracking)
+ * - Read from localStorage
+ * - Call onHydrate callback with value
+ *
+ *  @param orgId
+ *  @param isDraftReady
+ *  @param fieldKey
+ *  @param onHydrate
+ *  @param options
+ * @example
+ * // Hydrate columns
+ * useHydrateDraftField(
+ *   orgId,
+ *   isDraftReady,
+ *   'columns',
+ *   (columns) => setColumnsState(mergeColumnsWithDraft(defaultColumns, columns))
+ * );
+ *
+ * @example
+ * // Hydrate with conditional check
+ * useHydrateDraftField(
+ *   orgId,
+ *   isDraftReady,
+ *   'lastSeenCustomRange',
+ *   setLastSeenCustomRange,
+ *   {
+ *     shouldHydrate: () => normalizeLastSeenFilterValue(rawFilters.last_seen) === 'custom',
+ *     extraDeps: [rawFilters.last_seen]
+ *   }
+ * );
+ */
+export const useHydrateDraftField = <K extends keyof InventoryTableDraft>(
+  orgId: string | undefined,
+  isDraftReady: boolean,
+  fieldKey: K,
+  onHydrate: (value: NonNullable<InventoryTableDraft[K]>) => void,
+  options?: UseHydrateDraftFieldOptions,
+) => {
+  const hydratedRef = useRef(false);
+
+  useEffect(() => {
+    // Standard guards
+    if (!isDraftReady || orgId === undefined || hydratedRef.current) {
+      return;
+    }
+
+    // Optional additional condition
+    if (options?.shouldHydrate && !options.shouldHydrate()) {
+      return;
+    }
+
+    // Read draft and hydrate
+    const draft = readInventoryTableDraft(orgId);
+    const value = draft?.[fieldKey];
+
+    if (value !== undefined && value !== null) {
+      hydratedRef.current = true;
+      onHydrate(value as NonNullable<InventoryTableDraft[K]>);
+    }
+  }, [isDraftReady, orgId, fieldKey, onHydrate, ...(options?.extraDeps || [])]);
+};

--- a/src/components/SystemsView/hooks/useInventoryOrgId.ts
+++ b/src/components/SystemsView/hooks/useInventoryOrgId.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { getOrgIdFromChromeUser } from '../utils/inventoryTableDraftStorage';
+
+export const useInventoryOrgId = () => {
+  const chrome = useChrome();
+  const [orgId, setOrgId] = useState<string | undefined>();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    chrome.auth
+      .getUser()
+      .then((user) => {
+        if (cancelled) {
+          return;
+        }
+        setOrgId(getOrgIdFromChromeUser(user) ?? 'unknown');
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setOrgId('unknown');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chrome]);
+
+  return orgId;
+};

--- a/src/components/SystemsView/hooks/usePersistInventoryTableDraft.ts
+++ b/src/components/SystemsView/hooks/usePersistInventoryTableDraft.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react';
+import type { SortDirection } from '../SystemsView';
+import type { LastSeenCustomRange } from '../DataViewFiltersContext';
+import type { InventoryFilters } from '../filters/SystemsViewFilters';
+import type { Column } from '../columns/allColumnDefinitions';
+import {
+  saveInventoryTableDraft,
+  toStoredColumnPreferences,
+} from '../utils/inventoryTableDraftStorage';
+
+interface UsePersistInventoryTableDraftParams {
+  orgId: string | undefined;
+  columns: readonly Column[];
+  filters: InventoryFilters;
+  lastSeenCustomRange: LastSeenCustomRange;
+  sortBy?: string;
+  direction?: SortDirection;
+  page: number;
+  perPage: number;
+  isReady: boolean;
+}
+
+export const usePersistInventoryTableDraft = ({
+  orgId,
+  columns,
+  filters,
+  lastSeenCustomRange,
+  sortBy,
+  direction,
+  page,
+  perPage,
+  isReady,
+}: UsePersistInventoryTableDraftParams) => {
+  const skipInitialPersistRef = useRef(true);
+
+  useEffect(() => {
+    if (!isReady || orgId === undefined) {
+      return;
+    }
+
+    if (skipInitialPersistRef.current) {
+      skipInitialPersistRef.current = false;
+      return;
+    }
+
+    saveInventoryTableDraft(orgId, {
+      columns: toStoredColumnPreferences(columns),
+      filters,
+      lastSeenCustomRange,
+      ...(sortBy &&
+        direction && {
+          sort: { sortBy, direction },
+        }),
+      pagination: { page, perPage },
+    });
+  }, [
+    columns,
+    direction,
+    filters,
+    isReady,
+    lastSeenCustomRange,
+    orgId,
+    page,
+    perPage,
+    sortBy,
+  ]);
+};

--- a/src/components/SystemsView/inventoryFilterDefaults.ts
+++ b/src/components/SystemsView/inventoryFilterDefaults.ts
@@ -1,0 +1,14 @@
+import type { InventoryFilters } from './filters/SystemsViewFilters';
+
+export const INITIAL_INVENTORY_FILTERS: InventoryFilters = {
+  hostname_or_id: '',
+  status: [],
+  source: [],
+  rhcStatus: [],
+  system_type: [],
+  group_id: [],
+  last_seen: '',
+  tags: [],
+  operating_system: [],
+  workloads: [],
+};

--- a/src/components/SystemsView/utils/inventoryTableDraftStorage.test.ts
+++ b/src/components/SystemsView/utils/inventoryTableDraftStorage.test.ts
@@ -1,0 +1,159 @@
+import defaultColumns from '../columns/allColumnDefinitions';
+import { INITIAL_INVENTORY_FILTERS } from '../inventoryFilterDefaults';
+import {
+  applyDraftToSearchParams,
+  clearInventoryTableDraftFilters,
+  getInventoryTableDraftStorageKey,
+  getOrgIdFromChromeUser,
+  hasFilterOrSortInUrl,
+  hasPersistedTableState,
+  INVENTORY_TABLE_DRAFT_VERSION,
+  mergeColumnsWithDraft,
+  readInventoryTableDraft,
+  saveInventoryTableDraft,
+  writeInventoryTableDraft,
+} from './inventoryTableDraftStorage';
+
+const ORG_ID = 'test-org-123';
+
+describe('inventoryTableDraftStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('scopes storage keys by org id', () => {
+    expect(getInventoryTableDraftStorageKey(ORG_ID)).toBe(
+      `insights.inventory.systems-view.draft.${ORG_ID}`,
+    );
+  });
+
+  it('reads org id from chrome user identity', () => {
+    expect(
+      getOrgIdFromChromeUser({
+        identity: { internal: { org_id: 'org-1' }, account_number: 'acc-1' },
+      }),
+    ).toBe('org-1');
+
+    expect(
+      getOrgIdFromChromeUser({
+        identity: { account_number: 'acc-2' },
+      }),
+    ).toBe('acc-2');
+  });
+
+  it('writes and reads a draft', () => {
+    saveInventoryTableDraft(ORG_ID, {
+      filters: { ...INITIAL_INVENTORY_FILTERS, status: ['fresh'] },
+    });
+
+    expect(readInventoryTableDraft(ORG_ID)).toEqual({
+      version: INVENTORY_TABLE_DRAFT_VERSION,
+      filters: { ...INITIAL_INVENTORY_FILTERS, status: ['fresh'] },
+    });
+  });
+
+  it('ignores invalid stored drafts', () => {
+    window.localStorage.setItem(
+      getInventoryTableDraftStorageKey(ORG_ID),
+      '{not-json',
+    );
+    expect(readInventoryTableDraft(ORG_ID)).toBeNull();
+
+    window.localStorage.setItem(
+      getInventoryTableDraftStorageKey(ORG_ID),
+      JSON.stringify({ version: 99 }),
+    );
+    expect(readInventoryTableDraft(ORG_ID)).toBeNull();
+  });
+
+  it('detects filter and sort params in the url', () => {
+    expect(hasFilterOrSortInUrl(new URLSearchParams())).toBe(false);
+    expect(
+      hasFilterOrSortInUrl(new URLSearchParams('page=2&per_page=50')),
+    ).toBe(false);
+    expect(hasFilterOrSortInUrl(new URLSearchParams('status=fresh'))).toBe(
+      true,
+    );
+    expect(hasFilterOrSortInUrl(new URLSearchParams('sort=display_name'))).toBe(
+      true,
+    );
+  });
+
+  it('detects meaningful persisted table state', () => {
+    expect(
+      hasPersistedTableState({
+        version: INVENTORY_TABLE_DRAFT_VERSION,
+      }),
+    ).toBe(false);
+
+    expect(
+      hasPersistedTableState({
+        version: INVENTORY_TABLE_DRAFT_VERSION,
+        columns: [{ key: 'name', isShown: true }],
+      }),
+    ).toBe(true);
+
+    expect(
+      hasPersistedTableState({
+        version: INVENTORY_TABLE_DRAFT_VERSION,
+        filters: { ...INITIAL_INVENTORY_FILTERS, hostname_or_id: 'web' },
+      }),
+    ).toBe(true);
+  });
+
+  it('merges stored columns with defaults and inserts new columns', () => {
+    const stored = [
+      { key: 'os', isShown: true },
+      { key: 'name', isShown: false },
+    ];
+
+    const merged = mergeColumnsWithDraft(defaultColumns, stored);
+    expect(merged.find((column) => column.key === 'name')?.isShown).toBe(false);
+    expect(merged.find((column) => column.key === 'os')?.isShown).toBe(true);
+    expect(merged.map((column) => column.key).indexOf('os')).toBeLessThan(
+      merged.map((column) => column.key).indexOf('name'),
+    );
+    expect(merged.length).toBe(defaultColumns.length);
+  });
+
+  it('applies draft filters and sort to search params', () => {
+    const params = applyDraftToSearchParams(new URLSearchParams('page=9'), {
+      version: INVENTORY_TABLE_DRAFT_VERSION,
+      filters: {
+        ...INITIAL_INVENTORY_FILTERS,
+        status: ['fresh'],
+        hostname_or_id: 'web',
+      },
+      sort: { sortBy: 'display_name', direction: 'asc' },
+      pagination: { page: 2, perPage: 25 },
+    });
+
+    expect(params.get('hostname_or_id')).toBe('web');
+    expect(params.getAll('status')).toEqual(['fresh']);
+    expect(params.get('sort')).toBe('display_name');
+    expect(params.get('sort_dir')).toBe('asc');
+    expect(params.get('page')).toBe('2');
+    expect(params.get('per_page')).toBe('25');
+  });
+
+  it('clears filter state while preserving columns', () => {
+    writeInventoryTableDraft(ORG_ID, {
+      version: INVENTORY_TABLE_DRAFT_VERSION,
+      columns: [{ key: 'name', isShown: true }],
+      filters: {
+        ...INITIAL_INVENTORY_FILTERS,
+        hostname_or_id: 'web',
+      },
+      lastSeenCustomRange: { start: '2024-01-01', end: '2024-01-02' },
+    });
+
+    clearInventoryTableDraftFilters(ORG_ID);
+
+    expect(readInventoryTableDraft(ORG_ID)).toEqual({
+      version: INVENTORY_TABLE_DRAFT_VERSION,
+      columns: [{ key: 'name', isShown: true }],
+      filters: { ...INITIAL_INVENTORY_FILTERS },
+      lastSeenCustomRange: null,
+    });
+  });
+});

--- a/src/components/SystemsView/utils/inventoryTableDraftStorage.ts
+++ b/src/components/SystemsView/utils/inventoryTableDraftStorage.ts
@@ -1,0 +1,284 @@
+import type { ISortBy } from '@patternfly/react-table';
+import { INITIAL_INVENTORY_FILTERS } from '../inventoryFilterDefaults';
+import type { LastSeenCustomRange } from '../DataViewFiltersContext';
+import type { InventoryFilters } from '../filters/SystemsViewFilters';
+import type { Column } from '../columns/allColumnDefinitions';
+import { SORT_DIR_URL_PARAM, SORT_URL_PARAM } from '../constants';
+
+export const INVENTORY_TABLE_DRAFT_VERSION = 1;
+
+export const INVENTORY_TABLE_DRAFT_KEY_PREFIX =
+  'insights.inventory.systems-view.draft';
+
+export type StoredColumnPreference = {
+  key: string;
+  isShown: boolean;
+};
+
+export type InventoryTableDraft = {
+  version: typeof INVENTORY_TABLE_DRAFT_VERSION;
+  columns?: StoredColumnPreference[];
+  filters?: InventoryFilters;
+  lastSeenCustomRange?: LastSeenCustomRange;
+  sort?: {
+    sortBy: string;
+    direction: ISortBy['direction'];
+  };
+  pagination?: {
+    page: number;
+    perPage: number;
+  };
+};
+
+export const FILTER_PARAM_KEYS = Object.keys(
+  INITIAL_INVENTORY_FILTERS,
+) as (keyof InventoryFilters)[];
+
+const TABLE_URL_PARAM_KEYS = [
+  ...FILTER_PARAM_KEYS,
+  SORT_URL_PARAM,
+  SORT_DIR_URL_PARAM,
+  'page',
+  'per_page',
+] as const;
+
+export const getInventoryTableDraftStorageKey = (orgId: string) =>
+  `${INVENTORY_TABLE_DRAFT_KEY_PREFIX}.${orgId}`;
+
+export const getOrgIdFromChromeUser = (user: unknown): string | undefined => {
+  const identity = (
+    user as {
+      identity?: {
+        internal?: { org_id?: string };
+        account_number?: string;
+      };
+    }
+  )?.identity;
+
+  return identity?.internal?.org_id ?? identity?.account_number;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const parseStoredDraft = (raw: string): InventoryTableDraft | null => {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || parsed.version !== INVENTORY_TABLE_DRAFT_VERSION) {
+      return null;
+    }
+    return parsed as InventoryTableDraft;
+  } catch {
+    return null;
+  }
+};
+
+export const readInventoryTableDraft = (
+  orgId: string,
+): InventoryTableDraft | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const raw = window.localStorage.getItem(
+    getInventoryTableDraftStorageKey(orgId),
+  );
+  if (!raw) {
+    return null;
+  }
+
+  return parseStoredDraft(raw);
+};
+
+export const writeInventoryTableDraft = (
+  orgId: string,
+  draft: InventoryTableDraft,
+): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(
+    getInventoryTableDraftStorageKey(orgId),
+    JSON.stringify(draft),
+  );
+};
+
+export const saveInventoryTableDraft = (
+  orgId: string,
+  partial: Partial<Omit<InventoryTableDraft, 'version'>>,
+): void => {
+  const existing = readInventoryTableDraft(orgId);
+
+  writeInventoryTableDraft(orgId, {
+    version: INVENTORY_TABLE_DRAFT_VERSION,
+    ...existing,
+    ...partial,
+  });
+};
+
+export const clearInventoryTableDraftFilters = (orgId: string): void => {
+  const existing = readInventoryTableDraft(orgId);
+  if (!existing) {
+    return;
+  }
+
+  writeInventoryTableDraft(orgId, {
+    version: INVENTORY_TABLE_DRAFT_VERSION,
+    columns: existing.columns,
+    sort: existing.sort,
+    pagination: existing.pagination,
+    filters: { ...INITIAL_INVENTORY_FILTERS },
+    lastSeenCustomRange: null,
+  });
+};
+
+export const hasFilterOrSortInUrl = (
+  searchParams: URLSearchParams,
+): boolean => {
+  for (const key of FILTER_PARAM_KEYS) {
+    const initial = INITIAL_INVENTORY_FILTERS[key];
+    if (Array.isArray(initial)) {
+      if (searchParams.getAll(key).length > 0) {
+        return true;
+      }
+      continue;
+    }
+
+    if (searchParams.get(key)) {
+      return true;
+    }
+  }
+
+  return searchParams.has(SORT_URL_PARAM);
+};
+
+export const hasPersistedTableState = (draft: InventoryTableDraft): boolean => {
+  if (draft.columns?.length) {
+    return true;
+  }
+
+  if (draft.sort?.sortBy) {
+    return true;
+  }
+
+  if (draft.lastSeenCustomRange?.start || draft.lastSeenCustomRange?.end) {
+    return true;
+  }
+
+  if (draft.filters) {
+    for (const key of FILTER_PARAM_KEYS) {
+      const initial = INITIAL_INVENTORY_FILTERS[key];
+      const value = draft.filters[key];
+      if (Array.isArray(initial)) {
+        if (Array.isArray(value) && value.length > 0) {
+          return true;
+        }
+        continue;
+      }
+
+      if (typeof value === 'string' && value) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+export const mergeColumnsWithDraft = (
+  defaults: readonly Column[],
+  stored: StoredColumnPreference[] | undefined,
+): readonly Column[] => {
+  if (!stored?.length) {
+    return defaults;
+  }
+
+  const defaultByKey = new Map(defaults.map((column) => [column.key, column]));
+  const storedKeys = new Set(stored.map((column) => column.key));
+
+  const merged: Column[] = stored
+    .map(({ key, isShown }) => {
+      const column = defaultByKey.get(key);
+      return column ? { ...column, isShown } : null;
+    })
+    .filter((column): column is NonNullable<typeof column> => column !== null);
+
+  for (const column of defaults) {
+    if (storedKeys.has(column.key)) {
+      continue;
+    }
+
+    const defaultIndex = defaults.findIndex((item) => item.key === column.key);
+    let insertIndex = merged.length;
+
+    for (let index = 0; index < merged.length; index += 1) {
+      const mergedDefaultIndex = defaults.findIndex(
+        (item) => item.key === merged[index].key,
+      );
+      if (mergedDefaultIndex > defaultIndex) {
+        insertIndex = index;
+        break;
+      }
+    }
+
+    merged.splice(insertIndex, 0, { ...column });
+  }
+
+  return merged;
+};
+
+export const toStoredColumnPreferences = (
+  columns: readonly Column[],
+): StoredColumnPreference[] =>
+  columns.map((column) => ({
+    key: column.key,
+    isShown: column.isShown ?? column.isShownByDefault,
+  }));
+
+const setFilterSearchParam = (
+  params: URLSearchParams,
+  key: keyof InventoryFilters,
+  value: InventoryFilters[keyof InventoryFilters],
+) => {
+  params.delete(key);
+
+  if (Array.isArray(value)) {
+    value.forEach((entry) => {
+      if (entry) {
+        params.append(key, entry);
+      }
+    });
+    return;
+  }
+
+  if (value) {
+    params.set(key, value);
+  }
+};
+
+export const applyDraftToSearchParams = (
+  searchParams: URLSearchParams,
+  draft: InventoryTableDraft,
+): URLSearchParams => {
+  const params = new URLSearchParams(searchParams);
+
+  TABLE_URL_PARAM_KEYS.forEach((key) => params.delete(key));
+
+  const filters = draft.filters ?? INITIAL_INVENTORY_FILTERS;
+  FILTER_PARAM_KEYS.forEach((key) => {
+    setFilterSearchParam(params, key, filters[key]);
+  });
+
+  if (draft.sort?.sortBy && draft.sort.direction) {
+    params.set(SORT_URL_PARAM, draft.sort.sortBy);
+    params.set(SORT_DIR_URL_PARAM, draft.sort.direction);
+  }
+
+  if (draft.pagination) {
+    params.set('page', String(draft.pagination.page));
+    params.set('per_page', String(draft.pagination.perPage));
+  }
+
+  return params;
+};


### PR DESCRIPTION
## Jira
  [RHINENG-28009](https://redhat.atlassian.net/browse/RHINENG-28009)

  ## What
  Implements temporary draft persistence for SystemsView table configuration using localStorage. Users' table preferences (columns, filters, sorting,
  pagination) now survive page reloads.

  ## Why
  Enables users to maintain their preferred Inventory table configuration across sessions. This is a temporary localStorage solution until RHIN-2536
  (database-backed Inventory Views) is implemented.

  ## How
  - Created 4 new hooks: useInventoryOrgId, useBootstrapInventoryTableDraft, useHydrateDraftField, usePersistInventoryTableDraft
  - Added localStorage utilities for CRUD operations and URL param merging
  - Modified SystemsView to orchestrate bootstrap lifecycle with ready gate
  - Modified DataViewFiltersContext and useColumns to use shared hydration hook
  - Storage keyed per-org: `insights.inventory.systems-view.draft.{orgId}`
  - Added 5-second timeout fallback for production safety

  Lifecycle: Mount → fetch orgId → bootstrap (merge draft + URL) → hydrate fields → persist changes

  ## Testing
  - Verified column visibility/order persists across page reload
  - Verified filters and sorting persist across page reload
  - Verified URL params override draft (deep links work correctly)
  - Verified clear filters also clears draft from localStorage
  - Verified timeout fallback works when bootstrap hangs
  - Build passes with no TypeScript errors

[RHINENG-28009]: https://redhat.atlassian.net/browse/RHINENG-28009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add per-organization localStorage-backed draft persistence for SystemsView table state and gate rendering on a bootstrap-ready lifecycle.

New Features:
- Persist SystemsView columns, filters, sorting, and pagination across sessions using org-scoped localStorage drafts.
- Introduce hooks to bootstrap, hydrate, and persist inventory table draft state based on URL params and readiness.
- Support hydrating specific table fields (e.g., custom last seen range, columns) from stored drafts while respecting deep-link URLs.

Bug Fixes:
- Ensure SystemsView degrades gracefully with a timeout fallback if draft bootstrap hangs and avoids rendering before org context is available.
- Make clearing filters also clear persisted draft filter state while preserving column preferences.

Enhancements:
- Refactor filter defaults into a shared inventoryFilterDefaults module and reuse them across draft storage utilities.
- Add robust utilities for reading, writing, merging, and applying inventory table draft state, including org ID extraction from chrome identity.

Tests:
- Add unit tests for inventory draft storage utilities, including URL merging, column merging, filter clearing, and org scoping.
- Add tests for the draft bootstrap hook to verify URL hydration behavior and readiness signalling.