### PR TITLE
test: fix unit test for conditional filter

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -313,7 +313,7 @@ describe('EntityTableToolbar', () => {
         screen.getByRole('button', {
           name: /conditional filter/i,
         }),
-      ).toHaveTextContent('Name');
+      ).toHaveTextContent('Filter by text');
       expect(
         screen.getByRole('menuitem', {
           name: /filter by text/i,


### PR DESCRIPTION
## What
fix unit test for conditional filter

## Why
"Filter by text" comes directly from the test itself - it's the label field of the custom filter item passed as a prop:

```
  filterConfig={{
    items: [{ label: 'Filter by text', type: 'custom' }],  // line 302
  }}

```
  The test defines a custom filter with that label, then asserts the button and menuitem render it. It's not coming from any
  component source or DOM - it's a value the test itself supplies.

## Summary by Sourcery

Update unit tests for EntityTableToolbar conditional filter label.

Bug Fixes:
- Correct the expected conditional filter button text to match the custom filter label provided by the test.

Tests:
- Adjust conditional filter test assertions to use the custom filter label 'Filter by text' instead of 'Name'.