### PR TITLE
refactor(RHINENG-28478): InventoryViews update all inventory columns to use CellValue handling defaults uniformly

### DIFF
--- a/_playwright-tests/helpers/columnHelpers.ts
+++ b/_playwright-tests/helpers/columnHelpers.ts
@@ -153,13 +153,43 @@ export async function scrollColumnIntoView(element: Locator) {
     const scrollContainer = document.querySelector(
       '.ins-c-systems-view-table-scroll',
     );
-    if (cell && scrollContainer) {
-      const cellRect = cell.getBoundingClientRect();
-      const containerRect = scrollContainer.getBoundingClientRect();
-      const scrollNeeded = cellRect.right - containerRect.right + 100;
-      if (scrollNeeded > 0) {
-        scrollContainer.scrollLeft += scrollNeeded;
-      }
+    if (!cell || !scrollContainer) return;
+
+    const containerRect = scrollContainer.getBoundingClientRect();
+
+    // Effective left boundary: right edge of the sticky-left border column (Name column).
+    // Without this, scrolling right can push the target cell behind the sticky Name column.
+    const stickyLeftCell = scrollContainer.querySelector(
+      '.pf-v6-c-table__sticky-cell.pf-m-border-right',
+    );
+    const leftBound = stickyLeftCell
+      ? stickyLeftCell.getBoundingClientRect().right
+      : containerRect.left;
+
+    // Effective right boundary: left edge of the sticky-right action column.
+    const stickyRightCell = scrollContainer.querySelector(
+      '.pf-v6-c-table__action.pf-v6-c-table__sticky-cell',
+    );
+    const rightBound = stickyRightCell
+      ? stickyRightCell.getBoundingClientRect().left
+      : containerRect.right;
+
+    const MARGIN = 20;
+
+    // Step 1: scroll right if cell's right edge overflows the effective right boundary.
+    const rightOverflow =
+      cell.getBoundingClientRect().right - rightBound + MARGIN;
+    if (rightOverflow > 0) {
+      scrollContainer.scrollLeft += rightOverflow;
+    }
+
+    // Step 2: after the potential right-scroll, check if the cell's left edge is still
+    // hidden behind the sticky left column. getBoundingClientRect() forces a reflow so
+    // the value reflects the updated scrollLeft.
+    const leftUnderflow =
+      leftBound - cell.getBoundingClientRect().left + MARGIN;
+    if (leftUnderflow > 0) {
+      scrollContainer.scrollLeft -= leftUnderflow;
     }
   });
 }

--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -135,9 +135,13 @@ test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
     expect(await filterChipGroup.count()).toBeGreaterThanOrEqual(1);
 
     // OS version should contain expected major version of OS
-    const columnVersionOS = page.locator(
-      'span[aria-label="Formatted OS version"]',
-    );
+    const columnVersionOS = page
+      .locator('td[data-label="OS"]')
+      .or(
+        page.locator(
+          'td[data-ouia-component-id^="systems-view-table-td-"][data-ouia-component-id$="-3"]',
+        ),
+      );
     await assertAllContain(columnVersionOS, pattern);
   });
 
@@ -163,9 +167,10 @@ test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
         const columnVersionOS = page
           .locator('td[data-label="OS"]', { hasText: testData.OS })
           .or(
-            page.locator('span[aria-label="Formatted OS version"]', {
-              hasText: testData.OS,
-            }),
+            page.locator(
+              'td[data-ouia-component-id^="systems-view-table-td-"][data-ouia-component-id$="-3"]',
+              { hasText: testData.OS },
+            ),
           );
         await expect(columnVersionOS.first()).toBeVisible();
         const count = await columnVersionOS.count();

