### PR TITLE
fix(RHINENG-28481): Fix column storage when switching between stable and preview

### DIFF
--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useCallback, useEffect, useMemo } from 'react';
-
 import type { OnSort, SortDirection } from '../SystemsView';
 import {
   getColumnMinWidthStyle,

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useCallback, useEffect, useMemo } from 'react';
+
 import type { OnSort, SortDirection } from '../SystemsView';
 import {
   getColumnMinWidthStyle,

--- a/src/components/SystemsView/hooks/usePersistedColumns.test.tsx
+++ b/src/components/SystemsView/hooks/usePersistedColumns.test.tsx
@@ -8,6 +8,11 @@ const TEST_ACCOUNT_NUMBER = '1234567';
 const TEST_USERNAME = 'inventory-columns-test-user';
 const STORAGE_KEY = `ui.systems-view.columns.${TEST_ACCOUNT_NUMBER}.${TEST_USERNAME}`;
 
+jest.mock('../../../Utilities/useInventoryViewsFeatureFlag', () => ({
+  __esModule: true,
+  default: () => true,
+}));
+
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   __esModule: true,
   default: () => ({

--- a/src/components/SystemsView/hooks/usePersistedColumns.ts
+++ b/src/components/SystemsView/hooks/usePersistedColumns.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import useInventoryViewsFeatureFlag from '../../../Utilities/useInventoryViewsFeatureFlag';
 import type { Column } from '../columns/allColumnDefinitions';
 
 const STORAGE_KEY_PREFIX = 'ui.systems-view.columns';
@@ -106,12 +107,20 @@ const mergeColumnPrefs = (
 };
 
 export const usePersistedColumns = (defaultColumns: readonly Column[]) => {
+  const shouldPersist = useInventoryViewsFeatureFlag();
   const chrome = useChrome();
   const [storageKey, setStorageKey] = useState<string | null>(null);
   const [columns, setColumns] = useState<readonly Column[]>(defaultColumns);
   const loadedStorageKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
+    if (!shouldPersist) {
+      loadedStorageKeyRef.current = null;
+      setStorageKey(null);
+      setColumns(defaultColumns);
+      return;
+    }
+
     let cancelled = false;
 
     void chrome.auth
@@ -146,13 +155,13 @@ export const usePersistedColumns = (defaultColumns: readonly Column[]) => {
     return () => {
       cancelled = true;
     };
-  }, [chrome, defaultColumns]);
+  }, [chrome, defaultColumns, shouldPersist]);
 
   useEffect(() => {
-    if (storageKey) {
+    if (storageKey && shouldPersist) {
       saveColumnPrefs(storageKey, columns);
     }
-  }, [columns, storageKey]);
+  }, [columns, storageKey, shouldPersist]);
 
   return { columns, setColumns };
 };


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-28481

## What
Fix column storage when switching between stable and preview

## Why
In stable mode (inventory views disabled), the column management modal was showing and persisting columns that require the inventory views API

## How
`usePersistedColumns` now reads `useInventoryViewsFeatureFlag` internally. In stable mode (`isInventoryViewsEnabled=false)`:
  - Sets columns directly to defaults, bypassing `localStorage` entirely
  - Clears `loadedStorageKeyRef` so switching back to preview forces a fresh load and correctly restores saved preview `prefs`
  - Skips saving so preview `prefs` in `localStorage` are never overwritten

## Testing
1. navigate to systems page
2. in switch to preview and apply new columns
3. reload page and check that columns still applied 
4. switch to stable version -> only default columns are displayd
5. switch back to preview  -> previously applied new columns are back since in preview InventoryViews is enabled

## Summary by Sourcery

Ensure systems view column persistence is only applied when inventory views are enabled, resetting to defaults in stable mode.

Bug Fixes:
- Prevent stable mode from loading and persisting inventory-views-dependent column preferences so default columns are correctly shown when inventory views are disabled.

Tests:
- Update usePersistedColumns tests to mock the inventory views feature flag and validate behavior when column persistence is enabled.