### PR TITLE
fix(RHINENG-28664): Status column sort param crashes legacy inventory table

### DIFF
--- a/src/components/SystemsView/hooks/useSystemsQuery.ts
+++ b/src/components/SystemsView/hooks/useSystemsQuery.ts
@@ -1,5 +1,6 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getHostList, getHostTags } from '../../../api/hostInventoryApiTyped';
+import { getLegacyInventorySortKey } from '../../../constants';
 import { InventoryFilters } from '../filters/SystemsViewFilters';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import { SortDirection } from '../SystemsView';
@@ -73,10 +74,12 @@ export const useSystemsQuery = ({
   direction,
   enabled = true,
 }: UseSystemsQueryParams) => {
-  // Cross-app sort keys (e.g. 'vulnerability:total_cves') are not valid for the /hosts
-  // API. This can happen during the render between ui.inventory-views being toggled off
-  // and the useColumns useEffect resetting the URL to a valid sort key.
-  const validSortBy = sortBy?.includes(':') ? undefined : sortBy;
+  // Cross-app and SystemsView-only sort keys are not valid for the /hosts API. This can
+  // happen during the render between ui.inventory-views being toggled off and the
+  // useColumns useEffect resetting the URL to a valid sort key.
+  const validSortBy = getLegacyInventorySortKey(sortBy) as
+    | ApiOrderByEnum
+    | undefined;
 
   const { data, isLoading, isFetching, isError, error } = useQuery({
     queryKey: [

--- a/src/constants.js
+++ b/src/constants.js
@@ -143,6 +143,24 @@ export const extraShape = PropTypes.shape({
   onClick: PropTypes.func,
 });
 
+/** Sort URL keys valid in SystemsView but not as legacy InventoryTable / /hosts order_by. */
+export const LEGACY_INVENTORY_INVALID_SORT_KEYS = ['status'];
+
+export const getLegacyInventorySortKey = (rawSortKey) => {
+  if (!rawSortKey) {
+    return null;
+  }
+
+  if (
+    rawSortKey.includes(':') ||
+    LEGACY_INVENTORY_INVALID_SORT_KEYS.includes(rawSortKey)
+  ) {
+    return null;
+  }
+
+  return rawSortKey;
+};
+
 export const getSearchParams = (searchParams) => {
   const status = searchParams.getAll('status');
   const source = searchParams.getAll('source');
@@ -181,11 +199,11 @@ export const getSearchParams = (searchParams) => {
   const workloadFilter = searchParams.getAll(WORKLOAD_FILTER_KEY);
   const rawSort = searchParams.get('sort');
   const rawSortKey = rawSort?.startsWith('-') ? rawSort.slice(1) : rawSort;
-  // Cross-app sort keys contain ':' and are only
-  // valid in the Preview/SystemsView + ui.inventory-views mode. Ignore them here so the
+  // Cross-app sort keys contain ':' and SystemsView-only keys (e.g. status) are only
+  // valid in Preview/SystemsView + ui.inventory-views mode. Ignore them here so the
   // legacy table does not send an invalid order_by to the /hosts API.
   const sortBy = {
-    key: rawSortKey?.includes(':') ? null : rawSortKey,
+    key: getLegacyInventorySortKey(rawSortKey),
     direction: rawSort?.startsWith('-') ? 'desc' : 'asc',
   };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -148,14 +148,14 @@ export const LEGACY_INVENTORY_INVALID_SORT_KEYS = ['status'];
 
 export const getLegacyInventorySortKey = (rawSortKey) => {
   if (!rawSortKey) {
-    return null;
+    return undefined;
   }
 
   if (
     rawSortKey.includes(':') ||
     LEGACY_INVENTORY_INVALID_SORT_KEYS.includes(rawSortKey)
   ) {
-    return null;
+    return undefined;
   }
 
   return rawSortKey;

--- a/src/constants.test.js
+++ b/src/constants.test.js
@@ -1,11 +1,26 @@
 import {
   filterRows,
   generateFilters,
+  getLegacyInventorySortKey,
   isDate,
   onDeleteFilter,
   prepareRows,
   tagsMapper,
 } from './constants';
+
+describe('getLegacyInventorySortKey', () => {
+  it('returns legacy sort keys unchanged', () => {
+    expect(getLegacyInventorySortKey('display_name')).toBe('display_name');
+  });
+
+  it('rejects cross-app sort keys', () => {
+    expect(getLegacyInventorySortKey('vulnerability:total_cves')).toBeNull();
+  });
+
+  it('rejects SystemsView-only status sort', () => {
+    expect(getLegacyInventorySortKey('status')).toBeNull();
+  });
+});
 
 describe('tagsMapper', () => {
   it('maps URL tags to object', () => {

--- a/src/constants.test.js
+++ b/src/constants.test.js
@@ -14,11 +14,13 @@ describe('getLegacyInventorySortKey', () => {
   });
 
   it('rejects cross-app sort keys', () => {
-    expect(getLegacyInventorySortKey('vulnerability:total_cves')).toBeNull();
+    expect(
+      getLegacyInventorySortKey('vulnerability:total_cves'),
+    ).toBeUndefined();
   });
 
   it('rejects SystemsView-only status sort', () => {
-    expect(getLegacyInventorySortKey('status')).toBeNull();
+    expect(getLegacyInventorySortKey('status')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
RHINENG-28664

## What
sort param of newly added Inventory column was causing crash of InventoryTable. 
This PR expands on mechanism to filter out sort params of Columns which InventoryTable cannot handle. We're now going to filter out url sort of "Status" column as well 

## Testing
1. Go to Inventory Table
2. Enable Status column
3. Set sorting according this Column
4. Now switch on rendering of legacy table by localStorage.setItem("ui.legacy-inventory-table", "true")
5. Turn preview off

InventoryTable should render with default sort which should be acc. to lastSeen column

## Summary by Sourcery

Prevent legacy inventory table and SystemsView queries from using unsupported sort keys that crash the /hosts API.

Bug Fixes:
- Ignore SystemsView-only status sort key when deriving legacy inventory sortBy/order_by parameters to avoid crashes.
- Filter out cross-app and other invalid sort keys in SystemsView queries before calling the /hosts API.

Enhancements:
- Introduce a shared helper to validate and normalize sort keys for legacy inventory usage.

Tests:
- Add unit tests covering the new sort key validation helper for legacy inventory behavior.