### PR TITLE
fix(RHINENG-22668): Add primary button to all modals for closing

### DIFF
--- a/src/components/SystemDetails/Details.js
+++ b/src/components/SystemDetails/Details.js
@@ -1,14 +1,8 @@
 import React, { Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Grid,
-  GridItem,
-  Modal,
-  ModalHeader,
-  ModalBody,
-} from '@patternfly/react-core';
+import { Grid, GridItem } from '@patternfly/react-core';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
-import InfoTable from '../GeneralInfo/InfoTable';
+import SystemDetailsModal from './SystemDetailsModal';
 import '../GeneralInfo/system-details.scss';
 import { OperatingSystemCard } from '../GeneralInfo/OperatingSystemCard';
 import { BiosCard } from '../GeneralInfo/BiosCard';
@@ -157,24 +151,14 @@ const Details = ({
               )}
             </Grid>
           </GridItem>
-          <Modal
-            aria-label={`${modalTitle || ''} modal`}
-            isOpen={isModalOpen}
-            onClose={() => handleModalToggle()}
-            className="ins-c-inventory__detail--dialog"
-            variant={modalVariant}
-          >
-            <ModalHeader title={modalTitle || ''} />
-            <ModalBody>
-              <InfoTable
-                cells={modalData.cells}
-                rows={modalData.rows}
-                expandable={modalData.expandable}
-                onSort={onSort}
-                filters={modalData.filters}
-              />
-            </ModalBody>
-          </Modal>
+          <SystemDetailsModal
+            isModalOpen={isModalOpen}
+            modalTitle={modalTitle}
+            modalVariant={modalVariant}
+            modalData={modalData}
+            onSort={onSort}
+            handleModalToggle={handleModalToggle}
+          />
         </Grid>
       </div>
     </Wrapper>

--- a/src/components/SystemDetails/Details.test.js
+++ b/src/components/SystemDetails/Details.test.js
@@ -216,7 +216,7 @@ describe('Details', () => {
 
       await waitFor(() => {
         screen.getByRole('dialog', {
-          name: /ipv4 modal/i,
+          name: /ipv4/i,
         });
       });
     });
