### PR TITLE
(DO NOT MERGE): Test Plywright Tektons

### DIFF
--- a/.tekton/inventory-playwright-tests-pull-request.yaml
+++ b/.tekton/inventory-playwright-tests-pull-request.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/insights-inventory-frontend?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: console-upstream-playwright-suites
+    appstudio.openshift.io/component: inventory-playwright-tests
+    pipelines.appstudio.openshift.io/type: build
+  name: inventory-playwright-tests-on-pull-request
+  namespace: insights-management-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/insights-management-tenant/console-upstream-playwright-suites/inventory-playwright-tests:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: _playwright-tests/Dockerfile
+  - name: path-context
+    value: .
+  # Internal test-only image, never released to registry.redhat.io, so no source image needed.
+  - name: build-source-image
+    value: "false"
+  pipelineRef:
+    name: docker-build-oci-ta
+  taskRunSpecs:
+  - pipelineTaskName: build-container
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          cpu: 200m
+          memory: 1Gi
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-inventory-playwright-tests
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/inventory-playwright-tests-push.yaml
+++ b/.tekton/inventory-playwright-tests-push.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/RedHatInsights/insights-inventory-frontend?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: console-upstream-playwright-suites
+    appstudio.openshift.io/component: inventory-playwright-tests
+    pipelines.appstudio.openshift.io/type: build
+  name: inventory-playwright-tests-on-push
+  namespace: insights-management-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/insights-management-tenant/console-upstream-playwright-suites/inventory-playwright-tests:{{revision}}
+  - name: dockerfile
+    value: _playwright-tests/Dockerfile
+  - name: path-context
+    value: .
+  # Internal test-only image, never released to registry.redhat.io, so no source image needed.
+  - name: build-source-image
+    value: "false"
+  pipelineRef:
+    name: docker-build-oci-ta
+  taskRunSpecs:
+  - pipelineTaskName: build-container
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          cpu: 200m
+          memory: 1Gi
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-inventory-playwright-tests
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Jira
[RHINENG-xxxxx](https://redhat.atlassian.net/browse/RHINENG-xxxxx)

## What
<!-- Short description of the change -->

## Why
<!-- Reason for change / linked ticket -->

## How
<!-- Brief explanation of approach -->

## Testing
<!-- How was this tested? -->

## Screenshots/Videos (if applicable)
<!-- Please add screenshots or videos for UI changes -->

## Summary by Sourcery

Add Tekton PipelineRun definitions to build and publish the inventory Playwright test container image on master branch pull requests and pushes.

New Features:
- Introduce a pull-request-triggered pipeline to build Playwright test images for the inventory frontend.
- Introduce a push-triggered pipeline to build and publish Playwright test images for the inventory frontend.

Enhancements:
- Configure resource limits for SBOM preparation in the Playwright test build pipeline.
- Set up git authentication workspace and dedicated build service account for Playwright test pipelines.

CI:
- Wire Tekton Pipelines-as-Code triggers for master branch pull requests and pushes to run the inventory Playwright test image build.