### PR TITLE
chore(eslint): eradicate warnings related to jsdoc & conditionals in pw tests

### DIFF
--- a/_playwright-tests/test_integration.test.ts
+++ b/_playwright-tests/test_integration.test.ts
@@ -57,7 +57,6 @@ test.describe(
           `Found ${logs.length} critical console errors on ${service.name}`,
         ).toHaveLength(0);
 
-        // eslint-disable-next-line playwright/no-conditional-in-test
         if (service.name === 'Remediation Plan') {
           const systemsTab = page.getByLabel('SystemsTab');
           await systemsTab.click({ timeout: 1000 });

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -197,7 +197,6 @@ test.describe('Inventory Views application columns', () => {
                 .locator('..')
                 .getAttribute('aria-sort');
 
-              // eslint-disable-next-line playwright/no-conditional-in-test
               if (currentSort === 'ascending') {
                 break;
               }

--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -60,7 +60,6 @@ test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
       const resetFiltersButton = page
         .getByRole('button', { name: 'Reset filters' })
         .or(page.getByRole('button', { name: 'Clear filters' }));
-      // eslint-disable-next-line playwright/no-conditional-in-test
       if (await resetFiltersButton.isVisible({ timeout: 100 })) {
         await resetFiltersButton.click();
       }
@@ -219,7 +218,6 @@ test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
       );
 
       // When INVENTORY_VIEWS is enabled, scroll the Tags column into view
-      // eslint-disable-next-line playwright/no-conditional-in-test
       if (isInventoryViewsEnabled) {
         await scrollColumnIntoView(tagButton.first());
       }
@@ -273,7 +271,6 @@ test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
       const closeChipButton = page.locator(
         'button[aria-label^="Close"][aria-label*="days ago"]',
       );
-      // eslint-disable-next-line playwright/no-conditional-in-test
       if (await closeChipButton.first().isVisible({ timeout: 2000 })) {
         await closeChipButton.first().click();
         // Wait for skeleton table to disappear after chip removal

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,4 +99,17 @@ export default defineConfig([
       // Add other non-TypeScript specific rules here
     },
   },
+  {
+    files: ['_playwright-tests/**'],
+    rules: {
+      'jsdoc/require-param-description': 'off',
+      'jsdoc/require-returns': 'off',
+      'jsdoc/require-returns-description': 'off',
+      'jsdoc/require-param': 'off',
+      'jsdoc/require-description': 'off',
+      'jsdoc/check-param-names': 'off',
+      'jsdoc/check-line-alignment': 'off',
+      'jsdoc/check-tag-names': 'off',
+    },
+  },
 ]);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,6 +71,7 @@ export default defineConfig([
     rules: {
       ...playwright.configs['flat/recommended'].rules,
       'playwright/prefer-web-first-assertions': 'off',
+      'playwright/no-conditional-in-test': 'off',
     },
   },
   {


### PR DESCRIPTION
## Why
I believe we won't fix these anytime soon and they seem to bring not much value anyway.

## Summary by Sourcery

Disable specific ESLint rules for Playwright tests to remove noisy warnings around conditionals and JSDoc requirements.

Enhancements:
- Turn off the Playwright no-conditional-in-test rule and remove now-unnecessary inline disable comments in Playwright test files.
- Add a Playwright test-specific ESLint override that disables several JSDoc validation rules for files under _playwright-tests/.