@@ -234,8 +234,46 @@ describe('Details', () => {
       await userEvent.click(screen.getAllByText('2 addresses')[0]);
       await waitFor(() => {
         screen.getByRole('dialog', {
-          name: /ipv4 modal/i,
+          name: /ipv4/i,
         });
+      });
+    });
+
+    it('should have Close button in modal that closes on click', async () => {
+      const store = mockStore(initialState);
+      render(
+        <MemoryRouter initialEntries={['/example']}>
+          <Provider store={store}>
+            <Details entity={entity} inventoryId={'test-id'} />
+          </Provider>
+        </MemoryRouter>,
+      );
+
+      // Open modal
+      await userEvent.click(screen.getAllByText('2 addresses')[0]);
+
+      // Wait for modal and verify Close button exists
+      await waitFor(() => {
+        screen.getByRole('dialog', { name: /ipv4/i });
+      });
+
+      // Get all close buttons and find the primary one
+      const buttons = screen.getAllByRole('button', { name: /close/i });
+      const primaryCloseButton = buttons.find((button) =>
+        button.classList.contains('pf-m-primary'),
+      );
+
+      expect(primaryCloseButton).toBeInTheDocument();
+      expect(primaryCloseButton).toHaveClass('pf-m-primary');
+
+      // Click Close button
+      await userEvent.click(primaryCloseButton);
+
+      // Modal should be closed
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('dialog', { name: /ipv4/i }),
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/src/components/SystemDetails/Overview.js
+++ b/src/components/SystemDetails/Overview.js
@@ -1,13 +1,7 @@
 import React, { Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Grid,
-  GridItem,
-  Modal,
-  ModalHeader,
-  ModalBody,
-} from '@patternfly/react-core';
-import InfoTable from '../GeneralInfo/InfoTable';
+import { Grid, GridItem } from '@patternfly/react-core';
+import SystemDetailsModal from './SystemDetailsModal';
 import '../GeneralInfo/system-details.scss';
 import { SystemStatusCard } from '../GeneralInfo/SystemStatusCard';
 import SystemCard from '../GeneralInfo/SystemCard';
@@ -96,24 +90,14 @@ const Overview = ({
               )}
             </Grid>
           </GridItem>
-          <Modal
-            aria-label={`${modalTitle || ''} modal`}
-            isOpen={isModalOpen}
-            onClose={() => handleModalToggle()}
-            className="ins-c-inventory__detail--dialog"
-            variant={modalVariant}
-          >
-            <ModalHeader title={modalTitle || ''} />
-            <ModalBody>
-              <InfoTable
-                cells={modalData.cells}
-                rows={modalData.rows}
-                expandable={modalData.expandable}
-                onSort={onSort}
-                filters={modalData.filters}
-              />
-            </ModalBody>
-          </Modal>
+          <SystemDetailsModal
+            isModalOpen={isModalOpen}
+            modalTitle={modalTitle}
+            modalVariant={modalVariant}
+            modalData={modalData}
+            onSort={onSort}
+            handleModalToggle={handleModalToggle}
+          />
         </Grid>
       </div>
     </Wrapper>

--- a/src/components/SystemDetails/Overview.test.js
+++ b/src/components/SystemDetails/Overview.test.js
@@ -175,6 +175,26 @@ describe('Overview', () => {
 
       expect(fetchEntity).toHaveBeenCalledWith('test-id');
     });
+
+    it('should render SystemDetailsModal component', () => {
+      const store = mockStore(initialState);
+
+      // Render Overview which includes SystemDetailsModal
+      const view = render(
+        <MemoryRouter initialEntries={['/example']}>
+          <Provider store={store}>
+            <Overview entity={entity} inventoryId={'test-id'} />
+          </Provider>
+        </MemoryRouter>,
+      );
+
+      // Verify the component renders without errors
+      // Modal is closed by default (isModalOpen=false from useModalState)
+      expect(view.container).toBeInTheDocument();
+
+      // Verify no modal is visible initially
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   describe('conversion alert', () => {

--- a/src/components/SystemDetails/SystemDetailsModal.test.tsx
+++ b/src/components/SystemDetails/SystemDetailsModal.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SystemDetailsModal, {
+  SystemDetailsModalProps,
+} from './SystemDetailsModal';
+
+describe('SystemDetailsModal', () => {
+  const mockHandleModalToggle = jest.fn();
+  const mockOnSort = jest.fn();
+
+  const defaultProps: SystemDetailsModalProps = {
+    isModalOpen: true,
+    modalTitle: 'Test Modal',
+    modalVariant: 'medium',
+    modalData: {
+      cells: [{ title: 'Name' }, { title: 'Value' }],
+      rows: [
+        ['Row 1 Name', 'Row 1 Value'],
+        ['Row 2 Name', 'Row 2 Value'],
+      ],
+      expandable: false,
+      filters: [],
+    },
+    onSort: mockOnSort,
+    handleModalToggle: mockHandleModalToggle,
+  };
+
+  // Helper functions
+  const renderModal = (
+    overrides: Partial<SystemDetailsModalProps> = {},
+  ): ReturnType<typeof render> =>
+    render(<SystemDetailsModal {...defaultProps} {...overrides} />);
+
+  const getModal = () => screen.getByRole('dialog');
+
+  const getPrimaryCloseButton = () => screen.getByTestId('primary-close');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('should render modal when isModalOpen is true', () => {
+      renderModal();
+
+      expect(getModal()).toBeInTheDocument();
+      expect(screen.getByText('Test Modal')).toBeInTheDocument();
+    });
+
+    it('should not render modal when isModalOpen is false', () => {
+      renderModal({ isModalOpen: false });
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should render with empty title gracefully and use default', () => {
+      renderModal({ modalTitle: '' });
+
+      expect(getModal()).toBeInTheDocument();
+      expect(screen.getByText('System details')).toBeInTheDocument();
+    });
+
+    it('should render InfoTable with correct data', () => {
+      renderModal();
+
+      expect(screen.getByText('Row 1 Name')).toBeInTheDocument();
+      expect(screen.getByText('Row 1 Value')).toBeInTheDocument();
+      expect(screen.getByText('Row 2 Name')).toBeInTheDocument();
+      expect(screen.getByText('Row 2 Value')).toBeInTheDocument();
+    });
+  });
+
+  describe('Close button', () => {
+    it('should call handleModalToggle when Close button is clicked', async () => {
+      renderModal();
+
+      await userEvent.click(getPrimaryCloseButton());
+
+      expect(mockHandleModalToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('should close modal when Close button is clicked', async () => {
+      const { rerender } = renderModal();
+
+      // Verify modal is open
+      expect(getModal()).toBeInTheDocument();
+
+      // Click close button
+      await userEvent.click(getPrimaryCloseButton());
+
+      // Simulate parent component updating isModalOpen to false
+      rerender(<SystemDetailsModal {...defaultProps} isModalOpen={false} />);
+
+      // Modal should be closed
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('different modal variants', () => {
+    test.each<SystemDetailsModalProps['modalVariant']>([
+      'small',
+      'medium',
+      'large',
+    ])('should render with %s variant', (variant) => {
+      renderModal({ modalVariant: variant });
+      expect(getModal()).toBeInTheDocument();
+    });
+  });
+
+  describe('real-world scenarios', () => {
+    const scenarios = [
+      {
+        title: 'CPU flags',
+        modalVariant: 'large' as const,
+        cells: [{ title: 'Flag' }],
+        rows: [['fpu'], ['vme'], ['de'], ['pse']],
+        expectations: ['CPU flags', 'fpu', 'vme'],
+      },
+      {
+        title: 'IPv4',
+        modalVariant: 'medium' as const,
+        cells: [{ title: 'Address' }],
+        rows: [['192.168.1.1'], ['10.0.0.1']],
+        expectations: ['IPv4', '192.168.1.1', '10.0.0.1'],
+      },
+    ];
+
+    test.each(scenarios)(
+      'should render $title modal data',
+      ({ title, modalVariant, cells, rows, expectations }) => {
+        renderModal({
+          modalTitle: title,
+          modalVariant,
+          modalData: {
+            cells,
+            rows,
+            expandable: false,
+            filters: [],
+          },
+        });
+
+        expectations.forEach((text) =>
+          expect(screen.getByText(text)).toBeInTheDocument(),
+        );
+      },
+    );
+  });
+});

--- a/src/components/SystemDetails/SystemDetailsModal.tsx
+++ b/src/components/SystemDetails/SystemDetailsModal.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  Button,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from '@patternfly/react-core';
+import InfoTable from '../GeneralInfo/InfoTable';
+
+export interface ModalData {
+  cells: Array<{ title: string }>;
+  rows: Array<Array<string | Record<string, unknown>>>;
+  expandable: boolean;
+  filters: Array<{
+    index?: number;
+    title?: string;
+    type?: string;
+    options?: Array<{ value?: React.ReactNode; label?: React.ReactNode }>;
+  }>;
+}
+
+export interface SystemDetailsModalProps {
+  isModalOpen: boolean;
+  modalTitle?: string;
+  modalVariant?: 'small' | 'medium' | 'large';
+  modalData: ModalData;
+  onSort?: () => void;
+  handleModalToggle: () => void;
+}
+
+/**
+ * Shared modal component for displaying system details information in a table format.
+ * Used by both Overview and Details tabs to show expandable data like CPU flags,
+ * network interfaces, OS packages, etc.
+ */
+const SystemDetailsModal = ({
+  isModalOpen,
+  modalTitle,
+  modalVariant,
+  modalData,
+  onSort,
+  handleModalToggle,
+}: SystemDetailsModalProps) => {
+  return (
+    <Modal
+      aria-labelledby="system-details-modal-title"
+      isOpen={isModalOpen}
+      onClose={handleModalToggle}
+      className="ins-c-inventory__detail--dialog"
+      variant={modalVariant}
+    >
+      <ModalHeader
+        title={
+          <span id="system-details-modal-title">
+            {modalTitle || 'System details'}
+          </span>
+        }
+      />
+      <ModalBody>
+        <InfoTable
+          cells={modalData.cells as []}
+          rows={modalData.rows as []}
+          expandable={modalData.expandable}
+          onSort={onSort as undefined}
+          filters={modalData.filters as []}
+        />
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          onClick={handleModalToggle}
+          data-testid="primary-close"
+        >
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default SystemDetailsModal;


### PR DESCRIPTION
## Jira
[RHINENG-22668](https://redhat.atlassian.net/browse/RHINENG-22668)

## What
By PF guidelines, all modals must have a primary button that performs a primary action. When there is no action for a modal, it still must have a primary button to close the modal.

The modals in this PR have been given a "Close" button. Also, because the modal was exactly the same in both locations, I have combined them into 1 component and shared them. If you think this is overkill, I can easily revert.

## Screenshots/Videos (if applicable)
<img width="582" height="738" alt="image" src="https://github.com/user-attachments/assets/473503d8-0036-422a-b7da-41fdb06e7cc4" />

[RHINENG-22668]: https://redhat.atlassian.net/browse/RHINENG-22668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce a shared SystemDetailsModal component for system detail views and ensure its modal dialogs include a primary Close action.

New Features:
- Add a reusable SystemDetailsModal component used by both the Details and Overview tabs to display system information in a modal table.

Bug Fixes:
- Ensure system detail modals include a primary Close button and close correctly when it is clicked.
- Update the entity table toolbar conditional filter label text to match the current "Filter by text" menu option.

Enhancements:
- Add tests covering SystemDetailsModal behavior and its integration with the Details and Overview screens, including modal visibility and close interactions.

Tests:
- Add comprehensive unit tests for SystemDetailsModal, including rendering, variants, real-world data scenarios, and close behavior.
- Extend Details and Overview tests to verify presence and correct behavior of the new modal and Close button.