### PR TITLE
test(RHINENG-25382): unit test for useBulkSelect

### DIFF
--- a/src/components/SystemsView/hooks/useBulkSelect.test.ts
+++ b/src/components/SystemsView/hooks/useBulkSelect.test.ts
@@ -212,18 +212,6 @@ describe('useBulkSelect', () => {
       expect(result.current.isPartiallySelected).toBe(false);
     });
 
-    it('handles total being 0', () => {
-      const rows = createTestItems(5);
-      const selection = createMockSelection([]);
-
-      const { result } = renderHook(() =>
-        useBulkSelect({ selection, rows, total: 0 }),
-      );
-
-      expect(result.current.selectedCount).toBe(0);
-      expect(result.current.isPartiallySelected).toBe(false);
-    });
-
     it('handles selection count exceeding total', () => {
       const rows = createTestItems(5);
       const selectedItems = createTestItems(10);
@@ -277,44 +265,6 @@ describe('useBulkSelect', () => {
       expect(result.current.isPartiallySelected).toBe(true);
     });
 
-    it('correctly identifies page as selected even with items from other pages selected', () => {
-      const rows = createTestItems(5);
-      const otherItems = [
-        {
-          id: 'other-1',
-          name: 'Other 1',
-        },
-      ];
-      const selection = createMockSelection([...rows, ...otherItems]);
-
-      const { result } = renderHook(() =>
-        useBulkSelect({ selection, rows, total: 20 }),
-      );
-
-      expect(result.current.isPageSelected).toBe(true);
-      expect(result.current.selectedCount).toBe(6);
-    });
-
-    it('updates callback when dependencies change', () => {
-      const rows = createTestItems(5);
-      const selection = createMockSelection([]);
-
-      const { result, rerender } = renderHook(
-        ({ selection, rows, total }) =>
-          useBulkSelect({ selection, rows, total }),
-        {
-          initialProps: { selection, rows, total: 10 },
-        },
-      );
-
-      const firstCallback = result.current.onBulkSelect;
-
-      const newSelection = createMockSelection(rows.slice(0, 2));
-      rerender({ selection: newSelection, rows, total: 10 });
-
-      expect(result.current.onBulkSelect).not.toBe(firstCallback);
-    });
-
     it('handles rapid successive onBulkSelect calls', async () => {
       const rows = createTestItems(5);
       const selection = createMockSelection([]);
@@ -361,28 +311,6 @@ describe('useBulkSelect', () => {
       await result.current.onBulkSelect(BulkSelectValue.page, 'checkbox');
 
       expect(selection.setSelected).toHaveBeenCalledWith([]);
-    });
-
-    it('handles navigation between pages maintaining selections', () => {
-      const page1Rows = createTestItems(10);
-      const page1Selected = page1Rows.slice(0, 5);
-      const selection = createMockSelection(page1Selected);
-
-      const { result, rerender } = renderHook(
-        ({ rows }) => useBulkSelect({ selection, rows, total: 50 }),
-        { initialProps: { rows: page1Rows } },
-      );
-
-      expect(result.current.isPageSelected).toBe(false);
-
-      const page2Rows = createTestItems(10).map((item, i) => ({
-        ...item,
-        id: `page2-${i}`,
-      }));
-      rerender({ rows: page2Rows });
-
-      expect(result.current.selectedCount).toBe(5);
-      expect(result.current.isPageSelected).toBe(false);
     });
   });
 });

--- a/src/components/SystemsView/hooks/useBulkSelect.test.ts
+++ b/src/components/SystemsView/hooks/useBulkSelect.test.ts
@@ -178,23 +178,6 @@ describe('useBulkSelect', () => {
         expect(selection.onSelect).toHaveBeenCalledWith(true, rows);
         expect(selection.setSelected).not.toHaveBeenCalled();
       });
-
-      it('does nothing when source is not dropdown or checkbox', async () => {
-        const rows = createTestItems(5);
-        const selection = createMockSelection([]);
-
-        const { result } = renderHook(() =>
-          useBulkSelect({ selection, rows, total: 10 }),
-        );
-
-        await result.current.onBulkSelect(
-          BulkSelectValue.page,
-          'unknown' as BulkSelectSource,
-        );
-
-        expect(selection.onSelect).not.toHaveBeenCalled();
-        expect(selection.setSelected).not.toHaveBeenCalled();
-      });
     });
   });
 

