### PR TITLE
test: add E2E playwright tests for ColumnManagementModal

### DIFF
--- a/_playwright-tests/helpers/columnHelpers.ts
+++ b/_playwright-tests/helpers/columnHelpers.ts
@@ -18,6 +18,64 @@ export const defaultInventoryColumns = [
 // Total columns includes checkbox (first) and per-row actions (last)
 export const totalDefaultColumns = defaultInventoryColumns.length + 2;
 
+/**
+ * Returns visible inventory column header names in left-to-right table order.
+ */
+export async function getVisibleInventoryColumnOrder(
+  page: Page,
+): Promise<string[]> {
+  const headerTexts = (await page.locator('th').allTextContents()).map((text) =>
+    text.trim(),
+  );
+
+  return headerTexts
+    .map((text, index) => ({
+      index,
+      column: defaultInventoryColumns.find((name) =>
+        new RegExp(name).test(text),
+      ),
+    }))
+    .filter(
+      (item): item is { index: number; column: string } =>
+        item.column !== undefined,
+    )
+    .sort((a, b) => a.index - b.index)
+    .map((item) => item.column);
+}
+
+/**
+ * Asserts a column is hidden and the table has one fewer visible header than default.
+ * Retries via toPass to allow persisted column prefs to load after navigation/reload.
+ */
+export async function expectInventoryColumnHidden(
+  page: Page,
+  columnName: string,
+) {
+  const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
+  const columnHeader = page
+    .locator('th')
+    .filter({ hasText: new RegExp(`^${columnName}$`) });
+
+  await expect(async () => {
+    await expect(columnHeader).toBeHidden();
+    await expect(visibleHeaders).toHaveCount(totalDefaultColumns - 1);
+  }).toPass({ timeout: 30000 });
+}
+
+/**
+ * Asserts all default inventory columns are visible in the table.
+ */
+export async function expectDefaultInventoryColumnsVisible(page: Page) {
+  const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
+  await expect(visibleHeaders).toHaveCount(totalDefaultColumns);
+
+  for (const columnName of defaultInventoryColumns) {
+    await expect(
+      page.locator('th').filter({ hasText: new RegExp(columnName) }),
+    ).toBeVisible();
+  }
+}
+
 export const inventoryColumns = [
   'Created',
   'Workload',

--- a/_playwright-tests/helpers/columnHelpers.ts
+++ b/_playwright-tests/helpers/columnHelpers.ts
@@ -62,20 +62,6 @@ export async function expectInventoryColumnHidden(
   }).toPass({ timeout: 30000 });
 }
 
