### PR TITLE
Bump compute resources

### DIFF
--- a/.tekton/inventory-playwright-tests-pull-request.yaml
+++ b/.tekton/inventory-playwright-tests-pull-request.yaml
@@ -30,6 +30,9 @@ spec:
     value: _playwright-tests/Dockerfile
   - name: path-context
     value: .
+  # Internal test-only image, never released to registry.redhat.io, so no source image needed.
+  - name: build-source-image
+    value: "false"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -543,6 +546,17 @@ spec:
       optional: true
     - name: netrc
       optional: true
+  taskRunSpecs:
+  - pipelineTaskName: build-container
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          cpu: 200m
+          memory: 1Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-inventory-playwright-tests
   workspaces:

--- a/.tekton/inventory-playwright-tests-push.yaml
+++ b/.tekton/inventory-playwright-tests-push.yaml
@@ -27,6 +27,9 @@ spec:
     value: _playwright-tests/Dockerfile
   - name: path-context
     value: .
+  # Internal test-only image, never released to registry.redhat.io, so no source image needed.
+  - name: build-source-image
+    value: "false"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -540,6 +543,17 @@ spec:
       optional: true
     - name: netrc
       optional: true
+  taskRunSpecs:
+  - pipelineTaskName: build-container
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          cpu: 200m
+          memory: 1Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-inventory-playwright-tests
   workspaces:


### PR DESCRIPTION
Adds a `taskRunSpecs` override to bump the `prepare-sboms` step's compute
resources (memory: 512Mi→1Gi, cpu: 100m→200m limits) in the `build-container`
task, and explicitly disables the `build-source-image` task via the
`build-source-image: "false"` pipeline param, for both
`inventory-playwright-tests-pull-request.yaml` and
`inventory-playwright-tests-push.yaml`.

