### PR TITLE
feat(RHINENG-28009): persist column settings

### DIFF
--- a/src/components/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/src/components/ColumnManagementModal/ColumnManagementModal.tsx
@@ -92,16 +92,6 @@ export function ColumnManagementModal<
     })),
   );
 
-  // Sync with appliedColumns when they change
-  useEffect(() => {
-    setCurrentColumns(
-      appliedColumns.map((column) => ({
-        ...column,
-        isShown: column.isShown ?? column.isShownByDefault,
-      })),
-    );
-  }, [appliedColumns]);
-
   const hasChanges = useMemo(() => {
     const applied = getColumnSnapshot(appliedColumns);
     const current = getColumnSnapshot(currentColumns);
@@ -116,6 +106,20 @@ export function ColumnManagementModal<
         column.isShown !== current[index].isShown,
     );
   }, [appliedColumns, currentColumns]);
+
+  // Sync with appliedColumns when they change, but not while the user has unsaved edits.
+  useEffect(() => {
+    if (hasChanges) {
+      return;
+    }
+
+    setCurrentColumns(
+      appliedColumns.map((column) => ({
+        ...column,
+        isShown: column.isShown ?? column.isShownByDefault,
+      })),
+    );
+  }, [appliedColumns, hasChanges]);
 
   // Convert ColumnManagementModalColumn to ListManagerItem
   const listManagerItems: ListManagerItem[] = currentColumns.map((column) => ({

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import type { OnSort, SortDirection } from '../SystemsView';
 import {
   getColumnMinWidthStyle,
@@ -8,6 +8,7 @@ import {
 import { STICKY_ACTIONS_HEADER_PROPS } from '../utils/stickyActionsColumn';
 import { getStickyNameHeaderProps } from '../utils/stickyNameColumn';
 import defaultColumns, { type Column } from '../columns/allColumnDefinitions';
+import { usePersistedColumns } from './usePersistedColumns';
 
 export const INITIAL_SORT: {
   sortBy: Column['sortBy'];
@@ -25,103 +26,6 @@ const FALLBACK_SORT: {
   direction: 'asc',
 };
 
-const STORAGE_KEY = 'ui.systems-view.columns';
-
-type ColumnPref = {
-  key: string;
-  isShown: boolean;
-};
-
-const getColumnSnapshot = (columns: readonly Column[]): ColumnPref[] =>
-  columns.map((column) => ({
-    key: column.key,
-    isShown: column.isShown ?? column.isShownByDefault,
-  }));
-
-const loadColumnPrefs = (): ColumnPref[] | null => {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) {
-      return null;
-    }
-
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return null;
-    }
-
-    const prefs = parsed.filter(
-      (item): item is ColumnPref =>
-        typeof item === 'object' &&
-        item !== null &&
-        typeof (item as ColumnPref).key === 'string' &&
-        typeof (item as ColumnPref).isShown === 'boolean',
-    );
-
-    return prefs.length > 0 ? prefs : null;
-  } catch {
-    return null;
-  }
-};
-
-const saveColumnPrefs = (columns: readonly Column[]): void => {
-  try {
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify(getColumnSnapshot(columns)),
-    );
-  } catch {
-    // Ignore quota errors or storage unavailable (e.g. private browsing).
-  }
-};
-
-const mergeColumnPrefs = (
-  defaults: readonly Column[],
-  stored: ColumnPref[] | null,
-): readonly Column[] => {
-  if (!stored) {
-    return defaults;
-  }
-
-  const storedByKey = new Map(
-    stored.map((pref, index) => [
-      pref.key,
-      { isShown: pref.isShown, order: index },
-    ]),
-  );
-
-  const merged = defaults.map((column) => {
-    const pref = storedByKey.get(column.key);
-    if (pref) {
-      return { ...column, isShown: pref.isShown };
-    }
-
-    return column;
-  });
-
-  return [...merged].sort((a, b) => {
-    const aStored = storedByKey.get(a.key);
-    const bStored = storedByKey.get(b.key);
-
-    if (aStored && bStored) {
-      return aStored.order - bStored.order;
-    }
-
-    if (aStored) {
-      return -1;
-    }
-
-    if (bStored) {
-      return 1;
-    }
-
-    return (
-      defaults.findIndex((column) => column.key === a.key) -
-      defaults.findIndex((column) => column.key === b.key)
-    );
-  });
-};
-
 interface UseColumnParams {
   sortBy: Column['sortBy'];
   onSort: OnSort;
@@ -135,13 +39,7 @@ export const useColumns = ({
   direction,
   isInventoryViewsEnabled,
 }: UseColumnParams) => {
-  const [columns, setColumns] = useState<readonly Column[]>(() =>
-    mergeColumnPrefs(defaultColumns, loadColumnPrefs()),
-  );
-
-  useEffect(() => {
-    saveColumnPrefs(columns);
-  }, [columns]);
+  const { columns, setColumns } = usePersistedColumns(defaultColumns);
 
   const fromSortByToIndex = useCallback(
     (sortBy?: Column['sortBy']) =>

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -25,6 +25,103 @@ const FALLBACK_SORT: {
   direction: 'asc',
 };
 
+const STORAGE_KEY = 'ui.systems-view.columns';
+
+type ColumnPref = {
+  key: string;
+  isShown: boolean;
+};
+
+const getColumnSnapshot = (columns: readonly Column[]): ColumnPref[] =>
+  columns.map((column) => ({
+    key: column.key,
+    isShown: column.isShown ?? column.isShownByDefault,
+  }));
+
+const loadColumnPrefs = (): ColumnPref[] | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+
+    const prefs = parsed.filter(
+      (item): item is ColumnPref =>
+        typeof item === 'object' &&
+        item !== null &&
+        typeof (item as ColumnPref).key === 'string' &&
+        typeof (item as ColumnPref).isShown === 'boolean',
+    );
+
+    return prefs.length > 0 ? prefs : null;
+  } catch {
+    return null;
+  }
+};
+
+const saveColumnPrefs = (columns: readonly Column[]): void => {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(getColumnSnapshot(columns)),
+    );
+  } catch {
+    // Ignore quota errors or storage unavailable (e.g. private browsing).
+  }
+};
+
+const mergeColumnPrefs = (
+  defaults: readonly Column[],
+  stored: ColumnPref[] | null,
+): readonly Column[] => {
+  if (!stored) {
+    return defaults;
+  }
+
+  const storedByKey = new Map(
+    stored.map((pref, index) => [
+      pref.key,
+      { isShown: pref.isShown, order: index },
+    ]),
+  );
+
+  const merged = defaults.map((column) => {
+    const pref = storedByKey.get(column.key);
+    if (pref) {
+      return { ...column, isShown: pref.isShown };
+    }
+
+    return column;
+  });
+
+  return [...merged].sort((a, b) => {
+    const aStored = storedByKey.get(a.key);
+    const bStored = storedByKey.get(b.key);
+
+    if (aStored && bStored) {
+      return aStored.order - bStored.order;
+    }
+
+    if (aStored) {
+      return -1;
+    }
+
+    if (bStored) {
+      return 1;
+    }
+
+    return (
+      defaults.findIndex((column) => column.key === a.key) -
+      defaults.findIndex((column) => column.key === b.key)
+    );
+  });
+};
+
 interface UseColumnParams {
   sortBy: Column['sortBy'];
   onSort: OnSort;
@@ -38,7 +135,13 @@ export const useColumns = ({
   direction,
   isInventoryViewsEnabled,
 }: UseColumnParams) => {
-  const [columns, setColumns] = useState<readonly Column[]>(defaultColumns);
+  const [columns, setColumns] = useState<readonly Column[]>(() =>
+    mergeColumnPrefs(defaultColumns, loadColumnPrefs()),
+  );
+
+  useEffect(() => {
+    saveColumnPrefs(columns);
+  }, [columns]);
 
   const fromSortByToIndex = useCallback(
     (sortBy?: Column['sortBy']) =>

--- a/src/components/SystemsView/hooks/usePersistedColumns.test.tsx
+++ b/src/components/SystemsView/hooks/usePersistedColumns.test.tsx
@@ -1,0 +1,126 @@
+import '@testing-library/jest-dom';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { expect } from '@jest/globals';
+import type { Column } from '../columns/allColumnDefinitions';
+import { usePersistedColumns } from './usePersistedColumns';
+
+const TEST_ACCOUNT_NUMBER = '1234567';
+const TEST_USERNAME = 'inventory-columns-test-user';
+const STORAGE_KEY = `ui.systems-view.columns.${TEST_ACCOUNT_NUMBER}.${TEST_USERNAME}`;
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  default: () => ({
+    auth: {
+      getUser: () =>
+        Promise.resolve({
+          identity: {
+            account_number: TEST_ACCOUNT_NUMBER,
+            type: 'User',
+            user: {
+              username: TEST_USERNAME,
+              is_org_admin: true,
+            },
+          },
+          entitlements: {
+            hybrid_cloud: { is_entitled: true },
+            insights: { is_entitled: true },
+            openshift: { is_entitled: true },
+            smart_management: { is_entitled: false },
+          },
+        }),
+    },
+  }),
+}));
+
+const createTestColumn = (key: string, isShownByDefault: boolean): Column =>
+  ({
+    key,
+    title: key,
+    appName: 'inventory',
+    isShownByDefault,
+    isShown: isShownByDefault,
+    renderCell: () => null,
+  }) as Column;
+
+const defaultColumns = [
+  createTestColumn('name', true),
+  createTestColumn('workspace', true),
+  createTestColumn('tags', false),
+  createTestColumn('os', true),
+] as const;
+
+describe('usePersistedColumns', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('loads column preferences from localStorage for the signed-in user', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { key: 'os', isShown: true },
+        { key: 'name', isShown: false },
+        { key: 'workspace', isShown: true },
+      ]),
+    );
+
+    const { result } = renderHook(() => usePersistedColumns(defaultColumns));
+
+    await waitFor(() => {
+      expect(result.current.columns.map((column) => column.key)).toEqual([
+        'os',
+        'name',
+        'workspace',
+        'tags',
+      ]);
+    });
+
+    expect(
+      result.current.columns.find((column) => column.key === 'name'),
+    ).toMatchObject({
+      isShown: false,
+    });
+    expect(
+      result.current.columns.find((column) => column.key === 'os'),
+    ).toMatchObject({
+      isShown: true,
+    });
+    expect(
+      result.current.columns.find((column) => column.key === 'tags'),
+    ).toMatchObject({
+      isShown: false,
+    });
+  });
+
+  it('saves column preferences to localStorage when columns change', async () => {
+    const { result } = renderHook(() => usePersistedColumns(defaultColumns));
+
+    await waitFor(() => {
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    });
+
+    const updatedColumns = [
+      result.current.columns.find((column) => column.key === 'tags')!,
+      result.current.columns.find((column) => column.key === 'name')!,
+      {
+        ...result.current.columns.find((column) => column.key === 'workspace')!,
+        isShown: false,
+      },
+      result.current.columns.find((column) => column.key === 'os')!,
+    ];
+
+    act(() => {
+      result.current.setColumns(updatedColumns);
+    });
+
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual([
+        { key: 'tags', isShown: false },
+        { key: 'name', isShown: true },
+        { key: 'workspace', isShown: false },
+        { key: 'os', isShown: true },
+      ]);
+    });
+  });
+});

