### PR TITLE
test(RHINENG-25386): expands unit tests for Systemsview actions

### DIFF
--- a/src/components/SystemsView/SystemsViewBulkActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.test.tsx
@@ -1,0 +1,359 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { expect, jest } from '@jest/globals';
+import { SystemActionModalsContext } from './SystemActionModalsContext';
+import {
+  GENERAL_GROUPS_WRITE_PERMISSION,
+  GENERAL_HOSTS_WRITE_PERMISSIONS,
+} from '../../constants';
+import type { System } from '../InventoryViews/hooks/useHostsQuery';
+
+const mockOpenDeleteModal = jest.fn();
+const mockOpenAddToWorkspaceModal = jest.fn();
+const mockOpenMoveSystemsToWorkspaceModal = jest.fn();
+const mockOpenRemoveFromWorkspaceModal = jest.fn();
+const mockOpenColumnManagementModal = jest.fn();
+
+const mockContextValue = {
+  openDeleteModal: mockOpenDeleteModal,
+  openAddToWorkspaceModal: mockOpenAddToWorkspaceModal,
+  openMoveSystemsToWorkspaceModal: mockOpenMoveSystemsToWorkspaceModal,
+  openRemoveFromWorkspaceModal: mockOpenRemoveFromWorkspaceModal,
+  openEditModal: jest.fn(),
+  openTagsModal: jest.fn(),
+};
+
+jest.mock('./ColumnManagementModalContext', () => ({
+  useColumnManagementModalContext: () => ({
+    openColumnManagementModal: mockOpenColumnManagementModal,
+  }),
+}));
+
+function renderBulkActions({
+  selectedSystems = [createSystem()],
+  activeState = 'active',
+}: {
+  selectedSystems?: System[];
+  activeState?: string;
+} = {}) {
+  return render(
+    <SystemActionModalsContext.Provider value={mockContextValue}>
+      <SystemsViewBulkActions
+        selectedSystems={selectedSystems}
+        activeState={activeState}
+      />
+    </SystemActionModalsContext.Provider>,
+  );
+}
+
+jest.mock('./SystemsViewExport', () => ({
+  SystemsViewExport: () => null,
+}));
+
+const mockUseKesselMigrationFeatureFlag = jest.fn();
+
+jest.mock('../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
+}));
+
+jest.mock('../../Utilities/useInventoryViewsFeatureFlag', () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
+jest.mock('../../Utilities/hooks/useConditionalRBAC', () => ({
+  useConditionalRBAC: jest.fn(() => ({ hasAccess: false })),
+}));
+
+const { SystemsViewBulkActions } =
+  require('./SystemsViewBulkActions') as typeof import('./SystemsViewBulkActions');
+
+const baseTestSystem = {
+  id: 'host-1',
+  display_name: 'My Host',
+  groups: [] as System['groups'],
+  org_id: 'test-org',
+};
+
+function createSystem(systemOverrides: Partial<System> = {}): System {
+  return { ...baseTestSystem, ...systemOverrides };
+}
+
+function setConditionalRBAC(hasGroupsWrite: boolean, hasHostsWrite: boolean) {
+  const useConditionalRBACMock =
+    require('../../Utilities/hooks/useConditionalRBAC')
+      .useConditionalRBAC as jest.Mock;
+  useConditionalRBACMock.mockImplementation((...args: unknown[]) => {
+    const permissions = args[0] as string[];
+    if (permissions.includes(GENERAL_GROUPS_WRITE_PERMISSION)) {
+      return { hasAccess: hasGroupsWrite };
+    }
+    if (permissions.includes(GENERAL_HOSTS_WRITE_PERMISSIONS)) {
+      return { hasAccess: hasHostsWrite };
+    }
+    return { hasAccess: false };
+  });
+}
+
+function getActionsOverflowMenuButton() {
+  return screen.getByRole('button', { name: /actions overflow menu/i });
+}
+
+async function openActionsOverflowMenu() {
+  await userEvent.click(getActionsOverflowMenuButton());
+}
+
+function expectOverflowMenuItemDisabled(name: string | RegExp) {
+  const item = screen.getByRole('menuitem', { name });
+  expect(item).toBeInTheDocument();
+  expect(
+    item.hasAttribute('aria-disabled') ||
+      item.hasAttribute('disabled') ||
+      item.className.includes('disabled'),
+  ).toBe(true);
+}
+
+describe('SystemsViewBulkActions', () => {
+  beforeEach(() => {
+    mockOpenDeleteModal.mockClear();
+    mockOpenAddToWorkspaceModal.mockClear();
+    mockOpenMoveSystemsToWorkspaceModal.mockClear();
+    mockOpenRemoveFromWorkspaceModal.mockClear();
+    mockOpenColumnManagementModal.mockClear();
+    setConditionalRBAC(false, false);
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+  });
+
+  describe('when Kessel migration is enabled', () => {
+    beforeEach(() => {
+      mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    });
+
+    it('shows Move and Delete and hides legacy workspace actions', () => {
+      renderBulkActions();
+
+      expect(screen.getByRole('button', { name: 'Move' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Delete' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Add to workspace' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Remove from workspace' }),
+      ).not.toBeInTheDocument();
+    });
+
+    describe('Move', () => {
+      it('opens move modal when clicked', async () => {
+        const selectedSystems = [
+          createSystem(),
+          createSystem({ id: 'host-2' }),
+        ];
+
+        renderBulkActions({ selectedSystems });
+
+        await userEvent.click(screen.getByRole('button', { name: 'Move' }));
+        expect(mockOpenMoveSystemsToWorkspaceModal).toHaveBeenCalledWith(
+          selectedSystems,
+        );
+      });
+
+      it('is disabled when no systems are selected', () => {
+        renderBulkActions({ selectedSystems: [] });
+
+        expect(screen.getByRole('button', { name: 'Move' })).toBeDisabled();
+      });
+
+      it('is disabled when the table is not in the active state', () => {
+        renderBulkActions({ activeState: 'loading' });
+
+        expect(screen.getByRole('button', { name: 'Move' })).toBeDisabled();
+      });
+    });
+
+    describe('Delete', () => {
+      it('opens delete modal when clicked', async () => {
+        const selectedSystems = [createSystem()];
+
+        renderBulkActions({ selectedSystems });
+
+        await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+        expect(mockOpenDeleteModal).toHaveBeenCalledWith(selectedSystems);
+      });
+
+      it('is disabled when no systems are selected', () => {
+        renderBulkActions({ selectedSystems: [] });
+
+        expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+      });
+
+      it('is disabled when the table is not in the active state', () => {
+        renderBulkActions({ activeState: 'empty' });
+
+        expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+      });
+    });
+  });
+
+  describe('when Kessel migration is disabled', () => {
+    beforeEach(() => {
+      mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+    });
+
+    it('shows Add and Remove from workspace and hides Move', async () => {
+      setConditionalRBAC(true, true);
+
+      renderBulkActions();
+
+      await openActionsOverflowMenu();
+
+      expect(
+        screen.getByRole('menuitem', { name: 'Add to workspace' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitem', { name: 'Remove from workspace' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Move' }),
+      ).not.toBeInTheDocument();
+    });
+
+    describe('Add to workspace', () => {
+      it('opens add to workspace modal when clicked', async () => {
+        setConditionalRBAC(true, true);
+
+        const selectedSystems = [createSystem()];
+
+        renderBulkActions({ selectedSystems });
+
+        await openActionsOverflowMenu();
+        await userEvent.click(
+          screen.getByRole('menuitem', { name: 'Add to workspace' }),
+        );
+        expect(mockOpenAddToWorkspaceModal).toHaveBeenCalledWith(
+          selectedSystems,
+        );
+      });
+
+      it('is disabled when user lacks groups write permission', () => {
+        setConditionalRBAC(false, true);
+
+        renderBulkActions();
+
+        expect(getActionsOverflowMenuButton()).toBeDisabled();
+      });
+
+      it('is disabled when any selected host is already in a workspace', async () => {
+        setConditionalRBAC(true, true);
+
+        const selectedSystems = [
+          createSystem({
+            groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+          }),
+        ];
+
+        renderBulkActions({ selectedSystems });
+
+        await openActionsOverflowMenu();
+
+        expectOverflowMenuItemDisabled('Add to workspace');
+      });
+
+      it('is disabled when no systems are selected', () => {
+        setConditionalRBAC(true, true);
+
+        renderBulkActions({ selectedSystems: [] });
+
+        expect(getActionsOverflowMenuButton()).toBeDisabled();
+      });
+    });
+
+    describe('Remove from workspace', () => {
+      it('opens remove from workspace modal when clicked', async () => {
+        setConditionalRBAC(true, true);
+
+        const selectedSystems = [
+          createSystem({
+            groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+          }),
+        ];
+
+        renderBulkActions({ selectedSystems });
+
+        await openActionsOverflowMenu();
+        await userEvent.click(
+          screen.getByRole('menuitem', { name: 'Remove from workspace' }),
+        );
+        expect(mockOpenRemoveFromWorkspaceModal).toHaveBeenCalledWith(
+          selectedSystems,
+        );
+      });
+
+      it('is disabled when user lacks groups write permission', () => {
+        setConditionalRBAC(false, true);
+
+        const selectedSystems = [
+          createSystem({
+            groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+          }),
+        ];
+
+        renderBulkActions({ selectedSystems });
+
+        expect(getActionsOverflowMenuButton()).toBeDisabled();
+      });
+
+      it('is disabled when any selected host is not in a workspace', async () => {
+        setConditionalRBAC(true, true);
+
+        const selectedSystems = [createSystem()];
+
+        renderBulkActions({ selectedSystems });
+
+        await openActionsOverflowMenu();
+
+        expectOverflowMenuItemDisabled('Remove from workspace');
+      });
+
+      it('is disabled when no systems are selected', () => {
+        setConditionalRBAC(true, true);
+
+        renderBulkActions({ selectedSystems: [] });
+
+        expect(getActionsOverflowMenuButton()).toBeDisabled();
+      });
+    });
+
+    describe('Delete', () => {
+      it('opens delete modal when clicked', async () => {
+        setConditionalRBAC(false, true);
+
+        const selectedSystems = [createSystem()];
+
+        renderBulkActions({ selectedSystems });
+
+        await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+        expect(mockOpenDeleteModal).toHaveBeenCalledWith(selectedSystems);
+      });
+
+      it('is disabled when user lacks hosts write permission', () => {
+        setConditionalRBAC(false, false);
+
+        renderBulkActions();
+
+        expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+      });
+
+      it('is disabled when no systems are selected', () => {
+        setConditionalRBAC(false, true);
+
+        renderBulkActions({ selectedSystems: [] });
+
+        expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+      });
+    });
+  });
+});

--- a/src/components/SystemsView/SystemsViewBulkActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.test.tsx
@@ -4,32 +4,40 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { expect, jest } from '@jest/globals';
 import { SystemActionModalsContext } from './SystemActionModalsContext';
-import {
-  GENERAL_GROUPS_WRITE_PERMISSION,
-  GENERAL_HOSTS_WRITE_PERMISSIONS,
-} from '../../constants';
 import type { System } from '../InventoryViews/hooks/useHostsQuery';
+import {
+  createSystem,
+  expectMenuItemDisabled,
+  mockOpenAddToWorkspaceModal,
+  mockOpenDeleteModal,
+  mockOpenMoveSystemsToWorkspaceModal,
+  mockOpenRemoveFromWorkspaceModal,
+  mockSystemActionModalsContextValue,
+  mockUseKesselMigrationFeatureFlag,
+  resetSystemsViewActionsTestState,
+  setConditionalRBAC,
+  testWorkspaceGroup,
+} from './__fixtures__/systemsViewActionsTestHelpers';
 
-const mockOpenDeleteModal = jest.fn();
-const mockOpenAddToWorkspaceModal = jest.fn();
-const mockOpenMoveSystemsToWorkspaceModal = jest.fn();
-const mockOpenRemoveFromWorkspaceModal = jest.fn();
 const mockOpenColumnManagementModal = jest.fn();
-
-const mockContextValue = {
-  openDeleteModal: mockOpenDeleteModal,
-  openAddToWorkspaceModal: mockOpenAddToWorkspaceModal,
-  openMoveSystemsToWorkspaceModal: mockOpenMoveSystemsToWorkspaceModal,
-  openRemoveFromWorkspaceModal: mockOpenRemoveFromWorkspaceModal,
-  openEditModal: jest.fn(),
-  openTagsModal: jest.fn(),
-};
 
 jest.mock('./ColumnManagementModalContext', () => ({
   useColumnManagementModalContext: () => ({
     openColumnManagementModal: mockOpenColumnManagementModal,
   }),
 }));
+
+jest.mock('./SystemsViewExport', () => ({
+  SystemsViewExport: () => null,
+}));
+
+jest.mock('../../Utilities/useInventoryViewsFeatureFlag', () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
+const { SystemsViewBulkActions } =
+  require('./SystemsViewBulkActions') as typeof import('./SystemsViewBulkActions');
 
 function renderBulkActions({
   selectedSystems = [createSystem()],
@@ -39,62 +47,15 @@ function renderBulkActions({
   activeState?: string;
 } = {}) {
   return render(
-    <SystemActionModalsContext.Provider value={mockContextValue}>
+    <SystemActionModalsContext.Provider
+      value={mockSystemActionModalsContextValue}
+    >
       <SystemsViewBulkActions
         selectedSystems={selectedSystems}
         activeState={activeState}
       />
     </SystemActionModalsContext.Provider>,
   );
-}
-
-jest.mock('./SystemsViewExport', () => ({
-  SystemsViewExport: () => null,
-}));
-
-const mockUseKesselMigrationFeatureFlag = jest.fn();
-
-jest.mock('../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
-  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
-}));
-
-jest.mock('../../Utilities/useInventoryViewsFeatureFlag', () => ({
-  __esModule: true,
-  default: () => false,
-}));
-
-jest.mock('../../Utilities/hooks/useConditionalRBAC', () => ({
-  useConditionalRBAC: jest.fn(() => ({ hasAccess: false })),
-}));
-
-const { SystemsViewBulkActions } =
-  require('./SystemsViewBulkActions') as typeof import('./SystemsViewBulkActions');
-
-const baseTestSystem = {
-  id: 'host-1',
-  display_name: 'My Host',
-  groups: [] as System['groups'],
-  org_id: 'test-org',
-};
-
-function createSystem(systemOverrides: Partial<System> = {}): System {
-  return { ...baseTestSystem, ...systemOverrides };
-}
-
-function setConditionalRBAC(hasGroupsWrite: boolean, hasHostsWrite: boolean) {
-  const useConditionalRBACMock =
-    require('../../Utilities/hooks/useConditionalRBAC')
-      .useConditionalRBAC as jest.Mock;
-  useConditionalRBACMock.mockImplementation((...args: unknown[]) => {
-    const permissions = args[0] as string[];
-    if (permissions.includes(GENERAL_GROUPS_WRITE_PERMISSION)) {
-      return { hasAccess: hasGroupsWrite };
-    }
-    if (permissions.includes(GENERAL_HOSTS_WRITE_PERMISSIONS)) {
-      return { hasAccess: hasHostsWrite };
-    }
-    return { hasAccess: false };
-  });
 }
 
 function getActionsOverflowMenuButton() {
@@ -105,25 +66,10 @@ async function openActionsOverflowMenu() {
   await userEvent.click(getActionsOverflowMenuButton());
 }
 
-function expectOverflowMenuItemDisabled(name: string | RegExp) {
-  const item = screen.getByRole('menuitem', { name });
-  expect(item).toBeInTheDocument();
-  expect(
-    item.hasAttribute('aria-disabled') ||
-      item.hasAttribute('disabled') ||
-      item.className.includes('disabled'),
-  ).toBe(true);
-}
-
 describe('SystemsViewBulkActions', () => {
   beforeEach(() => {
-    mockOpenDeleteModal.mockClear();
-    mockOpenAddToWorkspaceModal.mockClear();
-    mockOpenMoveSystemsToWorkspaceModal.mockClear();
-    mockOpenRemoveFromWorkspaceModal.mockClear();
+    resetSystemsViewActionsTestState();
     mockOpenColumnManagementModal.mockClear();
-    setConditionalRBAC(false, false);
-    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
   });
 
   describe('when Kessel migration is enabled', () => {
@@ -251,7 +197,7 @@ describe('SystemsViewBulkActions', () => {
 
         const selectedSystems = [
           createSystem({
-            groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+            groups: [testWorkspaceGroup],
           }),
         ];
 
@@ -259,7 +205,7 @@ describe('SystemsViewBulkActions', () => {
 
         await openActionsOverflowMenu();
 
-        expectOverflowMenuItemDisabled('Add to workspace');
+        expectMenuItemDisabled('Add to workspace');
       });
 
       it('is disabled when no systems are selected', () => {
@@ -277,7 +223,7 @@ describe('SystemsViewBulkActions', () => {
 
         const selectedSystems = [
           createSystem({
-            groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+            groups: [testWorkspaceGroup],
           }),
         ];
 
@@ -297,7 +243,7 @@ describe('SystemsViewBulkActions', () => {
 
         const selectedSystems = [
           createSystem({
-            groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+            groups: [testWorkspaceGroup],
           }),
         ];
 
@@ -315,7 +261,7 @@ describe('SystemsViewBulkActions', () => {
 
         await openActionsOverflowMenu();
 
-        expectOverflowMenuItemDisabled('Remove from workspace');
+        expectMenuItemDisabled('Remove from workspace');
       });
 
       it('is disabled when no systems are selected', () => {

--- a/src/components/SystemsView/SystemsViewBulkActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.test.tsx
@@ -7,7 +7,6 @@ import { SystemActionModalsContext } from './SystemActionModalsContext';
 import type { System } from '../InventoryViews/hooks/useHostsQuery';
 import {
   createSystem,
-  expectMenuItemDisabled,
   mockOpenAddToWorkspaceModal,
   mockOpenDeleteModal,
   mockOpenMoveSystemsToWorkspaceModal,
@@ -192,20 +191,20 @@ describe('SystemsViewBulkActions', () => {
         expect(getActionsOverflowMenuButton()).toBeDisabled();
       });
 
-      it('is disabled when any selected host is already in a workspace', async () => {
+      it('is disabled when any selected host is already in a workspace', () => {
         setConditionalRBAC(true, true);
 
         const selectedSystems = [
           createSystem({
+            id: 'host-in-workspace',
             groups: [testWorkspaceGroup],
           }),
+          createSystem({ id: 'host-not-in-workspace' }),
         ];
 
         renderBulkActions({ selectedSystems });
 
-        await openActionsOverflowMenu();
-
-        expectMenuItemDisabled('Add to workspace');
+        expect(getActionsOverflowMenuButton()).toBeDisabled();
       });
 
       it('is disabled when no systems are selected', () => {
@@ -260,16 +259,20 @@ describe('SystemsViewBulkActions', () => {
         expect(getActionsOverflowMenuButton()).toBeDisabled();
       });
 
-      it('is disabled when any selected host is not in a workspace', async () => {
+      it('is disabled when any selected host is not in a workspace', () => {
         setConditionalRBAC(true, true);
 
-        const selectedSystems = [createSystem()];
+        const selectedSystems = [
+          createSystem({
+            id: 'host-in-workspace',
+            groups: [testWorkspaceGroup],
+          }),
+          createSystem({ id: 'host-not-in-workspace' }),
+        ];
 
         renderBulkActions({ selectedSystems });
 
-        await openActionsOverflowMenu();
-
-        expectMenuItemDisabled('Remove from workspace');
+        expect(getActionsOverflowMenuButton()).toBeDisabled();
       });
 
       it('is disabled when no systems are selected', () => {

--- a/src/components/SystemsView/SystemsViewBulkActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.test.tsx
@@ -113,7 +113,7 @@ describe('SystemsViewBulkActions', () => {
         expect(screen.getByRole('button', { name: 'Move' })).toBeDisabled();
       });
 
-      it('is disabled when the table is not in the active state', () => {
+      it('is disabled when the table is is in the loading state', () => {
         renderBulkActions({ activeState: 'loading' });
 
         expect(screen.getByRole('button', { name: 'Move' })).toBeDisabled();
@@ -136,8 +136,8 @@ describe('SystemsViewBulkActions', () => {
         expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
       });
 
-      it('is disabled when the table is not in the active state', () => {
-        renderBulkActions({ activeState: 'empty' });
+      it('is disabled when the table is in the loading state', () => {
+        renderBulkActions({ activeState: 'loading' });
 
         expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
       });
@@ -215,6 +215,14 @@ describe('SystemsViewBulkActions', () => {
 
         expect(getActionsOverflowMenuButton()).toBeDisabled();
       });
+
+      it('is disabled when the table is in the loading state', () => {
+        setConditionalRBAC(true, true);
+
+        renderBulkActions({ activeState: 'loading' });
+
+        expect(getActionsOverflowMenuButton()).toBeDisabled();
+      });
     });
 
     describe('Remove from workspace', () => {
@@ -271,6 +279,20 @@ describe('SystemsViewBulkActions', () => {
 
         expect(getActionsOverflowMenuButton()).toBeDisabled();
       });
+
+      it('is disabled when the table is in the loading state', () => {
+        setConditionalRBAC(true, true);
+
+        const selectedSystems = [
+          createSystem({
+            groups: [testWorkspaceGroup],
+          }),
+        ];
+
+        renderBulkActions({ selectedSystems, activeState: 'loading' });
+
+        expect(getActionsOverflowMenuButton()).toBeDisabled();
+      });
     });
 
     describe('Delete', () => {
@@ -297,6 +319,14 @@ describe('SystemsViewBulkActions', () => {
         setConditionalRBAC(false, true);
 
         renderBulkActions({ selectedSystems: [] });
+
+        expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+      });
+
+      it('is disabled when the table is in the loading state', () => {
+        setConditionalRBAC(false, true);
+
+        renderBulkActions({ activeState: 'loading' });
 
         expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
       });

--- a/src/components/SystemsView/SystemsViewRowActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.test.tsx
@@ -107,6 +107,69 @@ describe('SystemsViewRowActions', () => {
         expectMoveMenuItemDisabled();
       });
     });
+
+    describe('Edit display name', () => {
+      it('opens edit modal when clicked', async () => {
+        const system = createSystemWithPermissions({
+          hasWorkspaceEdit: true,
+          hasUpdate: true,
+          hasDelete: true,
+        });
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        await userEvent.click(screen.getByRole('menuitem', { name: 'Edit' }));
+        expect(mockOpenEditModal).toHaveBeenCalledWith([system]);
+      });
+
+      it('is disabled when missing update permission', async () => {
+        const system = createSystemWithPermissions({
+          hasWorkspaceEdit: true,
+          hasUpdate: false,
+          hasDelete: true,
+        });
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        expect(screen.getByRole('menuitem', { name: 'Edit' })).toHaveAttribute(
+          'aria-disabled',
+          'true',
+        );
+      });
+    });
+
+    describe('Delete from inventory', () => {
+      it('opens delete modal when clicked', async () => {
+        const system = createSystemWithPermissions({
+          hasWorkspaceEdit: true,
+          hasUpdate: true,
+          hasDelete: true,
+        });
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        await userEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+        expect(mockOpenDeleteModal).toHaveBeenCalledWith([system]);
+      });
+
+      it('is disabled when missing delete permission', async () => {
+        const system = createSystemWithPermissions({
+          hasWorkspaceEdit: true,
+          hasUpdate: true,
+          hasDelete: false,
+        });
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        expect(
+          screen.getByRole('menuitem', { name: 'Delete' }),
+        ).toHaveAttribute('aria-disabled', 'true');
+      });
+    });
   });
 
   describe('when Kessel migration is disabled', () => {

--- a/src/components/SystemsView/SystemsViewRowActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.test.tsx
@@ -2,100 +2,37 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { expect, jest } from '@jest/globals';
+import { expect } from '@jest/globals';
 import { SystemActionModalsContext } from './SystemActionModalsContext';
-import type { SystemWithPermissions } from '../../Utilities/hooks/useHostIdsWithKessel';
+import { MOVE_SYSTEM_MENU_TEXT } from '../../constants';
 import {
-  GENERAL_GROUPS_WRITE_PERMISSION,
-  GENERAL_HOSTS_WRITE_PERMISSIONS,
-  MOVE_SYSTEM_MENU_TEXT,
-} from '../../constants';
-import type { System } from '../InventoryViews/hooks/useHostsQuery';
-
-const mockOpenDeleteModal = jest.fn();
-const mockOpenAddToWorkspaceModal = jest.fn();
-const mockOpenMoveSystemsToWorkspaceModal = jest.fn();
-const mockOpenRemoveFromWorkspaceModal = jest.fn();
-const mockOpenEditModal = jest.fn();
-const mockOpenTagsModal = jest.fn();
-
-const mockContextValue = {
-  openDeleteModal: mockOpenDeleteModal,
-  openAddToWorkspaceModal: mockOpenAddToWorkspaceModal,
-  openMoveSystemsToWorkspaceModal: mockOpenMoveSystemsToWorkspaceModal,
-  openRemoveFromWorkspaceModal: mockOpenRemoveFromWorkspaceModal,
-  openEditModal: mockOpenEditModal,
-  openTagsModal: mockOpenTagsModal,
-};
+  createSystem,
+  createSystemWithPermissions,
+  expectMenuItemDisabled,
+  mockOpenAddToWorkspaceModal,
+  mockOpenDeleteModal,
+  mockOpenEditModal,
+  mockOpenMoveSystemsToWorkspaceModal,
+  mockOpenRemoveFromWorkspaceModal,
+  mockSystemActionModalsContextValue,
+  mockUseKesselMigrationFeatureFlag,
+  resetSystemsViewActionsTestState,
+  setConditionalRBAC,
+  testWorkspaceGroup,
+} from './__fixtures__/systemsViewActionsTestHelpers';
 
 function renderWithProvider(ui: React.ReactElement) {
   return render(
-    <SystemActionModalsContext.Provider value={mockContextValue}>
+    <SystemActionModalsContext.Provider
+      value={mockSystemActionModalsContextValue}
+    >
       {ui}
     </SystemActionModalsContext.Provider>,
   );
 }
 
-const mockUseKesselMigrationFeatureFlag = jest.fn();
-
-jest.mock('../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
-  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
-}));
-
-jest.mock('../../Utilities/hooks/useConditionalRBAC', () => ({
-  useConditionalRBAC: jest.fn(() => ({ hasAccess: false })),
-}));
-
 const SystemsViewRowActions = require('./SystemsViewRowActions')
   .default as typeof import('./SystemsViewRowActions').default;
-
-const baseTestSystem = {
-  id: 'host-1',
-  display_name: 'My Host',
-  groups: [] as System['groups'],
-  org_id: 'test-org',
-};
-
-function createSystemWithPermissions(
-  permissions: SystemWithPermissions['permissions'],
-  systemOverrides: Partial<System> = {},
-): SystemWithPermissions {
-  return {
-    ...baseTestSystem,
-    ...systemOverrides,
-    permissions,
-  } as unknown as SystemWithPermissions;
-}
-
-function createSystem(systemOverrides: Partial<System> = {}): System {
-  return { ...baseTestSystem, ...systemOverrides };
-}
-
-function setConditionalRBAC(hasGroupsWrite: boolean, hasHostsWrite: boolean) {
-  const useConditionalRBACMock =
-    require('../../Utilities/hooks/useConditionalRBAC')
-      .useConditionalRBAC as jest.Mock;
-  useConditionalRBACMock.mockImplementation((...args: unknown[]) => {
-    const permissions = args[0] as string[];
-    if (permissions.includes(GENERAL_GROUPS_WRITE_PERMISSION)) {
-      return { hasAccess: hasGroupsWrite };
-    }
-    if (permissions.includes(GENERAL_HOSTS_WRITE_PERMISSIONS)) {
-      return { hasAccess: hasHostsWrite };
-    }
-    return { hasAccess: false };
-  });
-}
-
-function expectMenuItemDisabled(name: string | RegExp) {
-  const item = screen.getByRole('menuitem', { name });
-  expect(item).toBeInTheDocument();
-  expect(
-    item.hasAttribute('aria-disabled') ||
-      item.hasAttribute('disabled') ||
-      item.className.includes('disabled'),
-  ).toBe(true);
-}
 
 function expectMoveMenuItemDisabled() {
   expectMenuItemDisabled(MOVE_SYSTEM_MENU_TEXT);
@@ -103,14 +40,7 @@ function expectMoveMenuItemDisabled() {
 
 describe('SystemsViewRowActions', () => {
   beforeEach(() => {
-    mockOpenDeleteModal.mockClear();
-    mockOpenAddToWorkspaceModal.mockClear();
-    mockOpenMoveSystemsToWorkspaceModal.mockClear();
-    mockOpenRemoveFromWorkspaceModal.mockClear();
-    mockOpenEditModal.mockClear();
-    mockOpenTagsModal.mockClear();
-    setConditionalRBAC(false, false);
-    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+    resetSystemsViewActionsTestState();
   });
 
   async function openKebabMenu() {
@@ -233,7 +163,7 @@ describe('SystemsViewRowActions', () => {
         setConditionalRBAC(true, false);
 
         const system = createSystem({
-          groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+          groups: [testWorkspaceGroup],
         });
 
         renderWithProvider(<SystemsViewRowActions system={system} />);
@@ -248,7 +178,7 @@ describe('SystemsViewRowActions', () => {
         setConditionalRBAC(true, false);
 
         const system = createSystem({
-          groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+          groups: [testWorkspaceGroup],
         });
 
         renderWithProvider(<SystemsViewRowActions system={system} />);
@@ -264,7 +194,7 @@ describe('SystemsViewRowActions', () => {
         setConditionalRBAC(false, false);
 
         const system = createSystem({
-          groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+          groups: [testWorkspaceGroup],
         });
 
         renderWithProvider(<SystemsViewRowActions system={system} />);

--- a/src/components/SystemsView/SystemsViewRowActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.test.tsx
@@ -2,9 +2,15 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import SystemsViewRowActions from './SystemsViewRowActions';
 import { expect, jest } from '@jest/globals';
 import { SystemActionModalsContext } from './SystemActionModalsContext';
+import type { SystemWithPermissions } from '../../Utilities/hooks/useHostIdsWithKessel';
+import {
+  GENERAL_GROUPS_WRITE_PERMISSION,
+  GENERAL_HOSTS_WRITE_PERMISSIONS,
+  MOVE_SYSTEM_MENU_TEXT,
+} from '../../constants';
+import type { System } from '../InventoryViews/hooks/useHostsQuery';
 
 const mockOpenDeleteModal = jest.fn();
 const mockOpenAddToWorkspaceModal = jest.fn();
@@ -30,26 +36,81 @@ function renderWithProvider(ui: React.ReactElement) {
   );
 }
 
-jest.mock('../../Utilities/useFeatureFlag', () => ({
-  __esModule: true,
-  default: jest.fn((key: string) => key === 'hbi.rbac-v2'),
+const mockUseKesselMigrationFeatureFlag = jest.fn();
+
+jest.mock('../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
 }));
 
 jest.mock('../../Utilities/hooks/useConditionalRBAC', () => ({
   useConditionalRBAC: jest.fn(() => ({ hasAccess: false })),
 }));
 
-// No mock for @patternfly/react-table - test via DOM (open kebab and check menu items)
+const SystemsViewRowActions = require('./SystemsViewRowActions')
+  .default as typeof import('./SystemsViewRowActions').default;
+
+const baseTestSystem = {
+  id: 'host-1',
+  display_name: 'My Host',
+  groups: [] as System['groups'],
+  org_id: 'test-org',
+};
+
+function createSystemWithPermissions(
+  permissions: SystemWithPermissions['permissions'],
+  systemOverrides: Partial<System> = {},
+): SystemWithPermissions {
+  return {
+    ...baseTestSystem,
+    ...systemOverrides,
+    permissions,
+  } as unknown as SystemWithPermissions;
+}
+
+function createSystem(systemOverrides: Partial<System> = {}): System {
+  return { ...baseTestSystem, ...systemOverrides };
+}
+
+function setConditionalRBAC(hasGroupsWrite: boolean, hasHostsWrite: boolean) {
+  const useConditionalRBACMock =
+    require('../../Utilities/hooks/useConditionalRBAC')
+      .useConditionalRBAC as jest.Mock;
+  useConditionalRBACMock.mockImplementation((...args: unknown[]) => {
+    const permissions = args[0] as string[];
+    if (permissions.includes(GENERAL_GROUPS_WRITE_PERMISSION)) {
+      return { hasAccess: hasGroupsWrite };
+    }
+    if (permissions.includes(GENERAL_HOSTS_WRITE_PERMISSIONS)) {
+      return { hasAccess: hasHostsWrite };
+    }
+    return { hasAccess: false };
+  });
+}
+
+function expectMenuItemDisabled(name: string | RegExp) {
+  const item = screen.getByRole('menuitem', { name });
+  expect(item).toBeInTheDocument();
+  expect(
+    item.hasAttribute('aria-disabled') ||
+      item.hasAttribute('disabled') ||
+      item.className.includes('disabled'),
+  ).toBe(true);
+}
+
+function expectMoveMenuItemDisabled() {
+  expectMenuItemDisabled(MOVE_SYSTEM_MENU_TEXT);
+}
 
 describe('SystemsViewRowActions', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    const useFeatureFlag = require('../../Utilities/useFeatureFlag').default;
-    useFeatureFlag.mockImplementation((key: string) => key === 'hbi.rbac-v2');
-    const useConditionalRBACMock =
-      require('../../Utilities/hooks/useConditionalRBAC')
-        .useConditionalRBAC as jest.Mock;
-    useConditionalRBACMock.mockReturnValue({ hasAccess: false });
+    mockOpenDeleteModal.mockClear();
+    mockOpenAddToWorkspaceModal.mockClear();
+    mockOpenMoveSystemsToWorkspaceModal.mockClear();
+    mockOpenRemoveFromWorkspaceModal.mockClear();
+    mockOpenEditModal.mockClear();
+    mockOpenTagsModal.mockClear();
+    setConditionalRBAC(false, false);
+    mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
   });
 
   async function openKebabMenu() {
@@ -58,118 +119,230 @@ describe('SystemsViewRowActions', () => {
     );
   }
 
-  describe('Move system (Kessel enabled)', () => {
-    it('disables Move system when user does not have workspace edit permission', async () => {
-      const system = {
-        id: 'host-1',
-        display_name: 'My Host',
-        groups: [],
-        org_id: 'test-org',
-        permissions: {
-          hasWorkspaceEdit: false,
-          hasUpdate: true,
-          hasDelete: true,
-        },
-      };
+  describe('when Kessel migration is enabled', () => {
+    beforeEach(() => {
+      mockUseKesselMigrationFeatureFlag.mockReturnValue(true);
+    });
+
+    it('shows Move system and hides legacy workspace menu items', async () => {
+      const system = createSystemWithPermissions({
+        hasWorkspaceEdit: true,
+        hasUpdate: true,
+        hasDelete: true,
+      });
 
       renderWithProvider(<SystemsViewRowActions system={system} />);
       await openKebabMenu();
 
-      const addOrMoveItem = screen.getByRole('menuitem', {
-        name: /move system|add to workspace/i,
-      });
-      expect(addOrMoveItem).toBeInTheDocument();
-      // PatternFly disables via class or aria; ensure it's not clickable when no permission
       expect(
-        addOrMoveItem.hasAttribute('aria-disabled') ||
-          addOrMoveItem.hasAttribute('disabled') ||
-          addOrMoveItem.className.includes('disabled'),
-      ).toBe(true);
+        screen.getByRole('menuitem', { name: MOVE_SYSTEM_MENU_TEXT }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('menuitem', { name: 'Add to workspace' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('menuitem', { name: 'Remove from workspace' }),
+      ).not.toBeInTheDocument();
     });
 
-    it('enables Move system when user has workspace edit permission', async () => {
-      const useConditionalRBACMock =
-        require('../../Utilities/hooks/useConditionalRBAC')
-          .useConditionalRBAC as jest.Mock;
-      useConditionalRBACMock.mockReturnValue({ hasAccess: true });
-
-      const system = {
-        id: 'host-1',
-        display_name: 'My Host',
-        groups: [],
-        org_id: 'test-org',
-        permissions: {
+    describe('Move system', () => {
+      it('opens move modal when clicked', async () => {
+        const system = createSystemWithPermissions({
           hasWorkspaceEdit: true,
           hasUpdate: true,
           hasDelete: true,
-        },
-      };
+        });
 
-      renderWithProvider(<SystemsViewRowActions system={system} />);
-      await openKebabMenu();
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
 
-      const addOrMoveItem = screen.getByRole('menuitem', {
-        name: /move system|add to workspace/i,
+        await userEvent.click(
+          screen.getByRole('menuitem', { name: MOVE_SYSTEM_MENU_TEXT }),
+        );
+        expect(mockOpenMoveSystemsToWorkspaceModal).toHaveBeenCalledWith([
+          system,
+        ]);
       });
-      expect(addOrMoveItem).toBeInTheDocument();
-      // When enabled, item should not be aria-disabled (PF may still set disabled on the element)
-      expect(addOrMoveItem.getAttribute('aria-disabled')).not.toBe('true');
-    });
 
-    it('opens move modal when Move system is clicked', async () => {
-      const useConditionalRBACMock =
-        require('../../Utilities/hooks/useConditionalRBAC')
-          .useConditionalRBAC as jest.Mock;
-      useConditionalRBACMock.mockReturnValue({ hasAccess: true });
-
-      const system = {
-        id: 'host-1',
-        display_name: 'My Host',
-        groups: [],
-        org_id: 'test-org',
-        permissions: {
-          hasWorkspaceEdit: true,
+      it('is disabled when missing workspace edit permission', async () => {
+        const system = createSystemWithPermissions({
+          hasWorkspaceEdit: false,
           hasUpdate: true,
           hasDelete: true,
-        },
-      };
+        });
 
-      renderWithProvider(<SystemsViewRowActions system={system} />);
-      await openKebabMenu();
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
 
-      await userEvent.click(
-        screen.getByRole('menuitem', { name: /move system/i }),
-      );
-      expect(mockOpenMoveSystemsToWorkspaceModal).toHaveBeenCalledWith([
-        system,
-      ]);
+        expectMoveMenuItemDisabled();
+      });
+    });
+  });
+
+  describe('when Kessel migration is disabled', () => {
+    beforeEach(() => {
+      mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
     });
 
-    it('disables Move system when permissions are undefined (no edit access)', async () => {
-      const system = {
-        id: 'host-1',
-        display_name: 'My Host',
-        groups: [],
-        org_id: 'test-org',
-        permissions: {
-          hasWorkspaceEdit: false,
-          hasUpdate: false,
-          hasDelete: false,
-        },
-      };
+    it('shows Add and Remove from workspace and hides Move system', async () => {
+      const system = createSystem();
 
       renderWithProvider(<SystemsViewRowActions system={system} />);
       await openKebabMenu();
 
-      const addOrMoveItem = screen.getByRole('menuitem', {
-        name: /move system|add to workspace/i,
-      });
-      expect(addOrMoveItem).toBeInTheDocument();
       expect(
-        addOrMoveItem.hasAttribute('aria-disabled') ||
-          addOrMoveItem.hasAttribute('disabled') ||
-          addOrMoveItem.className.includes('disabled'),
-      ).toBe(true);
+        screen.getByRole('menuitem', { name: 'Add to workspace' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitem', { name: 'Remove from workspace' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('menuitem', { name: MOVE_SYSTEM_MENU_TEXT }),
+      ).not.toBeInTheDocument();
+    });
+
+    describe('Add to workspace', () => {
+      it('opens add to workspace modal when clicked', async () => {
+        setConditionalRBAC(true, false);
+
+        const system = createSystem();
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        await userEvent.click(
+          screen.getByRole('menuitem', { name: 'Add to workspace' }),
+        );
+        expect(mockOpenAddToWorkspaceModal).toHaveBeenCalledWith([system]);
+      });
+
+      it('is disabled when user lacks groups write permission', async () => {
+        setConditionalRBAC(false, false);
+
+        const system = createSystem();
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        expect(
+          screen.getByRole('menuitem', { name: 'Add to workspace' }),
+        ).toHaveAttribute('aria-disabled', 'true');
+      });
+
+      it('is disabled when the host is already in a workspace', async () => {
+        setConditionalRBAC(true, false);
+
+        const system = createSystem({
+          groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+        });
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        expectMenuItemDisabled('Add to workspace');
+      });
+    });
+
+    describe('Remove from workspace', () => {
+      it('opens remove from workspace modal when clicked', async () => {
+        setConditionalRBAC(true, false);
+
+        const system = createSystem({
+          groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+        });
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        await userEvent.click(
+          screen.getByRole('menuitem', { name: 'Remove from workspace' }),
+        );
+        expect(mockOpenRemoveFromWorkspaceModal).toHaveBeenCalledWith([system]);
+      });
+
+      it('is disabled when user lacks groups write permission', async () => {
+        setConditionalRBAC(false, false);
+
+        const system = createSystem({
+          groups: [{ id: 'g1', name: 'Workspace A', ungrouped: false }],
+        });
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        expect(
+          screen.getByRole('menuitem', { name: 'Remove from workspace' }),
+        ).toHaveAttribute('aria-disabled', 'true');
+      });
+
+      it('is disabled when the host is not in a workspace', async () => {
+        setConditionalRBAC(true, false);
+
+        const system = createSystem();
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        expectMenuItemDisabled('Remove from workspace');
+      });
+    });
+
+    describe('Edit display name', () => {
+      it('opens edit modal when clicked', async () => {
+        setConditionalRBAC(false, true);
+
+        const system = createSystem();
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        await userEvent.click(
+          screen.getByRole('menuitem', { name: 'Edit display name' }),
+        );
+        expect(mockOpenEditModal).toHaveBeenCalledWith([system]);
+      });
+
+      it('is disabled when user lacks hosts write permission', async () => {
+        setConditionalRBAC(false, false);
+
+        const system = createSystem();
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        expect(
+          screen.getByRole('menuitem', { name: 'Edit display name' }),
+        ).toHaveAttribute('aria-disabled', 'true');
+      });
+    });
+
+    describe('Delete from inventory', () => {
+      it('opens delete modal when clicked', async () => {
+        setConditionalRBAC(false, true);
+
+        const system = createSystem();
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        await userEvent.click(
+          screen.getByRole('menuitem', { name: 'Delete from inventory' }),
+        );
+        expect(mockOpenDeleteModal).toHaveBeenCalledWith([system]);
+      });
+
+      it('is disabled when user lacks hosts write permission', async () => {
+        setConditionalRBAC(false, false);
+
+        const system = createSystem();
+
+        renderWithProvider(<SystemsViewRowActions system={system} />);
+        await openKebabMenu();
+
+        expect(
+          screen.getByRole('menuitem', { name: 'Delete from inventory' }),
+        ).toHaveAttribute('aria-disabled', 'true');
+      });
     });
   });
 });

--- a/src/components/SystemsView/__fixtures__/systemsViewActionsTestHelpers.ts
+++ b/src/components/SystemsView/__fixtures__/systemsViewActionsTestHelpers.ts
@@ -1,0 +1,106 @@
+import { expect, jest } from '@jest/globals';
+import { screen } from '@testing-library/react';
+import {
+  GENERAL_GROUPS_WRITE_PERMISSION,
+  GENERAL_HOSTS_WRITE_PERMISSIONS,
+} from '../../../constants';
+import type { SystemWithPermissions } from '../../../Utilities/hooks/useHostIdsWithKessel';
+import type { System } from '../../InventoryViews/hooks/useHostsQuery';
+
+export const mockUseKesselMigrationFeatureFlag = jest.fn();
+
+jest.mock('../../../Utilities/hooks/useKesselMigrationFeatureFlag', () => ({
+  useKesselMigrationFeatureFlag: () => mockUseKesselMigrationFeatureFlag(),
+}));
+
+jest.mock('../../../Utilities/hooks/useConditionalRBAC', () => ({
+  useConditionalRBAC: jest.fn(() => ({ hasAccess: false })),
+}));
+
+const baseTestSystem = {
+  id: 'host-1',
+  display_name: 'My Host',
+  groups: [] as System['groups'],
+  org_id: 'test-org',
+};
+
+export const testWorkspaceGroup = {
+  id: 'g1',
+  name: 'Workspace A',
+  ungrouped: false,
+} as const;
+
+export const mockOpenDeleteModal = jest.fn();
+export const mockOpenAddToWorkspaceModal = jest.fn();
+export const mockOpenMoveSystemsToWorkspaceModal = jest.fn();
+export const mockOpenRemoveFromWorkspaceModal = jest.fn();
+export const mockOpenEditModal = jest.fn();
+export const mockOpenTagsModal = jest.fn();
+
+export const mockSystemActionModalsContextValue = {
+  openDeleteModal: mockOpenDeleteModal,
+  openAddToWorkspaceModal: mockOpenAddToWorkspaceModal,
+  openMoveSystemsToWorkspaceModal: mockOpenMoveSystemsToWorkspaceModal,
+  openRemoveFromWorkspaceModal: mockOpenRemoveFromWorkspaceModal,
+  openEditModal: mockOpenEditModal,
+  openTagsModal: mockOpenTagsModal,
+};
+
+export function createSystem(systemOverrides: Partial<System> = {}): System {
+  return { ...baseTestSystem, ...systemOverrides };
+}
+
+export function createSystemWithPermissions(
+  permissions: SystemWithPermissions['permissions'],
+  systemOverrides: Partial<System> = {},
+): SystemWithPermissions {
+  return {
+    ...baseTestSystem,
+    ...systemOverrides,
+    permissions,
+  } as unknown as SystemWithPermissions;
+}
+
+export function setConditionalRBAC(
+  hasGroupsWrite: boolean,
+  hasHostsWrite: boolean,
+) {
+  const useConditionalRBACMock =
+    require('../../../Utilities/hooks/useConditionalRBAC')
+      .useConditionalRBAC as jest.Mock;
+  useConditionalRBACMock.mockImplementation((...args: unknown[]) => {
+    const permissions = args[0] as string[];
+    if (permissions.includes(GENERAL_GROUPS_WRITE_PERMISSION)) {
+      return { hasAccess: hasGroupsWrite };
+    }
+    if (permissions.includes(GENERAL_HOSTS_WRITE_PERMISSIONS)) {
+      return { hasAccess: hasHostsWrite };
+    }
+    return { hasAccess: false };
+  });
+}
+
+export function expectMenuItemDisabled(name: string | RegExp) {
+  const item = screen.getByRole('menuitem', { name });
+  expect(item).toBeInTheDocument();
+  expect(
+    item.hasAttribute('aria-disabled') ||
+      item.hasAttribute('disabled') ||
+      item.className.includes('disabled'),
+  ).toBe(true);
+}
+
+export function resetSystemActionModalMocks() {
+  mockOpenDeleteModal.mockClear();
+  mockOpenAddToWorkspaceModal.mockClear();
+  mockOpenMoveSystemsToWorkspaceModal.mockClear();
+  mockOpenRemoveFromWorkspaceModal.mockClear();
+  mockOpenEditModal.mockClear();
+  mockOpenTagsModal.mockClear();
+}
+
+export function resetSystemsViewActionsTestState() {
+  resetSystemActionModalMocks();
+  setConditionalRBAC(false, false);
+  mockUseKesselMigrationFeatureFlag.mockReturnValue(false);
+}


### PR DESCRIPTION
RHINENG-25386
RHINENG-25384

## What
Expands & refactors tests for Row Actions. I've created sets for both kessel enabled and disabled. Also incorporated RBAC states.

## Summary by Sourcery

Expand and refactor SystemsView action tests to cover both row-level and bulk actions under Kessel and non-Kessel scenarios with RBAC-aware behavior.

Tests:
- Add comprehensive tests for SystemsView row actions covering Kessel migration on/off, workspace membership, and RBAC-driven enable/disable states.
- Introduce a new test suite for SystemsView bulk actions (move, delete, add/remove workspace) including selection and table-state preconditions.
- Extract shared SystemsView test helpers and mocks into reusable fixtures for systems, permissions, feature flags, and modal contexts.