### PR TITLE
fix(RHINENG-27933): workspace filter not working in InventoryViews table  

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@redhat-cloud-services/frontend-components": "^7.8.0",
         "@redhat-cloud-services/frontend-components-notifications": "^6.9.1",
         "@redhat-cloud-services/frontend-components-utilities": "^7.4.0",
-        "@redhat-cloud-services/host-inventory-client": "^5.0.2",
+        "@redhat-cloud-services/host-inventory-client": "^5.0.7",
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.7",
         "@sentry/webpack-plugin": "^2.23.1",
         "@tanstack/react-query": "^5.90.21",
@@ -7805,9 +7805,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/host-inventory-client": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-5.0.2.tgz",
-      "integrity": "sha512-8PlOowj1xKY+ZIrdiXW+ynTOQXeGZYmR2LxoiAAgSdhFtkoZpPLyHbQ5QojxzsGUXR788k/aSLPWkXmjXxCqNw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-5.0.7.tgz",
+      "integrity": "sha512-GuVrgu9ybwLGhQi1YSZ92ZWrB1CivvgcDkWIAaqOG6k+nz41KH97FKRk/SA/tdm7hy7QM34HH9AklooZapTv1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@redhat-cloud-services/frontend-components": "^7.8.0",
     "@redhat-cloud-services/frontend-components-notifications": "^6.9.1",
     "@redhat-cloud-services/frontend-components-utilities": "^7.4.0",
-    "@redhat-cloud-services/host-inventory-client": "^5.0.2",
+    "@redhat-cloud-services/host-inventory-client": "^5.0.7",
     "@redhat-cloud-services/javascript-clients-shared": "^2.0.7",
     "@sentry/webpack-plugin": "^2.23.1",
     "@tanstack/react-query": "^5.90.21",

--- a/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
+++ b/src/components/SystemsView/hooks/useInventoryViewsQuery.ts
@@ -63,7 +63,6 @@ const fetchInventoryViews = async ({
   return { results, total };
 };
 
-/* `InventoryFilters.group_id` is ignored until workspace filtering exists on this endpoint. */
 export interface UseInventoryViewsQueryParams {
   page: number;
   perPage: number;

--- a/src/components/SystemsView/utils/buildGroupIdParam.ts
+++ b/src/components/SystemsView/utils/buildGroupIdParam.ts
@@ -1,0 +1,10 @@
+export const buildGroupIdParam = (
+  groupIds: string[] | undefined,
+): { groupId: string[] } | Record<string, never> => {
+  if (!groupIds?.length) return {};
+
+  const hasEmpty = groupIds.includes('');
+  const nonEmpty = groupIds.filter((id) => id !== '');
+
+  return { groupId: hasEmpty ? [...nonEmpty, ''] : nonEmpty };
+};

--- a/src/components/SystemsView/utils/buildHostListParams.ts
+++ b/src/components/SystemsView/utils/buildHostListParams.ts
@@ -10,6 +10,7 @@ import { buildSystemProfileFilters } from './buildSystemProfileFilters';
 import { buildHostQueryOptions } from './buildHostListOptions';
 import { lastSeenKeysToApiParams } from './lastSeenKeysToApiParams';
 import { buildSystemType } from './buildSystemType';
+import { buildGroupIdParam } from './buildGroupIdParam';
 
 const HOST_LIST_SYSTEM_PROFILE_FIELDS = [
   'operating_system',
@@ -26,17 +27,6 @@ export interface BuildHostListParamsInput {
   sortBy?: ApiHostGetHostListOrderByEnum;
   direction?: SortDirection;
 }
-
-const buildGroupIdParam = (
-  groupIds: string[] | undefined,
-): Pick<ApiHostGetHostListParams, 'groupId'> | Record<string, never> => {
-  if (!groupIds?.length) return {};
-
-  const hasEmpty = groupIds.includes('');
-  const nonEmpty = groupIds.filter((id) => id !== '');
-
-  return { groupId: hasEmpty ? [...nonEmpty, ''] : nonEmpty };
-};
 
 export const buildHostListParams = ({
   page,

--- a/src/components/SystemsView/utils/buildHostViewsParams.test.ts
+++ b/src/components/SystemsView/utils/buildHostViewsParams.test.ts
@@ -169,12 +169,20 @@ describe('buildHostViewsParams', () => {
   });
 
   describe('group_id', () => {
-    it('does not set groupId', () => {
+    it('sets workspaceId and preserves empty string for ungrouped hosts', () => {
       const params = buildParams({
-        filters: { group_id: ['workspace-1'] },
+        filters: { group_id: ['workspace-1', '', 'workspace-2'] },
       });
 
-      expect(params).not.toHaveProperty('groupId');
+      expect(params.workspaceId).toEqual(['workspace-1', 'workspace-2', '']);
+    });
+
+    it('omits workspaceId when group_id is empty', () => {
+      const params = buildParams({
+        filters: { group_id: [] },
+      });
+
+      expect(params.workspaceId).toBeUndefined();
     });
   });
 

--- a/src/components/SystemsView/utils/buildHostViewsParams.ts
+++ b/src/components/SystemsView/utils/buildHostViewsParams.ts
@@ -1,7 +1,6 @@
 import {
   ApiHostViewsGetHostViewsOrderByEnum,
   ApiHostViewsGetHostViewsRegisteredWithEnum,
-  ApiHostViewsGetHostViewsStalenessEnum,
   ApiHostViewsGetHostViewsSystemTypeEnum,
   type ApiHostViewsGetHostViewsParams,
 } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
@@ -13,6 +12,7 @@ import { buildSystemProfileFilters } from './buildSystemProfileFilters';
 import { buildHostQueryOptions } from './buildHostListOptions';
 import { lastSeenKeysToApiParams } from './lastSeenKeysToApiParams';
 import { buildSystemType } from './buildSystemType';
+import { buildGroupIdParam } from './buildGroupIdParam';
 
 const HOST_VIEWS_SYSTEM_PROFILE_FIELDS = [
   'operating_system',
@@ -52,6 +52,7 @@ export const buildHostViewsParams = ({
     filters.last_seen,
     lastSeenCustomRange,
   );
+  const { groupId } = buildGroupIdParam(filters.group_id);
 
   return {
     page,
@@ -74,6 +75,7 @@ export const buildHostViewsParams = ({
         Object.values(ApiHostViewsGetHostViewsSystemTypeEnum),
       ),
     }),
+    ...(groupId && { workspaceId: groupId }),
     ...(filters.tags && { tags: filters.tags }),
     ...(lastSeenParams ?? {}),
     options: buildHostQueryOptions(


### PR DESCRIPTION
RHINENG-27933

## What
This upgrades javascript-client dependency to latest and enables workspace filter in InventoryViews by using workspace_id query param. 

Note: group_id is still displayed in browsers search bar due to compatibility with older table. 

## Testing
Visit InventoryViews table
Try filtering with "Workspace" filter

<img width="1309" height="526" alt="image" src="https://github.com/user-attachments/assets/eac105b2-e512-4d35-8506-bc325598893f" />

## Summary by Sourcery

Enable workspace-based filtering in InventoryViews by wiring the group_id UI filter through to the host views API and updating the host inventory client dependency.

New Features:
- Support workspace filtering in InventoryViews via the workspaceId query parameter.

Enhancements:
- Refactor group ID parameter construction into a shared utility reused by host list and host views parameter builders.

Build:
- Upgrade @redhat-cloud-services/host-inventory-client dependency to version ^5.0.7.

Tests:
- Update buildHostViewsParams tests to cover workspaceId behavior when group_id includes workspace IDs and ungrouped hosts.