### PR TITLE
chore(RHINENG-28461): bump package @redhat-cloud-services/host-inventory-client to new version 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@redhat-cloud-services/frontend-components": "^7.10.4",
         "@redhat-cloud-services/frontend-components-notifications": "^6.11.4",
         "@redhat-cloud-services/frontend-components-utilities": "^7.5.2",
-        "@redhat-cloud-services/host-inventory-client": "^5.0.7",
+        "@redhat-cloud-services/host-inventory-client": "^6.0.0",
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.14",
         "@sentry/webpack-plugin": "^2.23.1",
         "@tanstack/react-query": "^5.90.21",
@@ -7821,9 +7821,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/host-inventory-client": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-5.0.7.tgz",
-      "integrity": "sha512-GuVrgu9ybwLGhQi1YSZ92ZWrB1CivvgcDkWIAaqOG6k+nz41KH97FKRk/SA/tdm7hy7QM34HH9AklooZapTv1A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-6.0.0.tgz",
+      "integrity": "sha512-4hPJFZ2XIJYI0rHimuGXvfo3LBDfFW5JzcZ04M9rtI9QQ4cxgaLgP8TuNtiAlTGVjOwfSjLRsrbIi0lfWsziXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@redhat-cloud-services/frontend-components": "^7.10.4",
     "@redhat-cloud-services/frontend-components-notifications": "^6.11.4",
     "@redhat-cloud-services/frontend-components-utilities": "^7.5.2",
-    "@redhat-cloud-services/host-inventory-client": "^5.0.7",
+    "@redhat-cloud-services/host-inventory-client": "^6.0.0",
     "@redhat-cloud-services/javascript-clients-shared": "^2.0.14",
     "@sentry/webpack-plugin": "^2.23.1",
     "@tanstack/react-query": "^5.90.21",

--- a/src/components/InventoryViews/Modals/ViewSaveAsModal.test.tsx
+++ b/src/components/InventoryViews/Modals/ViewSaveAsModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -32,8 +33,8 @@ const createTestQueryClient = () =>
 
 const mockConfiguration: ViewConfiguration = {
   columns: [
-    { key: 'display_name', visible: true },
-    { key: 'os', visible: true },
+    { key: 'display_name' },
+    { key: 'os' },
   ],
   sort: {
     key: 'display_name',

--- a/src/components/SystemsView/utils/workloadsFilter.ts
+++ b/src/components/SystemsView/utils/workloadsFilter.ts
@@ -1,3 +1,5 @@
+import type { SystemProfileWorkloads } from '@redhat-cloud-services/host-inventory-client';
+
 /**
  * Toolbar workload filter options. `value` is the key under `system_profile.workloads`
  * (see system_profile.spec.yaml → SystemProfile.properties.workloads.properties).
@@ -10,13 +12,12 @@ export const WORKLOAD_FILTER_OPTIONS = [
   { label: 'Microsoft SQL', value: 'mssql' },
   { label: 'Oracle DB', value: 'oracle_db' },
   { label: 'RHEL AI', value: 'rhel_ai' },
+  { label: 'Satellite', value: 'satellite' },
   { label: 'SAP', value: 'sap' },
 ] as const;
 
-type WorkloadFilterValue = (typeof WORKLOAD_FILTER_OPTIONS)[number]['value'];
-
 /** Table column acronyms for keys under `system_profile.workloads`. */
-export const WORKLOAD_ACRONYMS: Record<WorkloadFilterValue, string> = {
+export const WORKLOAD_ACRONYMS: Record<string, string> = {
   ansible: 'AAP',
   crowdstrike: 'CS',
   ibm_db2: 'DB2',
@@ -24,6 +25,7 @@ export const WORKLOAD_ACRONYMS: Record<WorkloadFilterValue, string> = {
   mssql: 'MSSQL',
   oracle_db: 'ORACLE',
   rhel_ai: 'RHEL AI',
+  satellite: 'Satellite',
   sap: 'SAP',
 };
 


### PR DESCRIPTION
bump package @redhat-cloud-services/host-inventory-client to new version 6.0.0
- new "Satellite" option for Workload filter will be enabled in `SystemsView` table (part of the work https://redhat.atlassian.net/browse/RHINENG-29219)

## Summary by Sourcery

Build:
- Update @redhat-cloud-services/host-inventory-client dependency version from 5.x to 6.0.0 in package.json and package-lock.json.