-/**
- * Asserts all default inventory columns are visible in the table.
- */
-export async function expectDefaultInventoryColumnsVisible(page: Page) {
-  const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
-  await expect(visibleHeaders).toHaveCount(totalDefaultColumns);
-
-  for (const columnName of defaultInventoryColumns) {
-    await expect(
-      page.locator('th').filter({ hasText: new RegExp(columnName) }),
-    ).toBeVisible();
-  }
-}
-
 export const inventoryColumns = [
   'Created',
   'Workload',

--- a/_playwright-tests/helpers/columnHelpers.ts
+++ b/_playwright-tests/helpers/columnHelpers.ts
@@ -1,6 +1,9 @@
 import { expect } from '@playwright/test';
 import { type Page, type Locator } from '@playwright/test';
 import { parseLastSeenToDays } from './filterHelpers';
+import { columnManagementModal } from './columnManagementModal';
+
+export { columnManagementModal } from './columnManagementModal';
 
 const NOT_AVAILABLE = '--';
 
@@ -59,40 +62,9 @@ export const allColumns = [
   ...vulnerabilityColumns,
 ];
 
-/**
- * Opens the 'Manage columns' modal from the systems view toolbar.
- * Wraps the action in toPass to handle loading skeletons and dropdown rendering.
- * Verifies the dialog is visible before returning.
- *  @param {Page}   page      - The Playwright page instance.
- *  @param {number} [timeout] - Optional timeout for the toPass block.
- */
-export async function openManageColumnsModal(page: Page, timeout = 45000) {
-  await expect(async () => {
-    // 1. Wait for the loading table skeleton to disappear
-    await expect(
-      page.locator('[data-ouia-component-id="SkeletonTable"]'),
-    ).toBeHidden();
-
-    // 2. Locate, verify, and click the toolbar actions dropdown
-    const toolbarActionsButton = page.locator(
-      "[data-ouia-component-id='systems-view-toolbar-actions-menu-dropdown-toggle']",
-    );
-    await expect(toolbarActionsButton).toBeVisible();
-    await expect(toolbarActionsButton).toBeEnabled();
-    await toolbarActionsButton.click();
-
-    // 3. Locate, verify, and click the 'Manage columns' button inside the dropdown
-    const manageColumnsButton = page
-      .locator('button')
-      .filter({ hasText: 'Manage columns' });
-    await expect(manageColumnsButton).toBeEnabled();
-    await manageColumnsButton.click();
-
-    // 4. Verify the column management dialog is visible
-    const dialog = page.locator('[role="dialog"]');
-    await expect(dialog).toBeVisible();
-  }).toPass({ timeout });
-}
+/** @deprecated Use columnManagementModal(page).open() */
+export const openManageColumnsModal = (page: Page, timeout = 45000) =>
+  columnManagementModal(page).open(timeout);
 
 /**
  * Checks if the systems table is horizontally scrollable.

--- a/_playwright-tests/helpers/columnManagementModal.ts
+++ b/_playwright-tests/helpers/columnManagementModal.ts
@@ -15,6 +15,9 @@ export type ColumnManagementModal = {
   selectedCount: Locator;
   readonly columns: Promise<ColumnListEntry[]>;
   open: (timeout?: number) => Promise<void>;
+  close: () => Promise<void>;
+  save: () => Promise<void>;
+  cancel: () => Promise<void>;
   enableColumn: (columnName: string) => Promise<void>;
   disableColumn: (columnName: string) => Promise<void>;
   dragColumnTo: (sourceColumn: string, targetColumn: string) => Promise<void>;
@@ -27,8 +30,7 @@ export type ColumnManagementModal = {
  * const modal = columnManagementModal(page);
  * await modal.open();
  * await modal.enableColumn('Status');
- * await modal.saveButton.click();
- * await expect(modal.root).toBeHidden();
+ * await modal.save();
  */
 export function columnManagementModal(
   page: Page,
@@ -38,21 +40,25 @@ export function columnManagementModal(
   const columnList = page.locator(
     `[data-ouia-component-id="${ouiaId}-column-list"]`,
   );
+  const saveButton = page.locator(
+    `[data-ouia-component-id="${ouiaId}-save-button"]`,
+  );
+  const cancelButton = page.locator(
+    `[data-ouia-component-id="${ouiaId}-cancel-button"]`,
+  );
+  const resetButton = page.locator(
+    `[data-ouia-component-id="${ouiaId}-reset-button"]`,
+  );
+  const closeButton = root.getByRole('button', { name: 'Close' });
   const columnCheckbox = (columnName: string) =>
     root.getByLabel(columnName, { exact: true });
 
   return {
     root,
-    saveButton: page.locator(
-      `[data-ouia-component-id="${ouiaId}-save-button"]`,
-    ),
-    cancelButton: page.locator(
-      `[data-ouia-component-id="${ouiaId}-cancel-button"]`,
-    ),
-    resetButton: page.locator(
-      `[data-ouia-component-id="${ouiaId}-reset-button"]`,
-    ),
-    closeButton: root.getByRole('button', { name: 'Close' }),
+    saveButton,
+    cancelButton,
+    resetButton,
+    closeButton,
     columnList,
     bulkSelectCheckbox: root.locator(
       '[data-ouia-component-id="BulkSelect-checkbox"]',
@@ -108,6 +114,30 @@ export function columnManagementModal(
 
         await expect(root).toBeVisible();
       }).toPass({ timeout });
+    },
+
+    /**
+     * Closes the modal via the header close button and verifies it is hidden.
+     */
+    async close() {
+      await closeButton.click();
+      await expect(root).toBeHidden();
+    },
+
+    /**
+     * Saves column changes and verifies the modal is hidden.
+     */
+    async save() {
+      await saveButton.click();
+      await expect(root).toBeHidden();
+    },
+
+    /**
+     * Cancels column changes and verifies the modal is hidden.
+     */
+    async cancel() {
+      await cancelButton.click();
+      await expect(root).toBeHidden();
     },
 
     /**

--- a/_playwright-tests/helpers/columnManagementModal.ts
+++ b/_playwright-tests/helpers/columnManagementModal.ts
@@ -1,0 +1,80 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+const DEFAULT_OUIA_ID = 'ColumnManagementModal';
+
+export type ColumnManagementModal = {
+  root: Locator;
+  saveButton: Locator;
+  cancelButton: Locator;
+  resetButton: Locator;
+  closeButton: Locator;
+  columnList: Locator;
+  bulkSelectCheckbox: Locator;
+  selectedCount: Locator;
+  open: (timeout?: number) => Promise<void>;
+};
+
+/**
+ * Locators for the ColumnManagementModal on the Systems view.
+ *
+ * @example
+ * const modal = columnManagementModal(page);
+ * await modal.open();
+ * await modal.root.getByLabel('Status', { exact: true }).check();
+ * await modal.saveButton.click();
+ * await expect(modal.root).toBeHidden();
+ */
+export function columnManagementModal(
+  page: Page,
+  ouiaId: string | number = DEFAULT_OUIA_ID,
+): ColumnManagementModal {
+  const root = page.locator(`[data-ouia-component-id="${ouiaId}"]`);
+
+  return {
+    root,
+    saveButton: page.locator(
+      `[data-ouia-component-id="${ouiaId}-save-button"]`,
+    ),
+    cancelButton: page.locator(
+      `[data-ouia-component-id="${ouiaId}-cancel-button"]`,
+    ),
+    resetButton: page.locator(
+      `[data-ouia-component-id="${ouiaId}-reset-button"]`,
+    ),
+    closeButton: root.getByRole('button', { name: 'Close' }),
+    columnList: page.locator(
+      `[data-ouia-component-id="${ouiaId}-column-list"]`,
+    ),
+    bulkSelectCheckbox: root.locator(
+      '[data-ouia-component-id="BulkSelect-checkbox"]',
+    ),
+    selectedCount: root.locator('[data-ouia-component-id="BulkSelect-text"]'),
+
+    /**
+     * Opens the modal from the Systems view toolbar overflow menu.
+     * Retries via toPass to handle loading skeletons and dropdown rendering.
+     */
+    async open(timeout = 45000) {
+      await expect(async () => {
+        await expect(
+          page.locator('[data-ouia-component-id="SkeletonTable"]'),
+        ).toBeHidden();
+
+        const toolbarActionsButton = page.locator(
+          "[data-ouia-component-id='systems-view-toolbar-actions-menu-dropdown-toggle']",
+        );
+        await expect(toolbarActionsButton).toBeVisible();
+        await expect(toolbarActionsButton).toBeEnabled();
+        await toolbarActionsButton.click();
+
+        const manageColumnsButton = page
+          .locator('button')
+          .filter({ hasText: 'Manage columns' });
+        await expect(manageColumnsButton).toBeEnabled();
+        await manageColumnsButton.click();
+
+        await expect(root).toBeVisible();
+      }).toPass({ timeout });
+    },
+  };
+}

--- a/_playwright-tests/helpers/columnManagementModal.ts
+++ b/_playwright-tests/helpers/columnManagementModal.ts
@@ -2,6 +2,8 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 const DEFAULT_OUIA_ID = 'ColumnManagementModal';
 
+export type ColumnListEntry = [columnName: string, isEnabled: boolean];
+
 export type ColumnManagementModal = {
   root: Locator;
   saveButton: Locator;
@@ -11,7 +13,11 @@ export type ColumnManagementModal = {
   columnList: Locator;
   bulkSelectCheckbox: Locator;
   selectedCount: Locator;
+  readonly columns: Promise<ColumnListEntry[]>;
   open: (timeout?: number) => Promise<void>;
+  enableColumn: (columnName: string) => Promise<void>;
+  disableColumn: (columnName: string) => Promise<void>;
+  dragColumnTo: (sourceColumn: string, targetColumn: string) => Promise<void>;
 };
 
 /**
@@ -20,7 +26,7 @@ export type ColumnManagementModal = {
  * @example
  * const modal = columnManagementModal(page);
  * await modal.open();
- * await modal.root.getByLabel('Status', { exact: true }).check();
+ * await modal.enableColumn('Status');
  * await modal.saveButton.click();
  * await expect(modal.root).toBeHidden();
  */
@@ -29,6 +35,11 @@ export function columnManagementModal(
   ouiaId: string | number = DEFAULT_OUIA_ID,
 ): ColumnManagementModal {
   const root = page.locator(`[data-ouia-component-id="${ouiaId}"]`);
+  const columnList = page.locator(
+    `[data-ouia-component-id="${ouiaId}-column-list"]`,
+  );
+  const columnCheckbox = (columnName: string) =>
+    root.getByLabel(columnName, { exact: true });
 
   return {
     root,
@@ -42,13 +53,35 @@ export function columnManagementModal(
       `[data-ouia-component-id="${ouiaId}-reset-button"]`,
     ),
     closeButton: root.getByRole('button', { name: 'Close' }),
-    columnList: page.locator(
-      `[data-ouia-component-id="${ouiaId}-column-list"]`,
-    ),
+    columnList,
     bulkSelectCheckbox: root.locator(
       '[data-ouia-component-id="BulkSelect-checkbox"]',
     ),
     selectedCount: root.locator('[data-ouia-component-id="BulkSelect-text"]'),
+
+    /**
+     * Each list item as [columnName, isEnabled] in display order.
+     */
+    get columns(): Promise<ColumnListEntry[]> {
+      return (async () => {
+        const rows = columnList.locator('li');
+        const count = await rows.count();
+        const entries: ColumnListEntry[] = [];
+
+        for (let index = 0; index < count; index++) {
+          const row = rows.nth(index);
+          const columnName = (
+            await row
+              .locator('[data-ouia-component-id$="-label"] label')
+              .textContent()
+          )?.trim();
+          const isEnabled = await row.getByRole('checkbox').isChecked();
+          entries.push([columnName ?? '', isEnabled]);
+        }
+
+        return entries;
+      })();
+    },
 
     /**
      * Opens the modal from the Systems view toolbar overflow menu.
@@ -75,6 +108,41 @@ export function columnManagementModal(
 
         await expect(root).toBeVisible();
       }).toPass({ timeout });
+    },
+
+    /**
+     * Enables a column and verifies its checkbox is checked.
+     */
+    async enableColumn(columnName: string) {
+      const checkbox = columnCheckbox(columnName);
+      await checkbox.check();
+      await expect(checkbox).toBeChecked();
+    },
+
+    /**
+     * Disables a column and verifies its checkbox is unchecked.
+     */
+    async disableColumn(columnName: string) {
+      const checkbox = columnCheckbox(columnName);
+      await checkbox.uncheck();
+      await expect(checkbox).not.toBeChecked();
+    },
+
+    /**
+     * Reorders a column by dragging its handle onto another column's row.
+     */
+    async dragColumnTo(sourceColumn: string, targetColumn: string) {
+      const columnRow = (columnName: string) =>
+        columnCheckbox(columnName).locator('xpath=ancestor::li[1]');
+
+      const source = columnRow(sourceColumn).getByRole('button', {
+        name: 'Drag button',
+      });
+      const target = columnRow(targetColumn);
+
+      await expect(source).toBeVisible();
+      await expect(target).toBeVisible();
+      await source.dragTo(target, { steps: 20 });
     },
   };
 }

--- a/_playwright-tests/test_column_management_modal.test.ts
+++ b/_playwright-tests/test_column_management_modal.test.ts
@@ -48,8 +48,7 @@ test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
 
     await modal.disableColumn(columnToDisable);
 
-    await modal.saveButton.click();
-    await expect(modal.root).toBeHidden();
+    await modal.save();
 
     await expectInventoryColumnHidden(page, columnToDisable);
   });
@@ -62,8 +61,7 @@ test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
 
     await modal.disableColumn(columnToDisable);
 
-    await modal.cancelButton.click();
-    await expect(modal.root).toBeHidden();
+    await modal.cancel();
 
     await expectDefaultInventoryColumnsVisible(page);
   });