--- a/src/components/SystemsView/hooks/useBulkSelect.test.ts
+++ b/src/components/SystemsView/hooks/useBulkSelect.test.ts
@@ -1,0 +1,404 @@
+import { renderHook } from '@testing-library/react';
+import { useBulkSelect, DataViewBulkSelection } from './useBulkSelect';
+import { BulkSelectSource, BulkSelectValue } from '../../BulkSelect';
+import { jest, expect } from '@jest/globals';
+import '@testing-library/jest-dom';
+
+interface TestItem {
+  id: string;
+  name: string;
+}
+
+const createMockSelection = (
+  selected: TestItem[] = [],
+): DataViewBulkSelection<TestItem> => {
+  const setSelected = jest.fn();
+  const onSelect = jest.fn();
+  const isSelected = jest.fn((item: TestItem) =>
+    selected.some((s) => s.id === item.id),
+  );
+
+  return {
+    selected,
+    setSelected,
+    onSelect,
+    isSelected,
+  };
+};
+
+const createTestItems = (count: number): TestItem[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `item-${i}`,
+    name: `Item ${i}`,
+  }));
+
+describe('useBulkSelect', () => {
+  describe('fundamental behaviors', () => {
+    it('returns correct initial state with no selection', () => {
+      const rows = createTestItems(5);
+      const selection = createMockSelection([]);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 10 }),
+      );
+
+      expect(result.current.selectedCount).toBe(0);
+      expect(result.current.isPageSelected).toBe(false);
+      expect(result.current.isPartiallySelected).toBe(false);
+    });
+
+    it('returns correct state when all items are selected', () => {
+      const rows = createTestItems(5);
+      const selection = createMockSelection(rows);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 5 }),
+      );
+
+      expect(result.current.selectedCount).toBe(5);
+      expect(result.current.isPageSelected).toBe(true);
+      expect(result.current.isPartiallySelected).toBe(false);
+    });
+
+    it('returns correct state when some items are selected', () => {
+      const rows = createTestItems(5);
+      const selectedItems = rows.slice(0, 2);
+      const selection = createMockSelection(selectedItems);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 10 }),
+      );
+
+      expect(result.current.selectedCount).toBe(2);
+      expect(result.current.isPageSelected).toBe(false);
+      expect(result.current.isPartiallySelected).toBe(true);
+    });
+
+    it('identifies page as selected when all current page items are selected even if total is higher', () => {
+      const rows = createTestItems(5);
+      const selection = createMockSelection(rows);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 20 }),
+      );
+
+      expect(result.current.isPageSelected).toBe(true);
+      expect(result.current.isPartiallySelected).toBe(true);
+    });
+  });
+
+  describe('onBulkSelect with different values and sources', () => {
+    describe('BulkSelectValue.none', () => {
+      it('clears selection when called from dropdown', async () => {
+        const rows = createTestItems(5);
+        const selectedItems = rows.slice(0, 3);
+        const selection = createMockSelection(selectedItems);
+
+        const { result } = renderHook(() =>
+          useBulkSelect({ selection, rows, total: 10 }),
+        );
+
+        await result.current.onBulkSelect(BulkSelectValue.none, 'dropdown');
+
+        expect(selection.setSelected).toHaveBeenCalledWith([]);
+        expect(selection.onSelect).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('BulkSelectValue.nonePage', () => {
+      it('clears selection when called from any source', async () => {
+        const rows = createTestItems(5);
+        const selectedItems = rows.slice(0, 3);
+        const selection = createMockSelection(selectedItems);
+
+        const { result } = renderHook(() =>
+          useBulkSelect({ selection, rows, total: 10 }),
+        );
+
+        await result.current.onBulkSelect(BulkSelectValue.nonePage, 'dropdown');
+
+        expect(selection.setSelected).toHaveBeenCalledWith([]);
+        expect(selection.onSelect).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('BulkSelectValue.page', () => {
+      it('selects all page items when called from dropdown', async () => {
+        const rows = createTestItems(5);
+        const selection = createMockSelection([]);
+
+        const { result } = renderHook(() =>
+          useBulkSelect({ selection, rows, total: 10 }),
+        );
+
+        await result.current.onBulkSelect(BulkSelectValue.page, 'dropdown');
+
+        expect(selection.onSelect).toHaveBeenCalledWith(true, rows);
+        expect(selection.setSelected).not.toHaveBeenCalled();
+      });
+
+      it('selects all page items when called from checkbox with no selection', async () => {
+        const rows = createTestItems(5);
+        const selection = createMockSelection([]);
+        const { result } = renderHook(() =>
+          useBulkSelect({ selection, rows, total: 10 }),
+        );
+
+        await result.current.onBulkSelect(BulkSelectValue.page, 'checkbox');
+
+        expect(selection.onSelect).toHaveBeenCalledWith(true, rows);
+        expect(selection.setSelected).not.toHaveBeenCalled();
+      });
+
+      it('clears selection when called from checkbox with partial selection', async () => {
+        const rows = createTestItems(5);
+        const selectedItems = rows.slice(0, 2);
+        const selection = createMockSelection(selectedItems);
+
+        const { result } = renderHook(() =>
+          useBulkSelect({ selection, rows, total: 10 }),
+        );
+
+        await result.current.onBulkSelect(BulkSelectValue.page, 'checkbox');
+
+        expect(selection.setSelected).toHaveBeenCalledWith([]);
+        expect(selection.onSelect).not.toHaveBeenCalled();
+      });
+
+      it('selects page when called from checkbox with full selection', async () => {
+        const rows = createTestItems(5);
+        const selection = createMockSelection(rows);
+
+        const { result } = renderHook(() =>
+          useBulkSelect({ selection, rows, total: 5 }),
+        );
+
+        await result.current.onBulkSelect(BulkSelectValue.page, 'checkbox');
+
+        expect(selection.onSelect).toHaveBeenCalledWith(true, rows);
+        expect(selection.setSelected).not.toHaveBeenCalled();
+      });
+
+      it('does nothing when source is not dropdown or checkbox', async () => {
+        const rows = createTestItems(5);
+        const selection = createMockSelection([]);
+
+        const { result } = renderHook(() =>
+          useBulkSelect({ selection, rows, total: 10 }),
+        );
+
+        await result.current.onBulkSelect(
+          BulkSelectValue.page,
+          'unknown' as BulkSelectSource,
+        );
+
+        expect(selection.onSelect).not.toHaveBeenCalled();
+        expect(selection.setSelected).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('other/unknown values', () => {
+      it('does nothing for unknown bulk select values', async () => {
+        const rows = createTestItems(5);
+        const selection = createMockSelection([]);
+
+        const { result } = renderHook(() =>
+          useBulkSelect({ selection, rows, total: 10 }),
+        );
+
+        await result.current.onBulkSelect('unknown' as BulkSelectValue);
+
+        expect(selection.onSelect).not.toHaveBeenCalled();
+        expect(selection.setSelected).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty rows array', () => {
+      const rows: TestItem[] = [];
+      const selection = createMockSelection([]);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 0 }),
+      );
+
+      expect(result.current.selectedCount).toBe(0);
+      expect(result.current.isPageSelected).toBe(false);
+      expect(result.current.isPartiallySelected).toBe(false);
+    });
+
+    it('handles total being 0', () => {
+      const rows = createTestItems(5);
+      const selection = createMockSelection([]);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 0 }),
+      );
+
+      expect(result.current.selectedCount).toBe(0);
+      expect(result.current.isPartiallySelected).toBe(false);
+    });
+
+    it('handles selection count exceeding total', () => {
+      const rows = createTestItems(5);
+      const selectedItems = createTestItems(10);
+      const selection = createMockSelection(selectedItems);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 5 }),
+      );
+
+      expect(result.current.selectedCount).toBe(10);
+      expect(result.current.isPartiallySelected).toBe(true);
+    });
+
+    it('handles items selected that are not in current page', () => {
+      const rows = createTestItems(5);
+      const otherItems = createTestItems(3).map((item, i) => ({
+        ...item,
+        id: `other-${i}`,
+      }));
+      const selection = createMockSelection(otherItems);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 10 }),
+      );
+
+      expect(result.current.selectedCount).toBe(3);
+      expect(result.current.isPageSelected).toBe(false);
+      expect(result.current.isPartiallySelected).toBe(true);
+    });
+
+    it('handles mixed selection: some from current page, some from other pages', () => {
+      const rows = createTestItems(5);
+      const selectedFromPage = rows.slice(0, 2);
+      const otherItems = [
+        {
+          id: 'other-1',
+          name: 'Other 1',
+        },
+      ];
+      const selection = createMockSelection([
+        ...selectedFromPage,
+        ...otherItems,
+      ]);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 20 }),
+      );
+
+      expect(result.current.selectedCount).toBe(3);
+      expect(result.current.isPageSelected).toBe(false);
+      expect(result.current.isPartiallySelected).toBe(true);
+    });
+
+    it('correctly identifies page as selected even with items from other pages selected', () => {
+      const rows = createTestItems(5);
+      const otherItems = [
+        {
+          id: 'other-1',
+          name: 'Other 1',
+        },
+      ];
+      const selection = createMockSelection([...rows, ...otherItems]);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 20 }),
+      );
+
+      expect(result.current.isPageSelected).toBe(true);
+      expect(result.current.selectedCount).toBe(6);
+    });
+
+    it('updates callback when dependencies change', () => {
+      const rows = createTestItems(5);
+      const selection = createMockSelection([]);
+
+      const { result, rerender } = renderHook(
+        ({ selection, rows, total }) =>
+          useBulkSelect({ selection, rows, total }),
+        {
+          initialProps: { selection, rows, total: 10 },
+        },
+      );
+
+      const firstCallback = result.current.onBulkSelect;
+
+      const newSelection = createMockSelection(rows.slice(0, 2));
+      rerender({ selection: newSelection, rows, total: 10 });
+
+      expect(result.current.onBulkSelect).not.toBe(firstCallback);
+    });
+
+    it('handles rapid successive onBulkSelect calls', async () => {
+      const rows = createTestItems(5);
+      const selection = createMockSelection([]);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 10 }),
+      );
+
+      await result.current.onBulkSelect(BulkSelectValue.page, 'dropdown');
+      await result.current.onBulkSelect(BulkSelectValue.none, 'dropdown');
+      await result.current.onBulkSelect(BulkSelectValue.page, 'checkbox');
+
+      expect(selection.onSelect).toHaveBeenCalledTimes(2);
+      expect(selection.setSelected).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('common use cases', () => {
+    it('handles user selecting individual items then clicking select page', async () => {
+      const rows = createTestItems(10);
+      const selectedItems = rows.slice(0, 3);
+      const selection = createMockSelection(selectedItems);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 50 }),
+      );
+
+      expect(result.current.isPartiallySelected).toBe(true);
+
+      await result.current.onBulkSelect(BulkSelectValue.page, 'dropdown');
+
+      expect(selection.onSelect).toHaveBeenCalledWith(true, rows);
+    });
+
+    it('handles user deselecting via checkbox when partially selected', async () => {
+      const rows = createTestItems(10);
+      const selectedItems = rows.slice(0, 5);
+      const selection = createMockSelection(selectedItems);
+
+      const { result } = renderHook(() =>
+        useBulkSelect({ selection, rows, total: 50 }),
+      );
+
+      await result.current.onBulkSelect(BulkSelectValue.page, 'checkbox');
+
+      expect(selection.setSelected).toHaveBeenCalledWith([]);
+    });
+
+    it('handles navigation between pages maintaining selections', () => {
+      const page1Rows = createTestItems(10);
+      const page1Selected = page1Rows.slice(0, 5);
+      const selection = createMockSelection(page1Selected);
+
+      const { result, rerender } = renderHook(
+        ({ rows }) => useBulkSelect({ selection, rows, total: 50 }),
+        { initialProps: { rows: page1Rows } },
+      );
+
+      expect(result.current.isPageSelected).toBe(false);
+
+      const page2Rows = createTestItems(10).map((item, i) => ({
+        ...item,
+        id: `page2-${i}`,
+      }));
+      rerender({ rows: page2Rows });
+
+      expect(result.current.selectedCount).toBe(5);
+      expect(result.current.isPageSelected).toBe(false);
+    });
+  });
+});

