### PR TITLE
feat(RHINENG-28361): Add Rename view modal with validation

### DIFF
--- a/src/api/inventoryViewsApi.ts
+++ b/src/api/inventoryViewsApi.ts
@@ -19,6 +19,67 @@ export type UpdateViewRequest = ViewPatch;
 export type InventoryView = ViewOut;
 
 // ============================================================================
+// MOCK DATA (Replace with real API when available)
+// ============================================================================
+
+export const ALL_SYSTEMS_VIEW_ID = 'all-systems';
+
+export const MOCK_VIEWS: ViewOut[] = [
+  {
+    id: ALL_SYSTEMS_VIEW_ID,
+    name: 'All systems',
+    description: 'Default view showing all inventory systems',
+    is_system_view: true,
+    org_id: 'org-123',
+    org_wide: true,
+    configuration: { columns: [] },
+    created_by: 'system',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    is_owner: false,
+  },
+  {
+    id: 'view-production',
+    name: 'Production view',
+    description: 'Production environment systems',
+    is_system_view: false,
+    org_id: 'org-123',
+    org_wide: false,
+    configuration: { columns: [] },
+    created_by: 'current-user',
+    created_at: '2026-06-15T10:00:00Z',
+    updated_at: '2026-07-20T14:30:00Z',
+    is_owner: true,
+  },
+  {
+    id: 'view-rhel9-staging',
+    name: 'RHEL 9 staging',
+    description: 'RHEL 9 systems in staging environment',
+    is_system_view: false,
+    org_id: 'org-123',
+    org_wide: false,
+    configuration: { columns: [] },
+    created_by: 'current-user',
+    created_at: '2026-07-01T09:00:00Z',
+    updated_at: '2026-07-25T11:00:00Z',
+    is_owner: true,
+  },
+  {
+    id: 'view-security',
+    name: 'Security overview',
+    description: 'Systems with security-related advisories',
+    is_system_view: true,
+    org_id: 'org-123',
+    org_wide: true,
+    configuration: { columns: [] },
+    created_by: 'system',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    is_owner: false,
+  },
+];
+
+// ============================================================================
 // DUMMY API FUNCTIONS (Replace with real API calls)
 // ============================================================================
 
@@ -37,13 +98,12 @@ export const listViewsApi = async (): Promise<ViewsListOut> => {
   // Simulate API delay
   await new Promise((resolve) => setTimeout(resolve, 300));
 
-  // Return mock response matching paginated API structure
   return {
-    count: 0,
+    count: MOCK_VIEWS.length,
     page: 1,
     per_page: 50,
-    total: 0,
-    results: [],
+    total: MOCK_VIEWS.length,
+    results: MOCK_VIEWS,
   };
 };
 

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -9,15 +9,24 @@ import { useViewsQuery } from './hooks/useViewsQuery';
 import useInventoryViewsPrivateFeatureFlag from '../../Utilities/useInventoryViewsPrivateFeatureFlag';
 import ViewsToolbar from './ViewsToolbar/ViewsToolbar';
 import ViewSaveAsModal from './Modals/ViewSaveAsModal';
+import ViewRenameModal from './Modals/ViewRenameModal';
 import type { ViewConfiguration } from '../../api/inventoryViewsApi';
 import { selectLegacyInventoryColumns } from './selectLegacyInventoryColumns';
 
