### PR TITLE
test: Enable E2E test - Move system to workspace test case

### DIFF
--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -449,13 +449,6 @@ test.describe('Workspace System Management', () => {
      * - requirements: inv-groups-add-hosts
      * - importance: high
      */
-    // eslint-disable-next-line playwright/no-skipped-test
-    test.skip(
-      process.env.PROD === 'true',
-      'Case is intended for non-prod environments only - Kessel feature',
-    );
-    test.fixme(true, 'https://redhat.atlassian.net/browse/RHINENG-29322');
-    
     const system = systems.workspaceSystems[2];
     const nameCell = page
       .locator('[data-ouia-component-id="systems-view-table-td-0-0"]')


### PR DESCRIPTION
## What
Enable E2E test - Move system to workspace test case

## Why
- Bug is resolved
- modal is enabled in production

## Summary by Sourcery

Tests:
- Re-enable the workspace system management Playwright E2E test by removing skip and fixme markers tied to previous production limitations.