### PR TITLE
feat(RHINENG-28356): Active View State Management

### DIFF
--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import SystemsView from '../SystemsView/SystemsView';
 import type { SortDirection } from '../SystemsView/SystemsView';
@@ -20,13 +20,19 @@ import {
   type ViewConfiguration,
 } from '../../api/inventoryViewsApi';
 import { createViewColumnSelector } from './createViewColumnSelector';
+import { selectLegacyInventoryColumns } from './selectLegacyInventoryColumns';
 import { SORT_URL_PARAM, SORT_DIR_URL_PARAM } from '../SystemsView/constants';
 import { INITIAL_SORT } from '../SystemsView/hooks/useColumns';
+import type { InventoryFilters } from '../SystemsView/filters/SystemsViewFilters';
 import type { Column } from '../SystemsView/columns/allColumnDefinitions';
 import {
   buildViewConfigFilters,
   parseViewConfigFilters,
 } from './utils/viewConfigFilters';
+import {
+  useViewDirtyState,
+  FILTER_PARAM_KEYS,
+} from './hooks/useViewDirtyState';
 
 const filtersToSearchParams = (
   filters?: Partial<Record<string, string | string[]>>,
@@ -96,24 +102,33 @@ const InventoryViews = () => {
   const isInventoryViewsPrivateEnabled = useInventoryViewsPrivateFeatureFlag();
   const { data: viewsData } = useViewsQuery();
   const viewsList = viewsData?.results ?? [];
-  const activeView = useMemo(
-    () => viewsList.find((v) => v.id === activeViewId),
-    [viewsList, activeViewId],
-  );
+  const activeView = viewsList.find((v) => v.id === activeViewId);
+  const isSystemView = activeView?.is_system_view ?? true;
+  const viewsLoaded = !!viewsData;
 
-  const viewConfiguration =
-    activeView?.configuration ?? ALL_SYSTEMS_CONFIGURATION;
-
-  const [currentColumns, setCurrentColumns] =
-    useState<ViewConfiguration['columns']>();
+  const baselineColumnsRef = useRef<readonly Column[]>();
+  const [currentColumns, setCurrentColumns] = useState<readonly Column[]>();
 
   const handleColumnsChange = useCallback((columns: readonly Column[]) => {
-    setCurrentColumns(normalizeViewColumns(columns));
+    if (!baselineColumnsRef.current) {
+      baselineColumnsRef.current = columns;
+    }
+    setCurrentColumns(columns);
   }, []);
 
+  // Synchronous render-time reset: useEffect would fire after child effects,
+  // causing onColumnsChange to run before the baseline clears.
+  const prevViewKeyRef = useRef(`${activeViewId}-${viewsLoaded}`);
+  const viewKey = `${activeViewId}-${viewsLoaded}`;
+  if (viewKey !== prevViewKeyRef.current) {
+    prevViewKeyRef.current = viewKey;
+    baselineColumnsRef.current = undefined;
+  }
+
   const columnSelector = useMemo(
-    () => createViewColumnSelector(viewConfiguration)!,
-    [viewConfiguration],
+    () => createViewColumnSelector(activeView?.configuration),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- recompute when view switches or views data loads
+    [activeViewId, viewsLoaded],
   );
 
   const initialSort = useMemo(() => {
@@ -123,12 +138,25 @@ const InventoryViews = () => {
       sortBy: sort.key,
       direction: (sort.direction ?? 'asc') as SortDirection,
     };
-  }, [activeView?.configuration?.sort]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- derive from view config on switch or data load
+  }, [activeViewId, viewsLoaded]);
 
-  const initialFilters = useMemo(
-    () => parseViewConfigFilters(activeView?.configuration?.filters),
-    [activeView?.configuration?.filters],
-  );
+  const initialFilters = useMemo(() => {
+    const filters = activeView?.configuration?.filters;
+    if (!filters || Object.keys(filters).length === 0) return undefined;
+    // Convert from backend nested format to flattened URL format for dirty state comparison
+    return parseViewConfigFilters(filters) as Partial<InventoryFilters>;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- derive from view config on switch or data load
+  }, [activeViewId, viewsLoaded]);
+
+  const isViewDirty = useViewDirtyState({
+    activeViewId,
+    savedConfiguration: activeView?.configuration,
+    searchParams,
+    initialFilters,
+    baselineColumns: baselineColumnsRef.current,
+    currentColumns,
+  });
 
   const handleSelectView = useCallback(
     (viewId: string) => {
@@ -173,7 +201,9 @@ const InventoryViews = () => {
   const getCurrentConfiguration = (): ViewConfiguration => {
     const sort = getSortFromSearchParams(searchParams);
     const filters = getFiltersFromSearchParams(searchParams);
-    const columns = currentColumns ?? activeView?.configuration?.columns ?? [];
+    const columns = currentColumns
+      ? normalizeViewColumns(currentColumns)
+      : (activeView?.configuration?.columns ?? []);
 
     return {
       columns,
@@ -193,7 +223,8 @@ const InventoryViews = () => {
           <ViewsToolbar
             viewsList={viewsList}
             activeViewId={activeViewId}
-            isSystemView={activeView?.is_system_view ?? true}
+            isSystemView={isSystemView}
+            isViewDirty={isViewDirty}
             onSelectView={handleSelectView}
             onSaveAs={handleSaveAs}
             onRename={handleRename}
@@ -228,8 +259,8 @@ const InventoryViews = () => {
         </>
       )}
       <SystemsView
-        key={activeViewId}
-        columns={columnSelector}
+        key={`${activeViewId}-${viewsLoaded}`}
+        columns={columnSelector ?? selectLegacyInventoryColumns}
         initialSort={initialSort}
         initialFilters={initialFilters}
         onColumnsChange={handleColumnsChange}

--- a/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
@@ -4,6 +4,7 @@ import {
   DropdownItem,
   DropdownList,
   MenuToggle,
+  MenuToggleAction,
   MenuToggleElement,
 } from '@patternfly/react-core';
 
@@ -12,6 +13,8 @@ export interface ManageViewButtonProps {
   currentViewId?: string | null;
   /** Whether current view is a system view (non-editable) */
   isSystemView?: boolean;
+  /** Whether the view is dirty */
+  isViewDirty?: boolean;
   /** Callback when Save As is clicked */
   onSaveAs: () => void;
   /** Callback when Rename is clicked */
@@ -23,6 +26,7 @@ export interface ManageViewButtonProps {
 export const ManageViewButton = ({
   currentViewId,
   isSystemView = true,
+  isViewDirty = false,
   onSaveAs,
   onRename,
   onDelete,
@@ -37,21 +41,50 @@ export const ManageViewButton = ({
     setIsOpen(false);
   };
 
+  // Determine the primary action based on view type and dirty state
+  const primaryAction = isViewDirty
+    ? isSystemView
+      ? { label: 'Save as', onClick: onSaveAs } // System view → Save as new view
+      : { label: 'Save', onClick: onSaveAs } // Custom view → Save changes (TODO: implement onSave)
+    : null;
+
   return (
     <Dropdown
       isOpen={isOpen}
       onSelect={onSelect}
       onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
-      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle
-          ref={toggleRef}
-          onClick={onToggle}
-          isExpanded={isOpen}
-          aria-label="Manage view actions"
-        >
-          Manage view
-        </MenuToggle>
-      )}
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) =>
+        primaryAction ? (
+          <MenuToggle
+            variant="primary"
+            ref={toggleRef}
+            onClick={onToggle}
+            isExpanded={isOpen}
+            aria-label="Manage view actions"
+            splitButtonItems={[
+              <MenuToggleAction
+                key="primary-action"
+                onClick={primaryAction.onClick}
+              >
+                {primaryAction.label}
+              </MenuToggleAction>,
+            ]}
+          />
+        ) : (
+          <MenuToggle
+            variant="secondary"
+            ref={toggleRef}
+            onClick={onToggle}
+            isExpanded={isOpen}
+            aria-label="Manage view actions"
+            splitButtonItems={[
+              <MenuToggleAction key="manage-view" onClick={onToggle}>
+                Manage view
+              </MenuToggleAction>,
+            ]}
+          />
+        )
+      }
     >
       <DropdownList>
         <DropdownItem key="save-as" onClick={onSaveAs}>

--- a/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
@@ -19,6 +19,7 @@ export interface ViewsToolbarProps {
   activeViewId: string;
   currentViewId?: string | null;
   isSystemView?: boolean;
+  isViewDirty?: boolean;
   viewsList?: ViewOut[];
   onSelectView: (viewId: string) => void;
   onSaveAs: () => void;
@@ -31,6 +32,7 @@ export const ViewsToolbar = ({
   activeViewId,
   currentViewId,
   isSystemView = true,
+  isViewDirty = false,
   viewsList = [],
   onSelectView,
   onSaveAs,
@@ -69,6 +71,7 @@ export const ViewsToolbar = ({
             <ManageViewButton
               currentViewId={currentViewId}
               isSystemView={isSystemView}
+              isViewDirty={isViewDirty}
               onSaveAs={onSaveAs}
               onRename={onRename}
               onDelete={onDelete}

--- a/src/components/InventoryViews/createViewColumnSelector.test.ts
+++ b/src/components/InventoryViews/createViewColumnSelector.test.ts
@@ -7,14 +7,8 @@ describe('createViewColumnSelector', () => {
     expect(createViewColumnSelector(undefined)).toBeUndefined();
   });
 
-  it('hides all columns when columns array is empty', () => {
-    const selector = createViewColumnSelector({ columns: [] });
-    expect(selector).toBeDefined();
-
-    const result = selector!(allColumns);
-    expect(result).toHaveLength(allColumns.length);
-    expect(result.every((c) => !c.isShown)).toBe(true);
-    expect(result.every((c) => !c.isShownByDefault)).toBe(true);
+  it('returns undefined when columns array is empty', () => {
+    expect(createViewColumnSelector({ columns: [] })).toBeUndefined();
   });
 
   it('shows only configured columns as visible', () => {

--- a/src/components/InventoryViews/createViewColumnSelector.ts
+++ b/src/components/InventoryViews/createViewColumnSelector.ts
@@ -5,22 +5,21 @@ import type { ColumnSelector } from '../SystemsView/columns/resolveColumnSelecto
 export const createViewColumnSelector = (
   configuration?: ViewConfiguration,
 ): ColumnSelector | undefined => {
-  if (!configuration) {
+  if (!configuration?.columns?.length) {
     return undefined;
   }
 
-  const configColumns = configuration.columns ?? [];
+  const configColumns = configuration.columns;
 
   return (allColumns) => {
     const catalogByKey = new Map(allColumns.map((col) => [col.key, col]));
-    const matchedKeys = new Set<string>();
+    const configuredKeys = new Set(configColumns.map((c) => c.key));
     const result: Column[] = [];
 
     for (const configCol of configColumns) {
       const catalogCol = catalogByKey.get(configCol.key);
       if (!catalogCol) continue;
 
-      matchedKeys.add(configCol.key);
       result.push({
         ...catalogCol,
         isShown: true,
@@ -29,7 +28,7 @@ export const createViewColumnSelector = (
     }
 
     for (const catalogCol of allColumns) {
-      if (matchedKeys.has(catalogCol.key)) continue;
+      if (configuredKeys.has(catalogCol.key)) continue;
       result.push({
         ...catalogCol,
         isShown: false,

--- a/src/components/InventoryViews/hooks/useViewDirtyState.test.ts
+++ b/src/components/InventoryViews/hooks/useViewDirtyState.test.ts
@@ -1,0 +1,179 @@
+import { expect } from '@jest/globals';
+import type { Column } from '../../SystemsView/columns/allColumnDefinitions';
+import type { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
+import {
+  isSortDirty,
+  areFiltersDirty,
+  areColumnsDirty,
+} from './useViewDirtyState';
+
+const makeParams = (entries: Record<string, string | string[]> = {}) => {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(entries)) {
+    if (Array.isArray(value)) {
+      value.forEach((v) => params.append(key, v));
+    } else {
+      params.set(key, value);
+    }
+  }
+  return params;
+};
+
+const makeColumn = (key: string, isShown: boolean) =>
+  ({ key, isShown }) as unknown as Column;
+
+describe('isSortDirty', () => {
+  it('returns false when no sort params in URL', () => {
+    expect(
+      isSortDirty(makeParams(), { key: 'display_name', direction: 'asc' }),
+    ).toBe(false);
+  });
+
+  it('returns false when URL sort matches saved sort', () => {
+    const params = makeParams({ sort: 'display_name', sort_dir: 'asc' });
+    expect(isSortDirty(params, { key: 'display_name', direction: 'asc' })).toBe(
+      false,
+    );
+  });
+
+  it('returns true when sort key differs', () => {
+    const params = makeParams({ sort: 'last_check_in', sort_dir: 'asc' });
+    expect(isSortDirty(params, { key: 'display_name', direction: 'asc' })).toBe(
+      true,
+    );
+  });
+
+  it('returns true when sort direction differs', () => {
+    const params = makeParams({ sort: 'display_name', sort_dir: 'desc' });
+    expect(isSortDirty(params, { key: 'display_name', direction: 'asc' })).toBe(
+      true,
+    );
+  });
+
+  it('returns false when only sort key is in URL and matches', () => {
+    const params = makeParams({ sort: 'display_name' });
+    expect(
+      isSortDirty(params, { key: 'display_name', direction: 'desc' }),
+    ).toBe(false);
+  });
+
+  it('falls back to INITIAL_SORT when no saved sort', () => {
+    // INITIAL_SORT = { sortBy: 'last_check_in', direction: 'desc' }
+    const params = makeParams({ sort: 'last_check_in', sort_dir: 'desc' });
+    expect(isSortDirty(params, undefined)).toBe(false);
+  });
+
+  it('detects change from INITIAL_SORT default', () => {
+    const params = makeParams({ sort: 'display_name', sort_dir: 'asc' });
+    expect(isSortDirty(params, undefined)).toBe(true);
+  });
+});
+
+describe('areFiltersDirty', () => {
+  it('returns false when no filters in URL and no initial filters', () => {
+    expect(areFiltersDirty(makeParams(), undefined)).toBe(false);
+  });
+
+  it('returns true when URL has a filter but initial is empty', () => {
+    const params = makeParams({ operating_system: ['RHEL9.6'] });
+    expect(areFiltersDirty(params, undefined)).toBe(true);
+  });
+
+  it('returns false when URL filters match initial filters', () => {
+    const params = makeParams({ operating_system: ['RHEL9.6'] });
+    const initial: Partial<InventoryFilters> = {
+      operating_system: ['RHEL9.6'],
+    };
+    expect(areFiltersDirty(params, initial)).toBe(false);
+  });
+
+  it('returns true when URL filter value differs from initial', () => {
+    const params = makeParams({ operating_system: ['RHEL8.4'] });
+    const initial: Partial<InventoryFilters> = {
+      operating_system: ['RHEL9.6'],
+    };
+    expect(areFiltersDirty(params, initial)).toBe(true);
+  });
+
+  it('returns true when URL has additional filter values', () => {
+    const params = makeParams({ operating_system: ['RHEL9.6', 'RHEL8.4'] });
+    const initial: Partial<InventoryFilters> = {
+      operating_system: ['RHEL9.6'],
+    };
+    expect(areFiltersDirty(params, initial)).toBe(true);
+  });
+
+  it('returns true when initial filter is removed from URL', () => {
+    const params = makeParams();
+    const initial: Partial<InventoryFilters> = {
+      operating_system: ['RHEL9.6'],
+    };
+    expect(areFiltersDirty(params, initial)).toBe(true);
+  });
+
+  it('handles multiple filter keys independently', () => {
+    const params = makeParams({
+      operating_system: ['RHEL9.6'],
+      tags: ['env=prod'],
+    });
+    const initial: Partial<InventoryFilters> = {
+      operating_system: ['RHEL9.6'],
+      tags: ['env=prod'],
+    };
+    expect(areFiltersDirty(params, initial)).toBe(false);
+  });
+
+  it('ignores order of multi-value filters', () => {
+    const params = makeParams({ tags: ['b', 'a'] });
+    const initial: Partial<InventoryFilters> = { tags: ['a', 'b'] };
+    expect(areFiltersDirty(params, initial)).toBe(false);
+  });
+});
+
+describe('areColumnsDirty', () => {
+  it('returns false when baseline is undefined', () => {
+    const current = [makeColumn('name', true)];
+    expect(areColumnsDirty(undefined, current)).toBe(false);
+  });
+
+  it('returns false when current is undefined', () => {
+    const baseline = [makeColumn('name', true)];
+    expect(areColumnsDirty(baseline, undefined)).toBe(false);
+  });
+
+  it('returns false when shown columns match', () => {
+    const baseline = [
+      makeColumn('name', true),
+      makeColumn('os', true),
+      makeColumn('tags', false),
+    ];
+    const current = [
+      makeColumn('name', true),
+      makeColumn('os', true),
+      makeColumn('tags', false),
+    ];
+    expect(areColumnsDirty(baseline, current)).toBe(false);
+  });
+
+  it('returns true when a column is hidden', () => {
+    const baseline = [makeColumn('name', true), makeColumn('os', true)];
+    const current = [makeColumn('name', true), makeColumn('os', false)];
+    expect(areColumnsDirty(baseline, current)).toBe(true);
+  });
+
+  it('returns true when a column is shown', () => {
+    const baseline = [makeColumn('name', true), makeColumn('os', false)];
+    const current = [makeColumn('name', true), makeColumn('os', true)];
+    expect(areColumnsDirty(baseline, current)).toBe(true);
+  });
+
+  it('returns true when column order changes', () => {
+    const baseline = [makeColumn('name', true), makeColumn('os', true)];
+    const current = [makeColumn('os', true), makeColumn('name', true)];
+    expect(areColumnsDirty(baseline, current)).toBe(true);
+  });
+
+  it('returns false when both are empty', () => {
+    expect(areColumnsDirty([], [])).toBe(false);
+  });
+});

--- a/src/components/InventoryViews/hooks/useViewDirtyState.ts
+++ b/src/components/InventoryViews/hooks/useViewDirtyState.ts
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+import type { ViewConfiguration } from '../../../api/inventoryViewsApi';
+import { ALL_SYSTEMS_VIEW_ID } from '../../../api/inventoryViewsApi';
+import type { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
+import type { Column } from '../../SystemsView/columns/allColumnDefinitions';
+import {
+  SORT_URL_PARAM,
+  SORT_DIR_URL_PARAM,
+} from '../../SystemsView/constants';
+import { INITIAL_SORT } from '../../SystemsView/hooks/useColumns';
+import { INITIAL_INVENTORY_FILTERS } from '../../SystemsView/DataViewFiltersContext';
+
+export const FILTER_PARAM_KEYS = Object.keys(INITIAL_INVENTORY_FILTERS);
+
+interface UseViewDirtyStateParams {
+  activeViewId: string;
+  savedConfiguration?: ViewConfiguration;
+  searchParams: URLSearchParams;
+  initialFilters?: Partial<InventoryFilters>;
+  baselineColumns?: readonly Column[];
+  currentColumns?: readonly Column[];
+}
+
+export const isSortDirty = (
+  searchParams: URLSearchParams,
+  savedSort?: ViewConfiguration['sort'],
+): boolean => {
+  const currentKey = searchParams.get(SORT_URL_PARAM);
+  const currentDir = searchParams.get(SORT_DIR_URL_PARAM);
+
+  if (!currentKey && !currentDir) return false;
+
+  const savedKey = savedSort?.key ?? INITIAL_SORT.sortBy;
+  const savedDir = savedSort?.direction ?? INITIAL_SORT.direction;
+
+  return (
+    (currentKey ?? savedKey) !== savedKey ||
+    (currentDir ?? savedDir) !== savedDir
+  );
+};
+
+export const areFiltersDirty = (
+  searchParams: URLSearchParams,
+  initialFilters?: Partial<InventoryFilters>,
+): boolean => {
+  const initial = (initialFilters ?? {}) as Record<string, unknown>;
+
+  for (const key of FILTER_PARAM_KEYS) {
+    const current = searchParams.getAll(key).sort();
+
+    const rawSaved = initial[key];
+    let saved: string[];
+    if (Array.isArray(rawSaved)) {
+      saved = rawSaved.map(String).sort();
+    } else if (typeof rawSaved === 'string' && rawSaved !== '') {
+      saved = [rawSaved];
+    } else if (typeof rawSaved === 'object' && rawSaved !== null) {
+      // Skip nested objects like system_profile filters - these are handled
+      // by DataViewFiltersContext and already synchronized with URL params
+      continue;
+    } else {
+      saved = [];
+    }
+
+    if (current.length !== saved.length) return true;
+    if (current.some((v, i) => v !== saved[i])) return true;
+  }
+
+  return false;
+};
+
+export const areColumnsDirty = (
+  baselineColumns?: readonly Column[],
+  currentColumns?: readonly Column[],
+): boolean => {
+  if (!baselineColumns || !currentColumns) return false;
+
+  const baselineShownKeys = baselineColumns
+    .filter((c) => c.isShown)
+    .map((c) => c.key);
+  const currentShownKeys = currentColumns
+    .filter((c) => c.isShown)
+    .map((c) => c.key);
+
+  if (baselineShownKeys.length !== currentShownKeys.length) return true;
+  return baselineShownKeys.some((k, i) => k !== currentShownKeys[i]);
+};
+
+export const useViewDirtyState = ({
+  activeViewId,
+  savedConfiguration,
+  searchParams,
+  initialFilters,
+  baselineColumns,
+  currentColumns,
+}: UseViewDirtyStateParams) =>
+  useMemo(() => {
+    // For All Systems view (system view), check if current state differs from defaults
+    // For custom views, check if current state differs from saved configuration
+    const hasColumnConfig = !!savedConfiguration?.columns?.length;
+
+    const sortIsDirty = isSortDirty(searchParams, savedConfiguration?.sort);
+    const filtersAreDirty = areFiltersDirty(searchParams, initialFilters);
+    const columnsAreDirty =
+      hasColumnConfig && areColumnsDirty(baselineColumns, currentColumns);
+
+    return sortIsDirty || filtersAreDirty || columnsAreDirty;
+  }, [
+    activeViewId,
+    savedConfiguration,
+    searchParams,
+    initialFilters,
+    // Note: baselineColumns is a ref value, so we only track currentColumns changes
+    currentColumns,
+  ]);


### PR DESCRIPTION
## Jira
[RHINENG-28356](https://redhat.atlassian.net/browse/RHINENG-28356)

## What
This PR tracks dirty states for a view. Essentially, when a filter, column and/or sort is changed for a saved view, that view state becomes "dirty". We'll use this state as a way to track when to enable or disable certain buttons in future PRs.

## Testing
To test, you can add a console.log in useViewDirtyState to see how the isViewDirty value is changed as you change state.

[RHINENG-28356]: https://redhat.atlassian.net/browse/RHINENG-28356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Track active view modifications and surface context-appropriate save actions in the inventory views toolbar.

New Features:
- Track whether the active inventory view differs from its saved filters, sorting, or visible column configuration.
- Expose dirty-state-aware primary actions in the view management toolbar, including Save or Save as for modified views.

Enhancements:
- Preserve legacy column behavior when a view has no configured columns and reset view state correctly when switching views or loading view data.

Tests:
- Add coverage for detecting changes to sorting, filters, and column visibility or order.