### PR TITLE
test(Prod CI): tests run  against SystemsView component in production

### DIFF
--- a/.github/workflows/prod-post-release-pw-tests.yml
+++ b/.github/workflows/prod-post-release-pw-tests.yml
@@ -62,7 +62,6 @@ jobs:
             echo "INTEGRATION=true"
             echo "PROD=true"
             echo "BASE_URL=$PROD_BASE_URL"
-            echo "LEGACY_INVENTORY_TABLE=true"
             echo "PROXY=$RH_PROXY_URL"
             echo "PROD_OFFLINE_TOKEN=$PROD_OFFLINE_TOKEN"
           } >> .env 2>/dev/null


### PR DESCRIPTION
## What
tests run  against SystemsView component in production

## Why
SystemsView was enabled in prod-stable

## Summary by Sourcery

CI:
- Remove the LEGACY_INVENTORY_TABLE environment flag from the prod post-release Playwright tests workflow.