### PR TITLE
fix: build requires dependency_helpers.sh

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,6 +12,7 @@ RUN mkdir -p /opt/app-root/bin/
 COPY  ./build-tools/universal_build.sh /opt/app-root/bin/universal_build.sh
 COPY ./build-tools/build_app_info.sh /opt/app-root/bin/build_app_info.sh
 COPY ./build-tools/server_config_gen.sh /opt/app-root/bin/server_config_gen.sh
+COPY ./build-tools/dependency_helpers.sh /opt/app-root/bin/dependency_helpers.sh
 
 COPY --chown=default . .
 


### PR DESCRIPTION
## What

the new version of build-tools added a new script (dependency_helpers.sh) that both build_app_info.sh and server_config_gen.sh now depend on. However, the project's Containerfile only copies three specific scripts into the image.

We're adding the fourth copy required.

## Summary by Sourcery

Build:
- Add dependency_helpers.sh to the list of build-tool scripts copied into the container image.

## Summary by Sourcery

Build:
- Update Containerfile to copy dependency_helpers.sh into /opt/app-root/bin alongside other build tools.