### PR TITLE
ci(IQE-4286): add Playwright test container image for OpenShift/Konflux

### DIFF
--- a/_playwright-tests/Dockerfile
+++ b/_playwright-tests/Dockerfile
@@ -1,0 +1,37 @@
+# Playwright test image for insights-inventory-frontend
+ARG NODE_IMAGE_TAG=9.8-1780607865
+FROM registry.access.redhat.com/ubi9/nodejs-22:${NODE_IMAGE_TAG}
+
+# Chromium headless-shell runtime dependencies for UBI9
+USER 0
+RUN dnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
+      nss nspr dbus-libs atk at-spi2-atk at-spi2-core cups-libs \
+      libXcomposite libXdamage libXext libXfixes libXrandr libxkbcommon \
+      mesa-libgbm cairo pango alsa-lib && \
+    dnf clean all && rm -rf /var/cache/dnf
+
+USER 1001
+WORKDIR /opt/app-root/src
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/app-root/src/.ms-playwright
+
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts --no-audit --no-fund && \
+    npm cache clean --force && rm -rf /opt/app-root/src/.npm
+
+RUN npx playwright install chromium --only-shell
+
+COPY playwright.config.js tsconfig.json ./
+COPY _playwright-tests ./_playwright-tests
+# apiHelpers.ts imports src/api/hostInventoryApi.js (only src/ dependency)
+COPY src/api/hostInventoryApi.js ./src/api/hostInventoryApi.js
+# Fixture archives uploaded by globalSetup via uploadArchive.ts
+COPY host_archives ./host_archives
+
+# Grant group write for dirs needing runtime writes (OpenShift runs with random UID, gid 0)
+USER 0
+RUN chown -R 1001:0 _playwright-tests host_archives && \
+    chmod -R g+w _playwright-tests host_archives
+USER 1001
+
+ENTRYPOINT ["npx", "playwright", "test"]


### PR DESCRIPTION
## Jira
[IQE-4286](https://redhat.atlassian.net/browse/IQE-4286)

## What
Adds a `Dockerfile` under `_playwright-tests/` that packages the Playwright E2E suite into a single runnable container image, for standalone execution via podman/docker or as an OpenShift CronJob.

## Why
Part of [IQE-4286](https://issues.redhat.com/browse/IQE-4286): POC to run post-deploy Playwright tests on Red Hat's own OpenShift infra (Konflux build + app-interface saas) — giving us app-interface visibility, Vault-managed secrets, and deployment gating.

We will build images with konflux and run jobs with app-interface in future. 

## How
- Base: `ubi9/nodejs-22`, installs `chromium --only-shell` (headless-only, smaller image)
- **Not** Microsoft's official `mcr.microsoft.com/playwright` image — Konflux/app-interface pipelines require images built from Red Hat-trusted registries (UBI/`registry.access.redhat.com`) to satisfy supply-chain policy (Enterprise Contract/SLSA). Pulling from `mcr.microsoft.com` would need explicit mirroring + an approved exception, so we build the Chromium runtime deps manually on UBI9 instead
- Copies an explicit allow-list of paths (config, `_playwright-tests/`, `host_archives`, one required `src/` file) — no app source or build artifacts baked in

## Testing

**Build:**
```bash
podman build -f _playwright-tests/Dockerfile -t insights-inventory-frontend-playwright .
```

**Run** (against stage, matching the existing `stage-daily-pw-tests.yml` filter):
```bash
podman run --rm \
  --env-file <your-stage.env> \
  -v /tmp/pw-reports:/opt/app-root/src/playwright-report:Z \
  insights-inventory-frontend-playwright \
  --grep-invert "@integration|@inventory-views"
```

[IQE-4286]: https://redhat.atlassian.net/browse/IQE-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IQE-4286]: https://redhat.atlassian.net/browse/IQE-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