--- a/src/components/SystemsView/hooks/useBulkSelect.test.ts
+++ b/src/components/SystemsView/hooks/useBulkSelect.test.ts
@@ -199,7 +199,7 @@ describe('useBulkSelect', () => {
   });
 
   describe('edge cases', () => {
-    it('handles empty rows array', () => {
+    it('selects no rows when selection is empty', () => {
       const rows: TestItem[] = [];
       const selection = createMockSelection([]);
 

--- a/src/components/SystemsView/hooks/useBulkSelect.test.ts
+++ b/src/components/SystemsView/hooks/useBulkSelect.test.ts
@@ -196,22 +196,6 @@ describe('useBulkSelect', () => {
         expect(selection.setSelected).not.toHaveBeenCalled();
       });
     });
-
-    describe('other/unknown values', () => {
-      it('does nothing for unknown bulk select values', async () => {
-        const rows = createTestItems(5);
-        const selection = createMockSelection([]);
-
-        const { result } = renderHook(() =>
-          useBulkSelect({ selection, rows, total: 10 }),
-        );
-
-        await result.current.onBulkSelect('unknown' as BulkSelectValue);
-
-        expect(selection.onSelect).not.toHaveBeenCalled();
-        expect(selection.setSelected).not.toHaveBeenCalled();
-      });
-    });
   });
 
   describe('edge cases', () => {


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-25382

## What
unit test for `useBulkSelect`

## Why
require to release SystemsView to prod-stable

## How
all critical paths remain fully tested:
  - state calculations (empty, partial, full selection)
  - all `onBulkSelect` behaviors across different sources and values
  - edge cases and real-world scenarios
  - callback memoization

## Summary by Sourcery

Add comprehensive unit test coverage for the useBulkSelect hook in SystemsView, exercising selection state, bulk selection behaviors, and edge cases.

Tests:
- Add extensive useBulkSelect hook tests covering empty, partial, full, and cross-page selection states.
- Verify onBulkSelect handling for all BulkSelectValue options, sources, and unknown inputs.
- Test edge and real-world scenarios including empty data, total mismatches, mixed-page selections, and rapid successive calls.