### PR TITLE
refactor(RHINENG-29373): update ViewsToolbar markup

### DIFF
--- a/src/components/InventoryViews/ImagesView/ImagesView.tsx
+++ b/src/components/InventoryViews/ImagesView/ImagesView.tsx
@@ -8,7 +8,7 @@ import { useRows } from './hooks/useRows';
 import { NO_HEADER } from '../constants';
 import NoEntitiesFound from '../../InventoryTable/NoEntitiesFound';
 import { ErrorState } from '@patternfly/react-component-groups';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import { useImageQueries } from './hooks/useImageQueries';
 import './ImagesView.scss';
 
@@ -46,32 +46,34 @@ export const ImagesView = () => {
   });
 
   return (
-    <DataView activeState={activeState}>
-      <DataViewTable
-        ouiaId="images-view-table"
-        columns={columns}
-        rows={rows}
-        headStates={{
-          loading: NO_HEADER,
-          empty: NO_HEADER,
-          error: NO_HEADER,
-        }}
-        bodyStates={{
-          loading: (
-            <Bullseye>
-              <Spinner />
-            </Bullseye>
-          ),
-          empty: <NoEntitiesFound entities="images" />,
-          error: (
-            <ErrorState
-              ouiaId="error-state"
-              titleText="Unable to load data"
-              bodyText="There was an error retrieving data. Check your connection and reload the page."
-            />
-          ),
-        }}
-      />
-    </DataView>
+    <PageSection hasBodyWrapper={false}>
+      <DataView activeState={activeState}>
+        <DataViewTable
+          ouiaId="images-view-table"
+          columns={columns}
+          rows={rows}
+          headStates={{
+            loading: NO_HEADER,
+            empty: NO_HEADER,
+            error: NO_HEADER,
+          }}
+          bodyStates={{
+            loading: (
+              <Bullseye>
+                <Spinner />
+              </Bullseye>
+            ),
+            empty: <NoEntitiesFound entities="images" />,
+            error: (
+              <ErrorState
+                ouiaId="error-state"
+                titleText="Unable to load data"
+                bodyText="There was an error retrieving data. Check your connection and reload the page."
+              />
+            ),
+          }}
+        />
+      </DataView>
+    </PageSection>
   );
 };

--- a/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.scss
+++ b/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.scss
@@ -1,10 +1,7 @@
-/**
- * Views Toolbar Styles
- */
-
 .ins-c-views-toolbar {
-  padding: var(--pf-v6-global--spacer--md) 0;
-
-  // Align toolbar items properly
-  align-items: center;
+  // Keep page-section horizontal inset; sit flush above SystemsView's PageSection.
+  --pf-v6-c-page__main-section--PaddingBlockEnd: 0;
+  margin-block-end: calc(
+    -1 * var(--pf-v6-c-page__main-section--PaddingBlockStart)
+  );
 }

