### PR TITLE
feat(RHINENG-28461): Generate V2 TypeScript Client for Views API

### DIFF
--- a/src/api/hostInventoryApiTyped.ts
+++ b/src/api/hostInventoryApiTyped.ts
@@ -39,7 +39,7 @@ export type {
   // Add other types you need from the client package
 } from '@redhat-cloud-services/host-inventory-client';
 
-const INVENTORY_API_BASE = '/api/inventory/v1';
+import { INVENTORY_API_BASE } from '../config';
 
 type FunctionProperties<T> = {
   [K in keyof T]: T[K] extends Function ? K : never;

--- a/src/api/inventoryViewsApi.ts
+++ b/src/api/inventoryViewsApi.ts
@@ -1,7 +1,18 @@
-// ============================================================================
-// TYPE IMPORTS (from @redhat-cloud-services/host-inventory-client)
-// ============================================================================
-
+import { APIFactory } from '@redhat-cloud-services/javascript-clients-shared';
+import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import * as clientExports from '@redhat-cloud-services/host-inventory-client';
+import type { AxiosInstance } from 'axios';
+import type {
+  ApiViewsGetViewsListParams,
+  ApiViewsGetViewsListReturnType,
+} from '@redhat-cloud-services/host-inventory-client/ApiViewsGetViewsList';
+import type {
+  ApiViewsGetViewByIdParams,
+  ApiViewsGetViewByIdReturnType,
+} from '@redhat-cloud-services/host-inventory-client/ApiViewsGetViewById';
+import type { ApiViewsCreateViewReturnType } from '@redhat-cloud-services/host-inventory-client/ApiViewsCreateView';
+import type { ApiViewsUpdateViewReturnType } from '@redhat-cloud-services/host-inventory-client/ApiViewsUpdateView';
+import type { ApiViewsCloneViewReturnType } from '@redhat-cloud-services/host-inventory-client/ApiViewsCloneView';
 import type {
   ViewConfiguration,
   ViewIn,
@@ -10,187 +21,83 @@ import type {
   ViewsListOut,
 } from '@redhat-cloud-services/host-inventory-client/types';
 
-// Re-export for convenience — consumers can import from this file
 export type { ViewConfiguration, ViewIn, ViewOut, ViewPatch, ViewsListOut };
 
-// Type aliases mapping to our domain terminology
 export type CreateViewRequest = ViewIn;
 export type UpdateViewRequest = ViewPatch;
 export type InventoryView = ViewOut;
 
-// ============================================================================
-// MOCK DATA (Replace with real API when available)
-// ============================================================================
-
 export const ALL_SYSTEMS_VIEW_ID = 'all-systems';
 
-export const MOCK_VIEWS: ViewOut[] = [
-  {
-    id: ALL_SYSTEMS_VIEW_ID,
-    name: 'All systems',
-    description: 'Default view showing all inventory systems',
-    is_system_view: true,
-    org_id: 'org-123',
-    org_wide: true,
-    configuration: { columns: [] },
-    created_by: 'system',
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-    is_owner: false,
-  },
-  {
-    id: 'view-production',
-    name: 'Production view',
-    description: 'Production environment systems',
-    is_system_view: false,
-    org_id: 'org-123',
-    org_wide: false,
-    configuration: { columns: [] },
-    created_by: 'current-user',
-    created_at: '2026-06-15T10:00:00Z',
-    updated_at: '2026-07-20T14:30:00Z',
-    is_owner: true,
-  },
-  {
-    id: 'view-rhel9-staging',
-    name: 'RHEL 9 staging',
-    description: 'RHEL 9 systems in staging environment',
-    is_system_view: false,
-    org_id: 'org-123',
-    org_wide: false,
-    configuration: { columns: [] },
-    created_by: 'current-user',
-    created_at: '2026-07-01T09:00:00Z',
-    updated_at: '2026-07-25T11:00:00Z',
-    is_owner: true,
-  },
-  {
-    id: 'view-security',
-    name: 'Security overview',
-    description: 'Systems with security-related advisories',
-    is_system_view: true,
-    org_id: 'org-123',
-    org_wide: true,
-    configuration: { columns: [] },
-    created_by: 'system',
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
-    is_owner: false,
-  },
-];
+const INVENTORY_API_BASE = '/api/inventory/v1';
 
-// ============================================================================
-// DUMMY API FUNCTIONS (Replace with real API calls)
-// ============================================================================
+type FunctionProperties<T> = {
+  [K in keyof T]: T[K] extends Function ? K : never;
+}[keyof T];
 
-/**
- * DUMMY: List all inventory views visible to the requesting user
- *
- * Real implementation (RHINENG-28461):
- * - GET /api/inventory/v1/views
- * - RBAC: @access(KesselResourceTypes.VIEWS.view)
- * - Returns system views, user's own views, and org-wide views
- * - Each view includes computed is_owner boolean
- */
-export const listViewsApi = async (): Promise<ViewsListOut> => {
-  console.log('[DUMMY API] Listing views');
+type ApiEndpoints = Pick<
+  typeof clientExports,
+  FunctionProperties<typeof clientExports>
+>;
 
-  // Simulate API delay
-  await new Promise((resolve) => setTimeout(resolve, 300));
+const endpoints = Object.fromEntries(
+  Object.entries(clientExports).filter(
+    ([, value]) => typeof value === 'function',
+  ),
+) as ApiEndpoints;
 
-  return {
-    count: MOCK_VIEWS.length,
-    page: 1,
-    per_page: 50,
-    total: MOCK_VIEWS.length,
-    results: MOCK_VIEWS,
+const inventoryApi = (axios: AxiosInstance = axiosInstance) =>
+  APIFactory(INVENTORY_API_BASE, endpoints, { axios });
+
+export const listViewsApi =
+  async (): Promise<ApiViewsGetViewsListReturnType> => {
+    return (await inventoryApi().apiViewsGetViewsList(
+      {},
+    )) as unknown as ApiViewsGetViewsListReturnType;
   };
+
+export const getViewsApi = async (
+  params: ApiViewsGetViewsListParams = {},
+): Promise<ApiViewsGetViewsListReturnType> => {
+  return (await inventoryApi().apiViewsGetViewsList(
+    params,
+  )) as unknown as ApiViewsGetViewsListReturnType;
 };
 
-/**
- * DUMMY: Create a new inventory view
- *
- * Real implementation (RHINENG-28461):
- * - POST /api/inventory/v1/views
- * - RBAC: @access(KesselResourceTypes.VIEWS.create)
- * - Backend sets org_id and created_by from Identity Header
- *  @param data
- */
+export const getViewApi = async (
+  params: ApiViewsGetViewByIdParams,
+): Promise<ApiViewsGetViewByIdReturnType> => {
+  return (await inventoryApi().apiViewsGetViewById(
+    params,
+  )) as unknown as ApiViewsGetViewByIdReturnType;
+};
+
 export const createViewApi = async (
   data: CreateViewRequest,
-): Promise<InventoryView> => {
-  console.log('[DUMMY API] Creating view:', data);
-
-  // Simulate API delay
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  // Return mock response matching V2 API structure
-  return {
-    id: `view-${Date.now()}`,
-    org_id: 'org-123', // Would come from Identity Header
-    name: data.name,
-    description: data.description || '',
-    is_system_view: false,
-    configuration: data.configuration,
-    org_wide: data.org_wide || false,
-    created_by: 'current-user', // Would come from Identity Header
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-    is_owner: true,
-  };
+): Promise<ApiViewsCreateViewReturnType> => {
+  return (await inventoryApi().apiViewsCreateView({
+    viewIn: data,
+  })) as unknown as ApiViewsCreateViewReturnType;
 };
 
-/**
- * DUMMY: Update an existing inventory view
- *
- * Real implementation (RHINENG-28461):
- * - PUT /api/inventory/v1/views/{id}
- * - RBAC: @access(KesselResourceTypes.VIEWS.update, id_param="view_id")
- * - Ownership check: created_by must match requester
- * - Immutability check: is_system_view must be FALSE
- *  @param id
- *  @param data
- */
 export const updateViewApi = async (
   id: string,
   data: UpdateViewRequest,
-): Promise<InventoryView> => {
-  console.log('[DUMMY API] Updating view:', id, data);
-
-  // Simulate API delay
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  // Return mock response
-  return {
-    id,
-    org_id: 'org-123',
-    name: data.name || 'Updated View',
-    description: data.description || '',
-    is_system_view: false,
-    configuration: data.configuration || { columns: [] },
-    org_wide: data.org_wide || false,
-    created_by: 'current-user',
-    created_at: new Date(Date.now() - 86400000).toISOString(), // 1 day ago
-    updated_at: new Date().toISOString(),
-    is_owner: true,
-  };
+): Promise<ApiViewsUpdateViewReturnType> => {
+  return (await inventoryApi().apiViewsUpdateView({
+    viewId: id,
+    viewPatch: data,
+  })) as unknown as ApiViewsUpdateViewReturnType;
 };
 
-/**
- * DUMMY: Delete an inventory view
- *
- * Real implementation (RHINENG-28461):
- * - DELETE /api/inventory/v1/views/{id}
- * - RBAC: @access(KesselResourceTypes.VIEWS.delete, id_param="view_id")
- * - Ownership check: created_by must match requester
- * - Immutability check: is_system_view must be FALSE
- *  @param id
- */
 export const deleteViewApi = async (id: string): Promise<void> => {
-  console.log('[DUMMY API] Deleting view:', id);
+  await inventoryApi().apiViewsDeleteView({ viewId: id });
+};
 
-  // Simulate API delay
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  // No return value for DELETE
+export const cloneViewApi = async (
+  id: string,
+): Promise<ApiViewsCloneViewReturnType> => {
+  return (await inventoryApi().apiViewsCloneView({
+    viewId: id,
+  })) as unknown as ApiViewsCloneViewReturnType;
 };

--- a/src/api/inventoryViewsApi.ts
+++ b/src/api/inventoryViewsApi.ts
@@ -6,7 +6,6 @@ import {
   apiViewsCreateView,
   apiViewsUpdateView,
   apiViewsDeleteView,
-  apiViewsCloneView,
 } from '@redhat-cloud-services/host-inventory-client';
 import type { AxiosInstance } from 'axios';
 import type {
@@ -19,7 +18,6 @@ import type {
 } from '@redhat-cloud-services/host-inventory-client/ApiViewsGetViewById';
 import type { ApiViewsCreateViewReturnType } from '@redhat-cloud-services/host-inventory-client/ApiViewsCreateView';
 import type { ApiViewsUpdateViewReturnType } from '@redhat-cloud-services/host-inventory-client/ApiViewsUpdateView';
-import type { ApiViewsCloneViewReturnType } from '@redhat-cloud-services/host-inventory-client/ApiViewsCloneView';
 import type {
   ViewConfiguration,
   ViewIn,
@@ -43,7 +41,6 @@ const endpoints = {
   apiViewsCreateView,
   apiViewsUpdateView,
   apiViewsDeleteView,
-  apiViewsCloneView,
 };
 
 const inventoryApi = (axios: AxiosInstance = axiosInstance) =>
@@ -85,12 +82,4 @@ export const updateViewApi = async (
 
 export const deleteViewApi = async (id: string): Promise<void> => {
   await inventoryApi().apiViewsDeleteView({ viewId: id });
-};
-
-export const cloneViewApi = async (
-  id: string,
-): Promise<ApiViewsCloneViewReturnType> => {
-  return (await inventoryApi().apiViewsCloneView({
-    viewId: id,
-  })) as unknown as ApiViewsCloneViewReturnType;
 };

--- a/src/api/inventoryViewsApi.ts
+++ b/src/api/inventoryViewsApi.ts
@@ -49,14 +49,7 @@ const endpoints = Object.fromEntries(
 const inventoryApi = (axios: AxiosInstance = axiosInstance) =>
   APIFactory(INVENTORY_API_BASE, endpoints, { axios });
 
-export const listViewsApi =
-  async (): Promise<ApiViewsGetViewsListReturnType> => {
-    return (await inventoryApi().apiViewsGetViewsList(
-      {},
-    )) as unknown as ApiViewsGetViewsListReturnType;
-  };
-
-export const getViewsApi = async (
+export const listViewsApi = async (
   params: ApiViewsGetViewsListParams = {},
 ): Promise<ApiViewsGetViewsListReturnType> => {
   return (await inventoryApi().apiViewsGetViewsList(

--- a/src/api/inventoryViewsApi.ts
+++ b/src/api/inventoryViewsApi.ts
@@ -1,6 +1,13 @@
 import { APIFactory } from '@redhat-cloud-services/javascript-clients-shared';
 import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
-import * as clientExports from '@redhat-cloud-services/host-inventory-client';
+import {
+  apiViewsGetViewsList,
+  apiViewsGetViewById,
+  apiViewsCreateView,
+  apiViewsUpdateView,
+  apiViewsDeleteView,
+  apiViewsCloneView,
+} from '@redhat-cloud-services/host-inventory-client';
 import type { AxiosInstance } from 'axios';
 import type {
   ApiViewsGetViewsListParams,
@@ -31,20 +38,14 @@ export const ALL_SYSTEMS_VIEW_ID = 'all-systems';
 
 const INVENTORY_API_BASE = '/api/inventory/v1';
 
-type FunctionProperties<T> = {
-  [K in keyof T]: T[K] extends Function ? K : never;
-}[keyof T];
-
-type ApiEndpoints = Pick<
-  typeof clientExports,
-  FunctionProperties<typeof clientExports>
->;
-
-const endpoints = Object.fromEntries(
-  Object.entries(clientExports).filter(
-    ([, value]) => typeof value === 'function',
-  ),
-) as ApiEndpoints;
+const endpoints = {
+  apiViewsGetViewsList,
+  apiViewsGetViewById,
+  apiViewsCreateView,
+  apiViewsUpdateView,
+  apiViewsDeleteView,
+  apiViewsCloneView,
+};
 
 const inventoryApi = (axios: AxiosInstance = axiosInstance) =>
   APIFactory(INVENTORY_API_BASE, endpoints, { axios });

--- a/src/api/inventoryViewsApi.ts
+++ b/src/api/inventoryViewsApi.ts
@@ -27,6 +27,7 @@ import type {
   ViewPatch,
   ViewsListOut,
 } from '@redhat-cloud-services/host-inventory-client/types';
+import { INVENTORY_API_BASE } from '../config';
 
 export type { ViewConfiguration, ViewIn, ViewOut, ViewPatch, ViewsListOut };
 
@@ -35,8 +36,6 @@ export type UpdateViewRequest = ViewPatch;
 export type InventoryView = ViewOut;
 
 export const ALL_SYSTEMS_VIEW_ID = 'all-systems';
-
-const INVENTORY_API_BASE = '/api/inventory/v1';
 
 const endpoints = {
   apiViewsGetViewsList,

--- a/src/components/InventoryViews/Modals/ViewDeleteModal.test.tsx
+++ b/src/components/InventoryViews/Modals/ViewDeleteModal.test.tsx
@@ -5,6 +5,10 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ViewDeleteModal from './ViewDeleteModal';
 
+jest.mock('../../../api/inventoryViewsApi', () => ({
+  deleteViewApi: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock(
   '@redhat-cloud-services/frontend-components-notifications/hooks',
   () => ({

--- a/src/components/InventoryViews/Modals/ViewRenameModal.test.tsx
+++ b/src/components/InventoryViews/Modals/ViewRenameModal.test.tsx
@@ -5,6 +5,21 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ViewRenameModal from './ViewRenameModal';
 
+jest.mock('../../../api/inventoryViewsApi', () => ({
+  updateViewApi: jest.fn().mockResolvedValue({
+    id: 'view-123',
+    name: 'Renamed View',
+    org_id: 'org-123',
+    configuration: { columns: [] },
+    is_system_view: false,
+    org_wide: false,
+    is_owner: true,
+    created_by: 'current-user',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }),
+}));
+
 jest.mock(
   '@redhat-cloud-services/frontend-components-notifications/hooks',
   () => ({

--- a/src/components/InventoryViews/Modals/ViewSaveAsModal.test.tsx
+++ b/src/components/InventoryViews/Modals/ViewSaveAsModal.test.tsx
@@ -7,6 +7,21 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ViewSaveAsModal from './ViewSaveAsModal';
 import type { ViewConfiguration } from '../../../api/inventoryViewsApi';
 
+jest.mock('../../../api/inventoryViewsApi', () => ({
+  createViewApi: jest.fn().mockResolvedValue({
+    id: 'new-view-123',
+    name: 'My Custom View',
+    org_id: 'org-123',
+    configuration: { columns: [] },
+    is_system_view: false,
+    org_wide: false,
+    is_owner: true,
+    created_by: 'current-user',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }),
+}));
+
 jest.mock(
   '@redhat-cloud-services/frontend-components-notifications/hooks',
   () => ({

--- a/src/components/InventoryViews/hooks/index.ts
+++ b/src/components/InventoryViews/hooks/index.ts
@@ -2,4 +2,5 @@ export { useCreateViewMutation } from './useCreateViewMutation';
 export { useUpdateViewMutation } from './useUpdateViewMutation';
 export { useDeleteViewMutation } from './useDeleteViewMutation';
 export { useViewsQuery } from './useViewsQuery';
+export { useViewQuery } from './useViewQuery';
 export { validateViewName } from './useViewNameValidation';

--- a/src/components/InventoryViews/hooks/useCreateViewMutation.ts
+++ b/src/components/InventoryViews/hooks/useCreateViewMutation.ts
@@ -15,8 +15,7 @@ export const useCreateViewMutation = () => {
         dismissable: true,
       });
 
-      // TODO: Invalidate views list query when RHINENG-28462 is complete
-      // queryClient.invalidateQueries({ queryKey: ['views'] });
+      void queryClient.invalidateQueries({ queryKey: ['views'] });
     },
     onError: (error) => {
       console.error(error);

--- a/src/components/InventoryViews/hooks/useDeleteViewMutation.ts
+++ b/src/components/InventoryViews/hooks/useDeleteViewMutation.ts
@@ -15,8 +15,7 @@ export const useDeleteViewMutation = () => {
         dismissable: true,
       });
 
-      // TODO: Invalidate views list when RHINENG-28462 is complete
-      // queryClient.invalidateQueries({ queryKey: ['views'] });
+      void queryClient.invalidateQueries({ queryKey: ['views'] });
     },
     onError: (error) => {
       console.error(error);

--- a/src/components/InventoryViews/hooks/useUpdateViewMutation.ts
+++ b/src/components/InventoryViews/hooks/useUpdateViewMutation.ts
@@ -17,9 +17,10 @@ export const useUpdateViewMutation = () => {
         dismissable: true,
       });
 
-      // TODO: Invalidate specific view + views list when RHINENG-28462 is complete
-      // queryClient.invalidateQueries({ queryKey: ['views'] });
-      // queryClient.invalidateQueries({ queryKey: ['view', updatedView.id] });
+      void queryClient.invalidateQueries({ queryKey: ['views'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['view', updatedView.id],
+      });
     },
     onError: (error) => {
       console.error(error);

--- a/src/components/InventoryViews/hooks/useViewQuery.ts
+++ b/src/components/InventoryViews/hooks/useViewQuery.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getViewApi } from '../../../api/inventoryViewsApi';
+
+export const useViewQuery = (viewId: string | undefined) => {
+  return useQuery({
+    queryKey: ['view', viewId],
+    queryFn: () => getViewApi({ viewId: viewId! }),
+    enabled: !!viewId,
+  });
+};

--- a/src/components/InventoryViews/hooks/useViewsQuery.ts
+++ b/src/components/InventoryViews/hooks/useViewsQuery.ts
@@ -11,6 +11,6 @@ import { listViewsApi } from '../../../api/inventoryViewsApi';
 export const useViewsQuery = () => {
   return useQuery({
     queryKey: ['views'],
-    queryFn: listViewsApi,
+    queryFn: () => listViewsApi(),
   });
 };


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-28461

## What
Generate TypeScript client for V2 Inventory Views API

## Why
Use real API

## How
Use the existing @redhat-cloud-services/host-inventory-client package instead of dummy/mocks

## Testing
- visit Systems page stage
- try to create/rename/delete view
<img width="1050" height="368" alt="image" src="https://github.com/user-attachments/assets/ac2d0c09-a822-403b-9712-01c4614cb01c" />
<img width="1050" height="368" alt="image" src="https://github.com/user-attachments/assets/cb376d7e-3c47-401a-b354-7fbe7237a3fb" />



## Summary by Sourcery

Replace the mock inventory views API with a real TypeScript client generated from the host-inventory V2 Views API and wire it into the existing views operations.

New Features:
- Introduce a typed client wrapper around the V2 Inventory Views API using the shared JavaScript client factory.

Enhancements:
- Switch list, get, create, update, delete, and clone inventory view operations from local dummy implementations to calls against the real backend Views API.
- Export additional typed helpers for view-related requests and responses to align with the generated client types.

Tests:
- Update modal unit tests to mock the new API client functions for creating, renaming, and deleting views.