@@ -76,8 +74,7 @@ test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
 
     await modal.disableColumn(columnToDisable);
 
-    await modal.closeButton.click();
-    await expect(modal.root).toBeHidden();
+    await modal.close();
 
     await expectDefaultInventoryColumnsVisible(page);
   });
@@ -90,8 +87,7 @@ test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
 
     await modal.disableColumn(columnToDisable);
 
-    await modal.saveButton.click();
-    await expect(modal.root).toBeHidden();
+    await modal.save();
 
     await expectInventoryColumnHidden(page, columnToDisable);
 
@@ -151,8 +147,7 @@ test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
     await modal.dragColumnTo(sourceColumn, targetColumn);
 
     await expect(modal.saveButton).toBeEnabled();
-    await modal.saveButton.click();
-    await expect(modal.root).toBeHidden();
+    await modal.save();
 
     expect(await getVisibleInventoryColumnOrder(page)).toEqual(
       reorderedColumnNames,

--- a/_playwright-tests/test_column_management_modal.test.ts
+++ b/_playwright-tests/test_column_management_modal.test.ts
@@ -1,0 +1,189 @@
+import { expect } from '@playwright/test';
+import { navigateToInventorySystemsFunc } from './helpers/navHelpers';
+import { test } from './helpers/fixtures';
+import { columnManagementModal } from './helpers/columnManagementModal';
+import {
+  totalDefaultColumns,
+  defaultInventoryColumns,
+  getVisibleInventoryColumnOrder,
+  expectInventoryColumnHidden,
+  expectDefaultInventoryColumnsVisible,
+} from './helpers/columnHelpers';
+
+test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToInventorySystemsFunc(page);
+
+    const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
+    await expect(visibleHeaders).toHaveCount(totalDefaultColumns);
+  });
+
+  test('open Manage Columns modal', async ({ page }) => {
+    const modal = columnManagementModal(page);
+
+    await modal.open();
+
+    await expect(modal.root).toBeVisible();
+    await expect(
+      modal.root.getByRole('heading', { name: 'Manage columns' }),
+    ).toBeVisible();
+  });
+
+  test('Name column is checked and cannot be toggled off', async ({ page }) => {
+    const modal = columnManagementModal(page);
+
+    await modal.open();
+
+    const nameColumn = modal.root.getByLabel('Name', { exact: true });
+
+    await expect(nameColumn).toBeChecked();
+    await expect(nameColumn).toBeDisabled();
+  });
+
+  test('disable a default column and save', async ({ page }) => {
+    const columnToDisable = 'Tags';
+    const modal = columnManagementModal(page);
+
+    await modal.open();
+
+    await modal.disableColumn(columnToDisable);
+
+    await modal.saveButton.click();
+    await expect(modal.root).toBeHidden();
+
+    await expectInventoryColumnHidden(page, columnToDisable);
+  });
+
+  test('cancel button disregards column changes', async ({ page }) => {
+    const columnToDisable = 'Tags';
+    const modal = columnManagementModal(page);
+
+    await modal.open();
+
+    await modal.disableColumn(columnToDisable);
+
+    await modal.cancelButton.click();
+    await expect(modal.root).toBeHidden();
+
+    await expectDefaultInventoryColumnsVisible(page);
+  });
+
+  test('close button disregards column changes', async ({ page }) => {
+    const columnToDisable = 'Tags';
+    const modal = columnManagementModal(page);
+
+    await modal.open();
+
+    await modal.disableColumn(columnToDisable);
+
+    await modal.closeButton.click();
+    await expect(modal.root).toBeHidden();
+
+    await expectDefaultInventoryColumnsVisible(page);
+  });
+
+  test('column changes persist after page reload', async ({ page }) => {
+    const columnToDisable = 'Tags';
+    const modal = columnManagementModal(page);
+
+    await modal.open();
+
+    await modal.disableColumn(columnToDisable);
+
+    await modal.saveButton.click();
+    await expect(modal.root).toBeHidden();
+
+    await expectInventoryColumnHidden(page, columnToDisable);
+
+    await page.reload({ waitUntil: 'load' });
+    await expect(
+      page.locator('[data-ouia-component-id="SkeletonTable"]'),
+    ).toBeHidden();
+
+    await expectInventoryColumnHidden(page, columnToDisable);
+  });
+
+  test('reset button restores default column state', async ({ page }) => {
+    const columnToEnable = 'Status';
+    const modal = columnManagementModal(page);
+
+    await modal.open();
+
+    const defaultModalColumns = await modal.columns;
+
+    await modal.enableColumn(columnToEnable);
+    await modal.dragColumnTo('Workspace', 'Tags');
+    await expect(modal.saveButton).toBeEnabled();
+    await expect(
+      modal.root.getByLabel(columnToEnable, { exact: true }),
+    ).toBeChecked();
+    expect(await modal.columns).not.toEqual(defaultModalColumns);
+
+    await modal.resetButton.click();
+
+    await expect(
+      modal.root.getByLabel(columnToEnable, { exact: true }),
+    ).not.toBeChecked();
+
+    expect(await modal.columns).toEqual(defaultModalColumns);
+    await expect(modal.saveButton).toBeDisabled();
+    await expectDefaultInventoryColumnsVisible(page);
+  });
+
+  test('drag and drop a column and save', async ({ page }) => {
+    const modal = columnManagementModal(page);
+
+    await modal.open();
+
+    const initialModalColumns = await modal.columns;
+    const enabledColumnNames = initialModalColumns
+      .filter(([, isEnabled]) => isEnabled)
+      .map(([columnName]) => columnName);
+
+    const sourceColumn = enabledColumnNames[1];
+    const targetColumn = enabledColumnNames[2];
+    const reorderedColumnNames = [...enabledColumnNames];
+    [reorderedColumnNames[1], reorderedColumnNames[2]] = [
+      reorderedColumnNames[2],
+      reorderedColumnNames[1],
+    ];
+
+    await modal.dragColumnTo(sourceColumn, targetColumn);
+
+    await expect(modal.saveButton).toBeEnabled();
+    await modal.saveButton.click();
+    await expect(modal.root).toBeHidden();
+
+    expect(await getVisibleInventoryColumnOrder(page)).toEqual(
+      reorderedColumnNames,
+    );
+  });
+
+  test('bulk select toggles all toggleable columns', async ({ page }) => {
+    const modal = columnManagementModal(page);
+
+    await modal.open();
+
+    await expect(modal.selectedCount).toHaveText(
+      `${defaultInventoryColumns.length} selected`,
+    );
+
+    await modal.bulkSelectCheckbox.check();
+
+    await expect(modal.bulkSelectCheckbox).toBeChecked();
+    expect((await modal.columns).every(([, isEnabled]) => isEnabled)).toBe(
+      true,
+    );
+
+    await modal.bulkSelectCheckbox.uncheck();
+
+    // every column but 'Name' should be disabled
+    expect(
+      (await modal.columns).every(
+        ([columnName, isEnabled]) => isEnabled === (columnName === 'Name'),
+      ),
+    ).toBe(true);
+
+    await expect(modal.saveButton).toBeEnabled();
+  });
+});