+const STATIC_ACTIVE_VIEW_ID = 'view-production';
+
 const InventoryViews = () => {
   const [isViewSaveAsModalOpen, setIsViewSaveAsModalOpen] = useState(false);
+  const [viewToRename, setViewToRename] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
   const queryClient = useQueryClient();
   const isInventoryViewsPrivateEnabled = useInventoryViewsPrivateFeatureFlag();
   const { data: viewsData } = useViewsQuery();
   const viewsList = viewsData?.results ?? [];
+  const activeView = viewsList.find((v) => v.id === STATIC_ACTIVE_VIEW_ID);
+  const isSystemView = activeView?.is_system_view ?? true;
 
   // Open Save As modal
   const handleSaveAs = () => {
@@ -29,6 +38,20 @@ const InventoryViews = () => {
     console.log('View created successfully:', { viewId, viewName });
     setIsViewSaveAsModalOpen(false);
     // TODO: Navigate to the new view or refresh view list
+  };
+
+  // Open Rename modal
+  const handleRename = () => {
+    // TODO: Replace STATIC_ACTIVE_VIEW_ID with dynamic view selection (RHINENG-28357)
+    if (STATIC_ACTIVE_VIEW_ID && activeView?.name) {
+      setViewToRename({ id: STATIC_ACTIVE_VIEW_ID, name: activeView.name });
+    }
+  };
+
+  // Handle successful view rename
+  const handleRenameSuccess = (viewId: string, viewName: string) => {
+    console.log('View renamed successfully:', { viewId, viewName });
+    setViewToRename(null);
   };
 
   // Get current table configuration
@@ -45,7 +68,12 @@ const InventoryViews = () => {
     <>
       {isInventoryViewsPrivateEnabled && (
         <>
-          <ViewsToolbar viewsList={viewsList} onSaveAs={handleSaveAs} />
+          <ViewsToolbar
+            viewsList={viewsList}
+            isSystemView={isSystemView}
+            onSaveAs={handleSaveAs}
+            onRename={handleRename}
+          />
           <ViewSaveAsModal
             isOpen={isViewSaveAsModalOpen}
             onClose={() => setIsViewSaveAsModalOpen(false)}
@@ -53,6 +81,16 @@ const InventoryViews = () => {
             viewsList={viewsList}
             onSuccess={handleSaveAsSuccess}
           />
+          {viewToRename && (
+            <ViewRenameModal
+              isOpen={!!viewToRename}
+              onClose={() => setViewToRename(null)}
+              viewId={viewToRename.id}
+              currentName={viewToRename.name}
+              viewsList={viewsList}
+              onSuccess={handleRenameSuccess}
+            />
+          )}
         </>
       )}
       <SystemsView

--- a/src/components/InventoryViews/Modals/ViewRenameModal.test.tsx
+++ b/src/components/InventoryViews/Modals/ViewRenameModal.test.tsx
@@ -1,0 +1,179 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ViewRenameModal from './ViewRenameModal';
+
+jest.mock(
+  '@redhat-cloud-services/frontend-components-notifications/hooks',
+  () => ({
+    useAddNotification: () => jest.fn(),
+  }),
+);
+
+let mockValidation: { isDuplicate: boolean; validated: 'default' | 'error' } = {
+  isDuplicate: false,
+  validated: 'default',
+};
+
+jest.mock('../hooks/useViewNameValidation', () => ({
+  validateViewName: () => mockValidation,
+}));
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+function renderRenameModal(props = {}) {
+  const queryClient = createTestQueryClient();
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    viewId: 'view-123',
+    currentName: 'My View',
+    viewsList: [],
+    onSuccess: jest.fn(),
+  };
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ViewRenameModal {...defaultProps} {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ViewRenameModal', () => {
+  beforeEach(() => {
+    mockValidation = { isDuplicate: false, validated: 'default' as const };
+  });
+
+  it('should render the modal when open', () => {
+    renderRenameModal();
+
+    expect(screen.getByText('Rename view')).toBeInTheDocument();
+    expect(screen.getByText('View name')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should not render when closed', () => {
+    renderRenameModal({ isOpen: false });
+
+    expect(screen.queryByText('Rename view')).not.toBeInTheDocument();
+  });
+
+  it('should pre-fill input with current view name', () => {
+    renderRenameModal({ currentName: 'My Custom View' });
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('My Custom View');
+  });
+
+  it('should have Save button disabled when name is unchanged', () => {
+    renderRenameModal({ currentName: 'My View' });
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('should enable Save button when name is changed', async () => {
+    const user = userEvent.setup();
+    renderRenameModal({ currentName: 'My View' });
+
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    await user.type(input, 'Renamed View');
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeEnabled();
+  });
+
+  it('should disable Save and show error when name is a duplicate', async () => {
+    mockValidation = { isDuplicate: true, validated: 'error' as const };
+
+    const user = userEvent.setup();
+    renderRenameModal({ currentName: 'My View' });
+
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    await user.type(input, 'Existing View');
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(
+      screen.getByText('A view with this name already exists.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should not call mutate when name is a duplicate', async () => {
+    mockValidation = { isDuplicate: true, validated: 'error' as const };
+
+    const user = userEvent.setup();
+    const onSuccess = jest.fn();
+    renderRenameModal({ onSuccess, currentName: 'My View' });
+
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    await user.type(input, 'Existing View');
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    await user.click(saveButton);
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should call onSuccess and onClose when view is renamed', async () => {
+    const user = userEvent.setup();
+    const onSuccess = jest.fn();
+    const onClose = jest.fn();
+
+    renderRenameModal({ onSuccess, onClose, currentName: 'My View' });
+
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    await user.type(input, 'Renamed View');
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(
+        expect.any(String),
+        'Renamed View',
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should call onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    renderRenameModal({ onClose });
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await user.click(cancelButton);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should reset form to current name when closed', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    renderRenameModal({ onClose, currentName: 'My View' });
+
+    const input = screen.getByRole('textbox');
+    await user.clear(input);
+    await user.type(input, 'Different Name');
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await user.click(cancelButton);
+
+    expect(input).toHaveValue('My View');
+  });
+});

--- a/src/components/InventoryViews/Modals/ViewRenameModal.tsx
+++ b/src/components/InventoryViews/Modals/ViewRenameModal.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TextInput,
+} from '@patternfly/react-core';
+import type { ViewOut } from '../../../api/inventoryViewsApi';
+import { useUpdateViewMutation } from '../hooks/useUpdateViewMutation';
+import { validateViewName } from '../hooks/useViewNameValidation';
+
+export interface ViewRenameModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  viewId: string;
+  currentName: string;
+  viewsList: ViewOut[];
+  onSuccess?: (viewId: string, viewName: string) => void;
+}
+
+const ViewRenameModal = ({
+  isOpen,
+  onClose,
+  viewId,
+  currentName,
+  viewsList,
+  onSuccess,
+}: ViewRenameModalProps) => {
+  const [viewName, setViewName] = useState(currentName);
+  const updateView = useUpdateViewMutation();
+  const trimmedName = viewName.trim();
+  const { isDuplicate, validated } = validateViewName(viewsList, trimmedName, {
+    excludeViewId: viewId,
+  });
+
+  useEffect(() => {
+    setViewName(currentName);
+  }, [currentName]);
+
+  const isLoading = updateView.isPending;
+  const isUnchanged = trimmedName === currentName.trim();
+  const canSave = !!trimmedName && !isDuplicate && !isLoading && !isUnchanged;
+
+  const handleSave = () => {
+    if (!canSave) {
+      return;
+    }
+
+    updateView.mutate(
+      {
+        id: viewId,
+        data: { name: trimmedName },
+      },
+      {
+        onSuccess: (updatedView) => {
+          onSuccess?.(updatedView.id, updatedView.name);
+          handleClose();
+        },
+      },
+    );
+  };
+
+  const handleClose = () => {
+    setViewName(currentName);
+    onClose();
+  };
+
+  return (
+    <Modal
+      variant="small"
+      isOpen={isOpen}
+      onClose={handleClose}
+      aria-labelledby="rename-modal-title"
+      ouiaId="inventory-rename-modal"
+    >
+      <ModalHeader title="Rename view" labelId="rename-modal-title" />
+      <ModalBody>
+        <p>Enter a new name for this view.</p>
+        <br />
+        <Form>
+          <FormGroup label="View name" fieldId="view-name-input">
+            <TextInput
+              id="view-name-input"
+              type="text"
+              value={viewName}
+              onChange={(_event, value) => setViewName(value)}
+              isDisabled={isLoading}
+              validated={validated}
+              autoFocus
+            />
+            {isDuplicate && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="error">
+                    A view with this name already exists.
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          key="save"
+          variant="primary"
+          onClick={handleSave}
+          isDisabled={!canSave}
+          isLoading={isLoading}
+        >
+          Save
+        </Button>
+        <Button key="cancel" variant="link" onClick={handleClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default ViewRenameModal;

--- a/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
@@ -13,13 +13,16 @@ export interface ManageViewButtonProps {
   /** Whether current view is a system view (non-editable) */
   isSystemView?: boolean;
   /** Callback when Save As is clicked */
-  onSaveAs?: () => void;
+  onSaveAs: () => void;
+  /** Callback when Rename is clicked */
+  onRename: () => void;
 }
 
 export const ManageViewButton = ({
   currentViewId,
   isSystemView = true,
   onSaveAs,
+  onRename,
 }: ManageViewButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -50,6 +53,9 @@ export const ManageViewButton = ({
       <DropdownList>
         <DropdownItem key="save-as" onClick={onSaveAs}>
           Save as
+        </DropdownItem>
+        <DropdownItem key="rename" onClick={onRename} isDisabled={isSystemView}>
+          Rename
         </DropdownItem>
       </DropdownList>
     </Dropdown>

--- a/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
@@ -9,7 +9,8 @@ export interface ViewsToolbarProps {
   currentViewId?: string | null;
   isSystemView?: boolean;
   viewsList?: ViewOut[];
-  onSaveAs?: () => void;
+  onSaveAs: () => void;
+  onRename: () => void;
 }
 
 export const ViewsToolbar = ({
@@ -18,6 +19,7 @@ export const ViewsToolbar = ({
   isSystemView = true,
   viewsList,
   onSaveAs,
+  onRename,
 }: ViewsToolbarProps) => {
   return (
     <Flex
@@ -33,6 +35,7 @@ export const ViewsToolbar = ({
           currentViewId={currentViewId}
           isSystemView={isSystemView}
           onSaveAs={onSaveAs}
+          onRename={onRename}
         />
       </FlexItem>
     </Flex>

--- a/src/components/InventoryViews/hooks/useUpdateViewMutation.ts
+++ b/src/components/InventoryViews/hooks/useUpdateViewMutation.ts
@@ -1,36 +1,37 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import type { UpdateViewRequest } from '../../../api/inventoryViewsApi';
 import { updateViewApi } from '../../../api/inventoryViewsApi';
 
-/**
- * Hook for updating an existing inventory view
- *
- * @example
- * const updateView = useUpdateViewMutation();
- * updateView.mutate({
- *   id: "view-123",
- *   data: { name: "Renamed View" }
- * });
- */
 export const useUpdateViewMutation = () => {
   const queryClient = useQueryClient();
+  const addNotification = useAddNotification();
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: UpdateViewRequest }) =>
       updateViewApi(id, data),
     onSuccess: (updatedView) => {
-      console.log('[UPDATE SUCCESS] View updated:', updatedView);
+      addNotification({
+        variant: 'success',
+        title: `View "${updatedView.name}" updated successfully`,
+        dismissable: true,
+      });
 
       // TODO: Invalidate specific view + views list when RHINENG-28462 is complete
       // queryClient.invalidateQueries({ queryKey: ['views'] });
       // queryClient.invalidateQueries({ queryKey: ['view', updatedView.id] });
-
-      // TODO: Add success toast notification (e.g. "View updated successfully")
     },
     onError: (error) => {
-      console.error('[UPDATE ERROR] Failed to update view:', error);
-
-      // TODO: Add error toast notification (e.g. "Failed to update view")
+      console.error(error);
+      addNotification({
+        variant: 'danger',
+        title: 'Failed to update view',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred.',
+        dismissable: true,
+      });
     },
   });
 };


### PR DESCRIPTION
## Jira
[RHINENG-28361](https://redhat.atlassian.net/browse/RHINENG-28361)

## What
Add a Rename modal following the same pattern as the Save As modal (RHINENG-28360). The modal pre-fills with the current view name, disables Save until the name changes, and validates against duplicate names (excluding the current view). Also adds toast notifications to useUpdateViewMutation and a "Rename" option in the Manage View dropdown (disabled for system views).

## Testing
The Rename modal is wired up in InventoryViews.tsx but currentViewId is currently set to null. To test manually, temporarily replace currentViewId and currentViewName in handleRename() with dummy values (e.g. a view ID and name from the views list). And comment out isDisabled for Rename modal.

[RHINENG-28361]: https://redhat.atlassian.net/browse/RHINENG-28361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a rename view workflow to inventory views, including a modal with validation, toolbar integration, and user feedback via notifications.

New Features:
- Introduce a Rename View modal that pre-fills the current view name and enforces name changes with duplicate-name validation.
- Add a Rename action to the Manage View dropdown, disabled for system views, wired through the views toolbar into the new modal.

Enhancements:
- Update the view update mutation hook to surface success and error toast notifications instead of console logging.
- Wire inventory views state to manage opening/closing of the Rename modal and tracking the selected view to rename.

Tests:
- Add unit tests for the ViewRenameModal covering rendering, validation behavior, button enablement, mutation triggering, and close/reset behaviors.