--- a/src/components/SystemsView/hooks/usePersistedColumns.ts
+++ b/src/components/SystemsView/hooks/usePersistedColumns.ts
@@ -1,0 +1,111 @@
+import { useEffect, useState } from 'react';
+import type { Column } from '../columns/allColumnDefinitions';
+
+const STORAGE_KEY = 'ui.systems-view.columns';
+
+type ColumnPref = {
+  key: string;
+  isShown: boolean;
+};
+
+const getColumnSnapshot = (columns: readonly Column[]): ColumnPref[] =>
+  columns.map((column) => ({
+    key: column.key,
+    isShown: column.isShown ?? column.isShownByDefault,
+  }));
+
+const loadColumnPrefs = (): ColumnPref[] | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+
+    const prefs = parsed.filter(
+      (item): item is ColumnPref =>
+        typeof item === 'object' &&
+        item !== null &&
+        typeof (item as ColumnPref).key === 'string' &&
+        typeof (item as ColumnPref).isShown === 'boolean',
+    );
+
+    return prefs.length > 0 ? prefs : null;
+  } catch {
+    return null;
+  }
+};
+
+const saveColumnPrefs = (columns: readonly Column[]): void => {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(getColumnSnapshot(columns)),
+    );
+  } catch {
+    // Ignore unavailable storage (e.g. private browsing).
+  }
+};
+
+const mergeColumnPrefs = (
+  defaults: readonly Column[],
+  stored: ColumnPref[] | null,
+): readonly Column[] => {
+  if (!stored) {
+    return defaults;
+  }
+
+  const storedByKey = new Map(
+    stored.map((pref, index) => [
+      pref.key,
+      { isShown: pref.isShown, index: index },
+    ]),
+  );
+
+  const merged = defaults.map((column) => {
+    const pref = storedByKey.get(column.key);
+    if (pref) {
+      return { ...column, isShown: pref.isShown };
+    }
+
+    return column;
+  });
+
+  return [...merged].sort((a, b) => {
+    const aStored = storedByKey.get(a.key);
+    const bStored = storedByKey.get(b.key);
+
+    if (aStored && bStored) {
+      return aStored.index - bStored.index;
+    }
+
+    if (aStored) {
+      return -1;
+    }
+
+    if (bStored) {
+      return 1;
+    }
+
+    return (
+      defaults.findIndex((column) => column.key === a.key) -
+      defaults.findIndex((column) => column.key === b.key)
+    );
+  });
+};
+
+export const usePersistedColumns = (defaultColumns: readonly Column[]) => {
+  const [columns, setColumns] = useState<readonly Column[]>(() =>
+    mergeColumnPrefs(defaultColumns, loadColumnPrefs()),
+  );
+
+  useEffect(() => {
+    saveColumnPrefs(columns);
+  }, [columns]);
+
+  return { columns, setColumns };
+};

