### PR TITLE
test: fix E2E RBAC tests

### DIFF
--- a/_playwright-tests/rbac/constants.ts
+++ b/_playwright-tests/rbac/constants.ts
@@ -6,3 +6,4 @@ export const GRANULAR_WORKPSACE_RW = 'RBAC_testing_read';
 export const NO_ACCESS_INVENTORY =
   'This application requires Inventory permissions';
 export const NO_ACCESS_STALENESS = 'Access permissions needed';
+export const NO_ACCESS_WORKPSACES = 'Workspace access permissions needed';

--- a/_playwright-tests/rbac/constants.ts
+++ b/_playwright-tests/rbac/constants.ts
@@ -6,4 +6,4 @@ export const GRANULAR_WORKPSACE_RW = 'RBAC_testing_read';
 export const NO_ACCESS_INVENTORY =
   'This application requires Inventory permissions';
 export const NO_ACCESS_STALENESS = 'Access permissions needed';
-export const NO_ACCESS_WORKPSACES = 'Workspace access permissions needed';
+export const NO_ACCESS_WORKSPACES = 'Workspace access permissions needed';

--- a/_playwright-tests/rbac/test_granular_access.test.ts
+++ b/_playwright-tests/rbac/test_granular_access.test.ts
@@ -86,9 +86,7 @@ test.describe('Granular access:', { tag: ['@rbac'] }, () => {
         .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')
         .or(page.locator('td[data-label="Name"]'));
       await expect(rows.first()).toBeVisible({ timeout: 20000 });
-      // Currenlty default workspace is displayed as well,
-      // so we expect 3 rows in total (2 workspaces + default workspace)
-      await expect(rows).toHaveCount(3);
+      await expect(rows).toHaveCount(2);
     });
   });
 

--- a/_playwright-tests/rbac/test_no_access.test.ts
+++ b/_playwright-tests/rbac/test_no_access.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import {
   NO_ACCESS_STALENESS,
   NO_ACCESS_INVENTORY,
-  NO_ACCESS_WORKPSACES,
+  NO_ACCESS_WORKSPACES,
 } from './constants';
 
 test.use({ storageState: '.auth/no_access_user.json' });
@@ -28,7 +28,7 @@ test.describe('No access:', { tag: ['@rbac'] }, () => {
     await expect(emptyState).toBeVisible({ timeout: 100000 });
 
     const heading = page.getByRole('heading', { level: 5 }).first();
-    await expect(heading).toContainText(NO_ACCESS_WORKPSACES);
+    await expect(heading).toContainText(NO_ACCESS_WORKSPACES);
   });
 
   test('Staleness and Deletion page - no access is displayed', async ({

--- a/_playwright-tests/rbac/test_no_access.test.ts
+++ b/_playwright-tests/rbac/test_no_access.test.ts
@@ -1,6 +1,10 @@
 import { test } from '../helpers/fixtures';
 import { expect } from '@playwright/test';
-import { NO_ACCESS_STALENESS, NO_ACCESS_INVENTORY } from './constants';
+import {
+  NO_ACCESS_STALENESS,
+  NO_ACCESS_INVENTORY,
+  NO_ACCESS_WORKPSACES,
+} from './constants';
 
 test.use({ storageState: '.auth/no_access_user.json' });
 
@@ -20,13 +24,11 @@ test.describe('No access:', { tag: ['@rbac'] }, () => {
   test('Workspaces page - no access is displayed', async ({ page }) => {
     await page.goto('/insights/inventory/workspaces', { timeout: 100000 });
 
-    const createButton = page.locator(
-      '[data-ouia-component-id="CreateGroupButton"]',
-    );
-    await expect(createButton).toBeVisible({ timeout: 100000 });
+    const emptyState = page.locator('.pf-v6-c-empty-state');
+    await expect(emptyState).toBeVisible({ timeout: 100000 });
 
-    const heading = page.getByRole('heading', { level: 4 }).first();
-    await expect(heading).toContainText('No workspaces');
+    const heading = page.getByRole('heading', { level: 5 }).first();
+    await expect(heading).toContainText(NO_ACCESS_WORKPSACES);
   });
 
   test('Staleness and Deletion page - no access is displayed', async ({

--- a/_playwright-tests/rbac/test_viewer_role_access.test.ts
+++ b/_playwright-tests/rbac/test_viewer_role_access.test.ts
@@ -73,19 +73,20 @@ test.describe('Viewer:', { tag: ['@rbac'] }, () => {
     });
   });
 
-  test('Staleness and Deletion page - all actions are disabled', async ({
-    page,
-  }) => {
-    // Staleness checks use the Root workspace under Kessel; stage policy for the
-    // viewer test user may not grant those relations yet (RHINENG-25942).
-    await installKesselStalenessViewOnly(page);
-    try {
-      await navigateToStalenessPageFunc(page);
+  test.fixme(
+    'Staleness and Deletion page - all actions are disabled',
+    async ({ page }) => {
+      // Staleness checks use the Root workspace under Kessel; stage policy for the
+      // viewer test user may not grant those relations yet (RHINENG-25942).
+      await installKesselStalenessViewOnly(page);
+      try {
+        await navigateToStalenessPageFunc(page);
 
-      const editButton = page.getByRole('button', { name: 'Edit' });
-      await expect(editButton).toBeDisabled();
-    } finally {
-      await uninstallKesselCheckSelfBulkMock(page);
-    }
-  });
+        const editButton = page.getByRole('button', { name: 'Edit' });
+        await expect(editButton).toBeDisabled();
+      } finally {
+        await uninstallKesselCheckSelfBulkMock(page);
+      }
+    },
+  );
 });


### PR DESCRIPTION
## What
Update the RBAC tests. 

## Why
Changes in  Kessel RBAC backend

## Summary by Sourcery

Update RBAC-related E2E Playwright tests to align with recent Kessel RBAC backend and workspace behavior changes.

Tests:
- Mark the viewer staleness and deletion RBAC test as pending using Playwright's fixme to avoid flaky behavior under current Kessel policies.
- Adjust the no-access workspace test to assert the new empty state UI and workspace-specific no-access messaging.
- Update granular access workspace expectations to reflect the new number of visible workspace rows.