### PR TITLE
fix(InventoryTable): avoid duplicated requests of name filter

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -62,7 +62,14 @@ global.insights = {
 };
 
 // Make lodash/debounce synchronous in tests to avoid act() timing warnings
-jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
+jest.mock('lodash/debounce', () =>
+  jest.fn((fn) => {
+    const wrapped = (...args) => fn(...args);
+    wrapped.cancel = jest.fn();
+    wrapped.flush = jest.fn();
+    return wrapped;
+  }),
+);
 
 // Mock Scalprum so AsyncComponent (and other federated modules) do not throw in tests
 jest.mock('@scalprum/react-core', () => ({

--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -1,5 +1,5 @@
 import './EntityTableToolbar.scss';
-import React, { Fragment, useEffect, useReducer } from 'react';
+import React, { Fragment, useEffect, useMemo, useReducer, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
@@ -245,22 +245,6 @@ const EntityTableToolbar = ({
     systemTypeValue,
     setSystemTypeValue,
   ] = useSystemTypeFilter(reducer);
-  /**
-   * Debounced function for fetching all tags.
-   */
-  const debounceGetAllTags = debounce((config, options) => {
-    if (showTags && !hasItems && hasAccess) {
-      dispatch(
-        fetchAllTags(
-          config,
-          {
-            ...options?.paginationhideFilters,
-          },
-          getTags,
-        ),
-      );
-    }
-  }, 800);
 
   const enabledFilters = {
     name: !(hideFilters.all && hideFilters.name !== false) && !hideFilters.name,
@@ -327,10 +311,52 @@ const EntityTableToolbar = ({
     }
   };
 
+  const updateDataRef = useRef(updateData);
+  updateDataRef.current = updateData;
+
   /**
-   * Debounced `updateData` function.
+   * Debounced `updateData` function
    */
-  const debouncedRefresh = debounce((config) => updateData(config), 800);
+  const debouncedRefresh = useMemo(
+    () => debounce((config) => updateDataRef.current(config), 800),
+    [],
+  );
+
+  const getAllTags = (config, options) => {
+    if (showTags && !hasItems && hasAccess) {
+      dispatch(
+        fetchAllTags(
+          config,
+          {
+            ...options?.paginationhideFilters,
+          },
+          getTags,
+        ),
+      );
+    }
+  };
+
+  const getAllTagsRef = useRef(getAllTags);
+  getAllTagsRef.current = getAllTags;
+
+  /**
+   * Debounced function for fetching all tags.
+   */
+  const debounceGetAllTags = useMemo(
+    () =>
+      debounce(
+        (config, options) => getAllTagsRef.current(config, options),
+        800,
+      ),
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedRefresh.cancel();
+      debounceGetAllTags.cancel();
+    };
+  }, [debouncedRefresh, debounceGetAllTags]);
 
   /**
    * Component did mount effect to calculate actual filters from redux.

--- a/src/components/InventoryTable/EntityTableToolbar.test.js
+++ b/src/components/InventoryTable/EntityTableToolbar.test.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import debounce from 'lodash/debounce';
 import React from 'react';
@@ -28,6 +28,13 @@ jest.mock('../../Utilities/hooks/useFetchOperatingSystems');
 jest.mock('../../Utilities/hooks/useFetchBatched');
 
 jest.mock('@redhat-cloud-services/frontend-components-utilities/interceptors');
+
+const syncDebounce = (fn) => {
+  const wrapped = (...args) => fn(...args);
+  wrapped.cancel = jest.fn();
+  wrapped.flush = jest.fn();
+  return wrapped;
+};
 
 const expectDefaultFiltersVisible = async () => {
   const DEFAULT_FILTERS = [
@@ -583,7 +590,7 @@ describe('EntityTableToolbar', () => {
 
     describe('delete filter', () => {
       it('should dispatch action on delete filter', async () => {
-        debounce.mockImplementation((fn) => fn);
+        debounce.mockImplementation(syncDebounce);
 
         const store = mockStore(stateWithActiveFilter);
         render(
@@ -615,7 +622,7 @@ describe('EntityTableToolbar', () => {
       });
 
       it('should remove textual filter', async () => {
-        debounce.mockImplementation((fn) => fn);
+        debounce.mockImplementation(syncDebounce);
         onRefreshData.mockClear();
         const store = mockStore({
           entities: {
@@ -655,7 +662,7 @@ describe('EntityTableToolbar', () => {
         });
       });
       it('should remove tag filter', async () => {
-        debounce.mockImplementation((fn) => fn);
+        debounce.mockImplementation(syncDebounce);
         onRefreshData.mockClear();
         const store = mockStore({
           entities: {
@@ -772,7 +779,7 @@ describe('EntityTableToolbar', () => {
     });
 
     it('trim leading/trailling whitespace ', async () => {
-      debounce.mockImplementation((fn) => fn);
+      debounce.mockImplementation(syncDebounce);
       const store = mockStore(initialState);
       render(
         <TestWrapper store={store}>
@@ -798,6 +805,119 @@ describe('EntityTableToolbar', () => {
         {},
         { filter: 'some-value', value: 'hostname_or_id' },
       ]);
+    });
+
+    it('debounces name filter refresh to a single onRefreshData call while typing', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const store = mockStore(initialState);
+        render(
+          <TestWrapper store={store}>
+            <EntityTableToolbar
+              hideFilters={{ all: true, name: false, group: true }}
+              page={1}
+              total={500}
+              perPage={50}
+              onRefreshData={onRefreshData}
+              loaded
+            />
+          </TestWrapper>,
+        );
+
+        await act(async () => {
+          jest.advanceTimersByTime(800);
+        });
+        onRefreshData.mockClear();
+
+        const nameInput = screen.getByRole('textbox', {
+          name: /text input/i,
+        });
+
+        fireEvent.input(nameInput, { target: { value: 'a' } });
+        fireEvent.input(nameInput, { target: { value: 'ab' } });
+        fireEvent.input(nameInput, { target: { value: 'abc' } });
+
+        expect(onRefreshData).not.toHaveBeenCalled();
+
+        await act(async () => {
+          jest.advanceTimersByTime(800);
+        });
+
+        expect(onRefreshData).toHaveBeenCalledTimes(1);
+        expect(onRefreshData).toHaveBeenCalledWith(
+          expect.objectContaining({
+            page: 1,
+            perPage: 50,
+            filters: expect.arrayContaining([
+              expect.objectContaining({
+                value: 'hostname_or_id',
+                filter: 'abc',
+              }),
+            ]),
+            options: {
+              axios: undefined,
+            },
+          }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('debounces tag filter search to a single fetchAllTags call while typing', async () => {
+      jest.useFakeTimers();
+      const getTags = jest.fn().mockResolvedValue({
+        results: [],
+        total: 0,
+        page: 1,
+        per_page: 10,
+      });
+
+      try {
+        const store = mockStore({
+          entities: {
+            ...initialState.entities,
+            allTagsLoaded: true,
+          },
+        });
+        render(
+          <TestWrapper store={store}>
+            <EntityTableToolbar
+              showTags
+              getTags={getTags}
+              hideFilters={{ all: true, tags: false }}
+              page={1}
+              total={500}
+              perPage={50}
+              onRefreshData={onRefreshData}
+              loaded
+            />
+          </TestWrapper>,
+        );
+
+        await act(async () => {
+          jest.advanceTimersByTime(800);
+        });
+        getTags.mockClear();
+
+        const tagsSearchInput = screen.getByPlaceholderText('Filter by tags');
+
+        fireEvent.change(tagsSearchInput, { target: { value: 'a' } });
+        fireEvent.change(tagsSearchInput, { target: { value: 'ab' } });
+        fireEvent.change(tagsSearchInput, { target: { value: 'abc' } });
+
+        expect(getTags).not.toHaveBeenCalled();
+
+        await act(async () => {
+          jest.advanceTimersByTime(800);
+        });
+
+        expect(getTags).toHaveBeenCalledTimes(1);
+        expect(getTags).toHaveBeenCalledWith('abc', {});
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Jira
[RHINENG-28602](https://redhat.atlassian.net/browse/RHINENG-28602)

## What
There are duplicated requests when any app uses inventory table name/tag filter when user starts typing something. So if you start typing `abcd` you will end up with 4 duplicated API requests.

Tests cover this issue and are failing with old implementation

https://stackoverflow.com/questions/59183495/cant-get-lodash-debounce-to-work-properly-executed-multiple-times-reac

## Testing

1. Navigate to Compliance systems page
2. When Name filter is active start typing `abcd`
3. Observe only 1 API request made with `abcd` filter
4. Repeat the same but with Tag filter


## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->


[RHINENG-28602]: https://redhat.atlassian.net/browse/RHINENG-28602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure inventory table name and tag filters debounce API interactions to avoid duplicated requests while typing.

Bug Fixes:
- Prevent multiple redundant onRefreshData calls when typing in the name filter.
- Prevent multiple redundant getTags requests when typing in the tag filter search.

Enhancements:
- Stabilize debounced data refresh and tag loading by using memoized debounce functions with refs to current handlers.

Tests:
- Add tests verifying that typing into the name and tag filters results in a single debounced API call.