### PR TITLE
fix: ignore InventoryViews sort keys when switching to legacy table

### DIFF
--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -42,10 +42,14 @@ export const useColumns = ({
   const { columns, setColumns } = usePersistedColumns(defaultColumns);
 
   const fromSortByToIndex = useCallback(
-    (sortBy?: Column['sortBy']) =>
-      columns
+    (sortBy?: Column['sortBy']): number | undefined => {
+      const index = columns
         .filter((col) => col.isShown)
-        .findIndex((col) => col.sortBy === sortBy),
+        .findIndex((col) => col.sortBy === sortBy);
+      // Return undefined (no active column) rather than -1 so PatternFly does not
+      // receive an out-of-bounds index while the fallback useEffect fires.
+      return index === -1 ? undefined : index;
+    },
     [columns],
   );
 

--- a/src/components/SystemsView/hooks/useSystemsQuery.ts
+++ b/src/components/SystemsView/hooks/useSystemsQuery.ts
@@ -73,6 +73,11 @@ export const useSystemsQuery = ({
   direction,
   enabled = true,
 }: UseSystemsQueryParams) => {
+  // Cross-app sort keys (e.g. 'vulnerability:total_cves') are not valid for the /hosts
+  // API. This can happen during the render between ui.inventory-views being toggled off
+  // and the useColumns useEffect resetting the URL to a valid sort key.
+  const validSortBy = sortBy?.includes(':') ? undefined : sortBy;
+
   const { data, isLoading, isFetching, isError, error } = useQuery({
     queryKey: [
       SYSTEMS_QUERY_KEY,
@@ -80,7 +85,7 @@ export const useSystemsQuery = ({
       perPage,
       filters,
       lastSeenCustomRange,
-      sortBy,
+      validSortBy,
       direction,
     ],
     queryFn: async () => {
@@ -89,7 +94,7 @@ export const useSystemsQuery = ({
         perPage,
         filters,
         lastSeenCustomRange,
-        sortBy,
+        sortBy: validSortBy,
         direction,
       });
     },

--- a/src/constants.js
+++ b/src/constants.js
@@ -180,8 +180,12 @@ export const getSearchParams = (searchParams) => {
   const systemTypeFilter = searchParams.getAll('system_type');
   const workloadFilter = searchParams.getAll(WORKLOAD_FILTER_KEY);
   const rawSort = searchParams.get('sort');
+  const rawSortKey = rawSort?.startsWith('-') ? rawSort.slice(1) : rawSort;
+  // Cross-app sort keys contain ':' and are only
+  // valid in the Preview/SystemsView + ui.inventory-views mode. Ignore them here so the
+  // legacy table does not send an invalid order_by to the /hosts API.
   const sortBy = {
-    key: rawSort?.startsWith('-') ? rawSort.slice(1) : rawSort,
+    key: rawSortKey?.includes(':') ? null : rawSortKey,
     direction: rawSort?.startsWith('-') ? 'desc' : 'asc',
   };
 


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-28346

## What
Ignore `InventoryViews` sort keys when switching to legacy table. 

## Why
Cross-app `InventoryViews` sort keys persisted in the URL after sorting in Preview mode (`SystemsView` +` ui.inventory-views`) were being read by the legacy table on switch to Stable, causing an invalid order_by sent to the /hosts API and a broken sort indicator.

## Testing
This bug can be reproduced when Legacy table is enabled in stable and `SystemsView`+`InventoryViews` in preview:

1. modify in stage unleash SystemsView flag to be enabled only in preview
2. Visit Systems page and make sure stable version displays Legacy table and preview is InventoryViews
3. In preview apply Total CVEs column
4. Sort by Total CVEs > make sure URL is changed - cves key is present in URL
5. switch to stable version > no Something went wrong is displayed, URL doesn't contain cves key

## Summary by Sourcery

Prevent invalid cross-app sort keys from breaking systems table sorting when switching between InventoryViews and the legacy table.

Bug Fixes:
- Ensure PatternFly does not receive an out-of-bounds sort column index when no matching column is shown.
- Ignore cross-app InventoryViews sort keys in URL and systems queries so the legacy /hosts table does not send invalid order_by parameters.