### PR TITLE
feat(RHINENG-28362): Add Delete view confirmation modal

### DIFF
--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -10,6 +10,7 @@ import useInventoryViewsPrivateFeatureFlag from '../../Utilities/useInventoryVie
 import ViewsToolbar from './ViewsToolbar/ViewsToolbar';
 import ViewSaveAsModal from './Modals/ViewSaveAsModal';
 import ViewRenameModal from './Modals/ViewRenameModal';
+import ViewDeleteModal from './Modals/ViewDeleteModal';
 import type { ViewConfiguration } from '../../api/inventoryViewsApi';
 import { selectLegacyInventoryColumns } from './selectLegacyInventoryColumns';
 
@@ -17,10 +18,8 @@ const STATIC_ACTIVE_VIEW_ID = 'view-production';
 
 const InventoryViews = () => {
   const [isViewSaveAsModalOpen, setIsViewSaveAsModalOpen] = useState(false);
-  const [viewToRename, setViewToRename] = useState<{
-    id: string;
-    name: string;
-  } | null>(null);
+  const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const queryClient = useQueryClient();
   const isInventoryViewsPrivateEnabled = useInventoryViewsPrivateFeatureFlag();
   const { data: viewsData } = useViewsQuery();
@@ -40,18 +39,23 @@ const InventoryViews = () => {
     // TODO: Navigate to the new view or refresh view list
   };
 
-  // Open Rename modal
   const handleRename = () => {
-    // TODO: Replace STATIC_ACTIVE_VIEW_ID with dynamic view selection (RHINENG-28357)
-    if (STATIC_ACTIVE_VIEW_ID && activeView?.name) {
-      setViewToRename({ id: STATIC_ACTIVE_VIEW_ID, name: activeView.name });
-    }
+    setIsRenameModalOpen(true);
   };
 
-  // Handle successful view rename
   const handleRenameSuccess = (viewId: string, viewName: string) => {
     console.log('View renamed successfully:', { viewId, viewName });
-    setViewToRename(null);
+    setIsRenameModalOpen(false);
+  };
+
+  const handleDelete = () => {
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleDeleteSuccess = (viewId: string) => {
+    console.log('View deleted successfully:', { viewId });
+    setIsDeleteModalOpen(false);
+    // TODO: Switch to "All systems" default view if deleted view was active
   };
 
   // Get current table configuration
@@ -73,6 +77,7 @@ const InventoryViews = () => {
             isSystemView={isSystemView}
             onSaveAs={handleSaveAs}
             onRename={handleRename}
+            onDelete={handleDelete}
           />
           <ViewSaveAsModal
             isOpen={isViewSaveAsModalOpen}
@@ -81,14 +86,23 @@ const InventoryViews = () => {
             viewsList={viewsList}
             onSuccess={handleSaveAsSuccess}
           />
-          {viewToRename && (
+          {activeView && (
             <ViewRenameModal
-              isOpen={!!viewToRename}
-              onClose={() => setViewToRename(null)}
-              viewId={viewToRename.id}
-              currentName={viewToRename.name}
+              isOpen={isRenameModalOpen}
+              onClose={() => setIsRenameModalOpen(false)}
+              viewId={activeView.id}
+              currentName={activeView.name}
               viewsList={viewsList}
               onSuccess={handleRenameSuccess}
+            />
+          )}
+          {activeView && (
+            <ViewDeleteModal
+              isOpen={isDeleteModalOpen}
+              onClose={() => setIsDeleteModalOpen(false)}
+              viewId={activeView.id}
+              viewName={activeView.name}
+              onSuccess={handleDeleteSuccess}
             />
           )}
         </>

--- a/src/components/InventoryViews/Modals/ViewDeleteModal.test.tsx
+++ b/src/components/InventoryViews/Modals/ViewDeleteModal.test.tsx
@@ -1,0 +1,102 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ViewDeleteModal from './ViewDeleteModal';
+
+jest.mock(
+  '@redhat-cloud-services/frontend-components-notifications/hooks',
+  () => ({
+    useAddNotification: () => jest.fn(),
+  }),
+);
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+function renderDeleteModal(props = {}) {
+  const queryClient = createTestQueryClient();
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    viewId: 'view-123',
+    viewName: 'My Custom View',
+    onSuccess: jest.fn(),
+  };
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ViewDeleteModal {...defaultProps} {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ViewDeleteModal', () => {
+  it('should render the modal when open', () => {
+    renderDeleteModal();
+
+    expect(screen.getByText('Delete view')).toBeInTheDocument();
+    expect(
+      screen.getByText(/My Custom View/, { exact: false }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/will be permanently deleted/, { exact: false }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render when closed', () => {
+    renderDeleteModal({ isOpen: false });
+
+    expect(screen.queryByText('Delete view')).not.toBeInTheDocument();
+  });
+
+  it('should show view name in warning text', () => {
+    renderDeleteModal({ viewName: 'Production Systems' });
+
+    expect(
+      screen.getByText(/Production Systems/, { exact: false }),
+    ).toBeInTheDocument();
+  });
+
+  it('should have Delete button enabled by default', () => {
+    renderDeleteModal();
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    expect(deleteButton).toBeEnabled();
+  });
+
+  it('should call onSuccess and onClose when confirmed', async () => {
+    const user = userEvent.setup();
+    const onSuccess = jest.fn();
+    const onClose = jest.fn();
+
+    renderDeleteModal({ onSuccess, onClose });
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    await user.click(deleteButton);
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith('view-123');
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should call onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    renderDeleteModal({ onClose });
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await user.click(cancelButton);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/InventoryViews/Modals/ViewDeleteModal.tsx
+++ b/src/components/InventoryViews/Modals/ViewDeleteModal.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@patternfly/react-core';
+import { useDeleteViewMutation } from '../hooks/useDeleteViewMutation';
+
+export interface ViewDeleteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  viewId: string;
+  viewName: string;
+  onSuccess?: (viewId: string) => void;
+}
+
+const ViewDeleteModal = ({
+  isOpen,
+  onClose,
+  viewId,
+  viewName,
+  onSuccess,
+}: ViewDeleteModalProps) => {
+  const deleteView = useDeleteViewMutation();
+
+  const handleDelete = () => {
+    deleteView.mutate(viewId, {
+      onSuccess: () => {
+        onSuccess?.(viewId);
+        onClose();
+      },
+    });
+  };
+
+  const isLoading = deleteView.isPending;
+
+  return (
+    <Modal
+      variant="small"
+      isOpen={isOpen}
+      onClose={onClose}
+      aria-labelledby="delete-view-modal-title"
+      ouiaId="inventory-delete-view-modal"
+    >
+      <ModalHeader
+        title="Delete view"
+        labelId="delete-view-modal-title"
+        titleIconVariant="warning"
+      />
+      <ModalBody>
+        <p>&ldquo;{viewName}&rdquo; will be permanently deleted.</p>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          key="delete"
+          variant="danger"
+          onClick={handleDelete}
+          isDisabled={isLoading}
+          isLoading={isLoading}
+        >
+          Delete
+        </Button>
+        <Button key="cancel" variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default ViewDeleteModal;

--- a/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
@@ -16,6 +16,8 @@ export interface ManageViewButtonProps {
   onSaveAs: () => void;
   /** Callback when Rename is clicked */
   onRename: () => void;
+  /** Callback when Delete is clicked */
+  onDelete: () => void;
 }
 
 export const ManageViewButton = ({
@@ -23,6 +25,7 @@ export const ManageViewButton = ({
   isSystemView = true,
   onSaveAs,
   onRename,
+  onDelete,
 }: ManageViewButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -56,6 +59,9 @@ export const ManageViewButton = ({
         </DropdownItem>
         <DropdownItem key="rename" onClick={onRename} isDisabled={isSystemView}>
           Rename
+        </DropdownItem>
+        <DropdownItem key="delete" onClick={onDelete} isDisabled={isSystemView}>
+          Delete
         </DropdownItem>
       </DropdownList>
     </Dropdown>

--- a/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
@@ -11,6 +11,7 @@ export interface ViewsToolbarProps {
   viewsList?: ViewOut[];
   onSaveAs: () => void;
   onRename: () => void;
+  onDelete: () => void;
 }
 
 export const ViewsToolbar = ({
@@ -20,6 +21,7 @@ export const ViewsToolbar = ({
   viewsList,
   onSaveAs,
   onRename,
+  onDelete,
 }: ViewsToolbarProps) => {
   return (
     <Flex
@@ -36,6 +38,7 @@ export const ViewsToolbar = ({
           isSystemView={isSystemView}
           onSaveAs={onSaveAs}
           onRename={onRename}
+          onDelete={onDelete}
         />
       </FlexItem>
     </Flex>

--- a/src/components/InventoryViews/hooks/useDeleteViewMutation.ts
+++ b/src/components/InventoryViews/hooks/useDeleteViewMutation.ts
@@ -1,30 +1,34 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import { deleteViewApi } from '../../../api/inventoryViewsApi';
 
-/**
- * Hook for deleting an inventory view
- *
- * @example
- * const deleteView = useDeleteViewMutation();
- * deleteView.mutate("view-123");
- */
 export const useDeleteViewMutation = () => {
   const queryClient = useQueryClient();
+  const addNotification = useAddNotification();
 
   return useMutation({
     mutationFn: deleteViewApi,
-    onSuccess: (_, deletedId) => {
-      console.log('[DELETE SUCCESS] View deleted:', deletedId);
+    onSuccess: () => {
+      addNotification({
+        variant: 'success',
+        title: 'View deleted successfully',
+        dismissable: true,
+      });
 
       // TODO: Invalidate views list when RHINENG-28462 is complete
       // queryClient.invalidateQueries({ queryKey: ['views'] });
-
-      // TODO: Add success toast notification (e.g. "View deleted successfully")
     },
     onError: (error) => {
-      console.error('[DELETE ERROR] Failed to delete view:', error);
-
-      // TODO: Add error toast notification (e.g. "Failed to delete view")
+      console.error(error);
+      addNotification({
+        variant: 'danger',
+        title: 'Failed to delete view',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred.',
+        dismissable: true,
+      });
     },
   });
 };


### PR DESCRIPTION
## Jira
[RHINENG-28362](https://redhat.atlassian.net/browse/RHINENG-28362)

## What
Add a Delete view modal with danger confirmation button and warning icon, following the same patterns as Save As and Rename modals. Includes toast notifications on useDeleteViewMutation and a danger-styled Delete option in the Manage View dropdown (disabled for system views).

## Testing
The Delete modal is wired up in InventoryViews.tsx but currentViewId is currently set to null. To test manually, temporarily replace currentViewId and currentViewName in handleDelete() with dummy values (e.g. a view ID and name from the views list). And comment out isDisabled for Delete modal.

[RHINENG-28362]: https://redhat.atlassian.net/browse/RHINENG-28362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a delete view confirmation flow to inventory views, including UI modal, toolbar integration, and user notifications.

New Features:
- Introduce a Delete view confirmation modal with warning styling and danger action for removing inventory views.
- Expose a Delete option in the Manage View dropdown, disabled for system views, to trigger the delete flow.

Enhancements:
- Wire the delete view modal into the InventoryViews toolbar and manage button with callbacks for opening and handling successful deletion.
- Add success and error toast notifications to the delete view mutation hook to inform users of deletion outcomes.

Tests:
- Add unit tests for the delete view modal covering rendering, behavior of Delete and Cancel actions, and callback invocation.