### PR TITLE
fix: bumping prefetch-dependencies-oci-ta from 0.3.2 → 0.7.1 

### DIFF
--- a/.tekton/inventory-playwright-tests-pull-request.yaml
+++ b/.tekton/inventory-playwright-tests-pull-request.yaml
@@ -200,7 +200,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3.2@sha256:389aea03a065e8118d36b7acb85b05cd13f6750e7e10ff8a85f270ee65b0167b
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:b8c8ad3f6e0a89a498ace429b81c4b334241d4f8bab2f16dc3dcb3c55db85456
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/inventory-playwright-tests-push.yaml
+++ b/.tekton/inventory-playwright-tests-push.yaml
@@ -197,7 +197,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3.2@sha256:389aea03a065e8118d36b7acb85b05cd13f6750e7e10ff8a85f270ee65b0167b
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.7.1@sha256:b8c8ad3f6e0a89a498ace429b81c4b334241d4f8bab2f16dc3dcb3c55db85456
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary by Sourcery

Add Tekton Konflux PipelineRun definitions to build and scan the inventory Playwright test image on pull requests and pushes to master.

CI:
- Introduce a pull-request PipelineRun that builds a short-lived inventory Playwright test container image, runs standard Konflux scans, and tags the image in quay.io.
- Introduce a push PipelineRun that builds a revision-tagged inventory Playwright test container image, runs standard Konflux scans, and publishes associated metadata and tags.