--- a/src/components/SystemsView/hooks/usePersistedColumns.ts
+++ b/src/components/SystemsView/hooks/usePersistedColumns.ts
@@ -1,7 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import type { Column } from '../columns/allColumnDefinitions';
 
-const STORAGE_KEY = 'ui.systems-view.columns';
+const STORAGE_KEY_PREFIX = 'ui.systems-view.columns';
+
+const getUserStorageKey = (accountNumber: string, username: string): string =>
+  `${STORAGE_KEY_PREFIX}.${accountNumber}.${username}`;
 
 type ColumnPref = {
   key: string;
@@ -14,9 +18,9 @@ const getColumnSnapshot = (columns: readonly Column[]): ColumnPref[] =>
     isShown: column.isShown ?? column.isShownByDefault,
   }));
 
-const loadColumnPrefs = (): ColumnPref[] | null => {
+const loadColumnPrefs = (storageKey: string): ColumnPref[] | null => {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(storageKey);
     if (!raw) {
       return null;
     }
@@ -40,10 +44,13 @@ const loadColumnPrefs = (): ColumnPref[] | null => {
   }
 };
 
-const saveColumnPrefs = (columns: readonly Column[]): void => {
+const saveColumnPrefs = (
+  storageKey: string,
+  columns: readonly Column[],
+): void => {
   try {
     localStorage.setItem(
-      STORAGE_KEY,
+      storageKey,
       JSON.stringify(getColumnSnapshot(columns)),
     );
   } catch {
@@ -99,13 +106,53 @@ const mergeColumnPrefs = (
 };
 
 export const usePersistedColumns = (defaultColumns: readonly Column[]) => {
-  const [columns, setColumns] = useState<readonly Column[]>(() =>
-    mergeColumnPrefs(defaultColumns, loadColumnPrefs()),
-  );
+  const chrome = useChrome();
+  const [storageKey, setStorageKey] = useState<string | null>(null);
+  const [columns, setColumns] = useState<readonly Column[]>(defaultColumns);
+  const loadedStorageKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
-    saveColumnPrefs(columns);
-  }, [columns]);
+    let cancelled = false;
+
+    void chrome.auth
+      .getUser()
+      .then((user) => {
+        if (cancelled) {
+          return;
+        }
+
+        const accountNumber = user?.identity?.account_number;
+        const username =
+          user?.identity?.user?.username ?? user?.identity?.user?.email;
+
+        if (!accountNumber || !username) {
+          return;
+        }
+
+        const key = getUserStorageKey(String(accountNumber), String(username));
+
+        if (loadedStorageKeyRef.current === key) {
+          return;
+        }
+
+        loadedStorageKeyRef.current = key;
+        setStorageKey(key);
+        setColumns(mergeColumnPrefs(defaultColumns, loadColumnPrefs(key)));
+      })
+      .catch(() => {
+        // Ignore unavailable user identity (e.g. chromeless mode).
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chrome, defaultColumns]);
+
+  useEffect(() => {
+    if (storageKey) {
+      saveColumnPrefs(storageKey, columns);
+    }
+  }, [columns, storageKey]);
 
   return { columns, setColumns };
 };


### PR DESCRIPTION
RHINENG-28009

## What
It Persists column settings temporarily inside localStorage. It saves them under acc&user specific key so they don't collide and allow multiple users. 

NOTE: This is temporary solution and will be superseeded by views management.

## Testing
1. Go to InventoryViews
2. change column settings and save
3. Refresh or navigate away from the page and come back
4. Make sure settings persisted
5. Try log in as different user, and make sure its settings are separate from first one

## Summary by Sourcery

Persist Systems View column configuration per user using localStorage and keep the column management UI in sync without overwriting unsaved edits.

New Features:
- Store Systems View column visibility and ordering in localStorage under an account- and user-specific key so column preferences persist across sessions.

Enhancements:
- Introduce a reusable hook to load, merge, and persist column preferences with sensible fallbacks when user identity or storage is unavailable.
- Update the column management modal to only resync from applied columns when there are no unsaved changes, preventing user edits from being overwritten.