### PR TITLE
refactor(RHINENG-29359): add columns prop to SystemsView

### DIFF
--- a/src/components/InventoryViews/InventoryHosts.tsx
+++ b/src/components/InventoryViews/InventoryHosts.tsx
@@ -2,12 +2,14 @@ import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import SystemsView from '../SystemsView/SystemsView';
 import { HOSTS_QUERY_KEY, useHostsQuery } from './hooks/useHostsQuery';
+import { selectLegacyInventoryColumns } from './selectLegacyInventoryColumns';
 
 const InventoryHosts = () => {
   const queryClient = useQueryClient();
 
   return (
     <SystemsView
+      columns={selectLegacyInventoryColumns}
       useDataQuery={useHostsQuery}
       onInvalidate={() =>
         queryClient.invalidateQueries({ queryKey: [HOSTS_QUERY_KEY] })

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -10,6 +10,7 @@ import useInventoryViewsPrivateFeatureFlag from '../../Utilities/useInventoryVie
 import ViewsToolbar from './ViewsToolbar/ViewsToolbar';
 import ViewSaveAsModal from './Modals/ViewSaveAsModal';
 import type { ViewConfiguration } from '../../api/inventoryViewsApi';
+import { selectLegacyInventoryColumns } from './selectLegacyInventoryColumns';
 
 const InventoryViews = () => {
   const [isViewSaveAsModalOpen, setIsViewSaveAsModalOpen] = useState(false);
@@ -55,6 +56,7 @@ const InventoryViews = () => {
         </>
       )}
       <SystemsView
+        columns={selectLegacyInventoryColumns}
         useDataQuery={useInventoryViewsQuery}
         onInvalidate={() =>
           queryClient.invalidateQueries({

--- a/src/components/InventoryViews/selectLegacyInventoryColumns.ts
+++ b/src/components/InventoryViews/selectLegacyInventoryColumns.ts
@@ -1,0 +1,22 @@
+import type { ColumnSelector } from '../SystemsView/columns/resolveColumnSelector';
+
+/** Default visible column keys for Inventory Views (not stored on catalog columns). */
+export const COLS_SHOWN_BY_DEFAULT = [
+  'name',
+  'workspace',
+  'tags',
+  'os',
+  'last_seen',
+] as const;
+
+const defaultShownKeys = new Set<string>(COLS_SHOWN_BY_DEFAULT);
+
+export const selectLegacyInventoryColumns: ColumnSelector = (all) =>
+  all.map((col) => {
+    const showByDefault = defaultShownKeys.has(col.key);
+    return {
+      ...col,
+      isShown: showByDefault,
+      isShownByDefault: showByDefault,
+    };
+  });

--- a/src/components/SystemsView/ColumnManagementModalContext.tsx
+++ b/src/components/SystemsView/ColumnManagementModalContext.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { ColumnManagementModal } from '../ColumnManagementModal';
-import defaultColumns, { Column } from './columns/allColumnDefinitions';
+import { Column } from './columns/allColumnDefinitions';
 
 interface SystemsViewColumnManagementContextValue {
   openColumnManagementModal: () => void;
@@ -22,12 +22,14 @@ export const useColumnManagementModalContext = () => {
 interface ColumnManagementModalProviderProps {
   children: React.ReactNode;
   columns: readonly Column[];
+  defaultColumns: readonly Column[];
   setColumns: React.Dispatch<React.SetStateAction<readonly Column[]>>;
 }
 
 export const ColumnManagementModalProvider = ({
   children,
   columns,
+  defaultColumns,
   setColumns,
 }: ColumnManagementModalProviderProps) => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -49,6 +49,10 @@ import type {
 } from '../InventoryViews/hooks/useHostsQuery';
 import { deriveActiveState } from './utils/deriveActiveState';
 import type { OnInvalidate } from './SystemActionModalsContext';
+import {
+  resolveColumnSelector,
+  type ColumnSelector,
+} from './columns/resolveColumnSelector';
 
 export type SortDirection = ISortBy['direction'];
 export type OnSort = (
@@ -73,6 +77,11 @@ export type UseSystemsViewDataQuery = (
 export type SystemsViewProps = {
   useDataQuery: UseSystemsViewDataQuery;
   onInvalidate: OnInvalidate;
+  /**
+   * Selects which columns are available in this view from the full catalog.
+   * Stable reference for selectors required! don't define them inline in JSX.
+   */
+  columns?: ColumnSelector;
 };
 
 interface SystemsViewInnerProps {
@@ -80,6 +89,7 @@ interface SystemsViewInnerProps {
   setSearchParams: SetURLSearchParams;
   useDataQuery: UseSystemsViewDataQuery;
   onInvalidate: OnInvalidate;
+  resolvedDefaultColumns: readonly Column[];
 }
 
 const SystemsViewInner = ({
@@ -87,6 +97,7 @@ const SystemsViewInner = ({
   setSearchParams,
   useDataQuery,
   onInvalidate,
+  resolvedDefaultColumns,
 }: SystemsViewInnerProps) => {
   const { filters, clearAllFilters, lastSeenCustomRange } =
     useDataViewFiltersContext();
@@ -171,6 +182,7 @@ const SystemsViewInner = ({
   const isInventoryViewsEnabled = useInventoryViewsFeatureFlag();
 
   const { columns, setColumns, tableHeaderNodes } = useColumns({
+    defaultColumns: resolvedDefaultColumns,
     sortBy,
     onSort,
     direction,
@@ -238,7 +250,11 @@ const SystemsViewInner = ({
       onInvalidate={onInvalidate}
       onSelectionClear={() => setSelected([])}
     >
-      <ColumnManagementModalProvider columns={columns} setColumns={setColumns}>
+      <ColumnManagementModalProvider
+        columns={columns}
+        setColumns={setColumns}
+        defaultColumns={resolvedDefaultColumns}
+      >
         <DataView selection={selection} activeState={activeState}>
           <PageSection hasBodyWrapper={false}>
             <DataViewToolbar
@@ -287,8 +303,13 @@ const SystemsViewInner = ({
 export const SystemsView = ({
   useDataQuery,
   onInvalidate,
+  columns,
 }: SystemsViewProps) => {
   const [searchParams, setSearchParams] = useSearchParamsWithFragment();
+  const resolvedDefaultColumns = useMemo(
+    () => resolveColumnSelector(columns),
+    [columns],
+  );
 
   return (
     <DataViewFiltersProvider
@@ -300,6 +321,7 @@ export const SystemsView = ({
         setSearchParams={setSearchParams}
         useDataQuery={useDataQuery}
         onInvalidate={onInvalidate}
+        resolvedDefaultColumns={resolvedDefaultColumns}
       />
     </DataViewFiltersProvider>
   );

--- a/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
@@ -11,8 +11,8 @@ const recommendationsColumn = {
   title: 'Recommendations',
   key: 'recommendations',
   minWidth: '10rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.Advisorrecommendations,
   renderCell: (system: InventoryViewSystem) => (
     <AdvisorCount
@@ -27,8 +27,8 @@ const incidentsColumn = {
   title: 'Incidents',
   key: 'incidents',
   minWidth: '7rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.Advisorincidents,
   renderCell: (system: InventoryViewSystem) => (
     <AdvisorCount appData={system?.app_data?.advisor} countField="incidents" />
@@ -40,8 +40,8 @@ const criticalColumn = {
   title: 'Critical',
   key: 'critical',
   minWidth: '7rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <AdvisorCount appData={system?.app_data?.advisor} countField="critical" />
   ),
@@ -52,8 +52,8 @@ const importantColumn = {
   title: 'Important',
   key: 'important',
   minWidth: '7rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <AdvisorCount appData={system?.app_data?.advisor} countField="important" />
   ),
@@ -64,8 +64,8 @@ const moderateColumn = {
   title: 'Moderate',
   key: 'moderate',
   minWidth: '7rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <AdvisorCount appData={system?.app_data?.advisor} countField="moderate" />
   ),
@@ -76,8 +76,8 @@ const lowColumn = {
   title: 'Low',
   key: 'low',
   minWidth: '6rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <AdvisorCount appData={system?.app_data?.advisor} countField="low" />
   ),

--- a/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
+++ b/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
@@ -13,7 +13,6 @@ import { NOT_AVAILABLE } from './CellValue';
 import inventoryColumns from './inventory/columnDefinitions';
 
 const inventoryKeys = inventoryColumns.map((col) => col.key);
-const defaultColumnsKeys = ['name', 'workspace', 'tags', 'os', 'last_seen'];
 const nonInventoryColumns = allColumns.filter(
   (col) => !inventoryKeys.includes(col.key),
 );
@@ -28,18 +27,8 @@ describe('allColumnDefinitions', () => {
     expect(new Set(keys).size).toBe(keys.length);
   });
 
-  it('should show default columns', () => {
-    const inventoryColumns = allColumns.filter((col) =>
-      defaultColumnsKeys.includes(col.key),
-    );
-    inventoryColumns.forEach((col) => {
-      expect(col.isShownByDefault).toBe(true);
-      expect(col.isShown).toBe(true);
-    });
-  });
-
-  it('should not show non-inventory columns by default', () => {
-    nonInventoryColumns.forEach((col) => {
+  it('should hide all catalog columns by default', () => {
+    allColumns.forEach((col) => {
       expect(col.isShownByDefault).toBe(false);
       expect(col.isShown).toBe(false);
     });

--- a/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
+++ b/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
@@ -27,10 +27,10 @@ describe('allColumnDefinitions', () => {
     expect(new Set(keys).size).toBe(keys.length);
   });
 
-  it('should hide all catalog columns by default', () => {
+  it('should show all catalog columns by default', () => {
     allColumns.forEach((col) => {
-      expect(col.isShownByDefault).toBe(false);
-      expect(col.isShown).toBe(false);
+      expect(col.isShownByDefault).toBe(true);
+      expect(col.isShown).toBe(true);
     });
   });
 

--- a/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
@@ -12,8 +12,8 @@ const lastComplianceScanColumn = {
   title: 'Last compliance scan',
   key: 'last_compliance_scan',
   minWidth: '12rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.CompliancelastScan,
   renderCell: (system: InventoryViewSystem) => (
     <LastComplianceScan appData={system?.app_data?.compliance} />
@@ -25,8 +25,8 @@ const policiesColumn = {
   title: 'Policies',
   key: 'policies',
   minWidth: '7rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <Policies appData={system?.app_data?.compliance} />
   ),

--- a/src/components/SystemsView/columns/content/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/content/columnDefinitions.tsx
@@ -10,8 +10,8 @@ const installableAdvisoriesColumn = {
   appName: APP_NAME,
   title: 'Installable advisories',
   key: 'installable-advisories',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: 'patch:advisories_rhsa_installable',
   renderCell(system: InventoryViewSystem) {
     return (
@@ -27,8 +27,8 @@ const templateColumn = {
   appName: APP_NAME,
   title: 'Template',
   key: 'template_name',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell(system: InventoryViewSystem) {
     return <Template appData={system?.app_data?.patch} />;
   },

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -23,8 +23,8 @@ const nameColumn = {
   title: 'Name',
   key: 'name',
   minWidth: DEFAULT_NAME_COLUMN_MIN_WIDTH,
-  isShownByDefault: true,
-  isShown: true,
+  isShownByDefault: false,
+  isShown: false,
   isUntoggleable: true,
   sortBy: ApiOrderByEnum.DisplayName,
   renderCell: (system: System) => (
@@ -43,8 +43,8 @@ const workspaceColumn = {
   title: 'Workspace',
   key: 'workspace',
   minWidth: '10rem',
-  isShownByDefault: true,
-  isShown: true,
+  isShownByDefault: false,
+  isShown: false,
   sortBy: ApiOrderByEnum.GroupName,
   renderCell: (system: InventoryViewSystem) => (
     <Workspace value={system.groups} />
@@ -56,8 +56,8 @@ const tagsColumn = {
   title: 'Tags',
   key: 'tags',
   minWidth: '6rem',
-  isShownByDefault: true,
-  isShown: true,
+  isShownByDefault: false,
+  isShown: false,
   renderCell: (system: InventoryViewSystem) => (
     <Tags value={system.tags} system={system} />
   ),
@@ -68,8 +68,8 @@ const operatingSystemColumn = {
   title: 'OS',
   key: 'os',
   minWidth: '11rem',
-  isShownByDefault: true,
-  isShown: true,
+  isShownByDefault: false,
+  isShown: false,
   sortBy: ApiOrderByEnum.OperatingSystem,
   renderCell: (system: InventoryViewSystem) => (
     <OperatingSystem value={system.system_profile?.operating_system} />
@@ -81,8 +81,8 @@ const lastSeenColumn = {
   title: <LastSeenColumnHeader />,
   key: 'last_seen',
   minWidth: '9rem',
-  isShownByDefault: true,
-  isShown: true,
+  isShownByDefault: false,
+  isShown: false,
   sortBy: ApiOrderByEnum.LastCheckIn,
   renderCell: (system: InventoryViewSystem) => (
     <LastSeen

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -23,8 +23,8 @@ const nameColumn = {
   title: 'Name',
   key: 'name',
   minWidth: DEFAULT_NAME_COLUMN_MIN_WIDTH,
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   isUntoggleable: true,
   sortBy: ApiOrderByEnum.DisplayName,
   renderCell: (system: System) => (
@@ -43,8 +43,8 @@ const workspaceColumn = {
   title: 'Workspace',
   key: 'workspace',
   minWidth: '10rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiOrderByEnum.GroupName,
   renderCell: (system: InventoryViewSystem) => (
     <Workspace value={system.groups} />
@@ -56,8 +56,8 @@ const tagsColumn = {
   title: 'Tags',
   key: 'tags',
   minWidth: '6rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <Tags value={system.tags} system={system} />
   ),
@@ -68,8 +68,8 @@ const operatingSystemColumn = {
   title: 'OS',
   key: 'os',
   minWidth: '11rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiOrderByEnum.OperatingSystem,
   renderCell: (system: InventoryViewSystem) => (
     <OperatingSystem value={system.system_profile?.operating_system} />
@@ -81,8 +81,8 @@ const lastSeenColumn = {
   title: <LastSeenColumnHeader />,
   key: 'last_seen',
   minWidth: '9rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiOrderByEnum.LastCheckIn,
   renderCell: (system: InventoryViewSystem) => (
     <LastSeen
@@ -102,8 +102,8 @@ const statusColumn = {
   title: 'Status',
   key: 'status',
   minWidth: '9rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: 'status',
   renderCell: (system: InventoryViewSystem) => (
     <Status
@@ -120,8 +120,8 @@ const infrastructureColumn = {
   appName: APP_NAME,
   title: 'Infrastructure',
   key: 'infrastructure',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <Infrastructure value={system.system_profile?.infrastructure_type} />
   ),
@@ -131,8 +131,8 @@ const vendorColumn = {
   appName: APP_NAME,
   title: 'Vendor',
   key: 'vendor',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <Vendor value={system.system_profile?.infrastructure_vendor} />
   ),
@@ -142,8 +142,8 @@ const workloadColumn = {
   appName: APP_NAME,
   title: 'Workload',
   key: 'workload',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <Workload value={system.system_profile?.workloads} />
   ),
@@ -153,8 +153,8 @@ const createdColumn = {
   appName: APP_NAME,
   title: 'Created',
   key: 'created',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell: (system: InventoryViewSystem) => (
     <Created value={system?.created} />
   ),

--- a/src/components/SystemsView/columns/inventoryViewsColumnSelector.test.ts
+++ b/src/components/SystemsView/columns/inventoryViewsColumnSelector.test.ts
@@ -1,0 +1,17 @@
+import allColumns from './allColumnDefinitions';
+import { COLS_SHOWN_BY_DEFAULT } from '../../InventoryViews/selectLegacyInventoryColumns';
+import { selectLegacyInventoryColumns } from '../../InventoryViews/selectLegacyInventoryColumns';
+
+describe('inventoryViewsColumnSelector', () => {
+  it('shows the inventory default columns', () => {
+    const columns = selectLegacyInventoryColumns(allColumns);
+
+    columns.forEach((col) => {
+      const shouldShow = (COLS_SHOWN_BY_DEFAULT as readonly string[]).includes(
+        col.key,
+      );
+      expect(col.isShown).toBe(shouldShow);
+      expect(col.isShownByDefault).toBe(shouldShow);
+    });
+  });
+});

--- a/src/components/SystemsView/columns/malware/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/malware/columnDefinitions.tsx
@@ -13,8 +13,8 @@ const lastMalwareStatusColumn = {
   title: 'Last malware status',
   key: 'last_malware_status',
   minWidth: '12rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell(system: InventoryViewSystem) {
     return <LastMalwareStatus appData={system?.app_data?.malware} />;
   },
@@ -25,8 +25,8 @@ const totalMalwareMatchesColumn = {
   title: 'Total malware matches',
   key: 'total_malware_matches',
   minWidth: '13rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   renderCell(system: InventoryViewSystem) {
     return (
       <TotalMalwareMatches
@@ -42,8 +42,8 @@ const lastMalwareScanColumn = {
   title: 'Last malware scan',
   key: 'last_malware_scan',
   minWidth: '12rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.MalwarelastScan,
   renderCell(system: InventoryViewSystem) {
     return <LastMalwareScan appData={system?.app_data?.malware} />;

--- a/src/components/SystemsView/columns/remediations/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/remediations/columnDefinitions.tsx
@@ -11,8 +11,8 @@ const remediationPlansColumn = {
   title: 'Remediation plans',
   key: 'remediations_plans',
   minWidth: '12rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.RemediationsremediationsPlans,
   renderCell: (system: InventoryViewSystem) => (
     <RemediationPlans appData={system?.app_data?.remediations} />

--- a/src/components/SystemsView/columns/resolveColumnSelector.test.ts
+++ b/src/components/SystemsView/columns/resolveColumnSelector.test.ts
@@ -1,0 +1,40 @@
+import { expect } from '@jest/globals';
+import allColumns from './allColumnDefinitions';
+import inventoryColumns from './inventory/columnDefinitions';
+import {
+  type ColumnSelector,
+  defaultColumnSelector,
+  resolveColumnSelector,
+  selectInventoryColumns,
+} from './resolveColumnSelector';
+
+const inventoryKeys = inventoryColumns.map((col) => col.key);
+
+describe('resolveColumnSelector', () => {
+  it('returns the full catalog with the default selector', () => {
+    expect(resolveColumnSelector()).toBe(allColumns);
+    expect(defaultColumnSelector(allColumns)).toBe(allColumns);
+  });
+
+  it('returns only inventory columns with selectInventoryColumns', () => {
+    const selected = selectInventoryColumns(allColumns);
+
+    expect(selected.every((col) => col.appName === 'inventory')).toBe(true);
+    expect(selected.map((col) => col.key)).toEqual(inventoryKeys);
+  });
+
+  it('allows custom selectors to reorder and override visibility', () => {
+    const customSelector: ColumnSelector = (all) => {
+      const byKey = Object.fromEntries(all.map((col) => [col.key, col]));
+      return [
+        { ...byKey.os, isShown: true, isShownByDefault: true },
+        { ...byKey.name, isShown: true, isShownByDefault: true },
+      ];
+    };
+
+    const selected = resolveColumnSelector(customSelector);
+
+    expect(selected.map((col) => col.key)).toEqual(['os', 'name']);
+    expect(selected.every((col) => col.isShown)).toBe(true);
+  });
+});

--- a/src/components/SystemsView/columns/resolveColumnSelector.test.ts
+++ b/src/components/SystemsView/columns/resolveColumnSelector.test.ts
@@ -5,7 +5,6 @@ import {
   type ColumnSelector,
   defaultColumnSelector,
   resolveColumnSelector,
-  selectInventoryColumns,
 } from './resolveColumnSelector';
 
 const inventoryKeys = inventoryColumns.map((col) => col.key);
@@ -14,13 +13,6 @@ describe('resolveColumnSelector', () => {
   it('returns the full catalog with the default selector', () => {
     expect(resolveColumnSelector()).toBe(allColumns);
     expect(defaultColumnSelector(allColumns)).toBe(allColumns);
-  });
-
-  it('returns only inventory columns with selectInventoryColumns', () => {
-    const selected = selectInventoryColumns(allColumns);
-
-    expect(selected.every((col) => col.appName === 'inventory')).toBe(true);
-    expect(selected.map((col) => col.key)).toEqual(inventoryKeys);
   });
 
   it('allows custom selectors to reorder and override visibility', () => {

--- a/src/components/SystemsView/columns/resolveColumnSelector.test.ts
+++ b/src/components/SystemsView/columns/resolveColumnSelector.test.ts
@@ -10,9 +10,9 @@ import {
 const inventoryKeys = inventoryColumns.map((col) => col.key);
 
 describe('resolveColumnSelector', () => {
-  it('returns the full catalog with the default selector', () => {
-    expect(resolveColumnSelector()).toBe(allColumns);
-    expect(defaultColumnSelector(allColumns)).toBe(allColumns);
+  it('returns no columns with the default selector', () => {
+    expect(resolveColumnSelector()).toEqual([]);
+    expect(defaultColumnSelector(allColumns)).toEqual([]);
   });
 
   it('allows custom selectors to reorder and override visibility', () => {

--- a/src/components/SystemsView/columns/resolveColumnSelector.ts
+++ b/src/components/SystemsView/columns/resolveColumnSelector.ts
@@ -1,0 +1,14 @@
+import allColumnDefinitions, { type Column } from './allColumnDefinitions';
+
+export type ColumnSelector = (
+  allColumns: readonly Column[],
+) => readonly Column[];
+
+export const defaultColumnSelector: ColumnSelector = (all) => all;
+
+export const selectInventoryColumns: ColumnSelector = (all) =>
+  all.filter((col) => col.appName === 'inventory');
+
+export const resolveColumnSelector = (
+  selector: ColumnSelector = defaultColumnSelector,
+): readonly Column[] => selector(allColumnDefinitions);

--- a/src/components/SystemsView/columns/resolveColumnSelector.ts
+++ b/src/components/SystemsView/columns/resolveColumnSelector.ts
@@ -1,13 +1,32 @@
 import allColumnDefinitions, { type Column } from './allColumnDefinitions';
 
+/**
+ * Picks which columns a `SystemsView` instance exposes to column
+ * management and the table. It receives full catalog of predefined column definitions
+ * `allColumnDefinitions`; return a (possibly reordered or filtered) list of columns
+ *
+ * The table only renders columns where `isShownByDefault` is true. map over `allColumns` and set this property
+ * to true for columns you want to visible on load—see
+ * `legacyInventoryColumnsSelector` in `InventoryViews/legacyInventoryColumnsSelector.ts`.
+ */
 export type ColumnSelector = (
   allColumns: readonly Column[],
 ) => readonly Column[];
 
+/**
+ * Default when `SystemsView` omits the `columns` prop: pass the entire catalog
+ * into column management without changing visibility.
+ *
+ * Every catalog column remains available in the manage-columns UI, but none
+ * appear in the table until the user toggles them or a custom selector sets
+ * `isShownByDefault` (e.g. `{ ...col, isShownByDefault: true }`
+ * for selected keys). Product views should pass an explicit selector instead of
+ * relying on this default.
+ *
+ *  @param all - Full column catalog from `allColumnDefinitions`.
+ *  @returns   The same columns; visibility flags unchanged (all hidden by default).
+ */
 export const defaultColumnSelector: ColumnSelector = (all) => all;
-
-export const selectInventoryColumns: ColumnSelector = (all) =>
-  all.filter((col) => col.appName === 'inventory');
 
 export const resolveColumnSelector = (
   selector: ColumnSelector = defaultColumnSelector,

--- a/src/components/SystemsView/columns/resolveColumnSelector.ts
+++ b/src/components/SystemsView/columns/resolveColumnSelector.ts
@@ -1,32 +1,23 @@
 import allColumnDefinitions, { type Column } from './allColumnDefinitions';
 
 /**
- * Picks which columns a `SystemsView` instance exposes to column
- * management and the table. It receives full catalog of predefined column definitions
- * `allColumnDefinitions`; return a (possibly reordered or filtered) list of columns
- *
- * The table only renders columns where `isShownByDefault` is true. map over `allColumns` and set this property
- * to true for columns you want to visible on load—see
- * `legacyInventoryColumnsSelector` in `InventoryViews/legacyInventoryColumnsSelector.ts`.
+ * Picks which columns a `SystemsView` instance displays in the table.
+ * It receives full catalog of predefined column definitions `allColumnDefinitions`;
+ * return a (possibly reordered or filtered) list of columns
  */
 export type ColumnSelector = (
   allColumns: readonly Column[],
 ) => readonly Column[];
 
 /**
- * Default when `SystemsView` omits the `columns` prop: pass the entire catalog
- * into column management without changing visibility.
+ * Default when `SystemsView` omits the `columns` prop: expose no columns.
  *
- * Every catalog column remains available in the manage-columns UI, but none
- * appear in the table until the user toggles them or a custom selector sets
- * `isShownByDefault` (e.g. `{ ...col, isShownByDefault: true }`
- * for selected keys). Product views should pass an explicit selector instead of
- * relying on this default.
+ * Product views should pass an explicit selector (e.g. legacy inventory) that
+ * returns the catalog subset they need.
  *
- *  @param all - Full column catalog from `allColumnDefinitions`.
- *  @returns   The same columns; visibility flags unchanged (all hidden by default).
+ *  @returns An empty list; no columns for the table.
  */
-export const defaultColumnSelector: ColumnSelector = (all) => all;
+export const defaultColumnSelector: ColumnSelector = () => [];
 
 export const resolveColumnSelector = (
   selector: ColumnSelector = defaultColumnSelector,

--- a/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
@@ -17,8 +17,8 @@ const totalCVEsColumn = {
   title: 'Total CVEs',
   key: 'total_cves',
   minWidth: '10rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitytotalCves,
   renderCell: (system: InventoryViewSystem) => (
     <VulnerabilityCount
@@ -35,8 +35,8 @@ const criticalCVEsColumn = {
   title: 'Critical CVEs',
   key: 'critical_cves',
   minWidth: '10rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitycriticalCves,
   renderCell: (system: InventoryViewSystem) => (
     <VulnerabilityCount
@@ -53,8 +53,8 @@ const importantCVEsColumn = {
   title: 'Important CVEs',
   key: 'important_cves',
   minWidth: '10rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: IMPORTANT_CVES_SORT_KEY,
   renderCell: (system: InventoryViewSystem) => (
     <VulnerabilityCount
@@ -71,8 +71,8 @@ const cvesWithSecurityRulesColumn = {
   title: 'CVEs with security rules',
   key: 'cves_with_security_rules',
   minWidth: '10rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: CVES_WITH_SECURITY_RULES_SORT_KEY,
   renderCell: (system: InventoryViewSystem) => (
     <VulnerabilityCount
@@ -89,8 +89,8 @@ const cvesWithKnownExploitsColumn = {
   title: 'CVEs with known exploits',
   key: 'cves_with_known_exploits',
   minWidth: '10rem',
-  isShownByDefault: false,
-  isShown: false,
+  isShownByDefault: true,
+  isShown: true,
   sortBy: CVES_WITH_KNOWN_EXPLOITS_SORT_KEY,
   renderCell: (system: InventoryViewSystem) => (
     <VulnerabilityCount

--- a/src/components/SystemsView/hooks/useColumns.tsx
+++ b/src/components/SystemsView/hooks/useColumns.tsx
@@ -7,7 +7,7 @@ import {
 } from '../utils/columnMinWidths';
 import { STICKY_ACTIONS_HEADER_PROPS } from '../utils/stickyActionsColumn';
 import { getStickyNameHeaderProps } from '../utils/stickyNameColumn';
-import defaultColumns, { type Column } from '../columns/allColumnDefinitions';
+import { type Column } from '../columns/allColumnDefinitions';
 import { usePersistedColumns } from './usePersistedColumns';
 
 export const INITIAL_SORT: {
@@ -27,6 +27,7 @@ const FALLBACK_SORT: {
 };
 
 interface UseColumnParams {
+  defaultColumns: readonly Column[];
   sortBy: Column['sortBy'];
   onSort: OnSort;
   direction: SortDirection;
@@ -34,6 +35,7 @@ interface UseColumnParams {
 }
 
 export const useColumns = ({
+  defaultColumns,
   sortBy,
   onSort,
   direction,

--- a/src/components/SystemsView/hooks/usePersistedColumns.test.tsx
+++ b/src/components/SystemsView/hooks/usePersistedColumns.test.tsx
@@ -55,6 +55,21 @@ const defaultColumns = [
   createTestColumn('os', true),
 ] as const;
 
+const getDefaultsId = (columns: readonly Column[]) =>
+  columns
+    .map((column) => `${column.key}:${column.isShownByDefault}`)
+    .sort()
+    .join('|');
+
+const persistedColumnPrefs = (
+  columns: readonly Column[],
+  prefs: { key: string; isShown: boolean }[],
+) =>
+  JSON.stringify({
+    defaultsId: getDefaultsId(columns),
+    columns: prefs,
+  });
+
 describe('usePersistedColumns', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -63,10 +78,11 @@ describe('usePersistedColumns', () => {
   it('loads column preferences from localStorage for the signed-in user', async () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify([
+      persistedColumnPrefs(defaultColumns, [
         { key: 'os', isShown: true },
         { key: 'name', isShown: false },
         { key: 'workspace', isShown: true },
+        { key: 'tags', isShown: false },
       ]),
     );
 
@@ -98,6 +114,60 @@ describe('usePersistedColumns', () => {
     });
   });
 
+  it('clears stored prefs when selector default visibility changes', async () => {
+    const previousDefaults = defaultColumns;
+    const nextDefaults = [
+      createTestColumn('name', true),
+      createTestColumn('workspace', true),
+      createTestColumn('tags', true),
+      createTestColumn('os', true),
+    ] as const;
+
+    localStorage.setItem(
+      STORAGE_KEY,
+      persistedColumnPrefs(previousDefaults, [
+        { key: 'name', isShown: false },
+        { key: 'workspace', isShown: true },
+        { key: 'tags', isShown: false },
+        { key: 'os', isShown: true },
+      ]),
+    );
+
+    const { result } = renderHook(() => usePersistedColumns(nextDefaults));
+
+    await waitFor(() => {
+      expect(result.current.columns.map((column) => column.key)).toEqual([
+        'name',
+        'workspace',
+        'tags',
+        'os',
+      ]);
+    });
+
+    expect(
+      result.current.columns.find((column) => column.key === 'name'),
+    ).toMatchObject({
+      isShown: true,
+    });
+    expect(
+      result.current.columns.find((column) => column.key === 'tags'),
+    ).toMatchObject({
+      isShown: true,
+    });
+
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({
+        defaultsId: getDefaultsId(nextDefaults),
+        columns: [
+          { key: 'name', isShown: true },
+          { key: 'workspace', isShown: true },
+          { key: 'tags', isShown: true },
+          { key: 'os', isShown: true },
+        ],
+      });
+    });
+  });
+
   it('saves column preferences to localStorage when columns change', async () => {
     const { result } = renderHook(() => usePersistedColumns(defaultColumns));
 
@@ -120,12 +190,15 @@ describe('usePersistedColumns', () => {
     });
 
     await waitFor(() => {
-      expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual([
-        { key: 'tags', isShown: false },
-        { key: 'name', isShown: true },
-        { key: 'workspace', isShown: false },
-        { key: 'os', isShown: true },
-      ]);
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({
+        defaultsId: getDefaultsId(defaultColumns),
+        columns: [
+          { key: 'tags', isShown: false },
+          { key: 'name', isShown: true },
+          { key: 'workspace', isShown: false },
+          { key: 'os', isShown: true },
+        ],
+      });
     });
   });
 });

--- a/src/components/SystemsView/hooks/usePersistedColumns.ts
+++ b/src/components/SystemsView/hooks/usePersistedColumns.ts
@@ -13,13 +13,54 @@ type ColumnPref = {
   isShown: boolean;
 };
 
+type PersistedColumnPrefs = {
+  defaultsId: string;
+  columns: ColumnPref[];
+};
+
 const getColumnSnapshot = (columns: readonly Column[]): ColumnPref[] =>
   columns.map((column) => ({
     key: column.key,
     isShown: column.isShown ?? column.isShownByDefault,
   }));
 
-const loadColumnPrefs = (storageKey: string): ColumnPref[] | null => {
+const getColumnKeySetId = (columns: readonly { key: string }[]): string =>
+  columns
+    .map((column) => column.key)
+    .sort()
+    .join(',');
+
+const getColumnDefaultsId = (columns: readonly Column[]): string =>
+  columns
+    .map((column) => `${column.key}:${column.isShownByDefault}`)
+    .sort()
+    .join('|');
+
+const parseColumnPrefs = (items: unknown[]): ColumnPref[] =>
+  items.filter(
+    (item): item is ColumnPref =>
+      typeof item === 'object' &&
+      item !== null &&
+      typeof (item as ColumnPref).key === 'string' &&
+      typeof (item as ColumnPref).isShown === 'boolean',
+  );
+
+const storedColumnKeysMatchDefaults = (
+  stored: ColumnPref[],
+  defaults: readonly Column[],
+): boolean => getColumnKeySetId(stored) === getColumnKeySetId(defaults);
+
+const removeColumnPrefs = (storageKey: string): void => {
+  try {
+    localStorage.removeItem(storageKey);
+  } catch {
+    // Ignore unavailable storage (e.g. private browsing).
+  }
+};
+
+const readPersistedColumnPrefs = (
+  storageKey: string,
+): PersistedColumnPrefs | ColumnPref[] | null => {
   try {
     const raw = localStorage.getItem(storageKey);
     if (!raw) {
@@ -27,32 +68,79 @@ const loadColumnPrefs = (storageKey: string): ColumnPref[] | null => {
     }
 
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return null;
+
+    if (Array.isArray(parsed)) {
+      const columns = parseColumnPrefs(parsed);
+      return columns.length > 0 ? columns : null;
     }
 
-    const prefs = parsed.filter(
-      (item): item is ColumnPref =>
-        typeof item === 'object' &&
-        item !== null &&
-        typeof (item as ColumnPref).key === 'string' &&
-        typeof (item as ColumnPref).isShown === 'boolean',
-    );
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof (parsed as PersistedColumnPrefs).defaultsId === 'string' &&
+      Array.isArray((parsed as PersistedColumnPrefs).columns)
+    ) {
+      const columns = parseColumnPrefs(
+        (parsed as PersistedColumnPrefs).columns,
+      );
+      if (columns.length === 0) {
+        return null;
+      }
 
-    return prefs.length > 0 ? prefs : null;
+      return {
+        defaultsId: (parsed as PersistedColumnPrefs).defaultsId,
+        columns,
+      };
+    }
+
+    return null;
   } catch {
     return null;
   }
 };
 
+const loadCompatibleColumnPrefs = (
+  storageKey: string,
+  defaults: readonly Column[],
+): ColumnPref[] | null => {
+  const stored = readPersistedColumnPrefs(storageKey);
+  if (!stored) {
+    return null;
+  }
+
+  const defaultsId = getColumnDefaultsId(defaults);
+  const columns = Array.isArray(stored) ? stored : stored.columns;
+
+  if (Array.isArray(stored)) {
+    removeColumnPrefs(storageKey);
+    return null;
+  }
+
+  if (!storedColumnKeysMatchDefaults(columns, defaults)) {
+    removeColumnPrefs(storageKey);
+    return null;
+  }
+
+  if (!Array.isArray(stored) && stored.defaultsId !== defaultsId) {
+    removeColumnPrefs(storageKey);
+    return null;
+  }
+
+  return columns;
+};
+
 const saveColumnPrefs = (
   storageKey: string,
   columns: readonly Column[],
+  defaultsId: string,
 ): void => {
   try {
     localStorage.setItem(
       storageKey,
-      JSON.stringify(getColumnSnapshot(columns)),
+      JSON.stringify({
+        defaultsId,
+        columns: getColumnSnapshot(columns),
+      } satisfies PersistedColumnPrefs),
     );
   } catch {
     // Ignore unavailable storage (e.g. private browsing).
@@ -111,11 +199,14 @@ export const usePersistedColumns = (defaultColumns: readonly Column[]) => {
   const chrome = useChrome();
   const [storageKey, setStorageKey] = useState<string | null>(null);
   const [columns, setColumns] = useState<readonly Column[]>(defaultColumns);
-  const loadedStorageKeyRef = useRef<string | null>(null);
+  const loadedPrefsContextRef = useRef<{
+    storageKey: string;
+    defaultsId: string;
+  } | null>(null);
 
   useEffect(() => {
     if (!shouldPersist) {
-      loadedStorageKeyRef.current = null;
+      loadedPrefsContextRef.current = null;
       setStorageKey(null);
       setColumns(defaultColumns);
       return;
@@ -139,14 +230,23 @@ export const usePersistedColumns = (defaultColumns: readonly Column[]) => {
         }
 
         const key = getUserStorageKey(String(accountNumber), String(username));
+        const defaultsId = getColumnDefaultsId(defaultColumns);
 
-        if (loadedStorageKeyRef.current === key) {
+        if (
+          loadedPrefsContextRef.current?.storageKey === key &&
+          loadedPrefsContextRef.current?.defaultsId === defaultsId
+        ) {
           return;
         }
 
-        loadedStorageKeyRef.current = key;
+        loadedPrefsContextRef.current = { storageKey: key, defaultsId };
         setStorageKey(key);
-        setColumns(mergeColumnPrefs(defaultColumns, loadColumnPrefs(key)));
+        setColumns(
+          mergeColumnPrefs(
+            defaultColumns,
+            loadCompatibleColumnPrefs(key, defaultColumns),
+          ),
+        );
       })
       .catch(() => {
         // Ignore unavailable user identity (e.g. chromeless mode).
@@ -158,10 +258,17 @@ export const usePersistedColumns = (defaultColumns: readonly Column[]) => {
   }, [chrome, defaultColumns, shouldPersist]);
 
   useEffect(() => {
-    if (storageKey && shouldPersist) {
-      saveColumnPrefs(storageKey, columns);
+    if (!storageKey || !shouldPersist) {
+      return;
     }
-  }, [columns, storageKey, shouldPersist]);
+
+    const defaultsId = getColumnDefaultsId(defaultColumns);
+    if (loadedPrefsContextRef.current?.defaultsId !== defaultsId) {
+      return;
+    }
+
+    saveColumnPrefs(storageKey, columns, defaultsId);
+  }, [columns, defaultColumns, storageKey, shouldPersist]);
 
   return { columns, setColumns };
 };

--- a/src/components/SystemsView/index.ts
+++ b/src/components/SystemsView/index.ts
@@ -8,3 +8,9 @@ export type {
 export type { SystemsViewFetchParams } from '../InventoryViews/hooks/useHostsQuery';
 export type { OnInvalidate } from './SystemActionModalsContext';
 export type { SystemsViewActiveState } from './utils/deriveActiveState';
+export type { Column } from './columns/allColumnDefinitions';
+export type { ColumnSelector } from './columns/resolveColumnSelector';
+export {
+  defaultColumnSelector,
+  selectInventoryColumns,
+} from './columns/resolveColumnSelector';

--- a/src/components/SystemsView/index.ts
+++ b/src/components/SystemsView/index.ts
@@ -10,7 +10,4 @@ export type { OnInvalidate } from './SystemActionModalsContext';
 export type { SystemsViewActiveState } from './utils/deriveActiveState';
 export type { Column } from './columns/allColumnDefinitions';
 export type { ColumnSelector } from './columns/resolveColumnSelector';
-export {
-  defaultColumnSelector,
-  selectInventoryColumns,
-} from './columns/resolveColumnSelector';
+export { defaultColumnSelector } from './columns/resolveColumnSelector';


### PR DESCRIPTION
RHINENG-29359


## What
This is continuation of extending configurability of SystemsView. It behaves same way as before when columns prop isn't specified. 

Think of this as dynamic configuration layer on top of columns. Until now we could set columns just statically via column definitions. We still can adjust those same definitions for more sane defaults but we also can adjust dynamically. This is useful as generic reusability feature but could also come handy for Views.

## How
Introduces new prop `columns` for `SystemsView` which accepts selector function which as input receives all column definitions we currently have defined in SystemsView. What does it output decides what columns will be shown in modal/table

If we don't specify the columns default selector is assumed. Default selector passes in all definitions we currently use. Understand even though we pass definition it's still doesn't have to be shown. This is still controlled via its properties like isShown and isShownByDefault but it can be tweaked now inside of this selector.
`export const defaultColumnSelector: ColumnSelector = (all) => all;`

Now if we just select all and not altern any of those definitions they behave exactly same way as they did till now.

## Testing
- Make sure correct columns are displayed for both InventoryViews and InventoryHosts.
- Try to manipulate the column definitions by passing your own selector into columns in Inventory. For example this selector function will pass in only inventory column definitions.

`columns={(all) => all.filter((col) => col.appName === 'inventory')}`

<img width="931" height="1081" alt="image" src="https://github.com/user-attachments/assets/f7e343a1-0095-400e-a109-e893f44944c6" />

## Summary by Sourcery

Make SystemsView columns configurable via an optional selector while preserving the existing default column set.

New Features:
- Add an optional columns selector prop to SystemsView to choose which columns from the full catalog are available in the view.
- Expose column-related types and helpers (Column, ColumnSelector, defaultColumnSelector, selectInventoryColumns) from the SystemsView public API for external configuration.

Enhancements:
- Wire resolved default columns through SystemsView, useColumns, and ColumnManagementModalProvider so column management operates on the selected column subset instead of a fixed catalog.

Tests:
- Introduce unit tests for resolveColumnSelector to cover default behavior, inventory-only selection, and custom selector overrides.