### PR TITLE
test(ci): update CI due enabling SystemsView in stage-stable

### DIFF
--- a/.github/workflows/playwright-inventory-views.yml
+++ b/.github/workflows/playwright-inventory-views.yml
@@ -1,4 +1,9 @@
-name: 'E2E: Inventory Views'
+name: 'E2E: InventoryViews Tests'
+
+# Description: Tests the InventoryViews feature (matches stage-preview environment)
+# - Feature flag: INVENTORY_VIEWS=true (implies SYSTEMS_VIEW=true)
+# - Runs only: @inventory-views, @systems-table tagged tests
+# - Excludes: @integration
 
 on:
   pull_request:

--- a/.github/workflows/playwright-legacy-table.yml
+++ b/.github/workflows/playwright-legacy-table.yml
@@ -51,7 +51,7 @@ jobs:
             echo "BASE_URL=https://stage.foo.redhat.com:1337"
             echo "CI=true"
             echo "PROXY=$PROXY"
-            echo "SYSTEMS_VIEW=false"
+            echo "LEGACY_INVENTORY_TABLE=true"
             echo "STAGE_OFFLINE_TOKEN=$STAGE_OFFLINE_TOKEN"
             echo "TEST_RUN_ID=systems-view-${{ github.run_id }}-${{ github.run_attempt }}"
           } >> .env

--- a/.github/workflows/playwright-legacy-table.yml
+++ b/.github/workflows/playwright-legacy-table.yml
@@ -53,7 +53,7 @@ jobs:
             echo "PROXY=$PROXY"
             echo "LEGACY_INVENTORY_TABLE=true"
             echo "STAGE_OFFLINE_TOKEN=$STAGE_OFFLINE_TOKEN"
-            echo "TEST_RUN_ID=systems-view-${{ github.run_id }}-${{ github.run_attempt }}"
+            echo "TEST_RUN_ID=legacy-table-${{ github.run_id }}-${{ github.run_attempt }}"
           } >> .env
 
           echo ".env file created successfully."

--- a/.github/workflows/playwright-legacy-table.yml
+++ b/.github/workflows/playwright-legacy-table.yml
@@ -1,4 +1,12 @@
-name: 'E2E: SystemsView + Kessel'
+name: 'E2E: Legacy Table Tests'
+
+# Description: Tests the legacy InventoryTable component with @systems-table tag
+# - Tests InventoryTable (still used by other applications consuming this component) 
+# - Feature flag: SYSTEMS_VIEW=false (legacy table component)
+# - Runs only: @systems-table tagged tests
+# - Excludes: @integration, @inventory-views
+# - Why: stage-stable uses SystemsView, stage-preview uses SystemsView + InventoryViews                                                                                                                                                                                                                                        
+#   This CI ensures the legacy InventoryTable component remains functional for other apps
 
 on:
   pull_request:
@@ -10,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  systems_view-tests:
+  legacy_table-tests:
     timeout-minutes: 30
     runs-on:
       - codebuild-host-inventory-frontend-${{ github.run_id }}-${{ github.run_attempt }}
@@ -43,7 +51,7 @@ jobs:
             echo "BASE_URL=https://stage.foo.redhat.com:1337"
             echo "CI=true"
             echo "PROXY=$PROXY"
-            echo "SYSTEMS_VIEW=true"
+            echo "SYSTEMS_VIEW=false"
             echo "STAGE_OFFLINE_TOKEN=$STAGE_OFFLINE_TOKEN"
             echo "TEST_RUN_ID=systems-view-${{ github.run_id }}-${{ github.run_attempt }}"
           } >> .env

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,9 @@
 name: 'E2E: Full Test Suite'
 
+# Description: Runs Playwright end-to-end tests on every PR
+# - Feature flag: SYSTEMS_VIEW=true (new table component) is enabled to match stage-stable environment
+# - Excludes @integration and @inventory-views tagged tests
+
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -43,6 +47,7 @@ jobs:
             echo "BASE_URL=https://stage.foo.redhat.com:1337"
             echo "CI=true"
             echo "PROXY=$PROXY"
