### PR TITLE
fix: Image toggle and Global tag filter reappearing on navigation

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -42,24 +42,18 @@ export const Routes = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   const isSystemsViewEnabled = useSystemsViewFeatureFlag();
-  const isBifrostEnabled = useFeatureFlag('hbi.ui.bifrost');
   const isLastCheckInEnabled = useFeatureFlag(
     'hbi.create_last_check_in_update_per_reporter_staleness',
   );
   const isLegacyInventoryTableEnabled = useLegacyInventoryTableFeatureFlag();
 
-  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
-    // zero state check
     (async () => {
       try {
         const hasConventionalSystems = await inventoryHasConventionalSystems();
         setHasSystems(hasConventionalSystems);
-
-        if (isBifrostEnabled) {
-          const hasBootc = await inventoryHasBootcImages();
-          setHasBootcImages(hasBootc);
-        }
+        const hasBootc = await inventoryHasBootcImages();
+        setHasBootcImages(hasBootc);
         setIsLoading(false);
       } catch (error) {
         console.error(error);
@@ -70,7 +64,6 @@ export const Routes = () => {
       }
     })();
   }, []);
-  /* eslint-enable react-hooks/exhaustive-deps */
 
   let element = useRoutes([
     {

--- a/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
+++ b/src/components/InventoryTabs/ConventionalSystems/ConventionalSystemsTab.js
@@ -255,7 +255,6 @@ const ConventionalSystemsTab = ({
     isKesselEnabled,
   );
 
-  const isBootcEnabled = useFeatureFlag('hbi.ui.bifrost');
   const { hasBootcImages } = useContext(AccountStatContext);
 
   const isLastCheckInEnabled = useFeatureFlag(
@@ -315,7 +314,7 @@ const ConventionalSystemsTab = ({
   return (
     <Fragment>
       <InventoryTableCmp
-        showSystemTypeFilter={isBootcEnabled && hasBootcImages}
+        showSystemTypeFilter={hasBootcImages}
         hasAccess={hasAccess}
         isRbacEnabled
         customFilters={{ filters, globalFilter }}

--- a/src/routes/InventoryComponents/InventoryPageHeader.js
+++ b/src/routes/InventoryComponents/InventoryPageHeader.js
@@ -16,7 +16,6 @@ import {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { DesktopIcon } from '@patternfly/react-icons';
-import useFeatureFlag from '../../Utilities/useFeatureFlag';
 import FontAwesomeImageIcon from '../../components/FontAwesomeImageIcon';
 import { AccountStatContext } from '../../Contexts';
 import { pageContents } from './InventoryPageContents';
@@ -62,7 +61,6 @@ const InventoryContentToggle = ({ changeMainContent, mainContent }) => (
 );
 
 const InventoryPageHeader = (toggleProps) => {
-  const isBifrostEnabled = useFeatureFlag('hbi.ui.bifrost');
   const { hasBootcImages } = useContext(AccountStatContext);
   return (
     <PageHeader className="pf-m-light">
@@ -79,7 +77,6 @@ const InventoryPageHeader = (toggleProps) => {
           </Flex>
         }
         actionsContent={
-          isBifrostEnabled &&
           hasBootcImages && <InventoryContentToggle {...toggleProps} />
         }
       />

--- a/src/routes/InventoryViews.tsx
+++ b/src/routes/InventoryViews.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useLayoutEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Flex, FlexItem, PageSection } from '@patternfly/react-core';
 import SystemsView from '../components/SystemsView';
 import {
@@ -24,13 +24,9 @@ const InventoryViews = ({ hasAccess }: InventoryViewsProps) => {
   const { hasBootcImages } = useContext(AccountStatContext);
   const chrome = useChrome();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     chrome?.hideGlobalFilter?.(true);
-
-    return () => {
-      chrome?.hideGlobalFilter?.(false);
-    };
-  }, [chrome]);
+  }, []);
 
   return (
     <>

--- a/src/routes/InventoryViews.tsx
+++ b/src/routes/InventoryViews.tsx
@@ -26,7 +26,7 @@ const InventoryViews = ({ hasAccess }: InventoryViewsProps) => {
 
   useEffect(() => {
     chrome?.hideGlobalFilter?.(true);
-  }, []);
+  }, [chrome]);
 
   return (
     <>


### PR DESCRIPTION
## What
Fix-up Image toggle and Global tag filter reappearing on navigation

## Why

- Bug: Images view toggle not appearing reliably (known issue)

 `useFeatureFlag` returns `undefined` while Unleash is loading. The `useEffect` in `Routes.js` ran once at mount with `isBifrostEnabled === undefined`, so `inventoryHasBootcImages()` was never called and `hasBootcImages` stayed `false` - the toggle never appeared.

- Bug: Global tag filter reappearing on navigation

`InventoryViews` used `useLayoutEffect` with `[chrome]` dependency. Any chrome reference change triggered cleanup (`hideGlobalFilter(false)`) followed by re-run (`hideGlobalFilter(true)`), causing the filter to flash visible. 

## How
- Feature flag removal (`hbi.ui.bifrost`) - the feature has been fully released to all users in production for ~2 years.
- Changed to `useEffect with [chrome] ` without cleanup (`hideGlobalFilter(false)`) 

## Testing
- Global tag filter is hidden on systems page when `SystemsView`/`InventoryViews`
- `ImageToggle` is always present when account has image based systems