### PR TITLE
feat: handle filter group deletion

### DIFF
--- a/src/components/InventoryTable/EntityTableToolbar.js
+++ b/src/components/InventoryTable/EntityTableToolbar.js
@@ -545,6 +545,26 @@ const EntityTableToolbar = ({
     [WORKLOAD_FILTER_KEY]: (deleted) =>
       setWorkloadFilterValue(onDeleteFilter(deleted, workloadFilterValue)),
   };
+
+  const deleteGroupMapper = {
+    [TEXTUAL_CHIP]: () => setTextFilter(''),
+    [TAG_CHIP]: () => {
+      setSelectedTags({});
+      onSetFilter([], 'tagFilters', updateData);
+    },
+    [STALE_CHIP]: () => setStaleFilter([]),
+    [REGISTERED_CHIP]: () => setRegisteredWithFilter([]),
+    [OS_CHIP]: () => setOsFilterValue([]),
+    [RHCD_FILTER_KEY]: () => setRhcdFilterValue([]),
+    [LAST_SEEN_CHIP]: () => {
+      setLastSeenFilterValue([]);
+      setStartDate();
+      setEndDate();
+    },
+    [HOST_GROUP_CHIP]: () => setHostGroupValue([]),
+    [SYSTEM_TYPE_KEY]: () => setSystemTypeValue([]),
+    [WORKLOAD_FILTER_KEY]: () => setWorkloadFilterValue([]),
+  };
   /**
    * Function to reset all filters with 'Reset Filter' is clicked
    */
@@ -604,6 +624,14 @@ const EntityTableToolbar = ({
           activeFiltersConfig.onDelete &&
           activeFiltersConfig.onDelete(e, [deleted, ...restDeleted], isAll);
       },
+      ...(activeFiltersConfig?.onDeleteGroup
+        ? {
+            onDeleteGroup: (e, deleted, groups) => {
+              deleteGroupMapper[deleted[0]?.type]?.();
+              activeFiltersConfig.onDeleteGroup(e, deleted, groups);
+            },
+          }
+        : {}),
     };
   };
 

--- a/src/modules/AsyncInventory.js
+++ b/src/modules/AsyncInventory.js
@@ -83,6 +83,7 @@ AsyncInventory.propTypes = {
     deleteTitle: PropTypes.string,
     filters: PropTypes.arrayOf(PropTypes.object),
     onDelete: PropTypes.func,
+    onDeleteGroup: PropTypes.func,
   }),
   autoRefresh: PropTypes.bool,
   axios: PropTypes.func,

--- a/src/modules/IOPInventoryTable.js
+++ b/src/modules/IOPInventoryTable.js
@@ -18,6 +18,7 @@ BaseIOPInventoryTable.propTypes = {
     deleteTitle: PropTypes.string,
     filters: PropTypes.arrayOf(PropTypes.object),
     onDelete: PropTypes.func,
+    onDeleteGroup: PropTypes.func,
   }),
   autoRefresh: PropTypes.bool,
   axios: PropTypes.func,


### PR DESCRIPTION
## Jira
[HMS-11117](https://redhat.atlassian.net/browse/HMS-11117)

## What
When services importing InventoryTable pass `onDeleteGroup` callback to remove a whole group of selected filter values of the same filter type, it does not always work as expected, because InventoryTable does not handle its internal state.

This change aims to correctly handle and pass on the built-in `onDeleteGroup` callback passed to `InventoryTable` thru `activeFiltersConfig`.

If no `onDeleteGroup` is provided, there should be no change.

## Why
Enable the use of `onDeleteGroup` to provide an option to delete a group of filters and thus improving UX. If the callback is present and multiple filter values are selected, the chip goes from `[type (foo x)(bar x)]` to `[type (foo x)(bar x) x]`.

## How
Add `deleteGroupMapper`, similar to how `onDelete` already has `deleteMapper`, that will handle the specific interactions.

## Testing
- ran like this, no change observed (as expected)
- added a mock `onDeleteGroup` to `GroupsTable` and observed the desired behavior

## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->


[HMS-11117]: https://redhat.atlassian.net/browse/HMS-11117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Handle filter group deletion by clearing the corresponding InventoryTable filter state before forwarding the configured callback.

New Features:
- Support deleting all selected filter values in a filter group through the InventoryTable active filters configuration.

Bug Fixes:
- Keep InventoryTable’s internal filter state synchronized when an onDeleteGroup callback removes a filter group.

Enhancements:
- Expose onDeleteGroup in the InventoryTable module prop types while preserving existing behavior when it is not provided.