+            echo "SYSTEMS_VIEW=true"
             echo "STAGE_OFFLINE_TOKEN=$STAGE_OFFLINE_TOKEN"
             echo "TEST_RUN_ID=full-suite-${{ github.run_id }}-${{ github.run_attempt }}"
           } >> .env

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -3,6 +3,7 @@ import {
   ensureNotInPreview,
   enableSystemsView,
   enableInventoryViews,
+  enableInventoryTable,
   logInAsRole,
   throwIfMissingAdminEnvVariables,
   throwIfMissingRbacEnvVariables,
@@ -23,6 +24,9 @@ async function authenticateUser(page: Page, user: UserConfig) {
   }
   if (isInventoryViewsEnabled) {
     await enableInventoryViews(page);
+  }
+  if (!isSystemsViewEnabled) {
+    await enableInventoryTable(page);
   }
   await closePopupsIfExist(page);
   await logInAsRole(page, user);

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -16,6 +16,7 @@ import {
 import {
   isSystemsViewEnabled,
   isInventoryViewsEnabled,
+  forceLegacyInventoryTable,
 } from './helpers/constants';
 
 async function authenticateUser(page: Page, user: UserConfig) {
@@ -25,7 +26,7 @@ async function authenticateUser(page: Page, user: UserConfig) {
   if (isInventoryViewsEnabled) {
     await enableInventoryViews(page);
   }
-  if (!isSystemsViewEnabled) {
+  if (forceLegacyInventoryTable) {
     await enableInventoryTable(page);
   }
   await closePopupsIfExist(page);

--- a/_playwright-tests/helpers/constants.ts
+++ b/_playwright-tests/helpers/constants.ts
@@ -14,6 +14,8 @@ export const GLOBAL_DATA_PATH = path.resolve(
 
 export const isSystemsViewEnabled = process.env.SYSTEMS_VIEW === 'true';
 export const isInventoryViewsEnabled = process.env.INVENTORY_VIEWS === 'true';
+export const forceLegacyInventoryTable =
+  process.env.LEGACY_INVENTORY_TABLE === 'true';
 
 // Base archives
 export const CENTOS_ARCHIVE = 'centos79.tar.gz';

--- a/_playwright-tests/helpers/loginHelpers.ts
+++ b/_playwright-tests/helpers/loginHelpers.ts
@@ -153,12 +153,19 @@ export const closeCookieBanner = async (page: Page) => {
 
 export const enableSystemsView = async (page: Page) => {
   await page.addInitScript(() => {
+    console.log('[Test Setup] Enabling SystemsView component');
     localStorage.setItem('ui.systems-view', 'true');
   });
 };
 
 export const enableInventoryTable = async (page: Page) => {
   await page.addInitScript(() => {
+    console.log(
+      '[Test Setup] Enabling legacy InventoryTable component (test override)',
+    );
+    // Test override flag - forces SystemsView hook to return false
+    localStorage.setItem('ui.legacy-inventory-table', 'true');
+    // also set these for consistency
     localStorage.setItem('ui.systems-view', 'false');
     localStorage.setItem('ui.inventory-views', 'false');
   });
@@ -166,6 +173,7 @@ export const enableInventoryTable = async (page: Page) => {
 
 export const enableInventoryViews = async (page: Page) => {
   await page.addInitScript(() => {
+    console.log('[Test Setup] Enabling InventoryViews feature');
     localStorage.setItem('ui.systems-view', 'true');
     localStorage.setItem('ui.inventory-views', 'true');
   });

--- a/_playwright-tests/helpers/loginHelpers.ts
+++ b/_playwright-tests/helpers/loginHelpers.ts
@@ -157,9 +157,10 @@ export const enableSystemsView = async (page: Page) => {
   });
 };
 
-export const disableSystemsView = async (page: Page) => {
+export const enableInventoryTable = async (page: Page) => {
   await page.addInitScript(() => {
     localStorage.setItem('ui.systems-view', 'false');
+    localStorage.setItem('ui.inventory-views', 'false');
   });
 };
 

--- a/_playwright-tests/test_system_details.test.ts
+++ b/_playwright-tests/test_system_details.test.ts
@@ -25,7 +25,9 @@ test.describe('System Details tests', () => {
     const packageSystem = systems.packageSystems[0];
 
     await test.step("Navigate to system's details page", async () => {
-      const nameCell = page.locator('td[data-label="Name"]');
+      const nameCell = page
+        .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')
+        .or(page.locator('td[data-label="Name"]'));
       await searchByName(page, packageSystem.hostname);
       await expect(nameCell).toHaveCount(1);
 
@@ -137,7 +139,9 @@ test.describe('System Details tests', () => {
     const bootcSystem = systems.bootcSystems[0];
 
     await test.step("Navigate to system's details page", async () => {
-      const nameCell = page.locator('td[data-label="Name"]');
+      const nameCell = page
+        .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')
+        .or(page.locator('td[data-label="Name"]'));
       await searchByName(page, bootcSystem.hostname);
       await expect(nameCell).toHaveCount(1);
 
@@ -181,7 +185,9 @@ test.describe('System Details tests', () => {
     const system = await createSystem();
     const editButtons = page.getByRole('button', { name: 'Edit' });
     const dialog = page.locator('[role="dialog"]');
-    const nameCell = page.locator('td[data-label="Name"]');
+    const nameCell = page
+      .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')
+      .or(page.locator('td[data-label="Name"]'));
     const newDisplayName = `host_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
     const newAnsibleName = `host_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
 

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -449,7 +449,9 @@ test.describe('Workspace System Management', () => {
      */
 
     const system = systems.workspaceSystems[2];
-    const nameCell = page.locator('td[data-label="Name"]');
+    const nameCell = page
+      .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')
+      .or(page.locator('td[data-label="Name"]'));
 
     await test.step('Navigate to Inventory → Systems', async () => {
       await navigateToInventorySystemsFunc(page);
@@ -502,21 +504,30 @@ test.describe('Workspace System Management', () => {
     });
 
     await test.step('Verify system was added to workspace', async () => {
-      const workspaceCellWithValue = page.locator(
-        'table tbody td[data-label="Workspace"]',
-        {
+      // Wait for table to refresh and show updated workspace
+      const workspaceCellWithValue = page
+        .locator('[data-ouia-component-id*="systems-view-table"]', {
           hasText: WORKSPACE_WITH_SYSTEMS,
-        },
-      );
-      await expect(workspaceCellWithValue.first()).toBeVisible();
+        })
+        .or(
+          page.locator('table tbody td[data-label="Workspace"]', {
+            hasText: WORKSPACE_WITH_SYSTEMS,
+          }),
+        );
+      await expect(workspaceCellWithValue.first()).toBeVisible({
+        timeout: 15000,
+      });
 
-      const nameCellWithValue = page.locator(
-        'table tbody td[data-label="Name"]',
-        {
+      const nameCellWithValue = page
+        .locator('[data-ouia-component-id*="systems-view-table"]', {
           hasText: system.hostname,
-        },
-      );
-      await expect(nameCellWithValue.first()).toBeVisible();
+        })
+        .or(
+          page.locator('table tbody td[data-label="Name"]', {
+            hasText: system.hostname,
+          }),
+        );
+      await expect(nameCellWithValue.first()).toBeVisible({ timeout: 15000 });
     });
   });
 });

--- a/src/Utilities/useSystemsViewFeatureFlag.ts
+++ b/src/Utilities/useSystemsViewFeatureFlag.ts
@@ -4,6 +4,13 @@ const useSystemsViewFeatureFlag = () => {
   const hasUnleashFlag = useFeatureFlag('ui.systems-view');
   const hasLocalFlag = localStorage.getItem('ui.systems-view') === 'true';
 
+  // Test override: Force legacy InventoryTable component
+  const forceInventoryTable =
+    localStorage.getItem('ui.legacy-inventory-table') === 'true';
+  if (forceInventoryTable) {
+    return false;
+  }
+
   return hasUnleashFlag || hasLocalFlag;
 };
 


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-28385

## What
Align Playwright E2E workflows and auth setup with new SystemsView and InventoryViews feature flag combinations for stage environments

## Why
-  enabled `SystemsView` and `InventoryViews` in stage environment 

## How
 - `playwright.yml`: `SYSTEMS_VIEW=true` (matches `stage-stable`) - tests against new `SystemsView` table component
 - `playwright-legacy-table.yml`: `LEGACY_INVENTORY_TABLE=true` - tests against legacy `InventoryTable` component
 - `playwright-inventory-views.ym`l: `INVENTORY_VIEWS=true` - no change, keep testing Inventory Views feature