### PR TITLE
refactor: add useLegacyInventoryTableFeatureFlag

### DIFF
--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -16,7 +16,7 @@ import {
 import {
   isSystemsViewEnabled,
   isInventoryViewsEnabled,
-  forceLegacyInventoryTable,
+  isLegacyInventoryTableEnabled,
 } from './helpers/constants';
 
 async function authenticateUser(page: Page, user: UserConfig) {
@@ -26,7 +26,7 @@ async function authenticateUser(page: Page, user: UserConfig) {
   if (isInventoryViewsEnabled) {
     await enableInventoryViews(page);
   }
-  if (forceLegacyInventoryTable) {
+  if (isLegacyInventoryTableEnabled) {
     await enableInventoryTable(page);
   }
   await closePopupsIfExist(page);

--- a/_playwright-tests/helpers/constants.ts
+++ b/_playwright-tests/helpers/constants.ts
@@ -14,7 +14,7 @@ export const GLOBAL_DATA_PATH = path.resolve(
 
 export const isSystemsViewEnabled = process.env.SYSTEMS_VIEW === 'true';
 export const isInventoryViewsEnabled = process.env.INVENTORY_VIEWS === 'true';
-export const forceLegacyInventoryTable =
+export const isLegacyInventoryTableEnabled =
   process.env.LEGACY_INVENTORY_TABLE === 'true';
 
 // Base archives

--- a/_playwright-tests/helpers/loginHelpers.ts
+++ b/_playwright-tests/helpers/loginHelpers.ts
@@ -163,11 +163,7 @@ export const enableInventoryTable = async (page: Page) => {
     console.log(
       '[Test Setup] Enabling legacy InventoryTable component (test override)',
     );
-    // Test override flag - forces SystemsView hook to return false
     localStorage.setItem('ui.legacy-inventory-table', 'true');
-    // also set these for consistency
-    localStorage.setItem('ui.systems-view', 'false');
-    localStorage.setItem('ui.inventory-views', 'false');
   });
 };
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,6 +3,7 @@ import { Navigate, useRoutes } from 'react-router-dom';
 import RenderWrapper from './Utilities/Wrapper';
 import useFeatureFlag from './Utilities/useFeatureFlag';
 import useSystemsViewFeatureFlag from './Utilities/useSystemsViewFeatureFlag';
+import useLegacyInventoryTableFeatureFlag from './Utilities/useLegacyInventoryTableFeatureFlag';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 import {
@@ -45,6 +46,7 @@ export const Routes = () => {
   const isLastCheckInEnabled = useFeatureFlag(
     'hbi.create_last_check_in_update_per_reporter_staleness',
   );
+  const isLegacyInventoryTableEnabled = useLegacyInventoryTableFeatureFlag();
 
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
@@ -73,11 +75,12 @@ export const Routes = () => {
   let element = useRoutes([
     {
       path: '/',
-      element: isSystemsViewEnabled ? (
-        <RenderWrapper cmp={InventoryViews} />
-      ) : (
-        <RenderWrapper cmp={InventoryPage} />
-      ),
+      element:
+        isSystemsViewEnabled && !isLegacyInventoryTableEnabled ? (
+          <RenderWrapper cmp={InventoryViews} />
+        ) : (
+          <RenderWrapper cmp={InventoryPage} />
+        ),
     },
     { path: '/:inventoryId', element: <InventoryDetail /> },
     { path: '/:inventoryId/:modalId', element: <InventoryDetail /> },

--- a/src/Utilities/useLegacyInventoryTableFeatureFlag.ts
+++ b/src/Utilities/useLegacyInventoryTableFeatureFlag.ts
@@ -1,0 +1,11 @@
+import useFeatureFlag from './useFeatureFlag';
+
+const useLegacyInventoryTableFeatureFlag = () => {
+  const hasUnleashFlag = useFeatureFlag('ui.legacy-inventory-table');
+  const hasLocalFlag =
+    localStorage.getItem('ui.legacy-inventory-table') === 'true';
+
+  return hasUnleashFlag || hasLocalFlag;
+};
+
+export default useLegacyInventoryTableFeatureFlag;

--- a/src/Utilities/useSystemsViewFeatureFlag.ts
+++ b/src/Utilities/useSystemsViewFeatureFlag.ts
@@ -3,14 +3,6 @@ import useFeatureFlag from './useFeatureFlag';
 const useSystemsViewFeatureFlag = () => {
   const hasUnleashFlag = useFeatureFlag('ui.systems-view');
   const hasLocalFlag = localStorage.getItem('ui.systems-view') === 'true';
-
-  // Test override: Force legacy InventoryTable component
-  const forceInventoryTable =
-    localStorage.getItem('ui.legacy-inventory-table') === 'true';
-  if (forceInventoryTable) {
-    return false;
-  }
-
   return hasUnleashFlag || hasLocalFlag;
 };
 


### PR DESCRIPTION
## What
- adds separate hook for LegacyIventoryTableFeatureFlag
- decouples two hooks
- makes override logic explicit in router rather than inside of a hook

## Why
- it keeps the established hook pattern
- makes hook influence clear and explicit at calling sites

## Summary by Sourcery

Introduce a dedicated legacy inventory table hook and move override logic into the router and tests.

Enhancements:
- Add a useLegacyInventoryTable hook to manage the legacy inventory table feature flag consistently.
- Simplify useSystemsViewFeatureFlag by removing legacy inventory override handling and keeping it focused on systems view state.
- Adjust route selection logic to explicitly prefer the legacy InventoryPage when the legacy inventory table flag is enabled, even if systems view is enabled.

Tests:
- Update Playwright test helpers and constants to use the new legacy inventory table flag naming and behavior, removing coupled overrides of other feature flags.