### PR TITLE
chore(build-tools): bump version and adjust Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,6 +12,7 @@ RUN mkdir -p /opt/app-root/bin/
 COPY  ./build-tools/universal_build.sh /opt/app-root/bin/universal_build.sh
 COPY ./build-tools/build_app_info.sh /opt/app-root/bin/build_app_info.sh
 COPY ./build-tools/server_config_gen.sh /opt/app-root/bin/server_config_gen.sh
+COPY ./build-tools/dependency_helpers.sh /opt/app-root/bin/dependency_helpers.sh
 
 COPY --chown=default . .
 


### PR DESCRIPTION
## What
latest build-tools needs adjustments to Containerfile in order to work.

## Summary by Sourcery

Build:
- Update Containerfile to copy dependency_helpers.sh into the application root bin directory.