### PR TITLE
fix: hide Global tag filter when SystemsView is enabled

### DIFF
--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -62,6 +62,7 @@ jobs:
             echo "INTEGRATION=true"
             echo "PROD=true"
             echo "BASE_URL=$PROD_BASE_URL"
+            echo "LEGACY_INVENTORY_TABLE=true"
             echo "PROXY=$RH_PROXY_URL"
             echo "PROD_OFFLINE_TOKEN=$PROD_OFFLINE_TOKEN"
           } >> .env 2>/dev/null

--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -58,7 +58,7 @@ export const filterSystemsWithConditionalFilter = async (
     // TODO: Implement logic to select the Status filter option.
     // Logic not implemented yet. Test continues without filtering.
   } else if (filterName === 'Tags') {
-    const inputLocator = page.getByPlaceholder('Filter by tags').nth(1);
+    const inputLocator = page.getByPlaceholder('Filter by tags');
     await inputLocator.click();
     await inputLocator.fill(option);
 

--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { type Locator, type Page } from '@playwright/test';
+import { isLegacyInventoryTableEnabled } from './constants';
 
 const SKELETON_TABLE = '[data-ouia-component-id="SkeletonTable"]';
 
@@ -58,7 +59,9 @@ export const filterSystemsWithConditionalFilter = async (
     // TODO: Implement logic to select the Status filter option.
     // Logic not implemented yet. Test continues without filtering.
   } else if (filterName === 'Tags') {
-    const inputLocator = page.getByPlaceholder('Filter by tags');
+    const inputLocator = isLegacyInventoryTableEnabled
+      ? page.getByPlaceholder('Filter by tags').nth(1)
+      : page.getByPlaceholder('Filter by tags');
     await inputLocator.click();
     await inputLocator.fill(option);
 

--- a/_playwright-tests/rbac/test_granular_access.test.ts
+++ b/_playwright-tests/rbac/test_granular_access.test.ts
@@ -82,9 +82,13 @@ test.describe('Granular access:', { tag: ['@rbac'] }, () => {
       });
       await expect(secondWorkspace).toBeVisible({ timeout: 100000 });
 
-      const rows = page.locator('td[data-label="Name"]');
+      const rows = page
+        .locator('[data-ouia-component-id="systems-view-table-td-0-1"]')
+        .or(page.locator('td[data-label="Workspace"]'));
       await expect(rows.first()).toBeVisible({ timeout: 20000 });
-      await expect(rows).toHaveCount(2);
+      // Currenlty default workspace is displayed as well,
+      // so we expect 3 rows in total (2 workspaces + default workspace)
+      await expect(rows).toHaveCount(3);
     });
   });
 

--- a/_playwright-tests/rbac/test_granular_access.test.ts
+++ b/_playwright-tests/rbac/test_granular_access.test.ts
@@ -83,8 +83,8 @@ test.describe('Granular access:', { tag: ['@rbac'] }, () => {
       await expect(secondWorkspace).toBeVisible({ timeout: 100000 });
 
       const rows = page
-        .locator('[data-ouia-component-id="systems-view-table-td-0-1"]')
-        .or(page.locator('td[data-label="Workspace"]'));
+        .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')
+        .or(page.locator('td[data-label="Name"]'));
       await expect(rows.first()).toBeVisible({ timeout: 20000 });
       // Currenlty default workspace is displayed as well,
       // so we expect 3 rows in total (2 workspaces + default workspace)

--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -12,6 +12,7 @@ import {
   TAG,
   isSystemsViewEnabled,
   isInventoryViewsEnabled,
+  isLegacyInventoryTableEnabled,
 } from './helpers/constants';
 import { scrollColumnIntoView } from './helpers/columnHelpers';
 
@@ -201,7 +202,9 @@ test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
 
     await test.step('Verify Tags Modal has expected tag', async () => {
       // TODO: Remove when RHINENG-22581 is fixed
-      const inputLocator = page.getByPlaceholder('Filter by tags').nth(1);
+      const inputLocator = isLegacyInventoryTableEnabled
+        ? page.getByPlaceholder('Filter by tags').nth(1)
+        : page.getByPlaceholder('Filter by tags');
       await inputLocator.fill('');
 
       // get name of system we check the tags to verify tags modal title
@@ -213,9 +216,7 @@ test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
       const expectedSystemName = await nameCell.innerText();
 
       // open Tags modal
-      const tagButton = page.locator(
-        '[data-ouia-component-id="TagCount-text"]',
-      );
+      const tagButton = page.locator('[data-ouia-component-id="TagCount"]');
 
       // When INVENTORY_VIEWS is enabled, scroll the Tags column into view
       if (isInventoryViewsEnabled) {

--- a/src/routes/InventoryViews.tsx
+++ b/src/routes/InventoryViews.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useLayoutEffect, useState } from 'react';
 import { Flex, FlexItem, PageSection } from '@patternfly/react-core';
 import SystemsView from '../components/SystemsView';
 import {
@@ -10,6 +10,7 @@ import { OutageAlert } from '../components/OutageAlert';
 import SystemsViewToggle from '../components/SystemsView/SystemsViewToggle';
 import { AccountStatContext } from '../Contexts';
 import { ImagesView } from '../components/InventoryViews/ImagesView/ImagesView';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import './inventory.scss';
 
 interface InventoryViewsProps {
@@ -21,6 +22,15 @@ export type View = 'systems' | 'images';
 const InventoryViews = ({ hasAccess }: InventoryViewsProps) => {
   const [view, setView] = useState<View>('systems');
   const { hasBootcImages } = useContext(AccountStatContext);
+  const chrome = useChrome();
+
+  useLayoutEffect(() => {
+    chrome?.hideGlobalFilter?.(true);
+
+    return () => {
+      chrome?.hideGlobalFilter?.(false);
+    };
+  }, [chrome]);
 
   return (
     <>


### PR DESCRIPTION
## What
hide Global tag filter when SystemsView is enabled

## Why
`SystemsView` table doesn't support Global tag filter

## How
Check for feature flag

## Testing
Stage: flag is enabled
- visit https://stage.foo.redhat.com:1337/
- navigate Systems page
- check for global tag filter
- shouldn't be visible since stage has enabled feature flag for systems view

## Summary by Sourcery

Bug Fixes:
- Ensure the global tag filter is hidden when SystemsView is enabled and restored when the view or feature flag is disabled.