### PR TITLE
test: disable e2e test in prod - workspace test case only for kessel

### DIFF
--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -448,7 +448,10 @@ test.describe('Workspace System Management', () => {
      * - importance: high
      */
     // eslint-disable-next-line playwright/no-skipped-test
-    test.skip(process.env.PROD === 'true', 'Skipping in prod');
+    test.skip(
+      process.env.PROD === 'true',
+      'Case is intended for non-prod environments only - Kessel feature',
+    );
     const system = systems.workspaceSystems[2];
     const nameCell = page
       .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -447,7 +447,8 @@ test.describe('Workspace System Management', () => {
      * - requirements: inv-groups-add-hosts
      * - importance: high
      */
-
+    // eslint-disable-next-line playwright/no-skipped-test
+    test.skip(process.env.PROD === 'true', 'Skipping in prod');
     const system = systems.workspaceSystems[2];
     const nameCell = page
       .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')


### PR DESCRIPTION
## What
disable test case intended only for Kessel enable feature for Prod CI

## Summary by Sourcery

Tests:
- Update workspace system management e2e test to be skipped when PROD environment is enabled.