--- a/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.scss
+++ b/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.scss
@@ -1,5 +1,5 @@
 .ins-c-views-toolbar {
-  // Keep page-section horizontal inset; sit flush above SystemsView's PageSection.
+  // Sit flush above the sibling SystemsView PageSection.
   --pf-v6-c-page__main-section--PaddingBlockEnd: 0;
   margin-block-end: calc(
     -1 * var(--pf-v6-c-page__main-section--PaddingBlockStart)

--- a/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import {
+  Button,
   PageSection,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  Tooltip,
 } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import type { ViewOut } from '../../../api/inventoryViewsApi';
 import { ManageViewButton } from './ManageViewButton';
@@ -41,8 +44,19 @@ export const ViewsToolbar = ({
     >
       <Toolbar ouiaId="views-toolbar">
         <ToolbarContent>
-          <ToolbarItem variant="label" alignSelf="center">
-            View:
+          <ToolbarItem
+            variant="label"
+            alignSelf="center"
+            gap={{ default: 'gapNone' }}
+          >
+            View
+            <Tooltip content="Select a Systems View">
+              <Button
+                variant="plain"
+                icon={<OutlinedQuestionCircleIcon />}
+                aria-label="View"
+              />
+            </Tooltip>
           </ToolbarItem>
           <ToolbarItem>
             <ViewSelector

--- a/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import {
+  PageSection,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
 import type { ViewOut } from '../../../api/inventoryViewsApi';
 import { ManageViewButton } from './ManageViewButton';
 import ViewSelector from './ViewSelector';
@@ -29,31 +35,34 @@ export const ViewsToolbar = ({
   onDelete,
 }: ViewsToolbarProps) => {
   return (
-    <Flex
-      className={`ins-c-views-toolbar ${className || ''}`}
-      spaceItems={{ default: 'spaceItemsMd' }}
-      alignItems={{ default: 'alignItemsCenter' }}
+    <PageSection
+      className={css('ins-c-views-toolbar', className)}
+      hasBodyWrapper={false}
     >
-      <FlexItem>
-        <div>View: </div>
-      </FlexItem>
-      <FlexItem>
-        <ViewSelector
-          views={viewsList}
-          activeViewId={activeViewId}
-          onSelectView={onSelectView}
-        />
-      </FlexItem>
-      <FlexItem>
-        <ManageViewButton
-          currentViewId={currentViewId}
-          isSystemView={isSystemView}
-          onSaveAs={onSaveAs}
-          onRename={onRename}
-          onDelete={onDelete}
-        />
-      </FlexItem>
-    </Flex>
+      <Toolbar ouiaId="views-toolbar">
+        <ToolbarContent>
+          <ToolbarItem variant="label" alignSelf="center">
+            View:
+          </ToolbarItem>
+          <ToolbarItem>
+            <ViewSelector
+              views={viewsList}
+              activeViewId={activeViewId}
+              onSelectView={onSelectView}
+            />
+          </ToolbarItem>
+          <ToolbarItem>
+            <ManageViewButton
+              currentViewId={currentViewId}
+              isSystemView={isSystemView}
+              onSaveAs={onSaveAs}
+              onRename={onRename}
+              onDelete={onDelete}
+            />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+    </PageSection>
   );
 };
 

--- a/src/routes/SystemsPage.tsx
+++ b/src/routes/SystemsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Flex, FlexItem, PageSection } from '@patternfly/react-core';
+import { Flex, FlexItem } from '@patternfly/react-core';
 import {
   PageHeader,
   PageHeaderTitle,
@@ -71,17 +71,15 @@ const InventoryViewsPage = ({ hasAccess = true }: SystemsPageProps) => {
         />
         <OutageAlert />
       </PageHeader>
-      <PageSection hasBodyWrapper={false}>
-        {view === 'systems' ? (
-          isInventoryViewsEnabled ? (
-            <InventoryViews />
-          ) : (
-            <InventoryHosts />
-          )
+      {view === 'systems' ? (
+        isInventoryViewsEnabled ? (
+          <InventoryViews />
         ) : (
-          <ImagesView />
-        )}
-      </PageSection>
+          <InventoryHosts />
+        )
+      ) : (
+        <ImagesView />
+      )}
     </>
   );
 };


### PR DESCRIPTION
RHINENG-29373

## What
This PR updates markup, of ViewsToolbar using Toolbar components so structurally much more similar to DataViewToolbar which we use for in SystemsView.
It also removes nested PageSection component which was adding unnecessary extra white space around SystemsView in InventoryViews. 
Vertical Gap between bettween ViewsToolbar and SystemsView got shrinked to size which I think is expected based on mock. 

Reference component can be found: https://github.com/patternfly/react-data-view/blob/6e33d36a58331e011a99a789639723286ace4fb9/packages/module/src/DataViewToolbar/DataViewToolbar.tsx#L6

## Why
By following same standards across whole Page we lower maintenance and improve readability. 

<img width="2195" height="860" alt="image" src="https://github.com/user-attachments/assets/ece2a5a4-0e14-4350-a8a0-9ea60ec0e1a2" />

## Summary by Sourcery

Align inventory views layout and toolbar structure with DataView toolbar patterns and page sections for consistent spacing and presentation.

Enhancements:
- Refactor ViewsToolbar to use PageSection and PatternFly Toolbar components for a more consistent toolbar layout.
- Wrap ImagesView content in a PageSection to align with surrounding page structure and states.
- Simplify SystemsPage layout by removing an extra PageSection wrapper around conditional inventory views.
- Adjust ViewsToolbar styling to sit flush with the SystemsView PageSection and eliminate excess vertical padding.