### PR TITLE
chore(RHINENG-28939): Replace platform.rbac.workspaces flag with hbi.rbac-v2 flag

### DIFF
--- a/src/Utilities/hooks/useKesselMigrationFeatureFlag.js
+++ b/src/Utilities/hooks/useKesselMigrationFeatureFlag.js
@@ -1,6 +1,6 @@
 import useFeatureFlag from '../useFeatureFlag';
 
 export const useKesselMigrationFeatureFlag = () => {
-  const isFlagEnabled = useFeatureFlag('platform.rbac.workspaces');
+  const isFlagEnabled = useFeatureFlag('hbi.rbac-v2');
   return isFlagEnabled || false;
 };

--- a/src/components/SystemsView/SystemsViewRowActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.test.tsx
@@ -43,9 +43,7 @@ describe('SystemsViewRowActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     const useFeatureFlag = require('../../Utilities/useFeatureFlag').default;
-    useFeatureFlag.mockImplementation(
-      (key: string) => key === 'hbi.rbac-v2',
-    );
+    useFeatureFlag.mockImplementation((key: string) => key === 'hbi.rbac-v2');
     const useConditionalRBACMock =
       require('../../Utilities/hooks/useConditionalRBAC')
         .useConditionalRBAC as jest.Mock;

--- a/src/components/SystemsView/SystemsViewRowActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.test.tsx
@@ -30,7 +30,7 @@ function renderWithProvider(ui: React.ReactElement) {
 
 jest.mock('../../Utilities/useFeatureFlag', () => ({
   __esModule: true,
-  default: jest.fn((key: string) => key === 'platform.rbac.workspaces'),
+  default: jest.fn((key: string) => key === 'hbi.rbac-v2'),
 }));
 
 jest.mock('../../Utilities/hooks/useConditionalRBAC', () => ({
@@ -44,7 +44,7 @@ describe('SystemsViewRowActions', () => {
     jest.clearAllMocks();
     const useFeatureFlag = require('../../Utilities/useFeatureFlag').default;
     useFeatureFlag.mockImplementation(
-      (key: string) => key === 'platform.rbac.workspaces',
+      (key: string) => key === 'hbi.rbac-v2',
     );
     const useConditionalRBACMock =
       require('../../Utilities/hooks/useConditionalRBAC')


### PR DESCRIPTION
## Jira
[RHINENG-28939](https://redhat.atlassian.net/browse/RHINENG-28939)

## What
Replace the `platform.rbac.workspaces` feature flag with the `hbi.rbac-v2` feature flag.

## Why
HBI needs to roll out RBAC v2 access checks independently of the "RBAC v2 experience". This new flag always includes the Org IDs listed in `platform.rbac.workspaces`, but can also roll out to more orgs.

## How
Simple find & replace

## Testing
None

## Screenshots/Videos (if applicable)
N/A


[RHINENG-28939]: https://redhat.atlassian.net/browse/RHINENG-28939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Replace usage of the legacy RBAC workspaces feature flag with the new RBAC v2 feature flag across relevant utilities and tests.

Enhancements:
- Update Kessel migration feature flag hook to rely on the new hbi.rbac-v2 feature flag instead of platform.rbac.workspaces.

Tests:
- Adjust SystemsViewRowActions tests to mock and assert against the hbi.rbac-v2 feature flag rather than platform.rbac.workspaces.