### PR TITLE
test(RHINENG-25383): add unit tests for action modals context 

### DIFF
--- a/src/components/InventoryTable/helpers.js
+++ b/src/components/InventoryTable/helpers.js
@@ -118,7 +118,7 @@ export const getGroupSystemsBulkActionDisabled = ({
  *  @param   {MoveSystemActionsColumnRow} row                     - `{ permissions }` from the system row (see
  *                                                                {@link MoveSystemActionsColumnRow})
  *  @param   {Function}                   onClick                 - Opens move modal,
- *                                                                e.g. `() => openAddToWorkspaceModal([system])`
+ *                                                                e.g. `() => openMoveSystemsToWorkspaceModal([system])`
  *  @param   {boolean}                    workspaceActionsAllowed - Page-level gate; Systems view passes `true`
  *  @returns {object}                                             ActionsColumn item: `{ title, onClick, isDisabled, tooltipProps? }` where
  *                                                                `title` is `MOVE_SYSTEM_MENU_TEXT` and `tooltipProps` is set when disabled

--- a/src/components/SystemsView/SystemActionModalsContext.test.tsx
+++ b/src/components/SystemsView/SystemActionModalsContext.test.tsx
@@ -23,6 +23,13 @@ jest.mock('./hooks/usePatchSystemsMutation', () => ({
   })),
 }));
 
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  default: () => ({
+    getUserPermissions: jest.fn(),
+  }),
+}));
+
 const testSystem = {
   id: 'host-1',
   display_name: 'Test Host',
@@ -41,14 +48,27 @@ function OpenDeleteModalButton({
   );
 }
 
-function renderWithProvider() {
+function OpenAddToWorkspaceModalButton({
+  systems = [testSystem],
+}: {
+  systems?: System[];
+}) {
+  const { openAddToWorkspaceModal } = useSystemActionModalsContext();
+  return (
+    <button type="button" onClick={() => openAddToWorkspaceModal(systems)}>
+      Open add to workspace modal
+    </button>
+  );
+}
+
+function renderWithProvider(ui: React.ReactNode) {
   const onInvalidate = jest.fn(async () => undefined);
   return {
     onInvalidate,
     ...render(
       <QueryClientProvider client={createTestQueryClient()}>
         <SystemActionModalsProvider onInvalidate={onInvalidate}>
-          <OpenDeleteModalButton />
+          {ui}
         </SystemActionModalsProvider>
       </QueryClientProvider>,
     ),
@@ -57,7 +77,7 @@ function renderWithProvider() {
 
 describe('SystemActionModalsProvider (delete modal)', () => {
   it('does not show the delete modal until openDeleteModal is called', () => {
-    renderWithProvider();
+    renderWithProvider(<OpenDeleteModalButton />);
 
     expect(
       screen.queryByText(/Delete system from inventory\?/i),
@@ -65,7 +85,7 @@ describe('SystemActionModalsProvider (delete modal)', () => {
   });
 
   it('opens the delete modal with the selected systems', async () => {
-    renderWithProvider();
+    renderWithProvider(<OpenDeleteModalButton />);
 
     await userEvent.click(
       screen.getByRole('button', { name: /open delete modal/i }),
@@ -82,7 +102,7 @@ describe('SystemActionModalsProvider (delete modal)', () => {
   });
 
   it('closes the delete modal when cancel is clicked', async () => {
-    renderWithProvider();
+    renderWithProvider(<OpenDeleteModalButton />);
 
     await userEvent.click(
       screen.getByRole('button', { name: /open delete modal/i }),
@@ -91,6 +111,42 @@ describe('SystemActionModalsProvider (delete modal)', () => {
 
     expect(
       screen.queryByText(/Delete system from inventory\?/i),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('SystemActionModalsProvider (add to workspace modal)', () => {
+  it('does not show the add to workspace modal until openAddToWorkspaceModal is called', () => {
+    renderWithProvider(<OpenAddToWorkspaceModalButton />);
+
+    expect(
+      screen.queryByRole('heading', { name: /add to workspace/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the add to workspace modal with the selected systems', async () => {
+    renderWithProvider(<OpenAddToWorkspaceModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open add to workspace modal/i }),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /add to workspace/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Test Host')).toBeInTheDocument();
+  });
+
+  it('closes the add to workspace modal when cancel is clicked', async () => {
+    renderWithProvider(<OpenAddToWorkspaceModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open add to workspace modal/i }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(
+      screen.queryByRole('heading', { name: /add to workspace/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/SystemsView/SystemActionModalsContext.test.tsx
+++ b/src/components/SystemsView/SystemActionModalsContext.test.tsx
@@ -10,6 +10,11 @@ import {
   SystemActionModalsProvider,
   useSystemActionModalsContext,
 } from './SystemActionModalsContext';
+import type { OpenTagsModalOptions } from './SystemActionModalsContext';
+import {
+  DataViewFiltersContext,
+  INITIAL_INVENTORY_FILTERS,
+} from './DataViewFiltersContext';
 
 jest.mock('./hooks/useDeleteSystemsMutation', () => ({
   useDeleteSystemsMutation: jest.fn(() => ({
@@ -30,9 +35,38 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   }),
 }));
 
+jest.mock(
+  '@redhat-cloud-services/frontend-components-notifications/hooks',
+  () => ({
+    useAddNotification: () => jest.fn(),
+  }),
+);
+
+jest.mock('../../Utilities/hooks/useDebouncedValue', () => ({
+  useDebouncedValue: (value: string) => value,
+}));
+
+jest.mock('./hooks/useTagsQuery', () => ({
+  __esModule: true,
+  useTagsQuery: jest.fn(() => ({
+    data: [],
+    total: 0,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+  })),
+}));
+
 const testSystem = {
   id: 'host-1',
   display_name: 'Test Host',
+} as System;
+
+const testSystemInWorkspace = {
+  id: 'host-1',
+  display_name: 'Test Host',
+  groups: [{ id: 'workspace-1', name: 'My Workspace' }],
 } as System;
 
 function OpenDeleteModalButton({
@@ -61,17 +95,98 @@ function OpenAddToWorkspaceModalButton({
   );
 }
 
-function renderWithProvider(ui: React.ReactNode) {
+function OpenMoveSystemsToWorkspaceModalButton({
+  systems = [testSystemInWorkspace],
+}: {
+  systems?: System[];
+}) {
+  const { openMoveSystemsToWorkspaceModal } = useSystemActionModalsContext();
+  return (
+    <button
+      type="button"
+      onClick={() => openMoveSystemsToWorkspaceModal(systems)}
+    >
+      Open move systems to workspace modal
+    </button>
+  );
+}
+
+function OpenRemoveFromWorkspaceModalButton({
+  systems = [testSystemInWorkspace],
+}: {
+  systems?: System[];
+}) {
+  const { openRemoveFromWorkspaceModal } = useSystemActionModalsContext();
+  return (
+    <button type="button" onClick={() => openRemoveFromWorkspaceModal(systems)}>
+      Open remove from workspace modal
+    </button>
+  );
+}
+
+function OpenEditModalButton({
+  systems = [testSystem],
+}: {
+  systems?: System[];
+}) {
+  const { openEditModal } = useSystemActionModalsContext();
+  return (
+    <button type="button" onClick={() => openEditModal(systems)}>
+      Open edit modal
+    </button>
+  );
+}
+
+function OpenTagsModalButton({
+  systems = [testSystem],
+  options,
+}: {
+  systems?: System[];
+  options?: OpenTagsModalOptions;
+}) {
+  const { openTagsModal } = useSystemActionModalsContext();
+  return (
+    <button type="button" onClick={() => openTagsModal(systems, options)}>
+      Open tags modal
+    </button>
+  );
+}
+
+function renderWithProvider(
+  ui: React.ReactNode,
+  { withFilters = false }: { withFilters?: boolean } = {},
+) {
   const onInvalidate = jest.fn(async () => undefined);
+  const onSetFilters = jest.fn();
+  const provider = (
+    <QueryClientProvider client={createTestQueryClient()}>
+      <SystemActionModalsProvider onInvalidate={onInvalidate}>
+        {ui}
+      </SystemActionModalsProvider>
+    </QueryClientProvider>
+  );
+
+  const tree = withFilters ? (
+    <DataViewFiltersContext.Provider
+      value={{
+        filters: { ...INITIAL_INVENTORY_FILTERS },
+        onSetFilters,
+        clearAllFilters: jest.fn(),
+        lastSeenCustomRange: null,
+        setLastSeenCustomRange: jest.fn(),
+        ungroupedWorkspaceId: undefined,
+      }}
+    >
+      {provider}
+    </DataViewFiltersContext.Provider>
+  ) : (
+    provider
+  );
+
   return {
     onInvalidate,
-    ...render(
-      <QueryClientProvider client={createTestQueryClient()}>
-        <SystemActionModalsProvider onInvalidate={onInvalidate}>
-          {ui}
-        </SystemActionModalsProvider>
-      </QueryClientProvider>,
-    ),
+    onSetFilters,
+    ...render(tree),
   };
 }
 
@@ -147,6 +262,202 @@ describe('SystemActionModalsProvider (add to workspace modal)', () => {
 
     expect(
       screen.queryByRole('heading', { name: /add to workspace/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('SystemActionModalsProvider (move systems to workspace modal)', () => {
+  it('does not show the move modal until openMoveSystemsToWorkspaceModal is called', () => {
+    renderWithProvider(<OpenMoveSystemsToWorkspaceModalButton />);
+
+    expect(
+      screen.queryByRole('heading', { name: /move system/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the move modal with the selected systems', async () => {
+    renderWithProvider(<OpenMoveSystemsToWorkspaceModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /open move systems to workspace modal/i,
+      }),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /move system/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Test Host')).toBeInTheDocument();
+    expect(screen.getByText('My Workspace')).toBeInTheDocument();
+  });
+
+  it('closes the move modal when cancel is clicked', async () => {
+    renderWithProvider(<OpenMoveSystemsToWorkspaceModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /open move systems to workspace modal/i,
+      }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(
+      screen.queryByRole('heading', { name: /move system/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('SystemActionModalsProvider (remove from workspace modal)', () => {
+  it('does not show the remove modal until openRemoveFromWorkspaceModal is called', () => {
+    renderWithProvider(<OpenRemoveFromWorkspaceModalButton />);
+
+    expect(
+      screen.queryByRole('heading', { name: /remove from workspace/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the remove modal with the selected systems', async () => {
+    renderWithProvider(<OpenRemoveFromWorkspaceModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open remove from workspace modal/i }),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /remove from workspace/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Test Host')).toBeInTheDocument();
+    expect(screen.getByText('My Workspace')).toBeInTheDocument();
+  });
+
+  it('closes the remove modal when cancel is clicked', async () => {
+    renderWithProvider(<OpenRemoveFromWorkspaceModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open remove from workspace modal/i }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(
+      screen.queryByRole('heading', { name: /remove from workspace/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('SystemActionModalsProvider (edit display name modal)', () => {
+  it('does not show the edit modal until openEditModal is called', () => {
+    renderWithProvider(<OpenEditModalButton />);
+
+    expect(
+      screen.queryByRole('heading', { name: /edit display name/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the edit modal with the selected system display name', async () => {
+    renderWithProvider(<OpenEditModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open edit modal/i }),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /edit display name/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Test Host')).toBeInTheDocument();
+  });
+
+  it('closes the edit modal when cancel is clicked', async () => {
+    renderWithProvider(<OpenEditModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open edit modal/i }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(
+      screen.queryByRole('heading', { name: /edit display name/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('SystemActionModalsProvider (single-host tags modal)', () => {
+  it('does not show the tags modal until openTagsModal is called', () => {
+    renderWithProvider(<OpenTagsModalButton />);
+
+    expect(
+      screen.queryByRole('heading', { name: /test host/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the single-host tags modal for the selected system', async () => {
+    renderWithProvider(<OpenTagsModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open tags modal/i }),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Test Host (0)' }),
+    ).toBeInTheDocument();
+  });
+
+  it('closes the single-host tags modal when Close is clicked', async () => {
+    renderWithProvider(<OpenTagsModalButton />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open tags modal/i }),
+    );
+
+    const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+    const footerClose = closeButtons.find((button) =>
+      button.className.includes('pf-m-primary'),
+    );
+    expect(footerClose).toBeDefined();
+    await userEvent.click(footerClose!);
+
+    expect(
+      screen.queryByRole('heading', { name: 'Test Host (0)' }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('SystemActionModalsProvider (all tags modal)', () => {
+  it('does not show the all-tags modal until openTagsModal is called with no systems', () => {
+    renderWithProvider(<OpenTagsModalButton systems={[]} />, {
+      withFilters: true,
+    });
+
+    expect(
+      screen.queryByRole('heading', { name: /all tags in inventory/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the all-tags modal when openTagsModal is called with an empty selection', async () => {
+    renderWithProvider(<OpenTagsModalButton systems={[]} />, {
+      withFilters: true,
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open tags modal/i }),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /all tags in inventory/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('closes the all-tags modal when cancel is clicked', async () => {
+    renderWithProvider(<OpenTagsModalButton systems={[]} />, {
+      withFilters: true,
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open tags modal/i }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(
+      screen.queryByRole('heading', { name: /all tags in inventory/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/SystemsView/SystemActionModalsContext.test.tsx
+++ b/src/components/SystemsView/SystemActionModalsContext.test.tsx
@@ -23,10 +23,6 @@ jest.mock('./hooks/usePatchSystemsMutation', () => ({
   })),
 }));
 
-jest.mock('../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
-  useKesselMigrationFeatureFlag: jest.fn(() => false),
-}));
-
 const testSystem = {
   id: 'host-1',
   display_name: 'Test Host',

--- a/src/components/SystemsView/SystemActionModalsContext.test.tsx
+++ b/src/components/SystemsView/SystemActionModalsContext.test.tsx
@@ -215,19 +215,6 @@ describe('SystemActionModalsProvider (delete modal)', () => {
       ),
     ).toBeInTheDocument();
   });
-
-  it('closes the delete modal when cancel is clicked', async () => {
-    renderWithProvider(<OpenDeleteModalButton />);
-
-    await userEvent.click(
-      screen.getByRole('button', { name: /open delete modal/i }),
-    );
-    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
-
-    expect(
-      screen.queryByText(/Delete system from inventory\?/i),
-    ).not.toBeInTheDocument();
-  });
 });
 
 describe('SystemActionModalsProvider (add to workspace modal)', () => {
@@ -250,19 +237,6 @@ describe('SystemActionModalsProvider (add to workspace modal)', () => {
       screen.getByRole('heading', { name: /add to workspace/i }),
     ).toBeInTheDocument();
     expect(screen.getByText('Test Host')).toBeInTheDocument();
-  });
-
-  it('closes the add to workspace modal when cancel is clicked', async () => {
-    renderWithProvider(<OpenAddToWorkspaceModalButton />);
-
-    await userEvent.click(
-      screen.getByRole('button', { name: /open add to workspace modal/i }),
-    );
-    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
-
-    expect(
-      screen.queryByRole('heading', { name: /add to workspace/i }),
-    ).not.toBeInTheDocument();
   });
 });
 
@@ -290,21 +264,6 @@ describe('SystemActionModalsProvider (move systems to workspace modal)', () => {
     expect(screen.getByText('Test Host')).toBeInTheDocument();
     expect(screen.getByText('My Workspace')).toBeInTheDocument();
   });
-
-  it('closes the move modal when cancel is clicked', async () => {
-    renderWithProvider(<OpenMoveSystemsToWorkspaceModalButton />);
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: /open move systems to workspace modal/i,
-      }),
-    );
-    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
-
-    expect(
-      screen.queryByRole('heading', { name: /move system/i }),
-    ).not.toBeInTheDocument();
-  });
 });
 
 describe('SystemActionModalsProvider (remove from workspace modal)', () => {
@@ -329,19 +288,6 @@ describe('SystemActionModalsProvider (remove from workspace modal)', () => {
     expect(screen.getByText('Test Host')).toBeInTheDocument();
     expect(screen.getByText('My Workspace')).toBeInTheDocument();
   });
-
-  it('closes the remove modal when cancel is clicked', async () => {
-    renderWithProvider(<OpenRemoveFromWorkspaceModalButton />);
-
-    await userEvent.click(
-      screen.getByRole('button', { name: /open remove from workspace modal/i }),
-    );
-    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
-
-    expect(
-      screen.queryByRole('heading', { name: /remove from workspace/i }),
-    ).not.toBeInTheDocument();
-  });
 });
 
 describe('SystemActionModalsProvider (edit display name modal)', () => {
@@ -365,19 +311,6 @@ describe('SystemActionModalsProvider (edit display name modal)', () => {
     ).toBeInTheDocument();
     expect(screen.getByDisplayValue('Test Host')).toBeInTheDocument();
   });
-
-  it('closes the edit modal when cancel is clicked', async () => {
-    renderWithProvider(<OpenEditModalButton />);
-
-    await userEvent.click(
-      screen.getByRole('button', { name: /open edit modal/i }),
-    );
-    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
-
-    expect(
-      screen.queryByRole('heading', { name: /edit display name/i }),
-    ).not.toBeInTheDocument();
-  });
 });
 
 describe('SystemActionModalsProvider (single-host tags modal)', () => {
@@ -399,25 +332,6 @@ describe('SystemActionModalsProvider (single-host tags modal)', () => {
     expect(
       screen.getByRole('heading', { name: 'Test Host (0)' }),
     ).toBeInTheDocument();
-  });
-
-  it('closes the single-host tags modal when Close is clicked', async () => {
-    renderWithProvider(<OpenTagsModalButton />);
-
-    await userEvent.click(
-      screen.getByRole('button', { name: /open tags modal/i }),
-    );
-
-    const closeButtons = screen.getAllByRole('button', { name: 'Close' });
-    const footerClose = closeButtons.find((button) =>
-      button.className.includes('pf-m-primary'),
-    );
-    expect(footerClose).toBeDefined();
-    await userEvent.click(footerClose!);
-
-    expect(
-      screen.queryByRole('heading', { name: 'Test Host (0)' }),
-    ).not.toBeInTheDocument();
   });
 });
 
@@ -444,20 +358,5 @@ describe('SystemActionModalsProvider (all tags modal)', () => {
     expect(
       screen.getByRole('heading', { name: /all tags in inventory/i }),
     ).toBeInTheDocument();
-  });
-
-  it('closes the all-tags modal when cancel is clicked', async () => {
-    renderWithProvider(<OpenTagsModalButton systems={[]} />, {
-      withFilters: true,
-    });
-
-    await userEvent.click(
-      screen.getByRole('button', { name: /open tags modal/i }),
-    );
-    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
-
-    expect(
-      screen.queryByRole('heading', { name: /all tags in inventory/i }),
-    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/SystemsView/SystemActionModalsContext.test.tsx
+++ b/src/components/SystemsView/SystemActionModalsContext.test.tsx
@@ -209,11 +209,6 @@ describe('SystemActionModalsProvider (delete modal)', () => {
     expect(
       screen.getByText(/Delete system from inventory\?/i),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        /Test Host will be removed from all localhost:5000 applications and services/i,
-      ),
-    ).toBeInTheDocument();
   });
 });
 

--- a/src/components/SystemsView/SystemActionModalsContext.test.tsx
+++ b/src/components/SystemsView/SystemActionModalsContext.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { expect, jest } from '@jest/globals';
+import { createTestQueryClient } from '../../Utilities/TestingUtilities';
+import type { System } from '../InventoryViews/hooks/useHostsQuery';
+import {
+  SystemActionModalsProvider,
+  useSystemActionModalsContext,
+} from './SystemActionModalsContext';
+
+jest.mock('./hooks/useDeleteSystemsMutation', () => ({
+  useDeleteSystemsMutation: jest.fn(() => ({
+    onDeleteConfirm: jest.fn(),
+  })),
+}));
+
+jest.mock('./hooks/usePatchSystemsMutation', () => ({
+  usePatchSystemsMutation: jest.fn(() => ({
+    onPatchConfirm: jest.fn(),
+  })),
+}));
+
+jest.mock('../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: jest.fn(() => false),
+}));
+
+const testSystem = {
+  id: 'host-1',
+  display_name: 'Test Host',
+} as System;
+
+function OpenDeleteModalButton({
+  systems = [testSystem],
+}: {
+  systems?: System[];
+}) {
+  const { openDeleteModal } = useSystemActionModalsContext();
+  return (
+    <button type="button" onClick={() => openDeleteModal(systems)}>
+      Open delete modal
+    </button>
+  );
+}
+
+function renderWithProvider() {
+  const onInvalidate = jest.fn(async () => undefined);
+  return {
+    onInvalidate,
+    ...render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <SystemActionModalsProvider onInvalidate={onInvalidate}>
+          <OpenDeleteModalButton />
+        </SystemActionModalsProvider>
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+describe('SystemActionModalsProvider (delete modal)', () => {
+  it('does not show the delete modal until openDeleteModal is called', () => {
+    renderWithProvider();
+
+    expect(
+      screen.queryByText(/Delete system from inventory\?/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens the delete modal with the selected systems', async () => {
+    renderWithProvider();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open delete modal/i }),
+    );
+
+    expect(
+      screen.getByText(/Delete system from inventory\?/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Test Host will be removed from all localhost:5000 applications and services/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('closes the delete modal when cancel is clicked', async () => {
+    renderWithProvider();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /open delete modal/i }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(
+      screen.queryByText(/Delete system from inventory\?/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/SystemsView/SystemActionModalsContext.tsx
+++ b/src/components/SystemsView/SystemActionModalsContext.tsx
@@ -12,7 +12,6 @@ import RemoveHostsFromGroupModal from '../InventoryGroups/Modals/RemoveHostsFrom
 import MoveSystemsToWorkspaceModal from '../InventoryTable/MoveSystemsToWorkspaceModal';
 import type { SystemForWorkspace } from '../InventoryTable/MoveSystemsToWorkspaceModal';
 import TextInputModal from '../GeneralInfo/TextInputModal/TextInputModal';
-import { useKesselMigrationFeatureFlag } from '../../Utilities/hooks/useKesselMigrationFeatureFlag';
 import { useDeleteSystemsMutation } from './hooks/useDeleteSystemsMutation';
 import { usePatchSystemsMutation } from './hooks/usePatchSystemsMutation';
 import type { System } from '../InventoryViews/hooks/useHostsQuery';
@@ -34,6 +33,7 @@ export type OpenTagsModalFn = (
 interface SystemActionModalsContextValue {
   openDeleteModal: OpenModalFn;
   openAddToWorkspaceModal: OpenModalFn;
+  openMoveSystemsToWorkspaceModal: OpenModalFn;
   openRemoveFromWorkspaceModal: OpenModalFn;
   openEditModal: OpenModalFn;
   openTagsModal: OpenTagsModalFn;
@@ -66,7 +66,6 @@ export const SystemActionModalsProvider = ({
   onInvalidate,
   onSelectionClear,
 }: SystemActionModalsProviderProps) => {
-  const isKesselEnabled = useKesselMigrationFeatureFlag();
   const [systemsForAction, setSystemsForAction] = useState<System[]>([]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [addHostGroupModalOpen, setAddHostGroupModalOpen] = useState(false);
@@ -110,17 +109,15 @@ export const SystemActionModalsProvider = ({
     setIsDeleteModalOpen(true);
   }, []);
 
-  const openAddToWorkspaceModal = useCallback(
-    (systems: System[]) => {
-      setSystemsForAction(systems);
-      if (isKesselEnabled) {
-        setMoveSystemsToWorkspaceModalOpen(true);
-      } else {
-        setAddHostGroupModalOpen(true);
-      }
-    },
-    [isKesselEnabled],
-  );
+  const openAddToWorkspaceModal = useCallback((systems: System[]) => {
+    setSystemsForAction(systems);
+    setAddHostGroupModalOpen(true);
+  }, []);
+
+  const openMoveSystemsToWorkspaceModal = useCallback((systems: System[]) => {
+    setSystemsForAction(systems);
+    setMoveSystemsToWorkspaceModalOpen(true);
+  }, []);
 
   const openRemoveFromWorkspaceModal = useCallback((systems: System[]) => {
     setSystemsForAction(systems);
@@ -150,6 +147,7 @@ export const SystemActionModalsProvider = ({
     () => ({
       openDeleteModal,
       openAddToWorkspaceModal,
+      openMoveSystemsToWorkspaceModal,
       openRemoveFromWorkspaceModal,
       openEditModal,
       openTagsModal,
@@ -157,6 +155,7 @@ export const SystemActionModalsProvider = ({
     [
       openDeleteModal,
       openAddToWorkspaceModal,
+      openMoveSystemsToWorkspaceModal,
       openRemoveFromWorkspaceModal,
       openEditModal,
       openTagsModal,

--- a/src/components/SystemsView/SystemsViewBulkActions.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.tsx
@@ -40,6 +40,7 @@ export const SystemsViewBulkActions = ({
   const {
     openDeleteModal,
     openAddToWorkspaceModal,
+    openMoveSystemsToWorkspaceModal,
     openRemoveFromWorkspaceModal,
   } = useSystemActionModalsContext();
   const { openColumnManagementModal } = useColumnManagementModalContext();
@@ -53,7 +54,7 @@ export const SystemsViewBulkActions = ({
         <ResponsiveActions ouiaId="systems-view-toolbar-actions">
           <ResponsiveAction
             isPersistent
-            onClick={() => openAddToWorkspaceModal(selectedSystems)}
+            onClick={() => openMoveSystemsToWorkspaceModal(selectedSystems)}
             isDisabled={moveDisabled}
           >
             Move

--- a/src/components/SystemsView/SystemsViewRowActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.test.tsx
@@ -8,6 +8,7 @@ import { SystemActionModalsContext } from './SystemActionModalsContext';
 
 const mockOpenDeleteModal = jest.fn();
 const mockOpenAddToWorkspaceModal = jest.fn();
+const mockOpenMoveSystemsToWorkspaceModal = jest.fn();
 const mockOpenRemoveFromWorkspaceModal = jest.fn();
 const mockOpenEditModal = jest.fn();
 const mockOpenTagsModal = jest.fn();
@@ -15,6 +16,7 @@ const mockOpenTagsModal = jest.fn();
 const mockContextValue = {
   openDeleteModal: mockOpenDeleteModal,
   openAddToWorkspaceModal: mockOpenAddToWorkspaceModal,
+  openMoveSystemsToWorkspaceModal: mockOpenMoveSystemsToWorkspaceModal,
   openRemoveFromWorkspaceModal: mockOpenRemoveFromWorkspaceModal,
   openEditModal: mockOpenEditModal,
   openTagsModal: mockOpenTagsModal,
@@ -138,7 +140,9 @@ describe('SystemsViewRowActions', () => {
       await userEvent.click(
         screen.getByRole('menuitem', { name: /move system/i }),
       );
-      expect(mockOpenAddToWorkspaceModal).toHaveBeenCalledWith([system]);
+      expect(mockOpenMoveSystemsToWorkspaceModal).toHaveBeenCalledWith([
+        system,
+      ]);
     });
 
     it('disables Move system when permissions are undefined (no edit access)', async () => {

--- a/src/components/SystemsView/SystemsViewRowActions.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.tsx
@@ -41,6 +41,7 @@ const SystemsViewRowActions = ({ system }: RowActionsProps) => {
   const {
     openDeleteModal,
     openAddToWorkspaceModal,
+    openMoveSystemsToWorkspaceModal,
     openRemoveFromWorkspaceModal,
     openEditModal,
   } = useSystemActionModalsContext();
@@ -59,7 +60,7 @@ const SystemsViewRowActions = ({ system }: RowActionsProps) => {
     ? [
         buildMoveSystemActionsColumnItem(
           moveSystemRow,
-          () => openAddToWorkspaceModal([system]),
+          () => openMoveSystemsToWorkspaceModal([system]),
           true,
         ),
         {

--- a/src/components/SystemsView/columns/inventory/cells/Tags.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Tags.test.tsx
@@ -15,6 +15,7 @@ const mockOpenTagsModal = jest.fn();
 const mockContextValue = {
   openDeleteModal: jest.fn(),
   openAddToWorkspaceModal: jest.fn(),
+  openMoveSystemsToWorkspaceModal: jest.fn(),
   openRemoveFromWorkspaceModal: jest.fn(),
   openEditModal: jest.fn(),
   openTagsModal: mockOpenTagsModal,

--- a/src/components/SystemsView/filters/TagsFilter.test.js
+++ b/src/components/SystemsView/filters/TagsFilter.test.js
@@ -22,6 +22,7 @@ function renderTagsFilter(props = {}) {
       value={{
         openDeleteModal: jest.fn(),
         openAddToWorkspaceModal: jest.fn(),
+        openMoveSystemsToWorkspaceModal: jest.fn(),
         openRemoveFromWorkspaceModal: jest.fn(),
         openEditModal: jest.fn(),
         openTagsModal: mockOpenTagsModal,


### PR DESCRIPTION
RHINENG-25383

## What
Add unit tests for modal control functions. 
Small refactor of Context component. I've cleaned some duplicit kessel conditional logic. The kessel routing is done already in consumers and was not needed in Context.

## Testing
To make sure refactored code works, try to use AddToWorkspace & MoveToWorkspace row actions. They both should open appropriate modals.

## Summary by Sourcery

Add dedicated modal openers for moving systems to workspaces and update systems view actions to use them, while introducing comprehensive unit tests for the SystemActionModals context and its consumers.

New Features:
- Expose a separate openMoveSystemsToWorkspaceModal action in the SystemActionModals context for workspace move workflows.

Bug Fixes:
- Align systems view row and bulk actions to use the correct move-to-workspace modal, ensuring consistent behavior for move actions.

Enhancements:
- Simplify SystemActionModalsContext by removing kessel migration feature flag routing for workspace-related modals.

Tests:
- Add a new SystemActionModalsContext test suite covering all modal open/close behaviors, including workspace and tags modals.
- Extend existing SystemsView row, bulk actions, and tags-related tests to support the new move-to-workspace modal action and updated context API.