### PR TITLE
Mark CI job as successful if retried tests pass in the currents rerun with warning

### DIFF
--- a/.github/workflows/playwright-inventory-views.yml
+++ b/.github/workflows/playwright-inventory-views.yml
@@ -99,12 +99,18 @@ jobs:
         continue-on-error: true
         run: USE_CTRF=1 npx playwright test --grep "@inventory-views|@systems-table"
 
-      - name: Report failures to Currents
+      - name: Rerun failed tests and report to Currents
+        id: pw_rerun
         if: steps.pw_run.outcome == 'failure'
+        continue-on-error: true
         run: CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-inventory-views-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep "@inventory-views|@systems-table" --last-failed
 
-      - name: Fail job if tests failed
-        if: steps.pw_run.outcome == 'failure'
+      - name: Warn about flaky tests
+        if: steps.pw_run.outcome == 'failure' && steps.pw_rerun.outcome == 'success'
+        run: echo "::warning::Some tests were flaky (failed initially but passed on retry). Check Currents for details."
+
+      - name: Fail job if rerun did not pass
+        if: steps.pw_run.outcome == 'failure' && steps.pw_rerun.outcome != 'success'
         run: exit 1
 
       - name: Publish front-end Test Report

--- a/.github/workflows/playwright-systems-view.yml
+++ b/.github/workflows/playwright-systems-view.yml
@@ -99,12 +99,18 @@ jobs:
         continue-on-error: true
         run: USE_CTRF=1 npx playwright test --grep @systems-table
 
-      - name: Report failures to Currents
+      - name: Rerun failed tests and report to Currents
+        id: pw_rerun
         if: steps.pw_run.outcome == 'failure'
+        continue-on-error: true
         run: CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-systems-view-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep @systems-table --last-failed
 
-      - name: Fail job if tests failed
-        if: steps.pw_run.outcome == 'failure'
+      - name: Warn about flaky tests
+        if: steps.pw_run.outcome == 'failure' && steps.pw_rerun.outcome == 'success'
+        run: echo "::warning::Some tests were flaky (failed initially but passed on retry). Check Currents for details."
+
+      - name: Fail job if rerun did not pass
+        if: steps.pw_run.outcome == 'failure' && steps.pw_rerun.outcome != 'success'
         run: exit 1
 
       - name: Publish front-end Test Report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -98,12 +98,18 @@ jobs:
         continue-on-error: true
         run: USE_CTRF=1 npx playwright test --grep-invert "@integration|@inventory-views"
 
-      - name: Report failures to Currents
+      - name: Rerun failed tests and report to Currents
+        id: pw_rerun
         if: steps.pw_run.outcome == 'failure'
+        continue-on-error: true
         run: CURRENTS_PROJECT_ID=ER8tBy CURRENTS_RECORD_KEY=$CURRENTS_RECORD_KEY CURRENTS_CI_BUILD_ID="${{ github.repository }}-e2e-full-${{ github.run_id }}-${{ github.run_attempt }}" npx playwright test --grep-invert "@integration|@inventory-views" --last-failed
 
-      - name: Fail job if tests failed
-        if: steps.pw_run.outcome == 'failure'
+      - name: Warn about flaky tests
+        if: steps.pw_run.outcome == 'failure' && steps.pw_rerun.outcome == 'success'
+        run: echo "::warning::Some tests were flaky (failed initially but passed on retry). Check Currents for details."
+
+      - name: Fail job if rerun did not pass
+        if: steps.pw_run.outcome == 'failure' && steps.pw_rerun.outcome != 'success'
         run: exit 1
 
       - name: Publish front-end Test Report


### PR DESCRIPTION
Jira
[RHINENG-28152](https://redhat.atlassian.net/browse/RHINENG-28152)

What
Mark CI job as successful when flaky tests pass on retry, and add a warning annotation for visibility.

Why
Currently, the CI pipeline marks the entire job as failed even when tests pass on the rerun step. This blocks PR merges unnecessarily for flaky tests that recover on retry.

How
Changed the rerun step to capture its outcome (continue-on-error: true + id: pw_rerun)
Job only fails if both the initial run and the rerun fail
Added a ::warning:: annotation when tests are flaky (failed initially but passed on retry)
Applied consistently across all 3 E2E workflows: Full Test Suite, SystemsView + Kessel, Inventory Views

Testing
Verified workflow logic: if pw_run fails and pw_rerun passes → job is green + warning shown
Verified workflow logic: if pw_run fails and pw_rerun fails → job is red (unchanged behavior)
Verified workflow logic: if pw_run passes → rerun is skipped entirely (unchanged behavior)

Screenshots/Videos (if applicable)
N/A - CI workflow change only

[RHINENG-28152]: https://redhat.atlassian.net/browse/RHINENG-28152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Treat flaky Playwright E2E tests as passing when they succeed on a rerun while emitting a warning, and only fail the CI job if both the initial run and rerun fail across all E2E workflows.

CI:
- Add rerun steps for failed Playwright E2E tests and capture their outcome in Currents across full, systems-view, and inventory-views workflows.
- Emit CI warnings when tests are flaky (fail initially but pass on rerun) and gate job failure on both initial and rerun failing.