### PR TITLE
fix: Disable navigation tests in stage CI

### DIFF
--- a/_playwright-tests/test_navigation.test.ts
+++ b/_playwright-tests/test_navigation.test.ts
@@ -2,6 +2,8 @@ import { expect } from '@playwright/test';
 import { test } from './helpers/fixtures';
 
 test.describe('Navigate to Inventory pages via side Navigation bar', () => {
+  test.fixme(true, 'Navigation bar requuires redesign');
+
   test.beforeEach(async ({ page }) => {
     await page.goto('/insights/inventory/');
     await expect(page.locator('[data-quickstart-id="Inventory"]')).toBeVisible({

--- a/_playwright-tests/test_navigation.test.ts
+++ b/_playwright-tests/test_navigation.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from './helpers/fixtures';
 
 test.describe('Navigate to Inventory pages via side Navigation bar', () => {
-  test.fixme(true, 'Navigation bar requuires redesign');
+  test.fixme(true, 'Navigation bar requires redesign');
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/insights/inventory/');


### PR DESCRIPTION
## What
Disable navigation tests in stage CI

## Why
Navigation side bar requires update

## Summary by Sourcery

Tests:
- Mark the navigation sidebar Playwright test suite as fixme so it is skipped in CI while the navigation bar is being redesigned.