--- a/_playwright-tests/test_column_management_modal.test.ts
+++ b/_playwright-tests/test_column_management_modal.test.ts
@@ -4,10 +4,8 @@ import { test } from './helpers/fixtures';
 import { columnManagementModal } from './helpers/columnManagementModal';
 import {
   totalDefaultColumns,
-  defaultInventoryColumns,
   getVisibleInventoryColumnOrder,
   expectInventoryColumnHidden,
-  expectDefaultInventoryColumnsVisible,
 } from './helpers/columnHelpers';
 
 test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
@@ -16,67 +14,6 @@ test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
 
     const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
     await expect(visibleHeaders).toHaveCount(totalDefaultColumns);
-  });
-
-  test('open Manage Columns modal', async ({ page }) => {
-    const modal = columnManagementModal(page);
-
-    await modal.open();
-
-    await expect(modal.root).toBeVisible();
-    await expect(
-      modal.root.getByRole('heading', { name: 'Manage columns' }),
-    ).toBeVisible();
-  });
-
-  test('Name column is checked and cannot be toggled off', async ({ page }) => {
-    const modal = columnManagementModal(page);
-
-    await modal.open();
-
-    const nameColumn = modal.root.getByLabel('Name', { exact: true });
-
-    await expect(nameColumn).toBeChecked();
-    await expect(nameColumn).toBeDisabled();
-  });
-
-  test('disable a default column and save', async ({ page }) => {
-    const columnToDisable = 'Tags';
-    const modal = columnManagementModal(page);
-
-    await modal.open();
-
-    await modal.disableColumn(columnToDisable);
-
-    await modal.save();
-
-    await expectInventoryColumnHidden(page, columnToDisable);
-  });
-
-  test('cancel button disregards column changes', async ({ page }) => {
-    const columnToDisable = 'Tags';
-    const modal = columnManagementModal(page);
-
-    await modal.open();
-
-    await modal.disableColumn(columnToDisable);
-
-    await modal.cancel();
-
-    await expectDefaultInventoryColumnsVisible(page);
-  });
-
-  test('close button disregards column changes', async ({ page }) => {
-    const columnToDisable = 'Tags';
-    const modal = columnManagementModal(page);
-
-    await modal.open();
-
-    await modal.disableColumn(columnToDisable);
-
-    await modal.close();
-
-    await expectDefaultInventoryColumnsVisible(page);
   });
 
   test('column changes persist after page reload', async ({ page }) => {
@@ -97,33 +34,6 @@ test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
     ).toBeHidden();
 
     await expectInventoryColumnHidden(page, columnToDisable);
-  });
-
-  test('reset button restores default column state', async ({ page }) => {
-    const columnToEnable = 'Status';
-    const modal = columnManagementModal(page);
-
-    await modal.open();
-
-    const defaultModalColumns = await modal.columns;
-
-    await modal.enableColumn(columnToEnable);
-    await modal.dragColumnTo('Workspace', 'Tags');
-    await expect(modal.saveButton).toBeEnabled();
-    await expect(
-      modal.root.getByLabel(columnToEnable, { exact: true }),
-    ).toBeChecked();
-    expect(await modal.columns).not.toEqual(defaultModalColumns);
-
-    await modal.resetButton.click();
-
-    await expect(
-      modal.root.getByLabel(columnToEnable, { exact: true }),
-    ).not.toBeChecked();
-
-    expect(await modal.columns).toEqual(defaultModalColumns);
-    await expect(modal.saveButton).toBeDisabled();
-    await expectDefaultInventoryColumnsVisible(page);
   });
 
   test('drag and drop a column and save', async ({ page }) => {
@@ -152,33 +62,5 @@ test.describe('Column Management Modal', { tag: ['@inventory-views'] }, () => {
     expect(await getVisibleInventoryColumnOrder(page)).toEqual(
       reorderedColumnNames,
     );
-  });
-
-  test('bulk select toggles all toggleable columns', async ({ page }) => {
-    const modal = columnManagementModal(page);
-
-    await modal.open();
-
-    await expect(modal.selectedCount).toHaveText(
-      `${defaultInventoryColumns.length} selected`,
-    );
-
-    await modal.bulkSelectCheckbox.check();
-
-    await expect(modal.bulkSelectCheckbox).toBeChecked();
-    expect((await modal.columns).every(([, isEnabled]) => isEnabled)).toBe(
-      true,
-    );
-
-    await modal.bulkSelectCheckbox.uncheck();
-
-    // every column but 'Name' should be disabled
-    expect(
-      (await modal.columns).every(
-        ([columnName, isEnabled]) => isEnabled === (columnName === 'Name'),
-      ),
-    ).toBe(true);
-
-    await expect(modal.saveButton).toBeEnabled();
   });
 });

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -104,23 +104,17 @@ test.describe('Inventory Views application columns', () => {
           await modal.open();
 
           for (const columnName of appColumns) {
-            await modal.root.getByLabel(columnName, { exact: true }).check();
-            await expect(
-              modal.root.getByLabel(columnName, { exact: true }),
-            ).toBeChecked();
+            await modal.enableColumn(columnName);
           }
-          // Verify it is applied by checking the "X selected" text in the dialog
-          const selected = modal.root.locator(
-            '[data-ouia-component-id="BulkSelect-text"]',
-          );
           const totalModifiedColumns =
             defaultInventoryColumns.length + appColumns.length;
-          await expect(selected).toHaveText(`${totalModifiedColumns} selected`);
+          await expect(modal.selectedCount).toHaveText(
+            `${totalModifiedColumns} selected`,
+          );
         });
 
         await test.step(`Verify ${name} columns are applied on systems table`, async () => {
-          await modal.saveButton.click();
-          await expect(modal.root).toBeHidden();
+          await modal.save();
 
           const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
           await expect(visibleHeaders).toHaveCount(
@@ -153,21 +147,14 @@ test.describe('Inventory Views application columns', () => {
           // For Inventory columns, unselect some default columns to reduce table width
           const columnsToUnselect = ['OS', 'Last seen', 'Tags', 'Workspace'];
           for (const columnName of columnsToUnselect) {
-            await modal.root.getByLabel(columnName, { exact: true }).uncheck();
-            await expect(
-              modal.root.getByLabel(columnName, { exact: true }),
-            ).not.toBeChecked();
+            await modal.disableColumn(columnName);
           }
 
           for (const column of appColumns) {
-            await modal.root.getByLabel(column.name, { exact: true }).check();
-            await expect(
-              modal.root.getByLabel(column.name, { exact: true }),
-            ).toBeChecked();
+            await modal.enableColumn(column.name);
           }
 
-          await modal.saveButton.click();
-          await expect(modal.root).toBeHidden();
+          await modal.save();
 
           const expectedColumnCount =
             totalDefaultColumns + appColumns.length - 4; // -4 for unselected columns
@@ -263,17 +250,13 @@ test.describe('Inventory Views application columns', () => {
       await test.step('Enable all columns via Bulk Select to create horizontal scroll', async () => {
         await modal.open();
 
-        await modal.root
-          .locator('[data-ouia-component-id="BulkSelect-checkbox"]')
-          .check();
+        await modal.bulkSelectCheckbox.check();
+        const columns = Object.fromEntries(await modal.columns);
         for (const columnName of allColumns) {
-          await expect(
-            modal.root.getByLabel(columnName, { exact: true }),
-          ).toBeChecked();
+          expect(columns[columnName]).toBe(true);
         }
 
-        await modal.saveButton.click();
-        await expect(modal.root).toBeHidden();
+        await modal.save();
 
         // Wait for table to load
         await expect(

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { navigateToInventorySystemsFunc } from './helpers/navHelpers';
 import { test } from './helpers/fixtures';
+import { columnManagementModal } from './helpers/columnManagementModal';
 import {
   totalDefaultColumns,
   defaultInventoryColumns,
-  openManageColumnsModal,
   advisorColumns,
   complianceColumns,
   patchColumns,
@@ -98,21 +98,19 @@ test.describe('Inventory Views application columns', () => {
       `User can enable ${name} columns via Manage Columns`,
       { tag: ['@inventory-views'] },
       async ({ page }) => {
-        const dialog = page.locator(
-          '[data-ouia-component-id="ColumnManagementModal"]',
-        );
+        const modal = columnManagementModal(page);
 
         await test.step(`Open Manage Columns and apply ${name} columns`, async () => {
-          await openManageColumnsModal(page);
+          await modal.open();
 
           for (const columnName of appColumns) {
-            await dialog.getByLabel(columnName, { exact: true }).check();
+            await modal.root.getByLabel(columnName, { exact: true }).check();
             await expect(
-              dialog.getByLabel(columnName, { exact: true }),
+              modal.root.getByLabel(columnName, { exact: true }),
             ).toBeChecked();
           }
           // Verify it is applied by checking the "X selected" text in the dialog
-          const selected = dialog.locator(
+          const selected = modal.root.locator(
             '[data-ouia-component-id="BulkSelect-text"]',
           );
           const totalModifiedColumns =
@@ -121,8 +119,8 @@ test.describe('Inventory Views application columns', () => {
         });
 
         await test.step(`Verify ${name} columns are applied on systems table`, async () => {
-          await dialog.getByRole('button', { name: 'Save' }).click();
-          await expect(dialog).toBeHidden();
+          await modal.saveButton.click();
+          await expect(modal.root).toBeHidden();
 
           const visibleHeaders = page.locator('th').filter({ hasText: /.+/ });
           await expect(visibleHeaders).toHaveCount(
@@ -147,31 +145,29 @@ test.describe('Inventory Views application columns', () => {
       `User can sort by ${name} columns`,
       { tag: ['@inventory-views'] },
       async ({ page }) => {
-        const dialog = page.locator(
-          '[data-ouia-component-id="ColumnManagementModal"]',
-        );
+        const modal = columnManagementModal(page);
 
         await test.step(`Open Manage Columns and apply ${name} columns`, async () => {
-          await openManageColumnsModal(page);
+          await modal.open();
 
           // For Inventory columns, unselect some default columns to reduce table width
           const columnsToUnselect = ['OS', 'Last seen', 'Tags', 'Workspace'];
           for (const columnName of columnsToUnselect) {
-            await dialog.getByLabel(columnName, { exact: true }).uncheck();
+            await modal.root.getByLabel(columnName, { exact: true }).uncheck();
             await expect(
-              dialog.getByLabel(columnName, { exact: true }),
+              modal.root.getByLabel(columnName, { exact: true }),
             ).not.toBeChecked();
           }
 
           for (const column of appColumns) {
-            await dialog.getByLabel(column.name, { exact: true }).check();
+            await modal.root.getByLabel(column.name, { exact: true }).check();
             await expect(
-              dialog.getByLabel(column.name, { exact: true }),
+              modal.root.getByLabel(column.name, { exact: true }),
             ).toBeChecked();
           }
 
-          await dialog.getByRole('button', { name: 'Save' }).click();
-          await expect(dialog).toBeHidden();
+          await modal.saveButton.click();
+          await expect(modal.root).toBeHidden();
 
           const expectedColumnCount =
             totalDefaultColumns + appColumns.length - 4; // -4 for unselected columns
@@ -246,9 +242,7 @@ test.describe('Inventory Views application columns', () => {
     'Sticky columns remain visible during horizontal scroll',
     { tag: ['@inventory-views'] },
     async ({ page }) => {
-      const dialog = page.locator(
-        '[data-ouia-component-id="ColumnManagementModal"]',
-      );
+      const modal = columnManagementModal(page);
 
       // Locators for sticky columns - declared once and reused throughout the test
       const checkboxHeader = page.locator('th').first();
@@ -267,19 +261,19 @@ test.describe('Inventory Views application columns', () => {
         .filter({ hasText: new RegExp('^OS$') });
 
       await test.step('Enable all columns via Bulk Select to create horizontal scroll', async () => {
-        await openManageColumnsModal(page);
+        await modal.open();
 
-        await dialog
+        await modal.root
           .locator('[data-ouia-component-id="BulkSelect-checkbox"]')
           .check();
         for (const columnName of allColumns) {
           await expect(
-            dialog.getByLabel(columnName, { exact: true }),
+            modal.root.getByLabel(columnName, { exact: true }),
           ).toBeChecked();
         }
 
-        await dialog.getByRole('button', { name: 'Save' }).click();
-        await expect(dialog).toBeHidden();
+        await modal.saveButton.click();
+        await expect(modal.root).toBeHidden();
 
         // Wait for table to load
         await expect(

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,6 +70,12 @@ export default defineConfig([
     files: ['_playwright-tests/**/*.test.ts', '_playwright-tests/helpers/**'],
     rules: {
       ...playwright.configs['flat/recommended'].rules,
+      'playwright/expect-expect': [
+        'warn',
+        {
+          assertFunctionPatterns: ['^expect.*'],
+        },
+      ],
       'playwright/prefer-web-first-assertions': 'off',
       'playwright/no-conditional-in-test': 'off',
     },


### PR DESCRIPTION
RHINENG-26760

## What
It adds helpers for ColumnManagementModal which makes it easier to test modal itself and other parts of InventoryViews.

It adds e2e coverage for ColumnManagementModal described by JIRA.

## Testing
Command I was using locally

<!-- How was this tested? -->
`INVENTORY_VIEWS="true" npx playwright test _playwright-tests/test_column_management_modal.test.ts --workers 4 --headed`

## Summary by Sourcery

Add Playwright end-to-end coverage and reusable helpers for the Inventory Systems Column Management modal.

New Features:
- Introduce a ColumnManagementModal helper API for interacting with the manage columns dialog in Playwright tests.
- Add dedicated E2E tests validating column enabling/disabling, persistence, reset, and drag-and-drop reordering in the Column Management modal.

Enhancements:
- Refactor existing inventory views column tests to reuse the ColumnManagementModal helper instead of direct locators.
- Add reusable helpers for asserting visible inventory columns, hidden columns, and column header ordering in the systems table.