### PR TITLE
fix(navigation): avoid having duplicated left-nav items

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -37,35 +37,45 @@ objects:
               - pathname: /insights/inventory
               - pathname: /ansible/inventory
 
+      navigationSegments:
+        - segmentId: systems-nav
+          navItems:
+            - id: systems
+              title: Systems
+              href: /insights/inventory
+              product: Red Hat Insights
+        - segmentId: workspaces-nav
+          navItems:
+            - id: workspaces
+              title: Workspaces
+              href: /insights/inventory/workspaces
+              product: Red Hat Insights
+
       bundleSegments:
         - segmentId: inventory-insights
           bundleId: insights
-          position: 500
+          position: 300
           navItems:
             - id: inventory
               title: Inventory
               expandable: true
               routes:
-                - id: systems
-                  title: Systems
-                  href: /insights/inventory
-                  product: Red Hat Insights
-                - id: workspaces
-                  title: Workspaces
-                  href: /insights/inventory/workspaces
-                  product: Red Hat Insights
-                - id: images
-                  title: Images
-                  href: /insights/image-builder
-                  product: Red Hat Insights
+                - segmentRef:
+                    segmentId: systems-nav
+                    frontendName: inventory
+                - segmentRef:
+                    segmentId: workspaces-nav
+                    frontendName: inventory
+                - segmentRef:
+                    segmentId: image-builder-nav
+                    frontendName: image-builder
                 - id: system-configuration
                   title: System Configuration
                   expandable: true
                   routes:
-                    - id: rhc
-                      title: Remote Host Configuration
-                      href: /insights/connector
-                      product: Red Hat Insights
+                    - segmentRef:
+                        segmentId: rhc-nav
+                        frontendName: connector
                     - id: activation-keys
                       title: Activation Keys
                       href: /insights/connector/activation-keys


### PR DESCRIPTION
## Jira
[RHINENG-28780](https://redhat.atlassian.net/browse/RHINENG-28780)

## What
Correcting navigation, inventory will take care of main `Inventory` bundle and will use references from other apps to put nav items


## Testing
I haven't found a proper way to test it with local env, but already made similar changes to other apps and it works

## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->

## Summary by Sourcery

Deduplicate and centralize left navigation items for inventory-related pages using reusable navigation segments.

Enhancements:
- Introduce reusable navigationSegments for systems, workspaces, image builder, and remote host configuration entries.
- Update inventory bundle segment to reference shared navigation segments and adjust its position within the bundle.

[RHINENG-28780]: https://redhat.atlassian.net/browse/RHINENG-28780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