--- a/src/components/SystemsView/columns/CellValue.tsx
+++ b/src/components/SystemsView/columns/CellValue.tsx
@@ -16,7 +16,7 @@ type PresentCellValueProps = {
 type NotSetCellValueProps = {
   type: 'notSet';
   /** Visible placeholder No __ */
-  value: string;
+  value: React.ReactNode;
 };
 
 /** Column applies, but data is missing for this system. */

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -60,7 +60,10 @@ const allColumns = [
   ...vulnerabilityColumns,
   ...malwareColumns,
   ...complianceColumns,
-  ...remediationsColumns,
+  /* 
+    Disabled remediantionsColumns on 6.7.2026 as they're on hold 
+  */
+  // ...remediationsColumns,
 ] as const satisfies readonly Column[];
 
 export default allColumns;

--- a/src/components/SystemsView/columns/inventory/cells/Created.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Created.test.tsx
@@ -1,0 +1,36 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Created from './Created';
+import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
+import { NOT_AVAILABLE } from '../../CellValue';
+
+function renderCreated(value: string | null | undefined) {
+  return render(
+    <TestWrapper>
+      <Created value={value} />
+    </TestWrapper>,
+  );
+}
+
+const LONG_AGO_CREATED = '2020-01-01T00:00:00.000Z';
+
+describe('Created cell', () => {
+  it(`should show ${NOT_AVAILABLE} when value is undefined`, () => {
+    renderCreated(undefined);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
+
+  it(`should show ${NOT_AVAILABLE} when value is null`, () => {
+    renderCreated(null);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
+
+  it('should render a relative date when value is set', () => {
+    renderCreated(LONG_AGO_CREATED);
+
+    expect(screen.getAllByText(/\d+ years ago/).length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/Created.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Created.test.tsx
@@ -5,7 +5,7 @@ import Created from './Created';
 import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
 import { NOT_AVAILABLE } from '../../CellValue';
 
-function renderCreated(value: string | null | undefined) {
+function renderCreated(value: string | undefined) {
   return render(
     <TestWrapper>
       <Created value={value} />
@@ -18,12 +18,6 @@ const LONG_AGO_CREATED = '2020-01-01T00:00:00.000Z';
 describe('Created cell', () => {
   it(`should show ${NOT_AVAILABLE} when value is undefined`, () => {
     renderCreated(undefined);
-
-    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
-  });
-
-  it(`should show ${NOT_AVAILABLE} when value is null`, () => {
-    renderCreated(null);
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
   });

--- a/src/components/SystemsView/columns/inventory/cells/Created.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Created.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import CellValue from '../../CellValue';
+import { System } from '../../../hooks/useSystemsQuery';
 
 interface CreatedProps {
-  value: string | null | undefined;
+  value: System['created'];
 }
 
 const Created = ({ value }: CreatedProps) => {
-  if (value === null || value === undefined) {
+  if (value === undefined) {
     return (
       <CellValue
         type="notAvailable"

--- a/src/components/SystemsView/columns/inventory/cells/Created.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Created.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import CellValue from '../../CellValue';
+
+interface CreatedProps {
+  value: string | null | undefined;
+}
+
+const Created = ({ value }: CreatedProps) => {
+  if (value === null || value === undefined) {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Created date is not available for this system"
+      />
+    );
+  }
+
+  return <CellValue type="present" value={<DateFormat date={value} />} />;
+};
+
+export default Created;

--- a/src/components/SystemsView/columns/inventory/cells/DisplayName.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/DisplayName.test.tsx
@@ -3,9 +3,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import DisplayName from './DisplayName';
+import DisplayName, { type DisplayNameValue } from './DisplayName';
+import { NOT_AVAILABLE } from '../../CellValue';
 import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
-import type { System } from '../../../hooks/useSystemsQuery';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 
 jest.mock(
@@ -23,7 +23,7 @@ const packageBasedSystem = {
   id: TEST_SYSTEM_ID,
   display_name: TEST_DISPLAY_NAME,
   system_profile: {},
-} as System;
+} satisfies DisplayNameValue;
 
 const imageBasedSystemBootcDigest = {
   id: TEST_SYSTEM_ID,
@@ -33,7 +33,7 @@ const imageBasedSystemBootcDigest = {
       booted: { image_digest: 'sha256:abc123' },
     },
   },
-} as System;
+} satisfies DisplayNameValue;
 
 const imageBasedSystemEdge = {
   id: TEST_SYSTEM_ID,
@@ -41,15 +41,15 @@ const imageBasedSystemEdge = {
   system_profile: {
     host_type: 'edge',
   },
-} as System;
+} satisfies DisplayNameValue;
 
 const centosSystem = {
   id: TEST_SYSTEM_ID,
   display_name: TEST_DISPLAY_NAME,
   system_profile: {
-    operating_system: { name: 'CentOS Linux' },
+    operating_system: { name: 'CentOS Linux', major: 7, minor: 4 },
   },
-} as System;
+} satisfies DisplayNameValue;
 
 function LocationProbe() {
   const { pathname } = useLocation();
@@ -64,7 +64,7 @@ describe('DisplayName cell', () => {
   it('should show the display name link', () => {
     render(
       <TestWrapper>
-        <DisplayName system={packageBasedSystem} />
+        <DisplayName value={packageBasedSystem} />
       </TestWrapper>,
     );
 
@@ -76,7 +76,7 @@ describe('DisplayName cell', () => {
   it('should show the package-based system icon', () => {
     render(
       <TestWrapper>
-        <DisplayName system={packageBasedSystem} />
+        <DisplayName value={packageBasedSystem} />
       </TestWrapper>,
     );
 
@@ -87,7 +87,7 @@ describe('DisplayName cell', () => {
   it('should show the image-based system icon when booted with a bootc image digest', () => {
     render(
       <TestWrapper>
-        <DisplayName system={imageBasedSystemBootcDigest} />
+        <DisplayName value={imageBasedSystemBootcDigest} />
       </TestWrapper>,
     );
 
@@ -100,7 +100,7 @@ describe('DisplayName cell', () => {
   it('should show the image-based system icon when host type is edge', () => {
     render(
       <TestWrapper>
-        <DisplayName system={imageBasedSystemEdge} />
+        <DisplayName value={imageBasedSystemEdge} />
       </TestWrapper>,
     );
 
@@ -113,7 +113,7 @@ describe('DisplayName cell', () => {
   it('should show ConversionPopover when operating system is CentOS Linux', () => {
     render(
       <TestWrapper>
-        <DisplayName system={centosSystem} />
+        <DisplayName value={centosSystem} />
       </TestWrapper>,
     );
 
@@ -126,7 +126,7 @@ describe('DisplayName cell', () => {
     render(
       <TestWrapper>
         <>
-          <DisplayName system={packageBasedSystem} />
+          <DisplayName value={packageBasedSystem} />
           <LocationProbe />
         </>
       </TestWrapper>,
@@ -139,5 +139,54 @@ describe('DisplayName cell', () => {
     expect(screen.getByTestId('current-pathname')).toHaveTextContent(
       `/${TEST_SYSTEM_ID}`,
     );
+  });
+
+  it(`should show ${NOT_AVAILABLE} when display name is missing`, () => {
+    const { rerender } = render(
+      <TestWrapper>
+        <DisplayName
+          value={{
+            id: TEST_SYSTEM_ID,
+            system_profile: {},
+          }}
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+
+    rerender(
+      <TestWrapper>
+        <DisplayName
+          value={
+            {
+              id: TEST_SYSTEM_ID,
+              display_name: null,
+              system_profile: {},
+            } as unknown as DisplayNameValue
+          }
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
+
+  it('should show display name as text when id is missing', () => {
+    render(
+      <TestWrapper>
+        <DisplayName
+          value={{
+            display_name: TEST_DISPLAY_NAME,
+            system_profile: {},
+          }}
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText(TEST_DISPLAY_NAME)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: TEST_DISPLAY_NAME }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/SystemsView/columns/inventory/cells/DisplayName.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/DisplayName.tsx
@@ -1,29 +1,53 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { ConversionPopover } from '../../../../InventoryTable/ConversionPopover/ConversionPopover';
 import { Flex, FlexItem, Icon, Popover } from '@patternfly/react-core';
 import { BundleIcon } from '@patternfly/react-icons';
 import FontAwesomeImageIcon from '../../../../FontAwesomeImageIcon';
+import CellValue from '../../CellValue';
 import type { System } from '../../../hooks/useSystemsQuery';
 
-const isImageBasedSystem = (system: System) =>
-  system?.system_profile?.bootc_status?.booted?.image_digest ||
-  system?.system_profile?.host_type === 'edge';
+export type DisplayNameValue = Pick<
+  System,
+  'id' | 'display_name' | 'system_profile'
+>;
 
-const isCentosLinuxSystem = (system: System) =>
-  system?.system_profile?.operating_system?.name === 'CentOS Linux';
+const isImageBasedSystem = (value: DisplayNameValue) =>
+  value.system_profile?.bootc_status?.booted?.image_digest ||
+  value.system_profile?.host_type === 'edge';
+
+const isCentosLinuxSystem = (value: DisplayNameValue) =>
+  value.system_profile?.operating_system?.name === 'CentOS Linux';
 
 interface DisplayNameProps {
-  system: System;
+  value: DisplayNameValue;
 }
 
-const DisplayName = ({ system }: DisplayNameProps) => {
-  return (
+const DisplayName = ({ value }: DisplayNameProps) => {
+  if (value.display_name === null || value.display_name === undefined) {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Display name data is not available for this system"
+      />
+    );
+  }
+
+  const displayNameContent =
+    value.id !== null && value.id !== undefined ? (
+      <InsightsLink app="inventory" to={value.id} preview={false}>
+        {value.display_name}
+      </InsightsLink>
+    ) : (
+      value.display_name
+    );
+
+  const displayNameValue = (
     <div className="ins-composed-col sentry-mask data-hj-suppress">
       <div key="data">
         <Flex gap={{ default: 'gapSm' }}>
           <FlexItem>
-            {isImageBasedSystem(system) ? (
+            {isImageBasedSystem(value) ? (
               <Popover
                 triggerAction="hover"
                 headerContent="Image-based system"
@@ -63,16 +87,16 @@ const DisplayName = ({ system }: DisplayNameProps) => {
               </Popover>
             )}
           </FlexItem>
+          <FlexItem>{displayNameContent}</FlexItem>
           <FlexItem>
-            <Link to={system.id || ''}>{system.display_name}</Link>
-          </FlexItem>
-          <FlexItem>
-            {isCentosLinuxSystem(system) && <ConversionPopover />}
+            {isCentosLinuxSystem(value) && <ConversionPopover />}
           </FlexItem>
         </Flex>
       </div>
     </div>
   );
+
+  return <CellValue type="present" value={displayNameValue} />;
 };
 
 export default DisplayName;

--- a/src/components/SystemsView/columns/inventory/cells/Infrastructure.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Infrastructure.test.tsx
@@ -16,10 +16,6 @@ describe('Infrastructure cell', () => {
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
 
-    rerender(<Infrastructure value={null} />);
-
-    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
-
     rerender(<Infrastructure value="" />);
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();

--- a/src/components/SystemsView/columns/inventory/cells/Infrastructure.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Infrastructure.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Infrastructure from './Infrastructure';
+import { NOT_AVAILABLE } from '../../CellValue';
+
+describe('Infrastructure cell', () => {
+  it('should show the infrastructure type when value is present', () => {
+    render(<Infrastructure value="virtual" />);
+
+    expect(screen.getByText('virtual')).toBeInTheDocument();
+  });
+
+  it(`should show ${NOT_AVAILABLE} when value is missing`, () => {
+    const { rerender } = render(<Infrastructure value={undefined} />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+
+    rerender(<Infrastructure value={null} />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+
+    rerender(<Infrastructure value="" />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/Infrastructure.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Infrastructure.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import CellValue from '../../CellValue';
+
+interface InfrastructureProps {
+  value: string | null | undefined;
+}
+
+const Infrastructure = ({ value }: InfrastructureProps) => {
+  if (value == null || value === '') {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Infrastructure data is not available for this system"
+      />
+    );
+  }
+
+  return <CellValue type="present" value={value} />;
+};
+
+export default Infrastructure;

--- a/src/components/SystemsView/columns/inventory/cells/Infrastructure.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Infrastructure.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import CellValue from '../../CellValue';
 
+type TemporaryInfrastructureValue = string | undefined;
+
 interface InfrastructureProps {
-  value: string | null | undefined;
+  value: TemporaryInfrastructureValue;
 }
 
 const Infrastructure = ({ value }: InfrastructureProps) => {
-  if (value == null || value === '') {
+  if (value === undefined || value === '') {
     return (
       <CellValue
         type="notAvailable"

--- a/src/components/SystemsView/columns/inventory/cells/LastSeen.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/LastSeen.test.tsx
@@ -1,72 +1,52 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import LastSeen from './LastSeen';
+import LastSeen, { type LastSeenValue } from './LastSeen';
 import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
-import type { System } from '../../../hooks/useSystemsQuery';
+import { NOT_AVAILABLE } from '../../CellValue';
 
 const LONG_AGO_LAST_SEEN = '2020-01-01T00:00:00.000Z';
 
-const SYSTEM_ID = 'test-system-id';
+function renderLastSeen(value: LastSeenValue) {
+  return render(
+    <TestWrapper>
+      <LastSeen value={value} />
+    </TestWrapper>,
+  );
+}
 
-const systemWithLongAgoLastCheckIn = {
-  id: SYSTEM_ID,
+const lastSeenValue: LastSeenValue = {
   last_check_in: LONG_AGO_LAST_SEEN,
-} as unknown as System;
-
-const systemWithUndefinedLastCheckIn = {
-  id: SYSTEM_ID,
-  last_check_in: undefined,
-} as unknown as System;
-
-const systemWithNullLastCheckIn = {
-  id: SYSTEM_ID,
-  last_check_in: null,
-} as unknown as System;
-
-const systemWithEmptyPerReporterStaleness = {
-  id: SYSTEM_ID,
-  last_check_in: LONG_AGO_LAST_SEEN,
-  per_reporter_staleness: {},
-} as unknown as System;
+  culled_timestamp: undefined,
+  stale_warning_timestamp: undefined,
+  stale_timestamp: undefined,
+  per_reporter_staleness: undefined,
+};
 
 describe('LastSeen cell', () => {
   it('should render a relative last seen label for last_check_in', () => {
-    render(
-      <TestWrapper>
-        <LastSeen system={systemWithLongAgoLastCheckIn} />
-      </TestWrapper>,
-    );
+    renderLastSeen(lastSeenValue);
 
     expect(screen.getAllByText(/\d+ years ago/).length).toBeGreaterThan(0);
   });
 
-  it('should show Invalid date when last_check_in is undefined', () => {
-    render(
-      <TestWrapper>
-        <LastSeen system={systemWithUndefinedLastCheckIn} />
-      </TestWrapper>,
-    );
+  it(`should show ${NOT_AVAILABLE} when last_check_in is undefined`, () => {
+    renderLastSeen({ ...lastSeenValue, last_check_in: undefined });
 
-    expect(screen.getAllByText('Invalid date').length).toBeGreaterThan(0);
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
   });
 
-  it('should show Invalid date when last_check_in is null', () => {
-    render(
-      <TestWrapper>
-        <LastSeen system={systemWithNullLastCheckIn} />
-      </TestWrapper>,
-    );
+  it(`should show ${NOT_AVAILABLE} when last_check_in is null`, () => {
+    renderLastSeen({ ...lastSeenValue, last_check_in: null });
 
-    expect(screen.getAllByText('Invalid date').length).toBeGreaterThan(0);
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
   });
 
   it('should show the disconnected indicator when puptoo is missing from per_reporter_staleness', () => {
-    render(
-      <TestWrapper>
-        <LastSeen system={systemWithEmptyPerReporterStaleness} />
-      </TestWrapper>,
-    );
+    renderLastSeen({
+      ...lastSeenValue,
+      per_reporter_staleness: {},
+    });
 
     expect(
       screen.getByLabelText(/disconnected indicator/i),

--- a/src/components/SystemsView/columns/inventory/cells/LastSeen.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/LastSeen.test.tsx
@@ -36,12 +36,6 @@ describe('LastSeen cell', () => {
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
   });
 
-  it(`should show ${NOT_AVAILABLE} when last_check_in is null`, () => {
-    renderLastSeen({ ...lastSeenValue, last_check_in: null });
-
-    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
-  });
-
   it('should show the disconnected indicator when puptoo is missing from per_reporter_staleness', () => {
     renderLastSeen({
       ...lastSeenValue,

--- a/src/components/SystemsView/columns/inventory/cells/LastSeen.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/LastSeen.tsx
@@ -4,27 +4,46 @@ import { DateFormat } from '@redhat-cloud-services/frontend-components/DateForma
 import { verifyCulledReporter } from '../../../../../Utilities/sharedFunctions';
 import InsightsDisconnected from '../../../../../Utilities/InsightsDisconnected';
 import { REPORTER_PUPTOO } from '../../../../../Utilities/constants';
+import CellValue from '../../CellValue';
 import { System } from '../../../hooks/useSystemsQuery';
 
 type CullingDate = string | number | Date;
 
 const DEFAULT_CULLING_DATE: CullingDate = new Date(0);
 
+export type LastSeenValue = Pick<
+  System,
+  | 'culled_timestamp'
+  | 'stale_warning_timestamp'
+  | 'stale_timestamp'
+  | 'per_reporter_staleness'
+> & {
+  last_check_in?: string | null;
+};
+
 interface LastSeenProps {
-  system: System;
+  value: LastSeenValue;
 }
 
-const LastSeen = ({ system }: LastSeenProps) => {
-  const updated = system.last_check_in;
-  const culled = system.culled_timestamp;
-  const staleWarn = system.stale_warning_timestamp;
-  const stale = system.stale_timestamp;
-  const perReporterStaleness = system.per_reporter_staleness;
+const LastSeen = ({ value }: LastSeenProps) => {
+  const {
+    last_check_in: updated,
+    culled_timestamp: culled,
+    stale_warning_timestamp: staleWarn,
+    stale_timestamp: stale,
+    per_reporter_staleness: perReporterStaleness,
+  } = value;
 
-  const displayDate: string | number | Date =
-    updated === undefined || updated === null ? '' : updated;
+  if (updated === undefined || updated === null) {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Last seen date is not available for this system"
+      />
+    );
+  }
 
-  return (
+  const presentValue = (
     <CullingInformation
       className=""
       content=""
@@ -35,7 +54,7 @@ const LastSeen = ({ system }: LastSeenProps) => {
       render={({ msg }) => (
         <React.Fragment>
           <DateFormat
-            date={displayDate}
+            date={updated}
             extraTitle={
               <React.Fragment>
                 <div>{msg}</div>
@@ -50,10 +69,12 @@ const LastSeen = ({ system }: LastSeenProps) => {
       )}
     >
       <span>
-        <DateFormat date={displayDate} />
+        <DateFormat date={updated} />
       </span>
     </CullingInformation>
   );
+
+  return <CellValue type="present" value={presentValue} />;
 };
 
 export default LastSeen;

--- a/src/components/SystemsView/columns/inventory/cells/LastSeen.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/LastSeen.tsx
@@ -17,10 +17,8 @@ export type LastSeenValue = Pick<
   | 'stale_warning_timestamp'
   | 'stale_timestamp'
   | 'per_reporter_staleness'
-> & {
-  last_check_in?: string | null;
-};
-
+  | 'last_check_in'
+>;
 interface LastSeenProps {
   value: LastSeenValue;
 }

--- a/src/components/SystemsView/columns/inventory/cells/OperatingSystem.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/OperatingSystem.test.tsx
@@ -43,11 +43,7 @@ describe('OperatingSystem cell', () => {
   });
 
   it(`should show ${NOT_AVAILABLE} when operating system data is missing`, () => {
-    const { rerender } = render(<OperatingSystem value={undefined} />);
-
-    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
-
-    rerender(<OperatingSystem value={{ name: null } as never} />);
+    render(<OperatingSystem value={undefined} />);
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
   });

--- a/src/components/SystemsView/columns/inventory/cells/OperatingSystem.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/OperatingSystem.test.tsx
@@ -1,72 +1,54 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import type { SystemProfileOperatingSystem } from '@redhat-cloud-services/host-inventory-client';
 import OperatingSystem from './OperatingSystem';
-import type { System } from '../../../hooks/useSystemsQuery';
+import { NOT_AVAILABLE } from '../../CellValue';
 
-const SYSTEM_ID = 'test-system-id';
+const rhelOs: SystemProfileOperatingSystem = {
+  name: 'RHEL',
+  major: 8,
+  minor: 10,
+};
 
-const systemWithRhelOs = {
-  id: SYSTEM_ID,
-  system_profile: {
-    operating_system: {
-      name: 'RHEL',
-      major: 8,
-      minor: 10,
-    },
-  },
-} as unknown as System;
-
-const systemWithCentosOs = {
-  id: SYSTEM_ID,
-  system_profile: {
-    operating_system: {
-      name: 'CentOS Linux',
-      major: 7,
-      minor: 4,
-    },
-  },
-} as unknown as System;
-
-const systemWithoutProfile = {
-  id: SYSTEM_ID,
-} as unknown as System;
-
-const systemWithProfileButNoOs = {
-  id: SYSTEM_ID,
-  system_profile: {},
-} as unknown as System;
+const centosOs: SystemProfileOperatingSystem = {
+  name: 'CentOS Linux',
+  major: 7,
+  minor: 4,
+};
 
 describe('OperatingSystem cell', () => {
-  it('should show OS version from system_profile.operating_system', () => {
-    render(<OperatingSystem system={systemWithRhelOs} />);
+  it('should show OS version for RHEL', () => {
+    render(<OperatingSystem value={rhelOs} />);
 
-    expect(screen.getByLabelText('Formatted OS version')).toHaveTextContent(
-      'RHEL 8.10',
-    );
+    expect(screen.getByText('RHEL 8.10')).toBeInTheDocument();
   });
 
-  it('should show CentOS Linux OS version from system_profile.operating_system', () => {
-    render(<OperatingSystem system={systemWithCentosOs} />);
+  it('should show OS version for CentOS Linux', () => {
+    render(<OperatingSystem value={centosOs} />);
 
-    expect(screen.getByLabelText('Formatted OS version')).toHaveTextContent(
-      'CentOS Linux 7.4',
-    );
+    expect(screen.getByText('CentOS Linux 7.4')).toBeInTheDocument();
   });
 
-  it('should show Not available when operating system data is missing', () => {
-    const { rerender } = render(
-      <OperatingSystem system={systemWithoutProfile} />,
-    );
+  it('should show OS name without version for other operating systems', () => {
+    const centosStream = {
+      name: 'CentOS Stream',
+      major: 7,
+      minor: 4,
+    } as unknown as SystemProfileOperatingSystem;
 
-    expect(screen.getByLabelText('Formatted OS version')).toHaveTextContent(
-      'Not available',
-    );
+    render(<OperatingSystem value={centosStream} />);
 
-    rerender(<OperatingSystem system={systemWithProfileButNoOs} />);
+    expect(screen.getByText('CentOS Stream')).toBeInTheDocument();
+  });
 
-    expect(screen.getByLabelText('Formatted OS version')).toHaveTextContent(
-      'Not available',
-    );
+  it(`should show ${NOT_AVAILABLE} when operating system data is missing`, () => {
+    const { rerender } = render(<OperatingSystem value={undefined} />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+
+    rerender(<OperatingSystem value={{ name: null } as never} />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
   });
 });

--- a/src/components/SystemsView/columns/inventory/cells/OperatingSystem.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/OperatingSystem.tsx
@@ -1,15 +1,38 @@
 import React from 'react';
-import OperatingSystemFormatter from '../../../../../Utilities/OperatingSystemFormatter';
-import { System } from '../../../hooks/useSystemsQuery';
+import type { SystemProfileOperatingSystem } from '@redhat-cloud-services/host-inventory-client';
+import CellValue from '../../CellValue';
 
 interface OperatingSystemProps {
-  system: System;
+  value: SystemProfileOperatingSystem | undefined;
 }
 
-const OperatingSystem = ({ system }: OperatingSystemProps) => (
-  <OperatingSystemFormatter
-    operatingSystem={system.system_profile?.operating_system}
-  />
-);
+const formatOperatingSystem = (
+  operatingSystem: SystemProfileOperatingSystem,
+): string => {
+  if (
+    operatingSystem.name === 'RHEL' ||
+    operatingSystem.name === 'CentOS Linux'
+  ) {
+    const { name, major, minor } = operatingSystem;
+    const hasVersion = typeof major === 'number' && typeof minor === 'number';
+
+    return hasVersion ? `${name} ${major}.${minor}` : name;
+  }
+
+  return operatingSystem.name;
+};
+
+const OperatingSystem = ({ value }: OperatingSystemProps) => {
+  if (value == null || value.name == null) {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Operating system data is not available for this system"
+      />
+    );
+  }
+
+  return <CellValue type="present" value={formatOperatingSystem(value)} />;
+};
 
 export default OperatingSystem;

--- a/src/components/SystemsView/columns/inventory/cells/OperatingSystem.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/OperatingSystem.tsx
@@ -23,7 +23,7 @@ const formatOperatingSystem = (
 };
 
 const OperatingSystem = ({ value }: OperatingSystemProps) => {
-  if (value == null || value.name == null) {
+  if (value === undefined) {
     return (
       <CellValue
         type="notAvailable"

--- a/src/components/SystemsView/columns/inventory/cells/OperatingSystem.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/OperatingSystem.tsx
@@ -32,7 +32,16 @@ const OperatingSystem = ({ value }: OperatingSystemProps) => {
     );
   }
 
-  return <CellValue type="present" value={formatOperatingSystem(value)} />;
+  return (
+    <CellValue
+      type="present"
+      value={
+        <span aria-label="Formatted OS version">
+          {formatOperatingSystem(value)}
+        </span>
+      }
+    />
+  );
 };
 
 export default OperatingSystem;

--- a/src/components/SystemsView/columns/inventory/cells/Status.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Status.test.tsx
@@ -1,56 +1,66 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import Status, { getHostStalenessStatus } from './Status';
+import Status, {
+  getHostStalenessStatus,
+  type StatusTimestamps,
+} from './Status';
 import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
-import type { System } from '../../../hooks/useSystemsQuery';
 import { NOT_AVAILABLE } from '../../CellValue';
 
 const NOW = new Date('2024-06-15T12:00:00.000Z');
 
-const freshSystem = {
-  id: 'fresh-system',
+const freshValue: StatusTimestamps = {
   stale_timestamp: '2024-07-01T00:00:00.000Z',
   stale_warning_timestamp: '2024-08-01T00:00:00.000Z',
   culled_timestamp: '2024-09-01T00:00:00.000Z',
-} as System;
+};
 
-const staleSystem = {
-  id: 'stale-system',
+const staleValue: StatusTimestamps = {
   stale_timestamp: '2024-06-01T00:00:00.000Z',
   stale_warning_timestamp: '2024-07-01T00:00:00.000Z',
   culled_timestamp: '2024-08-01T00:00:00.000Z',
-} as System;
+};
 
-const staleWarningSystem = {
-  id: 'stale-warning-system',
+const staleWarningValue: StatusTimestamps = {
   stale_timestamp: '2024-05-01T00:00:00.000Z',
   stale_warning_timestamp: '2024-06-01T00:00:00.000Z',
   culled_timestamp: '2024-08-01T00:00:00.000Z',
-} as System;
+};
 
-const unknownSystem = {
-  id: 'unknown-system',
+const unknownValue: StatusTimestamps = {
   stale_timestamp: null,
-} as System;
+  stale_warning_timestamp: undefined,
+  culled_timestamp: undefined,
+};
+
+const culledValue: StatusTimestamps = {
+  stale_timestamp: '2024-01-01T00:00:00.000Z',
+  stale_warning_timestamp: '2024-02-01T00:00:00.000Z',
+  culled_timestamp: '2024-03-01T00:00:00.000Z',
+};
 
 describe('getHostStalenessStatus', () => {
   it('returns Fresh when the current time is before stale_timestamp', () => {
-    expect(getHostStalenessStatus(freshSystem, NOW)).toBe('Fresh');
+    expect(getHostStalenessStatus(freshValue, NOW)).toBe('Fresh');
   });
 
   it('returns Stale when the current time is past stale_timestamp but before stale_warning_timestamp', () => {
-    expect(getHostStalenessStatus(staleSystem, NOW)).toBe('Stale');
+    expect(getHostStalenessStatus(staleValue, NOW)).toBe('Stale');
   });
 
   it('returns Stale warning when the current time is past stale_warning_timestamp but before culled_timestamp', () => {
-    expect(getHostStalenessStatus(staleWarningSystem, NOW)).toBe(
+    expect(getHostStalenessStatus(staleWarningValue, NOW)).toBe(
       'Stale warning',
     );
   });
 
-  it(`returns ${NOT_AVAILABLE} when stale_timestamp is missing`, () => {
-    expect(getHostStalenessStatus(unknownSystem, NOW)).toBe(NOT_AVAILABLE);
+  it('returns null when stale_timestamp is missing', () => {
+    expect(getHostStalenessStatus(unknownValue, NOW)).toBeNull();
+  });
+
+  it('returns null when all staleness timestamps are in the past', () => {
+    expect(getHostStalenessStatus(culledValue, NOW)).toBeNull();
   });
 });
 
@@ -67,7 +77,7 @@ describe('Status cell', () => {
   it('renders plain Fresh text without an icon', () => {
     render(
       <TestWrapper>
-        <Status system={freshSystem} />
+        <Status value={freshValue} />
       </TestWrapper>,
     );
 
@@ -78,7 +88,7 @@ describe('Status cell', () => {
   it('renders Stale with a warning icon and warning text color', () => {
     render(
       <TestWrapper>
-        <Status system={staleSystem} />
+        <Status value={staleValue} />
       </TestWrapper>,
     );
 
@@ -91,7 +101,7 @@ describe('Status cell', () => {
   it('renders Stale warning with a danger icon and danger text color', () => {
     render(
       <TestWrapper>
-        <Status system={staleWarningSystem} />
+        <Status value={staleWarningValue} />
       </TestWrapper>,
     );
 
@@ -104,7 +114,7 @@ describe('Status cell', () => {
   it(`renders ${NOT_AVAILABLE} when staleness cannot be determined`, () => {
     render(
       <TestWrapper>
-        <Status system={unknownSystem} />
+        <Status value={unknownValue} />
       </TestWrapper>,
     );
 

--- a/src/components/SystemsView/columns/inventory/cells/Status.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Status.tsx
@@ -4,26 +4,24 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
-import { NOT_AVAILABLE } from '../../CellValue';
+import CellValue from '../../CellValue';
 import { System } from '../../../hooks/useSystemsQuery';
 
-export type HostStalenessStatus =
-  | 'Fresh'
-  | 'Stale'
-  | 'Stale warning'
-  | typeof NOT_AVAILABLE;
+export type HostStalenessStatus = 'Fresh' | 'Stale' | 'Stale warning';
+
+export type StatusTimestamps = Pick<
+  System,
+  'stale_timestamp' | 'stale_warning_timestamp' | 'culled_timestamp'
+>;
 
 export const getHostStalenessStatus = (
-  system: Pick<
-    System,
-    'stale_timestamp' | 'stale_warning_timestamp' | 'culled_timestamp'
-  >,
+  value: StatusTimestamps,
   now: Date = new Date(),
-): HostStalenessStatus => {
-  const { stale_timestamp, stale_warning_timestamp, culled_timestamp } = system;
+): HostStalenessStatus | null => {
+  const { stale_timestamp, stale_warning_timestamp, culled_timestamp } = value;
 
   if (!stale_timestamp) {
-    return NOT_AVAILABLE;
+    return null;
   }
 
   const nowMs = now.getTime();
@@ -51,43 +49,56 @@ export const getHostStalenessStatus = (
     return 'Stale warning';
   }
 
-  return NOT_AVAILABLE;
+  return null;
 };
 
 interface StatusProps {
-  system: System;
+  value: StatusTimestamps;
 }
 
-const Status = ({ system }: StatusProps) => {
-  const status = getHostStalenessStatus(system);
+const staleStatus = (
+  <span className="pf-v6-u-display-inline-flex pf-v6-u-align-items-center">
+    <Icon status="warning" className="pf-v6-u-mr-xs">
+      <ExclamationTriangleIcon />
+    </Icon>
+    <span className="pf-v6-u-text-color-status-warning pf-v6-u-font-weight-bold">
+      Stale
+    </span>
+  </span>
+);
+
+const staleWarningStatus = (
+  <span className="pf-v6-u-display-inline-flex pf-v6-u-align-items-center">
+    <Icon status="danger" className="pf-v6-u-mr-xs">
+      <ExclamationCircleIcon />
+    </Icon>
+    <span className="pf-v6-u-text-color-status-danger pf-v6-u-font-weight-bold">
+      Stale warning
+    </span>
+  </span>
+);
+
+const Status = ({ value }: StatusProps) => {
+  const status = getHostStalenessStatus(value);
+
+  if (status === null) {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Status data is not available for this system"
+      />
+    );
+  }
 
   if (status === 'Stale') {
-    return (
-      <span className="pf-v6-u-display-inline-flex pf-v6-u-align-items-center">
-        <Icon status="warning" className="pf-v6-u-mr-xs">
-          <ExclamationTriangleIcon />
-        </Icon>
-        <span className="pf-v6-u-text-color-status-warning pf-v6-u-font-weight-bold">
-          Stale
-        </span>
-      </span>
-    );
+    return <CellValue type="present" value={staleStatus} />;
   }
 
   if (status === 'Stale warning') {
-    return (
-      <span className="pf-v6-u-display-inline-flex pf-v6-u-align-items-center">
-        <Icon status="danger" className="pf-v6-u-mr-xs">
-          <ExclamationCircleIcon />
-        </Icon>
-        <span className="pf-v6-u-text-color-status-danger pf-v6-u-font-weight-bold">
-          Stale warning
-        </span>
-      </span>
-    );
+    return <CellValue type="present" value={staleWarningStatus} />;
   }
 
-  return status;
+  return <CellValue type="present" value="Fresh" />;
 };
 
 export default Status;

--- a/src/components/SystemsView/columns/inventory/cells/Tags.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Tags.test.tsx
@@ -2,9 +2,11 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import type { StructuredTag } from '@redhat-cloud-services/host-inventory-client';
 import Tags from './Tags';
 import { SystemActionModalsContext } from '../../../SystemActionModalsContext';
 import type { System } from '../../../hooks/useSystemsQuery';
+import { NOT_AVAILABLE } from '../../CellValue';
 
 const SYSTEM_ID = 'test-system-id';
 
@@ -18,10 +20,10 @@ const mockContextValue = {
   openTagsModal: mockOpenTagsModal,
 };
 
-function renderTags(system: System) {
+function renderTags(value: StructuredTag[] | undefined, system: System) {
   return render(
     <SystemActionModalsContext.Provider value={mockContextValue}>
-      <Tags system={system} />
+      <Tags value={value} system={system} />
     </SystemActionModalsContext.Provider>,
   );
 }
@@ -45,26 +47,22 @@ describe('Tags cell', () => {
     jest.clearAllMocks();
   });
 
-  it('should show tag count from system.tags length', () => {
-    renderTags(systemWithTags);
+  it('should show tag count from value length', () => {
+    renderTags(systemWithTags.tags, systemWithTags);
 
     expect(
       screen.getByRole('button', { name: /tag count/i }),
     ).toHaveTextContent('1');
   });
 
-  it('should show zero when tags are missing or empty', () => {
-    const { rerender } = renderTags(systemWithoutTags);
+  it(`should show ${NOT_AVAILABLE} when tag data is missing`, () => {
+    renderTags(undefined, systemWithoutTags);
 
-    expect(
-      screen.getByRole('button', { name: /tag count/i }),
-    ).toHaveTextContent('0');
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
 
-    rerender(
-      <SystemActionModalsContext.Provider value={mockContextValue}>
-        <Tags system={systemWithEmptyTags} />
-      </SystemActionModalsContext.Provider>,
-    );
+  it('should show zero when tags are empty', () => {
+    renderTags([], systemWithEmptyTags);
 
     expect(
       screen.getByRole('button', { name: /tag count/i }),
@@ -73,7 +71,7 @@ describe('Tags cell', () => {
 
   it('should call openTagsModal with the system when tag count is clicked', async () => {
     const user = userEvent.setup();
-    renderTags(systemWithTags);
+    renderTags(systemWithTags.tags, systemWithTags);
 
     await user.click(screen.getByRole('button', { name: /tag count/i }));
 

--- a/src/components/SystemsView/columns/inventory/cells/Tags.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Tags.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { TagCount } from '@redhat-cloud-services/frontend-components/TagCount';
-import type { StructuredTag } from '@redhat-cloud-services/host-inventory-client';
 import { useSystemActionModalsContext } from '../../../SystemActionModalsContext';
 import { System } from '../../../hooks/useSystemsQuery';
 import CellValue from '../../CellValue';
 
 interface TagsProps {
-  value: StructuredTag[] | undefined;
+  value: System['tags'];
   system: System;
 }
 

--- a/src/components/SystemsView/columns/inventory/cells/Tags.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Tags.tsx
@@ -1,18 +1,36 @@
 import React from 'react';
 import { TagCount } from '@redhat-cloud-services/frontend-components/TagCount';
+import type { StructuredTag } from '@redhat-cloud-services/host-inventory-client';
 import { useSystemActionModalsContext } from '../../../SystemActionModalsContext';
 import { System } from '../../../hooks/useSystemsQuery';
+import CellValue from '../../CellValue';
 
 interface TagsProps {
+  value: StructuredTag[] | undefined;
   system: System;
 }
-export const Tags = ({ system }: TagsProps) => {
+
+export const Tags = ({ value, system }: TagsProps) => {
   const { openTagsModal } = useSystemActionModalsContext();
 
+  if (value === undefined) {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Tag data is not available for this system"
+      />
+    );
+  }
+
   return (
-    <TagCount
-      count={system.tags?.length || 0}
-      onTagClick={() => openTagsModal([system])}
+    <CellValue
+      type="present"
+      value={
+        <TagCount
+          count={value.length}
+          onTagClick={() => openTagsModal([system])}
+        />
+      }
     />
   );
 };

--- a/src/components/SystemsView/columns/inventory/cells/Vendor.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Vendor.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Vendor from './Vendor';
+import { NOT_AVAILABLE } from '../../CellValue';
+
+describe('Vendor cell', () => {
+  it('should show the vendor when value is present', () => {
+    render(<Vendor value="qemu" />);
+
+    expect(screen.getByText('qemu')).toBeInTheDocument();
+  });
+
+  it(`should show ${NOT_AVAILABLE} when value is missing`, () => {
+    const { rerender } = render(<Vendor value={undefined} />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+
+    rerender(<Vendor value={null} />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+
+    rerender(<Vendor value="" />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/columns/inventory/cells/Vendor.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Vendor.test.tsx
@@ -16,10 +16,6 @@ describe('Vendor cell', () => {
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
 
-    rerender(<Vendor value={null} />);
-
-    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
-
     rerender(<Vendor value="" />);
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();

--- a/src/components/SystemsView/columns/inventory/cells/Vendor.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Vendor.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import CellValue from '../../CellValue';
+
+interface VendorProps {
+  value: string | null | undefined;
+}
+
+const Vendor = ({ value }: VendorProps) => {
+  if (value == null || value === '') {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Vendor data is not available for this system"
+      />
+    );
+  }
+
+  return <CellValue type="present" value={value} />;
+};
+
+export default Vendor;

--- a/src/components/SystemsView/columns/inventory/cells/Vendor.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Vendor.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import CellValue from '../../CellValue';
 
+type TemporaryVendorValue = string | undefined;
+
 interface VendorProps {
-  value: string | null | undefined;
+  value: TemporaryVendorValue;
 }
 
 const Vendor = ({ value }: VendorProps) => {
-  if (value == null || value === '') {
+  if (value === undefined || value === '') {
     return (
       <CellValue
         type="notAvailable"

--- a/src/components/SystemsView/columns/inventory/cells/Workload.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workload.test.tsx
@@ -1,47 +1,28 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import type { SystemProfileWorkloads } from '@redhat-cloud-services/host-inventory-client';
 import Workload from './Workload';
 import { NOT_AVAILABLE } from '../../CellValue';
-import type { InventoryViewSystem } from '../../../hooks/useInventoryViewsQuery';
 
-const SYSTEM_ID = 'test-system-id';
-
-const systemWithWorkloads = {
-  id: SYSTEM_ID,
-  system_profile: {
-    workloads: {
-      sap: { sids: ['PRD'] },
-      ansible: { controller_version: '4.0' },
-    },
-  },
-} as unknown as InventoryViewSystem;
-
-const systemWithEmptyWorkloads = {
-  id: SYSTEM_ID,
-  system_profile: {
-    workloads: {},
-  },
-} as unknown as InventoryViewSystem;
-
-const systemWithoutWorkloads = {
-  id: SYSTEM_ID,
-  system_profile: {},
-} as unknown as InventoryViewSystem;
+const workloadsWithValues: SystemProfileWorkloads = {
+  sap: { sids: new Set(['PRD']) },
+  ansible: { controller_version: '4.0' },
+};
 
 describe('Workload cell', () => {
   it('should show comma-separated workload acronyms for present keys', () => {
-    render(<Workload system={systemWithWorkloads} />);
+    render(<Workload value={workloadsWithValues} />);
 
     expect(screen.getByText('AAP, SAP')).toBeInTheDocument();
   });
 
   it(`should show ${NOT_AVAILABLE} when no workloads are present`, () => {
-    const { rerender } = render(<Workload system={systemWithEmptyWorkloads} />);
+    const { rerender } = render(<Workload value={{}} />);
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
 
-    rerender(<Workload system={systemWithoutWorkloads} />);
+    rerender(<Workload value={undefined} />);
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
   });

--- a/src/components/SystemsView/columns/inventory/cells/Workload.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workload.tsx
@@ -1,31 +1,38 @@
-import { NOT_AVAILABLE } from '../../CellValue';
-import { InventoryViewSystem } from '../../../hooks/useInventoryViewsQuery';
+import React from 'react';
+import type { SystemProfileWorkloads } from '@redhat-cloud-services/host-inventory-client';
+import CellValue from '../../CellValue';
 import { WORKLOAD_ACRONYMS } from '../../../utils/workloadsFilter';
 
 interface WorkloadProps {
-  system: InventoryViewSystem;
+  value: SystemProfileWorkloads | undefined;
 }
 
-const Workload = ({ system }: WorkloadProps) => {
-  const workloads = system.system_profile?.workloads as
-    | Record<string, unknown>
-    | undefined;
-
-  if (!workloads) {
-    return NOT_AVAILABLE;
+const Workload = ({ value }: WorkloadProps) => {
+  if (value === undefined) {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Workload data is not available for this system"
+      />
+    );
   }
 
-  const acronyms = Object.keys(workloads)
-    .filter((key) => workloads[key] != null)
-    .map((key) => WORKLOAD_ACRONYMS[key as keyof typeof WORKLOAD_ACRONYMS])
+  const acronyms = (Object.keys(value) as Array<keyof SystemProfileWorkloads>)
+    .filter((key) => value[key] != null)
+    .map((key) => WORKLOAD_ACRONYMS[key])
     .filter((acronym): acronym is string => acronym != null)
     .sort();
 
   if (acronyms.length === 0) {
-    return NOT_AVAILABLE;
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="No workloads are present for this system"
+      />
+    );
   }
 
-  return acronyms.join(', ');
+  return <CellValue type="present" value={acronyms.join(', ')} />;
 };
 
 export default Workload;

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.test.tsx
@@ -2,19 +2,33 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import Workspace from './Workspace';
-import type { System } from '../../../hooks/useSystemsQuery';
-
-const SYSTEM_ID = 'test-system-id';
-
-const systemWithNamedWorkspace = {
-  id: SYSTEM_ID,
-  groups: [{ name: 'Production' }],
-} as unknown as System;
+import { NOT_AVAILABLE } from '../../CellValue';
+import { UNGROUPED_HOSTS_LABEL } from '../../../constants';
 
 describe('Workspace cell', () => {
-  it('should show the first workspace name when present', () => {
-    render(<Workspace system={systemWithNamedWorkspace} />);
+  it('should show the workspace name when present', () => {
+    render(<Workspace value={[{ name: 'Production' }]} />);
 
     expect(screen.getByText('Production')).toBeInTheDocument();
+  });
+
+  it('should show the ungrouped hosts label as not set when the workspace is ungrouped', () => {
+    render(<Workspace value={[{ ungrouped: true }]} />);
+
+    expect(screen.getByText(UNGROUPED_HOSTS_LABEL)).toBeInTheDocument();
+  });
+
+  it(`should show ${NOT_AVAILABLE} when workspace data is missing`, () => {
+    const { rerender } = render(<Workspace value={undefined} />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+
+    rerender(<Workspace value={[]} />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+
+    rerender(<Workspace value={[{}]} />);
+
+    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
   });
 });

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import Workspace from './Workspace';
 import { NOT_AVAILABLE } from '../../CellValue';
-import { UNGROUPED_HOSTS_LABEL } from '../../../constants';
+const UNGROUPED_HOSTS_LABEL = 'Ungrouped Hosts';
 
 describe('Workspace cell', () => {
   it('should show the workspace name when present', () => {
@@ -12,22 +12,12 @@ describe('Workspace cell', () => {
     expect(screen.getByText('Production')).toBeInTheDocument();
   });
 
-  it('should show the ungrouped hosts label as not set when the workspace is ungrouped', () => {
-    render(<Workspace value={[{ ungrouped: true }]} />);
-
-    expect(screen.getByText(UNGROUPED_HOSTS_LABEL)).toBeInTheDocument();
-  });
-
   it(`should show ${NOT_AVAILABLE} when workspace data is missing`, () => {
     const { rerender } = render(<Workspace value={undefined} />);
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
 
     rerender(<Workspace value={[]} />);
-
-    expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
-
-    rerender(<Workspace value={[{}]} />);
 
     expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
   });

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
@@ -18,10 +18,6 @@ const Workspace = ({ value }: WorkspaceProps) => {
     );
   }
 
-  if (firstGroup.ungrouped) {
-    return <CellValue type="notSet" value={firstGroup.name} />;
-  }
-
   return <CellValue type="present" value={firstGroup.name} />;
 };
 

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import CellValue from '../../CellValue';
-import type { GroupOut } from '@redhat-cloud-services/host-inventory-client';
+import { System } from '../../../hooks/useSystemsQuery';
 
 interface WorkspaceProps {
-  value: GroupOut[] | undefined;
+  value: System['groups'] | undefined;
 }
 
 const Workspace = ({ value }: WorkspaceProps) => {

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
@@ -1,21 +1,41 @@
-import { NOT_AVAILABLE } from '../../CellValue';
+import React from 'react';
+import CellValue from '../../CellValue';
 import { UNGROUPED_HOSTS_LABEL } from '../../../constants';
-import { System } from '../../../hooks/useSystemsQuery';
 
-interface WorkspaceProps {
-  system: System;
+interface WorkspaceGroup {
+  name?: string | null;
+  ungrouped?: boolean;
 }
 
-const Workspace = ({ system }: WorkspaceProps) => {
-  const [firstGroup] = system.groups ?? [];
+interface WorkspaceProps {
+  value: WorkspaceGroup[] | undefined;
+}
+
+const Workspace = ({ value }: WorkspaceProps) => {
+  const [firstGroup] = value ?? [];
 
   if (firstGroup === undefined) {
-    return NOT_AVAILABLE;
+    return (
+      <CellValue
+        type="notAvailable"
+        reason="Workspace data is not available for this system"
+      />
+    );
+  }
+
+  if (firstGroup.ungrouped) {
+    return <CellValue type="notSet" value={UNGROUPED_HOSTS_LABEL} />;
+  }
+
+  if (firstGroup.name != null && firstGroup.name !== '') {
+    return <CellValue type="present" value={firstGroup.name} />;
   }
 
   return (
-    firstGroup.name ??
-    (firstGroup.ungrouped ? UNGROUPED_HOSTS_LABEL : NOT_AVAILABLE)
+    <CellValue
+      type="notAvailable"
+      reason="Workspace name is not available for this system"
+    />
   );
 };
 

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
 import CellValue from '../../CellValue';
-import { UNGROUPED_HOSTS_LABEL } from '../../../constants';
-
-interface WorkspaceGroup {
-  name?: string | null;
-  ungrouped?: boolean;
-}
+import type { GroupOut } from '@redhat-cloud-services/host-inventory-client';
 
 interface WorkspaceProps {
-  value: WorkspaceGroup[] | undefined;
+  value: GroupOut[] | undefined;
 }
 
 const Workspace = ({ value }: WorkspaceProps) => {
@@ -24,19 +19,10 @@ const Workspace = ({ value }: WorkspaceProps) => {
   }
 
   if (firstGroup.ungrouped) {
-    return <CellValue type="notSet" value={UNGROUPED_HOSTS_LABEL} />;
+    return <CellValue type="notSet" value={firstGroup.name} />;
   }
 
-  if (firstGroup.name != null && firstGroup.name !== '') {
-    return <CellValue type="present" value={firstGroup.name} />;
-  }
-
-  return (
-    <CellValue
-      type="notAvailable"
-      reason="Workspace name is not available for this system"
-    />
-  );
+  return <CellValue type="present" value={firstGroup.name} />;
 };
 
 export default Workspace;

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -8,13 +8,13 @@ import Status from './cells/Status';
 import Tags from './cells/Tags';
 import Workload from './cells/Workload';
 import Vendor from './cells/Vendor';
+import Infrastructure from './cells/Infrastructure';
 import Created from './cells/Created';
 import { LastSeenColumnHeader } from '../../../../Utilities/LastSeenColumnHeader';
 import { System } from '../../hooks/useSystemsQuery';
 import type { Column } from '../allColumnDefinitions';
 import { DEFAULT_NAME_COLUMN_MIN_WIDTH } from '../../utils/columnMinWidths';
 import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
-import { valueOrNotAvailable } from '../helpers';
 
 const APP_NAME = 'inventory' as const;
 
@@ -102,13 +102,9 @@ const infrastructureColumn = {
   key: 'infrastructure',
   isShownByDefault: false,
   isShown: false,
-  renderCell(system: InventoryViewSystem) {
-    return (
-      <span key={`${this.key}-${system.id}`}>
-        {valueOrNotAvailable(system?.system_profile?.infrastructure_type)}
-      </span>
-    );
-  },
+  renderCell: (system: InventoryViewSystem) => (
+    <Infrastructure value={system.system_profile?.infrastructure_type} />
+  ),
 };
 
 const vendorColumn = {

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -65,8 +65,8 @@ const operatingSystemColumn = {
   isShownByDefault: true,
   isShown: true,
   sortBy: ApiOrderByEnum.OperatingSystem,
-  renderCell: (system: System) => (
-    <OperatingSystem key={`os-${system.id}`} system={system} />
+  renderCell: (system: InventoryViewSystem) => (
+    <OperatingSystem value={system.system_profile?.operating_system} />
   ),
 };
 

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -78,8 +78,16 @@ const lastSeenColumn = {
   isShownByDefault: true,
   isShown: true,
   sortBy: ApiOrderByEnum.LastCheckIn,
-  renderCell: (system: System) => (
-    <LastSeen key={`lastseen-${system.id}`} system={system} />
+  renderCell: (system: InventoryViewSystem) => (
+    <LastSeen
+      value={{
+        last_check_in: system.last_check_in,
+        culled_timestamp: system.culled_timestamp,
+        stale_warning_timestamp: system.stale_warning_timestamp,
+        stale_timestamp: system.stale_timestamp,
+        per_reporter_staleness: system.per_reporter_staleness,
+      }}
+    />
   ),
 };
 

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -52,8 +52,8 @@ const tagsColumn = {
   minWidth: '6rem',
   isShownByDefault: true,
   isShown: true,
-  renderCell: (system: System) => (
-    <Tags key={`tags-${system.id}`} system={system} />
+  renderCell: (system: InventoryViewSystem) => (
+    <Tags value={system.tags} system={system} />
   ),
 };
 

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -91,8 +91,14 @@ const statusColumn = {
   isShownByDefault: false,
   isShown: false,
   sortBy: 'status',
-  renderCell: (system: System) => (
-    <Status key={`status-${system.id}`} system={system} />
+  renderCell: (system: InventoryViewSystem) => (
+    <Status
+      value={{
+        stale_timestamp: system.stale_timestamp,
+        stale_warning_timestamp: system.stale_warning_timestamp,
+        culled_timestamp: system.culled_timestamp,
+      }}
+    />
   ),
 };
 

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -131,9 +131,9 @@ const workloadColumn = {
   key: 'workload',
   isShownByDefault: false,
   isShown: false,
-  renderCell(system: InventoryViewSystem) {
-    return <Workload key={`${this.key}-${system.id}`} system={system} />;
-  },
+  renderCell: (system: InventoryViewSystem) => (
+    <Workload value={system.system_profile?.workloads} />
+  ),
 };
 
 const createdColumn = {

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -28,7 +28,13 @@ const nameColumn = {
   isUntoggleable: true,
   sortBy: ApiOrderByEnum.DisplayName,
   renderCell: (system: System) => (
-    <DisplayName key={`name-${system.id}`} system={system} />
+    <DisplayName
+      value={{
+        id: system.id,
+        display_name: system.display_name,
+        system_profile: system.system_profile,
+      }}
+    />
   ),
 };
 

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -7,6 +7,7 @@ import OperatingSystem from './cells/OperatingSystem';
 import Status from './cells/Status';
 import Tags from './cells/Tags';
 import Workload from './cells/Workload';
+import Vendor from './cells/Vendor';
 import Created from './cells/Created';
 import { LastSeenColumnHeader } from '../../../../Utilities/LastSeenColumnHeader';
 import { System } from '../../hooks/useSystemsQuery';
@@ -116,13 +117,9 @@ const vendorColumn = {
   key: 'vendor',
   isShownByDefault: false,
   isShown: false,
-  renderCell(system: InventoryViewSystem) {
-    return (
-      <span key={`${this.key}-${system.id}`}>
-        {valueOrNotAvailable(system?.system_profile?.infrastructure_vendor)}
-      </span>
-    );
-  },
+  renderCell: (system: InventoryViewSystem) => (
+    <Vendor value={system.system_profile?.infrastructure_vendor} />
+  ),
 };
 
 const workloadColumn = {

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -40,8 +40,8 @@ const workspaceColumn = {
   isShownByDefault: true,
   isShown: true,
   sortBy: ApiOrderByEnum.GroupName,
-  renderCell: (system: System) => (
-    <Workspace key={`workspace-${system.id}`} system={system} />
+  renderCell: (system: InventoryViewSystem) => (
+    <Workspace value={system.groups} />
   ),
 };
 

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -7,13 +7,12 @@ import OperatingSystem from './cells/OperatingSystem';
 import Status from './cells/Status';
 import Tags from './cells/Tags';
 import Workload from './cells/Workload';
+import Created from './cells/Created';
 import { LastSeenColumnHeader } from '../../../../Utilities/LastSeenColumnHeader';
 import { System } from '../../hooks/useSystemsQuery';
 import type { Column } from '../allColumnDefinitions';
 import { DEFAULT_NAME_COLUMN_MIN_WIDTH } from '../../utils/columnMinWidths';
 import { InventoryViewSystem } from '../../hooks/useInventoryViewsQuery';
-import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
-import { NOT_AVAILABLE } from '../CellValue';
 import { valueOrNotAvailable } from '../helpers';
 
 const APP_NAME = 'inventory' as const;
@@ -143,14 +142,9 @@ const createdColumn = {
   key: 'created',
   isShownByDefault: false,
   isShown: false,
-  renderCell(system: InventoryViewSystem) {
-    const value = system?.created;
-    return value ? (
-      <DateFormat key={`${this.key}-${system.id}`} date={value} />
-    ) : (
-      NOT_AVAILABLE
-    );
-  },
+  renderCell: (system: InventoryViewSystem) => (
+    <Created value={system?.created} />
+  ),
 };
 
 export default [


### PR DESCRIPTION
RHINENG-28478

## What
This is follow up refactor on: #3300 

It refactors all Inventory based colums, so they all behave in unified way. (namely in rendering missing and default values).
Some columns didn't have a cells yet so they were created and appropriate unit tests as well.

## Why
We need consistency between cells in their API and how they handle missing values

## How
CellValues codifies handling of missing and default values. All column cells were refactored to use it.

## Testing
Go to Inventory / Systems with preview on
Enable all Inventory based columns via ColumnManagementModal.
Observe values are appropriately rendered in similar fashion to other third party columns


## Screenshots/Videos (if applicable)
<img width="3241" height="995" alt="image" src="https://github.com/user-attachments/assets/33042108-1dfc-49a3-a615-6359b03d262e" />


## Summary by Sourcery

Unify SystemsView inventory columns around the shared CellValue component for consistent handling of present and missing data, while narrowing cell inputs to focused value props instead of full System objects.

Enhancements:
- Refactor DisplayName, OperatingSystem, Status, LastSeen, Workspace, Workload, and Tags cells to accept specific value-based props and render via CellValue with standardized not-available and present states.
- Introduce dedicated Created, Infrastructure, and Vendor cell components that encapsulate formatting and CellValue usage for their respective inventory fields.
- Update inventory column definitions in SystemsView to wire the new value-based cell props and use the new cell components instead of inline render logic.

Tests:
- Expand and adapt unit tests for all affected inventory cells to cover the new value-focused APIs, CellValue-based missing-data behavior, and updated formatting rules.