### PR TITLE
chore(build-tools): adjust Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,6 +12,7 @@ RUN mkdir -p /opt/app-root/bin/
 COPY  ./build-tools/universal_build.sh /opt/app-root/bin/universal_build.sh
 COPY ./build-tools/build_app_info.sh /opt/app-root/bin/build_app_info.sh
 COPY ./build-tools/server_config_gen.sh /opt/app-root/bin/server_config_gen.sh
+COPY ./build-tools/dependency_helpers.sh /opt/app-root/bin/dependency_helpers.sh
 
 COPY --chown=default . .
 


### PR DESCRIPTION
## What
Adjust Containerfile.

This same change as without needing to bump build-tools: #3374

## Summary by Sourcery

Build:
- Copy dependency_helpers.sh into the container image alongside other build-tools scripts.