### PR TITLE
feat(RHINENG-29491): SystemsView add props for generic fetching

### DIFF
--- a/src/Utilities/DeleteModal.tsx
+++ b/src/Utilities/DeleteModal.tsx
@@ -13,7 +13,7 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { System } from '../components/InventoryViews/hooks/useHostsQuery';
+import { System } from '../components/InventoryViews/hostsQueryOptions';
 
 export interface DeleteModalProps {
   handleModalToggle?: (open: boolean) => void;

--- a/src/Utilities/hooks/useHostIdsWithKessel.ts
+++ b/src/Utilities/hooks/useHostIdsWithKessel.ts
@@ -11,7 +11,7 @@ import {
   KESSEL_REPORTER,
   KESSEL_WORKSPACE_REPORTER,
 } from '../../constants';
-import { System } from '../../components/InventoryViews/hooks/useHostsQuery';
+import { System } from '../../components/InventoryViews/hostsQueryOptions';
 
 interface HostPermissions {
   hasUpdate: boolean;

--- a/src/components/InventoryViews/ImagesView/hooks/useImageQueries.tsx
+++ b/src/components/InventoryViews/ImagesView/hooks/useImageQueries.tsx
@@ -11,7 +11,7 @@ import type {
 } from '@redhat-cloud-services/host-inventory-client';
 import { useQueries } from '@tanstack/react-query';
 import { INITIAL_PAGE } from '../../constants';
-import { System } from '../../hooks/useHostsQuery';
+import { System } from '../../hostsQueryOptions';
 import { PER_PAGE_MAX } from '../../../../constants';
 
 export type BootcSystem = System & {

--- a/src/components/InventoryViews/InventoryHosts.tsx
+++ b/src/components/InventoryViews/InventoryHosts.tsx
@@ -1,12 +1,10 @@
-import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import SystemsView from '../SystemsView/SystemsView';
-import { HOSTS_QUERY_KEY, useHostsQuery } from './hooks/useHostsQuery';
+import { hostsQueryOptions } from './hooks/useHostsQuery';
 import { useAnsibleWorkloadDefault } from './hooks/useAnsibleWorkloadDefault';
 import { selectLegacyInventoryColumns } from './selectLegacyInventoryColumns';
 
 const InventoryHosts = () => {
-  const queryClient = useQueryClient();
   const { isReady, defaultFilters } = useAnsibleWorkloadDefault();
 
   if (!isReady) {
@@ -16,11 +14,8 @@ const InventoryHosts = () => {
   return (
     <SystemsView
       columns={selectLegacyInventoryColumns}
-      useDataQuery={useHostsQuery}
+      queryOptions={hostsQueryOptions}
       defaultFilters={defaultFilters}
-      onInvalidate={() =>
-        queryClient.invalidateQueries({ queryKey: [HOSTS_QUERY_KEY] })
-      }
     />
   );
 };

--- a/src/components/InventoryViews/InventoryHosts.tsx
+++ b/src/components/InventoryViews/InventoryHosts.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SystemsView from '../SystemsView/SystemsView';
-import { hostsQueryOptions } from './hooks/useHostsQuery';
+import { hostsQueryOptions } from './hostsQueryOptions';
 import { useAnsibleWorkloadDefault } from './hooks/useAnsibleWorkloadDefault';
 import { selectLegacyInventoryColumns } from './selectLegacyInventoryColumns';
 

--- a/src/components/InventoryViews/InventoryHosts.tsx
+++ b/src/components/InventoryViews/InventoryHosts.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SystemsView from '../SystemsView/SystemsView';
-import { hostsQueryOptions } from './hostsQueryOptions';
+import { fetchHosts, HOSTS_QUERY_KEY } from './hostsQueryOptions';
 import { useAnsibleWorkloadDefault } from './hooks/useAnsibleWorkloadDefault';
 import { selectLegacyInventoryColumns } from './selectLegacyInventoryColumns';
 
@@ -14,7 +14,8 @@ const InventoryHosts = () => {
   return (
     <SystemsView
       columns={selectLegacyInventoryColumns}
-      queryOptions={hostsQueryOptions}
+      queryKeyPrefix={HOSTS_QUERY_KEY}
+      fetchData={fetchHosts}
       defaultFilters={defaultFilters}
     />
   );

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -3,10 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import SystemsView from '../SystemsView/SystemsView';
 import type { SortDirection } from '../SystemsView/SystemsView';
-import {
-  INVENTORY_VIEWS_QUERY_KEY,
-  useInventoryViewsQuery,
-} from './hooks/useInventoryViewsQuery';
+import { inventoryViewsQueryOptions } from './hooks/useInventoryViewsQuery';
 import { useAnsibleWorkloadDefault } from './hooks/useAnsibleWorkloadDefault';
 import { useViewsQuery } from './hooks/useViewsQuery';
 import useInventoryViewsPrivateFeatureFlag from '../../Utilities/useInventoryViewsPrivateFeatureFlag';
@@ -233,13 +230,8 @@ const InventoryViews = () => {
         initialSort={initialSort}
         initialFilters={initialFilters}
         onColumnsChange={handleColumnsChange}
-        useDataQuery={useInventoryViewsQuery}
+        queryOptions={inventoryViewsQueryOptions}
         defaultFilters={defaultFilters}
-        onInvalidate={() =>
-          queryClient.invalidateQueries({
-            queryKey: [INVENTORY_VIEWS_QUERY_KEY],
-          })
-        }
       />
     </>
   );

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import SystemsView from '../SystemsView/SystemsView';
 import type { SortDirection } from '../SystemsView/SystemsView';
-import { inventoryViewsQueryOptions } from './hooks/useInventoryViewsQuery';
+import { inventoryViewsQueryOptions } from './inventoryViewsQueryOptions';
 import { useAnsibleWorkloadDefault } from './hooks/useAnsibleWorkloadDefault';
 import { useViewsQuery } from './hooks/useViewsQuery';
 import useInventoryViewsPrivateFeatureFlag from '../../Utilities/useInventoryViewsPrivateFeatureFlag';

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -3,7 +3,10 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import SystemsView from '../SystemsView/SystemsView';
 import type { SortDirection } from '../SystemsView/SystemsView';
-import { inventoryViewsQueryOptions } from './inventoryViewsQueryOptions';
+import {
+  fetchInventoryViews,
+  INVENTORY_VIEWS_QUERY_KEY,
+} from './inventoryViewsQueryOptions';
 import { useAnsibleWorkloadDefault } from './hooks/useAnsibleWorkloadDefault';
 import { useViewsQuery } from './hooks/useViewsQuery';
 import useInventoryViewsPrivateFeatureFlag from '../../Utilities/useInventoryViewsPrivateFeatureFlag';
@@ -230,7 +233,8 @@ const InventoryViews = () => {
         initialSort={initialSort}
         initialFilters={initialFilters}
         onColumnsChange={handleColumnsChange}
-        queryOptions={inventoryViewsQueryOptions}
+        queryKeyPrefix={INVENTORY_VIEWS_QUERY_KEY}
+        fetchData={fetchInventoryViews}
         defaultFilters={defaultFilters}
       />
     </>

--- a/src/components/InventoryViews/hooks/useHostsQuery.ts
+++ b/src/components/InventoryViews/hooks/useHostsQuery.ts
@@ -3,22 +3,17 @@ import { getHostList, getHostTags } from '../../../api/hostInventoryApiTyped';
 import { getLegacyInventorySortKey } from '../../../constants';
 import { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
-import type { ISortBy } from '@patternfly/react-table';
-import type { Column } from '../../SystemsView/columns/allColumnDefinitions';
-import { SortDirection } from '../../SystemsView/SystemsView';
+import type {
+  SortDirection,
+  SystemsViewFetchParams,
+} from '../../SystemsView/types';
 import { buildHostListParams } from '../utils/buildHostListParams';
-import type { LastSeenCustomRange } from '../../SystemsView/DataViewFiltersContext';
+import {
+  useDataViewFiltersContext,
+  type LastSeenCustomRange,
+} from '../../SystemsView/DataViewFiltersContext';
 
 export const HOSTS_QUERY_KEY = 'hosts' as const;
-
-export type SystemsViewFetchParams = {
-  page: number;
-  perPage: number;
-  filters: InventoryFilters;
-  lastSeenCustomRange: LastSeenCustomRange;
-  sortBy: Column['sortBy'];
-  direction: ISortBy['direction'] | undefined;
-};
 
 type FetchHostsReturnedValue = Awaited<ReturnType<typeof fetchHosts>>;
 export type System = FetchHostsReturnedValue['results'][number];
@@ -66,19 +61,19 @@ const fetchHosts = async ({
   return { results, total };
 };
 
-export interface UseHostsQueryParams extends SystemsViewFetchParams {
+export type UseHostsQueryParams = SystemsViewFetchParams<InventoryFilters> & {
   /** When false, the query is not run (e.g. when user has no access). Default true. */
   enabled?: boolean;
-}
+};
 export const useHostsQuery = ({
   page,
   perPage,
   filters,
-  lastSeenCustomRange,
   sortBy,
   direction,
   enabled = true,
 }: UseHostsQueryParams) => {
+  const { lastSeenCustomRange } = useDataViewFiltersContext();
   // Cross-app and SystemsView-only sort keys are not valid for the /hosts API. This can
   // happen during the render between ui.inventory-views being toggled off and the
   // useColumns useEffect resetting the URL to a valid sort key.

--- a/src/components/InventoryViews/hooks/useHostsQuery.ts
+++ b/src/components/InventoryViews/hooks/useHostsQuery.ts
@@ -4,14 +4,11 @@ import { getLegacyInventorySortKey } from '../../../constants';
 import { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import type {
+  LastSeenCustomRange,
   SortDirection,
   SystemsViewFetchParams,
 } from '../../SystemsView/types';
 import { buildHostListParams } from '../utils/buildHostListParams';
-import {
-  useDataViewFiltersContext,
-  type LastSeenCustomRange,
-} from '../../SystemsView/DataViewFiltersContext';
 
 export const HOSTS_QUERY_KEY = 'hosts' as const;
 
@@ -71,9 +68,9 @@ export const useHostsQuery = ({
   filters,
   sortBy,
   direction,
+  lastSeenCustomRange,
   enabled = true,
 }: UseHostsQueryParams) => {
-  const { lastSeenCustomRange } = useDataViewFiltersContext();
   // Cross-app and SystemsView-only sort keys are not valid for the /hosts API. This can
   // happen during the render between ui.inventory-views being toggled off and the
   // useColumns useEffect resetting the URL to a valid sort key.

--- a/src/components/InventoryViews/hooks/useHostsQuery.ts
+++ b/src/components/InventoryViews/hooks/useHostsQuery.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { queryOptions, type QueryKey } from '@tanstack/react-query';
 import { getHostList, getHostTags } from '../../../api/hostInventoryApiTyped';
 import { getLegacyInventorySortKey } from '../../../constants';
 import { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
@@ -58,57 +58,26 @@ const fetchHosts = async ({
   return { results, total };
 };
 
-export type UseHostsQueryParams = SystemsViewFetchParams<InventoryFilters> & {
-  /** When false, the query is not run (e.g. when user has no access). Default true. */
-  enabled?: boolean;
-};
-export const useHostsQuery = ({
-  page,
-  perPage,
-  filters,
-  sortBy,
-  direction,
-  lastSeenCustomRange,
-  enabled = true,
-}: UseHostsQueryParams) => {
+export const hostsQueryOptions = (
+  params: SystemsViewFetchParams<InventoryFilters>,
+) => {
   // Cross-app and SystemsView-only sort keys are not valid for the /hosts API. This can
   // happen during the render between ui.inventory-views being toggled off and the
   // useColumns useEffect resetting the URL to a valid sort key.
-  const validSortBy = getLegacyInventorySortKey(sortBy) as
+  const validSortBy = getLegacyInventorySortKey(params.sortBy) as
     | ApiOrderByEnum
     | undefined;
 
-  const { data, isLoading, isFetching, isError, error } = useQuery({
-    queryKey: [
-      HOSTS_QUERY_KEY,
-      page,
-      perPage,
-      filters,
-      lastSeenCustomRange,
-      validSortBy,
-      direction,
-    ],
-    queryFn: async () => {
-      return await fetchHosts({
-        page,
-        perPage,
-        filters,
-        lastSeenCustomRange,
+  return queryOptions({
+    queryKey: [HOSTS_QUERY_KEY, params] as QueryKey,
+    queryFn: () =>
+      fetchHosts({
+        page: params.page,
+        perPage: params.perPage,
+        filters: params.filters,
+        lastSeenCustomRange: params.lastSeenCustomRange,
         sortBy: validSortBy,
-        direction,
-      });
-    },
-    placeholderData: keepPreviousData,
-    refetchOnWindowFocus: false,
-    enabled,
+        direction: params.direction,
+      }),
   });
-
-  return {
-    data: data?.results,
-    total: data?.total,
-    isLoading,
-    isFetching,
-    isError,
-    error,
-  };
 };

--- a/src/components/InventoryViews/hooks/useInventoryViewsQuery.ts
+++ b/src/components/InventoryViews/hooks/useInventoryViewsQuery.ts
@@ -3,13 +3,10 @@ import { getHostTags, getHostViews } from '../../../api/hostInventoryApiTyped';
 import { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import type {
+  LastSeenCustomRange,
   SortDirection,
   SystemsViewFetchParams,
 } from '../../SystemsView/types';
-import {
-  useDataViewFiltersContext,
-  type LastSeenCustomRange,
-} from '../../SystemsView/DataViewFiltersContext';
 import { buildHostViewsParams } from '../utils/buildHostViewsParams';
 import useInventoryViewsColumnsRbacFeatureFlag from '../../../Utilities/useInventoryViewsColumnsRbacFeatureFlag';
 
@@ -92,11 +89,11 @@ export const useInventoryViewsQuery = ({
   filters,
   sortBy,
   direction,
+  lastSeenCustomRange,
   enabled = true,
 }: UseInventoryViewsQueryParams) => {
   const isInventoryViewsRbacEnabled = useInventoryViewsColumnsRbacFeatureFlag();
 
-  const { lastSeenCustomRange } = useDataViewFiltersContext();
   const { data, isLoading, isFetching, isError, error } = useQuery({
     queryKey: [
       INVENTORY_VIEWS_QUERY_KEY,

--- a/src/components/InventoryViews/hooks/useInventoryViewsQuery.ts
+++ b/src/components/InventoryViews/hooks/useInventoryViewsQuery.ts
@@ -2,10 +2,15 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getHostTags, getHostViews } from '../../../api/hostInventoryApiTyped';
 import { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
-import { SortDirection } from '../../SystemsView/SystemsView';
-import type { LastSeenCustomRange } from '../../SystemsView/DataViewFiltersContext';
+import type {
+  SortDirection,
+  SystemsViewFetchParams,
+} from '../../SystemsView/types';
+import {
+  useDataViewFiltersContext,
+  type LastSeenCustomRange,
+} from '../../SystemsView/DataViewFiltersContext';
 import { buildHostViewsParams } from '../utils/buildHostViewsParams';
-import type { SystemsViewFetchParams } from './useHostsQuery';
 import useInventoryViewsColumnsRbacFeatureFlag from '../../../Utilities/useInventoryViewsColumnsRbacFeatureFlag';
 
 export const INVENTORY_VIEWS_QUERY_KEY = 'inventory-views' as const;
@@ -75,22 +80,23 @@ const fetchInventoryViews = async ({
   return { results, total, deniedServices };
 };
 
-export interface UseInventoryViewsQueryParams extends SystemsViewFetchParams {
-  /** When false, the query is not run (e.g. when user has no access). Default true. */
-  enabled?: boolean;
-}
+export type UseInventoryViewsQueryParams =
+  SystemsViewFetchParams<InventoryFilters> & {
+    /** When false, the query is not run (e.g. when user has no access). Default true. */
+    enabled?: boolean;
+  };
 
 export const useInventoryViewsQuery = ({
   page,
   perPage,
   filters,
-  lastSeenCustomRange,
   sortBy,
   direction,
   enabled = true,
 }: UseInventoryViewsQueryParams) => {
   const isInventoryViewsRbacEnabled = useInventoryViewsColumnsRbacFeatureFlag();
 
+  const { lastSeenCustomRange } = useDataViewFiltersContext();
   const { data, isLoading, isFetching, isError, error } = useQuery({
     queryKey: [
       INVENTORY_VIEWS_QUERY_KEY,

--- a/src/components/InventoryViews/hooks/useInventoryViewsQuery.ts
+++ b/src/components/InventoryViews/hooks/useInventoryViewsQuery.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { queryOptions, type QueryKey } from '@tanstack/react-query';
 import { getHostTags, getHostViews } from '../../../api/hostInventoryApiTyped';
 import { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
@@ -8,11 +8,8 @@ import type {
   SystemsViewFetchParams,
 } from '../../SystemsView/types';
 import { buildHostViewsParams } from '../utils/buildHostViewsParams';
-import useInventoryViewsColumnsRbacFeatureFlag from '../../../Utilities/useInventoryViewsColumnsRbacFeatureFlag';
 
 export const INVENTORY_VIEWS_QUERY_KEY = 'inventory-views' as const;
-
-const EMPTY_SERVICES: string[] = [];
 
 const BACKEND_SERVICE_TO_APP_NAME: Record<string, string> = {
   patch: 'content',
@@ -77,57 +74,20 @@ const fetchInventoryViews = async ({
   return { results, total, deniedServices };
 };
 
-export type UseInventoryViewsQueryParams =
-  SystemsViewFetchParams<InventoryFilters> & {
-    /** When false, the query is not run (e.g. when user has no access). Default true. */
-    enabled?: boolean;
-  };
-
-export const useInventoryViewsQuery = ({
-  page,
-  perPage,
-  filters,
-  sortBy,
-  direction,
-  lastSeenCustomRange,
-  enabled = true,
-}: UseInventoryViewsQueryParams) => {
-  const isInventoryViewsRbacEnabled = useInventoryViewsColumnsRbacFeatureFlag();
-
-  const { data, isLoading, isFetching, isError, error } = useQuery({
-    queryKey: [
-      INVENTORY_VIEWS_QUERY_KEY,
-      page,
-      perPage,
-      filters,
-      lastSeenCustomRange,
-      sortBy,
-      direction,
-    ],
-    queryFn: async () => {
-      return await fetchInventoryViews({
-        page,
-        perPage,
-        filters,
-        lastSeenCustomRange,
-        sortBy: sortBy as ApiHostViewsGetHostViewsOrderByEnum | undefined,
-        direction,
-      });
-    },
-    placeholderData: keepPreviousData,
-    refetchOnWindowFocus: false,
-    enabled,
+export const inventoryViewsQueryOptions = (
+  params: SystemsViewFetchParams<InventoryFilters>,
+) =>
+  queryOptions({
+    queryKey: [INVENTORY_VIEWS_QUERY_KEY, params] as QueryKey,
+    queryFn: () =>
+      fetchInventoryViews({
+        page: params.page,
+        perPage: params.perPage,
+        filters: params.filters,
+        lastSeenCustomRange: params.lastSeenCustomRange,
+        sortBy: params.sortBy as
+          | ApiHostViewsGetHostViewsOrderByEnum
+          | undefined,
+        direction: params.direction,
+      }),
   });
-
-  return {
-    data: data?.results,
-    total: data?.total,
-    deniedServices: isInventoryViewsRbacEnabled
-      ? (data?.deniedServices ?? EMPTY_SERVICES)
-      : EMPTY_SERVICES,
-    isLoading,
-    isFetching,
-    isError,
-    error,
-  };
-};

--- a/src/components/InventoryViews/hostsQueryOptions.ts
+++ b/src/components/InventoryViews/hostsQueryOptions.ts
@@ -1,41 +1,20 @@
-import { queryOptions, type QueryKey } from '@tanstack/react-query';
 import { getHostList, getHostTags } from '../../api/hostInventoryApiTyped';
 import { getLegacyInventorySortKey } from '../../constants';
 import { InventoryFilters } from '../SystemsView/filters/SystemsViewFilters';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import type { SystemsViewFetchParams } from '../SystemsView/types';
-import {
-  buildHostListParams,
-  type BuildHostListParamsInput,
-} from './utils/buildHostListParams';
+import { buildHostListParams } from './utils/buildHostListParams';
 
 export const HOSTS_QUERY_KEY = 'hosts' as const;
 
 type FetchHostsReturnedValue = Awaited<ReturnType<typeof fetchHosts>>;
 export type System = FetchHostsReturnedValue['results'][number];
 
-const fetchHosts = async (params: BuildHostListParamsInput) => {
-  const fetchParams = buildHostListParams(params);
+const hasHostId = <T extends { id?: string }>(
+  host: T,
+): host is T & { id: string } => typeof host.id === 'string';
 
-  const { results: hosts, total } = await getHostList(fetchParams);
-
-  if (total === 0) return { results: [], total };
-
-  const { results: hostsTags = {} } = await getHostTags({
-    hostIdList: hosts
-      .map(({ id }) => id)
-      .filter((id): id is string => id !== undefined),
-  });
-
-  const results = hosts.map((host) => ({
-    ...host,
-    ...(host.id && hostsTags[host.id] ? { tags: hostsTags[host.id] } : {}),
-  }));
-
-  return { results, total };
-};
-
-export const hostsQueryOptions = (
+export const fetchHosts = async (
   params: SystemsViewFetchParams<InventoryFilters>,
 ) => {
   // Cross-app and SystemsView-only sort keys are not valid for the /hosts API. This can
@@ -45,16 +24,29 @@ export const hostsQueryOptions = (
     | ApiOrderByEnum
     | undefined;
 
-  return queryOptions({
-    queryKey: [HOSTS_QUERY_KEY, params] as QueryKey,
-    queryFn: () =>
-      fetchHosts({
-        page: params.page,
-        perPage: params.perPage,
-        filters: params.filters,
-        lastSeenCustomRange: params.lastSeenCustomRange,
-        sortBy: validSortBy,
-        direction: params.direction,
-      }),
+  const fetchParams = buildHostListParams({
+    page: params.page,
+    perPage: params.perPage,
+    filters: params.filters,
+    lastSeenCustomRange: params.lastSeenCustomRange,
+    sortBy: validSortBy,
+    direction: params.direction,
   });
+
+  const { results: hosts, total } = await getHostList(fetchParams);
+
+  if (total === 0) return { results: [], total };
+
+  const hostsWithId = hosts.filter(hasHostId);
+
+  const { results: hostsTags = {} } = await getHostTags({
+    hostIdList: hostsWithId.map(({ id }) => id),
+  });
+
+  const results = hostsWithId.map((host) => ({
+    ...host,
+    ...(hostsTags[host.id] ? { tags: hostsTags[host.id] } : {}),
+  }));
+
+  return { results, total };
 };

--- a/src/components/InventoryViews/hostsQueryOptions.ts
+++ b/src/components/InventoryViews/hostsQueryOptions.ts
@@ -3,44 +3,21 @@ import { getHostList, getHostTags } from '../../api/hostInventoryApiTyped';
 import { getLegacyInventorySortKey } from '../../constants';
 import { InventoryFilters } from '../SystemsView/filters/SystemsViewFilters';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
-import type {
-  LastSeenCustomRange,
-  SortDirection,
-  SystemsViewFetchParams,
-} from '../SystemsView/types';
-import { buildHostListParams } from './utils/buildHostListParams';
+import type { SystemsViewFetchParams } from '../SystemsView/types';
+import {
+  buildHostListParams,
+  type BuildHostListParamsInput,
+} from './utils/buildHostListParams';
 
 export const HOSTS_QUERY_KEY = 'hosts' as const;
 
 type FetchHostsReturnedValue = Awaited<ReturnType<typeof fetchHosts>>;
 export type System = FetchHostsReturnedValue['results'][number];
 
-interface FetchHostsParams {
-  page: number;
-  perPage: number;
-  filters: InventoryFilters;
-  lastSeenCustomRange: LastSeenCustomRange;
-  sortBy: ApiOrderByEnum | undefined;
-  direction: SortDirection | undefined;
-}
-const fetchHosts = async ({
-  page,
-  perPage,
-  filters,
-  lastSeenCustomRange,
-  sortBy,
-  direction,
-}: FetchHostsParams) => {
-  const params = buildHostListParams({
-    page,
-    perPage,
-    filters,
-    lastSeenCustomRange,
-    sortBy,
-    direction,
-  });
+const fetchHosts = async (params: BuildHostListParamsInput) => {
+  const fetchParams = buildHostListParams(params);
 
-  const { results: hosts, total } = await getHostList(params);
+  const { results: hosts, total } = await getHostList(fetchParams);
 
   if (total === 0) return { results: [], total };
 

--- a/src/components/InventoryViews/hostsQueryOptions.ts
+++ b/src/components/InventoryViews/hostsQueryOptions.ts
@@ -1,14 +1,14 @@
 import { queryOptions, type QueryKey } from '@tanstack/react-query';
-import { getHostList, getHostTags } from '../../../api/hostInventoryApiTyped';
-import { getLegacyInventorySortKey } from '../../../constants';
-import { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
+import { getHostList, getHostTags } from '../../api/hostInventoryApiTyped';
+import { getLegacyInventorySortKey } from '../../constants';
+import { InventoryFilters } from '../SystemsView/filters/SystemsViewFilters';
 import { ApiHostGetHostListOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import type {
   LastSeenCustomRange,
   SortDirection,
   SystemsViewFetchParams,
-} from '../../SystemsView/types';
-import { buildHostListParams } from '../utils/buildHostListParams';
+} from '../SystemsView/types';
+import { buildHostListParams } from './utils/buildHostListParams';
 
 export const HOSTS_QUERY_KEY = 'hosts' as const;
 

--- a/src/components/InventoryViews/inventoryViewsQueryOptions.ts
+++ b/src/components/InventoryViews/inventoryViewsQueryOptions.ts
@@ -1,12 +1,8 @@
-import { queryOptions, type QueryKey } from '@tanstack/react-query';
 import { getHostTags, getHostViews } from '../../api/hostInventoryApiTyped';
 import { InventoryFilters } from '../SystemsView/filters/SystemsViewFilters';
 import { ApiHostViewsGetHostViewsOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import type { SystemsViewFetchParams } from '../SystemsView/types';
-import {
-  buildHostViewsParams,
-  type BuildHostViewsParamsInput,
-} from './utils/buildHostViewsParams';
+import { buildHostViewsParams } from './utils/buildHostViewsParams';
 
 export const INVENTORY_VIEWS_QUERY_KEY = 'inventory-views' as const;
 
@@ -25,8 +21,21 @@ type FetchInventoryViewsReturnedValue = Awaited<
 export type InventoryViewSystem =
   FetchInventoryViewsReturnedValue['results'][number];
 
-const fetchInventoryViews = async (params: BuildHostViewsParamsInput) => {
-  const fetchParams = buildHostViewsParams(params);
+const hasHostId = <T extends { id?: string }>(
+  host: T,
+): host is T & { id: string } => typeof host.id === 'string';
+
+export const fetchInventoryViews = async (
+  params: SystemsViewFetchParams<InventoryFilters>,
+) => {
+  const fetchParams = buildHostViewsParams({
+    page: params.page,
+    perPage: params.perPage,
+    filters: params.filters,
+    lastSeenCustomRange: params.lastSeenCustomRange,
+    sortBy: params.sortBy as ApiOrderByEnum | undefined,
+    direction: params.direction,
+  });
 
   const response = await getHostViews(fetchParams);
   const { results: hosts, total } = response;
@@ -36,32 +45,16 @@ const fetchInventoryViews = async (params: BuildHostViewsParamsInput) => {
 
   if (total === 0) return { results: [], total, deniedServices };
 
+  const hostsWithId = hosts.filter(hasHostId);
+
   const { results: hostsTags = {} } = await getHostTags({
-    hostIdList: hosts
-      .map(({ id }) => id)
-      .filter((id): id is string => id !== undefined),
+    hostIdList: hostsWithId.map(({ id }) => id),
   });
 
-  const results = hosts.map((host) => ({
+  const results = hostsWithId.map((host) => ({
     ...host,
-    ...(host.id && hostsTags[host.id] ? { tags: hostsTags[host.id] } : {}),
+    ...(hostsTags[host.id] ? { tags: hostsTags[host.id] } : {}),
   }));
 
   return { results, total, deniedServices };
 };
-
-export const inventoryViewsQueryOptions = (
-  params: SystemsViewFetchParams<InventoryFilters>,
-) =>
-  queryOptions({
-    queryKey: [INVENTORY_VIEWS_QUERY_KEY, params] as QueryKey,
-    queryFn: () =>
-      fetchInventoryViews({
-        page: params.page,
-        perPage: params.perPage,
-        filters: params.filters,
-        lastSeenCustomRange: params.lastSeenCustomRange,
-        sortBy: params.sortBy as ApiOrderByEnum | undefined,
-        direction: params.direction,
-      }),
-  });

--- a/src/components/InventoryViews/inventoryViewsQueryOptions.ts
+++ b/src/components/InventoryViews/inventoryViewsQueryOptions.ts
@@ -1,13 +1,13 @@
 import { queryOptions, type QueryKey } from '@tanstack/react-query';
-import { getHostTags, getHostViews } from '../../../api/hostInventoryApiTyped';
-import { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
+import { getHostTags, getHostViews } from '../../api/hostInventoryApiTyped';
+import { InventoryFilters } from '../SystemsView/filters/SystemsViewFilters';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import type {
   LastSeenCustomRange,
   SortDirection,
   SystemsViewFetchParams,
-} from '../../SystemsView/types';
-import { buildHostViewsParams } from '../utils/buildHostViewsParams';
+} from '../SystemsView/types';
+import { buildHostViewsParams } from './utils/buildHostViewsParams';
 
 export const INVENTORY_VIEWS_QUERY_KEY = 'inventory-views' as const;
 

--- a/src/components/InventoryViews/inventoryViewsQueryOptions.ts
+++ b/src/components/InventoryViews/inventoryViewsQueryOptions.ts
@@ -1,13 +1,12 @@
 import { queryOptions, type QueryKey } from '@tanstack/react-query';
 import { getHostTags, getHostViews } from '../../api/hostInventoryApiTyped';
 import { InventoryFilters } from '../SystemsView/filters/SystemsViewFilters';
-import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
-import type {
-  LastSeenCustomRange,
-  SortDirection,
-  SystemsViewFetchParams,
-} from '../SystemsView/types';
-import { buildHostViewsParams } from './utils/buildHostViewsParams';
+import { ApiHostViewsGetHostViewsOrderByEnum as ApiOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
+import type { SystemsViewFetchParams } from '../SystemsView/types';
+import {
+  buildHostViewsParams,
+  type BuildHostViewsParamsInput,
+} from './utils/buildHostViewsParams';
 
 export const INVENTORY_VIEWS_QUERY_KEY = 'inventory-views' as const;
 
@@ -26,33 +25,10 @@ type FetchInventoryViewsReturnedValue = Awaited<
 export type InventoryViewSystem =
   FetchInventoryViewsReturnedValue['results'][number];
 
-interface FetchInventoryViewsParams {
-  page: number;
-  perPage: number;
-  filters: InventoryFilters;
-  lastSeenCustomRange: LastSeenCustomRange;
-  sortBy: ApiHostViewsGetHostViewsOrderByEnum | undefined;
-  direction: SortDirection | undefined;
-}
+const fetchInventoryViews = async (params: BuildHostViewsParamsInput) => {
+  const fetchParams = buildHostViewsParams(params);
 
-const fetchInventoryViews = async ({
-  page,
-  perPage,
-  filters,
-  lastSeenCustomRange,
-  sortBy,
-  direction,
-}: FetchInventoryViewsParams) => {
-  const params = buildHostViewsParams({
-    page,
-    perPage,
-    filters,
-    lastSeenCustomRange,
-    sortBy,
-    direction,
-  });
-
-  const response = await getHostViews(params);
+  const response = await getHostViews(fetchParams);
   const { results: hosts, total } = response;
   const deniedServices: string[] = (response.denied_services ?? []).map(
     (s) => BACKEND_SERVICE_TO_APP_NAME[s] ?? s,
@@ -85,9 +61,7 @@ export const inventoryViewsQueryOptions = (
         perPage: params.perPage,
         filters: params.filters,
         lastSeenCustomRange: params.lastSeenCustomRange,
-        sortBy: params.sortBy as
-          | ApiHostViewsGetHostViewsOrderByEnum
-          | undefined,
+        sortBy: params.sortBy as ApiOrderByEnum | undefined,
         direction: params.direction,
       }),
   });

--- a/src/components/InventoryViews/utils/buildHostListParams.ts
+++ b/src/components/InventoryViews/utils/buildHostListParams.ts
@@ -4,7 +4,7 @@ import {
   ApiHostGetHostListOrderByEnum,
 } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
 import type { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
-import type { LastSeenCustomRange } from '../../SystemsView/DataViewFiltersContext';
+import type { LastSeenCustomRange } from '../../SystemsView/types';
 import type { SortDirection } from '../../SystemsView/SystemsView';
 import { buildSystemProfileFilters } from './buildSystemProfileFilters';
 import { buildHostQueryOptions } from './buildHostListOptions';

--- a/src/components/InventoryViews/utils/buildHostViewsParams.ts
+++ b/src/components/InventoryViews/utils/buildHostViewsParams.ts
@@ -6,7 +6,7 @@ import {
 } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import type { Column } from '../../SystemsView/columns/allColumnDefinitions';
 import type { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
-import type { LastSeenCustomRange } from '../../SystemsView/DataViewFiltersContext';
+import type { LastSeenCustomRange } from '../../SystemsView/types';
 import type { SortDirection } from '../../SystemsView/SystemsView';
 import { buildSystemProfileFilters } from './buildSystemProfileFilters';
 import { buildHostQueryOptions } from './buildHostListOptions';

--- a/src/components/InventoryViews/utils/lastSeenKeysToApiParams.ts
+++ b/src/components/InventoryViews/utils/lastSeenKeysToApiParams.ts
@@ -1,5 +1,5 @@
 import type { ApiHostGetHostListParams } from '@redhat-cloud-services/host-inventory-client/ApiHostGetHostList';
-import type { LastSeenCustomRange } from '../../SystemsView/DataViewFiltersContext';
+import type { LastSeenCustomRange } from '../../SystemsView/types';
 import {
   resolveLastSeenBounds,
   type LastSeenKey,

--- a/src/components/SystemsView/DataViewFiltersContext.tsx
+++ b/src/components/SystemsView/DataViewFiltersContext.tsx
@@ -12,11 +12,9 @@ import { normalizeLastSeenFilterValue } from './constants';
 import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';
 import { GENERAL_GROUPS_READ_PERMISSION } from '../../constants';
 import { useUngroupedWorkspaceId } from '../../hooks/useUngroupedWorkspaceId';
+import type { LastSeenCustomRange } from './types';
 
-export type LastSeenCustomRange = {
-  start?: string;
-  end?: string;
-} | null;
+export type { LastSeenCustomRange } from './types';
 
 export const INITIAL_INVENTORY_FILTERS: InventoryFilters = {
   hostname_or_id: '',

--- a/src/components/SystemsView/SystemActionModalsContext.test.tsx
+++ b/src/components/SystemsView/SystemActionModalsContext.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { expect, jest } from '@jest/globals';
 import { createTestQueryClient } from '../../Utilities/TestingUtilities';
-import type { System } from '../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../InventoryViews/hostsQueryOptions';
 import {
   SystemActionModalsProvider,
   useSystemActionModalsContext,

--- a/src/components/SystemsView/SystemActionModalsContext.tsx
+++ b/src/components/SystemsView/SystemActionModalsContext.tsx
@@ -14,7 +14,7 @@ import type { SystemForWorkspace } from '../InventoryTable/MoveSystemsToWorkspac
 import TextInputModal from '../GeneralInfo/TextInputModal/TextInputModal';
 import { useDeleteSystemsMutation } from './hooks/useDeleteSystemsMutation';
 import { usePatchSystemsMutation } from './hooks/usePatchSystemsMutation';
-import type { System } from '../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../InventoryViews/hostsQueryOptions';
 import { AllTagsModal } from './TagsModal/AllTagsModal';
 import { SingleHostTagsModal } from './TagsModal/SingleHostTagsModal';
 export type OnInvalidate = () => void | Promise<void>;

--- a/src/components/SystemsView/SystemsView.rbac.cy.js
+++ b/src/components/SystemsView/SystemsView.rbac.cy.js
@@ -98,18 +98,16 @@ const createMockHosts = () => [
   },
 ];
 
-const createMockQuery = (deniedServices = []) => {
-  return () => ({
-    data: createMockHosts(),
-    total: 2,
-    deniedServices,
-    isLoading: false,
-    isFetching: false,
-    isError: false,
-  });
+const createMockFetchData = (deniedServices = []) => {
+  return () =>
+    Promise.resolve({
+      results: createMockHosts(),
+      total: 2,
+      deniedServices,
+    });
 };
 
-const setInventoryViewsFeatureFlag = () => {
+const setInventoryViewsFeatureFlags = () => {
   cy.intercept('GET', '/feature_flags*', {
     statusCode: 200,
     body: {
@@ -122,20 +120,29 @@ const setInventoryViewsFeatureFlag = () => {
             enabled: true,
           },
         },
+        {
+          name: 'hbi.inventory-views-rbac',
+          enabled: true,
+          variant: {
+            name: 'enabled',
+            enabled: true,
+          },
+        },
       ],
     },
   }).as('getFeatureFlag');
 };
 
 const mountSystemsView = (deniedServices = [], routerProps = {}) => {
-  setInventoryViewsFeatureFlag();
+  setInventoryViewsFeatureFlags();
   systemProfileInterceptors['operating system, successful empty']();
   groupsInterceptors['successful empty']();
   localStorage.setItem('ui.inventory-views', 'true');
+  localStorage.setItem('hbi.inventory-views-rbac', 'true');
   cy.mockWindowInsights();
   cy.mountWithContext(SystemsView, routerProps, {
-    useDataQuery: createMockQuery(deniedServices),
-    onInvalidate: cy.stub(),
+    queryKeyPrefix: 'systems-view-rbac',
+    fetchData: createMockFetchData(deniedServices),
     columns: selectTestColumns,
   });
 };

--- a/src/components/SystemsView/SystemsView.test.tsx
+++ b/src/components/SystemsView/SystemsView.test.tsx
@@ -2,11 +2,9 @@ import '@testing-library/jest-dom';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { expect, jest } from '@jest/globals';
 import React from 'react';
-import {
-  SystemsView,
-  type SystemsViewQueryData,
-  type SystemsViewQueryOptionsFn,
-} from './SystemsView';
+import { SystemsView, type SystemsViewQueryData } from './SystemsView';
+import type { SystemsViewFetchData } from './types';
+import type { InventoryFilters } from './filters/SystemsViewFilters';
 import type { ColumnSelector } from './columns/resolveColumnSelector';
 import type { System } from '../InventoryViews/hostsQueryOptions';
 import {
@@ -21,7 +19,7 @@ const mockSystem = {
   display_name: 'Test Host',
 } as System;
 
-const successData: SystemsViewQueryData = {
+const successData: SystemsViewQueryData<System> = {
   results: [mockSystem],
   total: 1,
 };
@@ -65,21 +63,17 @@ jest.mock('../../Utilities/useFeatureFlag', () => ({
 const selectNameColumn: ColumnSelector = (allColumns) =>
   allColumns.filter((column) => column.key === 'display_name');
 
-const createQueryOptions = (
-  queryFn: () => Promise<SystemsViewQueryData>,
-): SystemsViewQueryOptionsFn =>
-  jest.fn((params) => ({
-    queryKey: [TEST_QUERY_KEY, params],
-    queryFn,
-  }));
-
 const renderSystemsView = (
-  queryOptions: SystemsViewQueryOptionsFn,
+  fetchData: SystemsViewFetchData<System, InventoryFilters>,
   client = createTestQueryClient(),
 ) =>
   render(
     <TestWrapper client={client}>
-      <SystemsView queryOptions={queryOptions} columns={selectNameColumn} />
+      <SystemsView
+        queryKeyPrefix={TEST_QUERY_KEY}
+        fetchData={fetchData}
+        columns={selectNameColumn}
+      />
     </TestWrapper>,
   );
 
@@ -90,7 +84,7 @@ describe('SystemsView', () => {
   });
 
   it('renders a column when the columns selector includes it', async () => {
-    renderSystemsView(createQueryOptions(() => Promise.resolve(successData)));
+    renderSystemsView(() => Promise.resolve(successData));
 
     expect(
       await screen.findByRole('columnheader', { name: 'Name' }),
@@ -98,18 +92,20 @@ describe('SystemsView', () => {
   });
 
   it('passes lastSeenCustomRange in fetch params', async () => {
-    const queryOptions = createQueryOptions(() => Promise.resolve(successData));
-    renderSystemsView(queryOptions);
+    const fetchData = jest.fn<SystemsViewFetchData<System, InventoryFilters>>(
+      () => Promise.resolve(successData),
+    );
+    renderSystemsView(fetchData);
 
     await screen.findByRole('columnheader', { name: 'Name' });
 
-    expect(queryOptions).toHaveBeenCalledWith(
+    expect(fetchData).toHaveBeenCalledWith(
       expect.objectContaining({ lastSeenCustomRange: null }),
     );
   });
 
   it('shows a loading state when the query is pending', () => {
-    renderSystemsView(createQueryOptions(() => new Promise(() => {})));
+    renderSystemsView(() => new Promise(() => {}));
 
     expect(
       screen.getByRole('checkbox', { name: 'Select row 0' }),
@@ -119,18 +115,13 @@ describe('SystemsView', () => {
 
   it('shows a loading state while a refetch is in flight', async () => {
     let hangNextFetch = false;
-    const queryFn = jest.fn<() => Promise<SystemsViewQueryData>>(() =>
-      hangNextFetch ? new Promise(() => {}) : Promise.resolve(successData),
+    const fetchData = jest.fn<SystemsViewFetchData<System, InventoryFilters>>(
+      () =>
+        hangNextFetch ? new Promise(() => {}) : Promise.resolve(successData),
     );
     const client = createTestQueryClient();
 
-    renderSystemsView(
-      () => ({
-        queryKey: [TEST_QUERY_KEY],
-        queryFn,
-      }),
-      client,
-    );
+    renderSystemsView(fetchData, client);
 
     expect(await screen.findByText('Test Host')).toBeInTheDocument();
 
@@ -148,9 +139,7 @@ describe('SystemsView', () => {
   });
 
   it('shows an error state when the query fails', async () => {
-    renderSystemsView(
-      createQueryOptions(() => Promise.reject(new Error('failed to load'))),
-    );
+    renderSystemsView(() => Promise.reject(new Error('failed to load')));
 
     expect(await screen.findByText(/Unable to load data/i)).toBeInTheDocument();
     expect(screen.getByText(/error retrieving data/i)).toBeInTheDocument();
@@ -158,9 +147,7 @@ describe('SystemsView', () => {
   });
 
   it('shows an empty state when the query succeeds with no systems', async () => {
-    renderSystemsView(
-      createQueryOptions(() => Promise.resolve({ results: [], total: 0 })),
-    );
+    renderSystemsView(() => Promise.resolve({ results: [], total: 0 }));
 
     expect(
       await screen.findByText(/No matching systems found/i),

--- a/src/components/SystemsView/SystemsView.test.tsx
+++ b/src/components/SystemsView/SystemsView.test.tsx
@@ -8,7 +8,7 @@ import {
   type SystemsViewQueryOptionsFn,
 } from './SystemsView';
 import type { ColumnSelector } from './columns/resolveColumnSelector';
-import type { System } from '../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../InventoryViews/hostsQueryOptions';
 import {
   createTestQueryClient,
   TestWrapper,

--- a/src/components/SystemsView/SystemsView.test.tsx
+++ b/src/components/SystemsView/SystemsView.test.tsx
@@ -2,9 +2,11 @@ import '@testing-library/jest-dom';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { expect, jest } from '@jest/globals';
 import React from 'react';
-import { SystemsView, type SystemsViewQueryData } from './SystemsView';
-import type { SystemsViewFetchData } from './types';
-import type { InventoryFilters } from './filters/SystemsViewFilters';
+import {
+  SystemsView,
+  type SystemsViewFetchData,
+  type SystemsViewQueryData,
+} from './SystemsView';
 import type { ColumnSelector } from './columns/resolveColumnSelector';
 import type { System } from '../InventoryViews/hostsQueryOptions';
 import {
@@ -19,7 +21,7 @@ const mockSystem = {
   display_name: 'Test Host',
 } as System;
 
-const successData: SystemsViewQueryData<System> = {
+const successData: SystemsViewQueryData = {
   results: [mockSystem],
   total: 1,
 };
@@ -64,7 +66,7 @@ const selectNameColumn: ColumnSelector = (allColumns) =>
   allColumns.filter((column) => column.key === 'display_name');
 
 const renderSystemsView = (
-  fetchData: SystemsViewFetchData<System, InventoryFilters>,
+  fetchData: SystemsViewFetchData,
   client = createTestQueryClient(),
 ) =>
   render(
@@ -92,8 +94,8 @@ describe('SystemsView', () => {
   });
 
   it('passes lastSeenCustomRange in fetch params', async () => {
-    const fetchData = jest.fn<SystemsViewFetchData<System, InventoryFilters>>(
-      () => Promise.resolve(successData),
+    const fetchData = jest.fn<SystemsViewFetchData>(() =>
+      Promise.resolve(successData),
     );
     renderSystemsView(fetchData);
 
@@ -115,9 +117,8 @@ describe('SystemsView', () => {
 
   it('shows a loading state while a refetch is in flight', async () => {
     let hangNextFetch = false;
-    const fetchData = jest.fn<SystemsViewFetchData<System, InventoryFilters>>(
-      () =>
-        hangNextFetch ? new Promise(() => {}) : Promise.resolve(successData),
+    const fetchData = jest.fn<SystemsViewFetchData>(() =>
+      hangNextFetch ? new Promise(() => {}) : Promise.resolve(successData),
     );
     const client = createTestQueryClient();
 

--- a/src/components/SystemsView/SystemsView.test.tsx
+++ b/src/components/SystemsView/SystemsView.test.tsx
@@ -1,25 +1,30 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { expect, jest } from '@jest/globals';
 import React from 'react';
-import { SystemsView, type UseSystemsViewDataQuery } from './SystemsView';
-import type { OnInvalidate } from './SystemActionModalsContext';
+import {
+  SystemsView,
+  type SystemsViewQueryData,
+  type SystemsViewQueryOptionsFn,
+} from './SystemsView';
 import type { ColumnSelector } from './columns/resolveColumnSelector';
 import type { System } from '../InventoryViews/hooks/useHostsQuery';
-import { TestWrapper } from '../../Utilities/TestingUtilities';
+import {
+  createTestQueryClient,
+  TestWrapper,
+} from '../../Utilities/TestingUtilities';
+
+const TEST_QUERY_KEY = 'systems-view-test' as const;
 
 const mockSystem = {
   id: 'host-1',
   display_name: 'Test Host',
 } as System;
 
-const mockUseDataQuery = jest.fn<UseSystemsViewDataQuery>(() => ({
-  data: [mockSystem],
+const successData: SystemsViewQueryData = {
+  results: [mockSystem],
   total: 1,
-  isLoading: false,
-  isFetching: false,
-  isError: false,
-}));
+};
 
 jest.mock('../../Utilities/hooks/useHostIdsWithKessel', () => ({
   useHostIdsWithKessel: (hosts: System[] | undefined) => ({
@@ -60,14 +65,21 @@ jest.mock('../../Utilities/useFeatureFlag', () => ({
 const selectNameColumn: ColumnSelector = (allColumns) =>
   allColumns.filter((column) => column.key === 'display_name');
 
-const renderSystemsView = () =>
+const createQueryOptions = (
+  queryFn: () => Promise<SystemsViewQueryData>,
+): SystemsViewQueryOptionsFn =>
+  jest.fn((params) => ({
+    queryKey: [TEST_QUERY_KEY, params],
+    queryFn,
+  }));
+
+const renderSystemsView = (
+  queryOptions: SystemsViewQueryOptionsFn,
+  client = createTestQueryClient(),
+) =>
   render(
-    <TestWrapper>
-      <SystemsView
-        useDataQuery={mockUseDataQuery}
-        onInvalidate={jest.fn<OnInvalidate>()}
-        columns={selectNameColumn}
-      />
+    <TestWrapper client={client}>
+      <SystemsView queryOptions={queryOptions} columns={selectNameColumn} />
     </TestWrapper>,
   );
 
@@ -75,90 +87,83 @@ describe('SystemsView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
-    mockUseDataQuery.mockImplementation(() => ({
-      data: [mockSystem],
-      total: 1,
-      isLoading: false,
-      isFetching: false,
-      isError: false,
-    }));
   });
 
   it('renders a column when the columns selector includes it', async () => {
-    renderSystemsView();
+    renderSystemsView(createQueryOptions(() => Promise.resolve(successData)));
 
     expect(
       await screen.findByRole('columnheader', { name: 'Name' }),
     ).toBeInTheDocument();
   });
 
-  it('shows a loading state when isLoading is true', () => {
-    mockUseDataQuery.mockImplementation(() => ({
-      data: undefined,
-      total: undefined,
-      isLoading: true,
-      isFetching: false,
-      isError: false,
-    }));
+  it('passes lastSeenCustomRange in fetch params', async () => {
+    const queryOptions = createQueryOptions(() => Promise.resolve(successData));
+    renderSystemsView(queryOptions);
 
-    renderSystemsView();
+    await screen.findByRole('columnheader', { name: 'Name' });
+
+    expect(queryOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ lastSeenCustomRange: null }),
+    );
+  });
+
+  it('shows a loading state when the query is pending', () => {
+    renderSystemsView(createQueryOptions(() => new Promise(() => {})));
 
     expect(
       screen.getByRole('checkbox', { name: 'Select row 0' }),
     ).toBeDisabled();
-    expect(
-      screen.queryByRole('cell', { name: 'Test Host' }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Test Host')).not.toBeInTheDocument();
   });
 
-  it('shows a loading state when isFetching is true', () => {
-    mockUseDataQuery.mockImplementation(() => ({
-      data: [mockSystem],
-      total: 1,
-      isLoading: false,
-      isFetching: true,
-      isError: false,
-    }));
+  it('shows a loading state while a refetch is in flight', async () => {
+    let hangNextFetch = false;
+    const queryFn = jest.fn<() => Promise<SystemsViewQueryData>>(() =>
+      hangNextFetch ? new Promise(() => {}) : Promise.resolve(successData),
+    );
+    const client = createTestQueryClient();
 
-    renderSystemsView();
+    renderSystemsView(
+      () => ({
+        queryKey: [TEST_QUERY_KEY],
+        queryFn,
+      }),
+      client,
+    );
 
-    expect(
-      screen.getByRole('checkbox', { name: 'Select row 0' }),
-    ).toBeDisabled();
-    expect(
-      screen.queryByRole('cell', { name: 'Test Host' }),
-    ).not.toBeInTheDocument();
+    expect(await screen.findByText('Test Host')).toBeInTheDocument();
+
+    hangNextFetch = true;
+    act(() => {
+      void client.invalidateQueries({ queryKey: [TEST_QUERY_KEY] });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('checkbox', { name: 'Select row 0' }),
+      ).toBeDisabled();
+    });
+    expect(screen.queryByText('Test Host')).not.toBeInTheDocument();
   });
 
-  it('shows an error state when isError is true', () => {
-    mockUseDataQuery.mockImplementation(() => ({
-      data: [],
-      total: 0,
-      isLoading: false,
-      isFetching: false,
-      isError: true,
-    }));
+  it('shows an error state when the query fails', async () => {
+    renderSystemsView(
+      createQueryOptions(() => Promise.reject(new Error('failed to load'))),
+    );
 
-    renderSystemsView();
-
-    expect(screen.getByText(/Unable to load data/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Unable to load data/i)).toBeInTheDocument();
     expect(screen.getByText(/error retrieving data/i)).toBeInTheDocument();
-    expect(
-      screen.queryByRole('cell', { name: 'Test Host' }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Test Host')).not.toBeInTheDocument();
   });
 
-  it('shows an empty state when the query succeeds with no systems', () => {
-    mockUseDataQuery.mockImplementation(() => ({
-      data: [],
-      total: 0,
-      isLoading: false,
-      isFetching: false,
-      isError: false,
-    }));
+  it('shows an empty state when the query succeeds with no systems', async () => {
+    renderSystemsView(
+      createQueryOptions(() => Promise.resolve({ results: [], total: 0 })),
+    );
 
-    renderSystemsView();
-
-    expect(screen.getByText(/No matching systems found/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/No matching systems found/i),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -59,9 +59,8 @@ import type { Column } from './columns/allColumnDefinitions';
 import type { System } from '../InventoryViews/hostsQueryOptions';
 import type {
   SortDirection,
-  SystemsViewFetchData,
   SystemsViewFetchParams,
-  SystemsViewItem,
+  SystemsViewQueryData,
 } from './types';
 import { deriveActiveState } from './utils/deriveActiveState';
 import {
@@ -71,11 +70,10 @@ import {
 import useInventoryViewsColumnsRbacFeatureFlag from '../../Utilities/useInventoryViewsColumnsRbacFeatureFlag';
 
 export type { SortDirection } from './types';
-export type {
-  SystemsViewItem,
-  SystemsViewQueryData,
-  SystemsViewFetchData,
-} from './types';
+export type { SystemsViewItem, SystemsViewQueryData } from './types';
+export type SystemsViewFetchData = (
+  params: SystemsViewFetchParams<InventoryFilters>,
+) => Promise<SystemsViewQueryData>;
 export type OnSort = (
   _event: React.MouseEvent | React.KeyboardEvent | MouseEvent | undefined,
   newSortBy: string,
@@ -83,40 +81,39 @@ export type OnSort = (
 ) => void;
 export type Pagination = ReturnType<typeof useDataViewPagination>;
 
-export type SystemsViewProps<TItem extends SystemsViewItem = SystemsViewItem> =
-  {
-    /**
-     * Unique & stable queryKey prefix (`'hosts'`, `'inventory-views'`). SystemsView keys the
-     * inner query as `[queryKeyPrefix, fetchParams]` and invalidates by this prefix after mutations.
-     */
-    queryKeyPrefix: string;
-    /**
-     * Fetches the data for table. Receives table state for pagination, sorting, and
-     * filtering, and should use those values to fetch from backend.
-     */
-    fetchData: SystemsViewFetchData<TItem, InventoryFilters>;
-    /**
-     * Selects which columns are available in this view from the full catalog.
-     * Stable reference for selectors required! don't define them inline in JSX.
-     */
-    columns?: ColumnSelector;
-    defaultFilters?: Partial<InventoryFilters>;
-    initialSort?: { sortBy: Column['sortBy']; direction: SortDirection };
-    initialFilters?: Partial<InventoryFilters>;
-    onColumnsChange?: (columns: readonly Column[]) => void;
-  };
+export type SystemsViewProps = {
+  /**
+   * Unique & stable queryKey prefix (`'hosts'`, `'inventory-views'`). SystemsView keys the
+   * inner query as `[queryKeyPrefix, fetchParams]` and invalidates by this prefix after mutations.
+   */
+  queryKeyPrefix: string;
+  /**
+   * Fetches the data for table. Receives table state for pagination, sorting, and
+   * filtering, and should use those values to fetch from backend.
+   */
+  fetchData: SystemsViewFetchData;
+  /**
+   * Selects which columns are available in this view from the full catalog.
+   * Stable reference for selectors required! don't define them inline in JSX.
+   */
+  columns?: ColumnSelector;
+  defaultFilters?: Partial<InventoryFilters>;
+  initialSort?: { sortBy: Column['sortBy']; direction: SortDirection };
+  initialFilters?: Partial<InventoryFilters>;
+  onColumnsChange?: (columns: readonly Column[]) => void;
+};
 
-interface SystemsViewInnerProps<TItem extends SystemsViewItem> {
+interface SystemsViewInnerProps {
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
   queryKeyPrefix: string;
-  fetchData: SystemsViewFetchData<TItem, InventoryFilters>;
+  fetchData: SystemsViewFetchData;
   resolvedDefaultColumns: readonly Column[];
   initialSort?: { sortBy: Column['sortBy']; direction: SortDirection };
   onColumnsChange?: (columns: readonly Column[]) => void;
 }
 
-function SystemsViewInner<TItem extends SystemsViewItem>({
+function SystemsViewInner({
   searchParams,
   setSearchParams,
   queryKeyPrefix,
@@ -124,7 +121,7 @@ function SystemsViewInner<TItem extends SystemsViewItem>({
   resolvedDefaultColumns,
   initialSort,
   onColumnsChange,
-}: SystemsViewInnerProps<TItem>) {
+}: SystemsViewInnerProps) {
   const queryClient = useQueryClient();
   const { filters, clearAllFilters, hasDefaultFilters, lastSeenCustomRange } =
     useDataViewFiltersContext();
@@ -151,7 +148,7 @@ function SystemsViewInner<TItem extends SystemsViewItem>({
     [filters, debouncedName],
   );
 
-  const selection = useDataViewSelection<SystemsViewTableRow<TItem>>({
+  const selection = useDataViewSelection<SystemsViewTableRow>({
     matchOption: (a, b) => a.id === b.id,
     initialSelected: [],
   });
@@ -251,9 +248,8 @@ function SystemsViewInner<TItem extends SystemsViewItem>({
     rowsData as unknown as System[] | undefined,
   );
 
-  // FIXME remove type casting
   const rows = mapSystemsToRows({
-    data: (hostsWithPermissions ?? rowsData) as unknown as TItem[] | undefined,
+    data: hostsWithPermissions ?? rowsData,
     columns,
     isInventoryViewsEnabled,
   });
@@ -376,7 +372,7 @@ function SystemsViewInner<TItem extends SystemsViewItem>({
   );
 }
 
-export function SystemsView<TItem extends SystemsViewItem = SystemsViewItem>({
+export function SystemsView({
   queryKeyPrefix,
   fetchData,
   columns,
@@ -384,7 +380,7 @@ export function SystemsView<TItem extends SystemsViewItem = SystemsViewItem>({
   initialSort,
   initialFilters,
   onColumnsChange,
-}: SystemsViewProps<TItem>) {
+}: SystemsViewProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const resolvedDefaultColumns = useMemo(
     () => resolveColumnSelector(columns),

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -58,7 +58,7 @@ import {
 } from './constants';
 import useInventoryViewsFeatureFlag from '../../Utilities/useInventoryViewsFeatureFlag';
 import type { Column } from './columns/allColumnDefinitions';
-import type { System } from '../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../InventoryViews/hostsQueryOptions';
 import type { SortDirection, SystemsViewFetchParams } from './types';
 import { deriveActiveState } from './utils/deriveActiveState';
 import {

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -169,8 +169,16 @@ const SystemsViewInner = ({
       filters: queryFilters,
       sortBy,
       direction,
+      lastSeenCustomRange,
     }),
-    [pagination.page, pagination.perPage, queryFilters, sortBy, direction],
+    [
+      pagination.page,
+      pagination.perPage,
+      queryFilters,
+      sortBy,
+      direction,
+      lastSeenCustomRange,
+    ],
   );
 
   const { data, total, deniedServices, isLoading, isFetching, isError } =

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -32,7 +32,7 @@ import {
   type SystemsViewTableRow,
 } from './utils/mapSystemsToRows';
 import './SystemsView.scss';
-import { InnerScrollContainer, ISortBy } from '@patternfly/react-table';
+import { InnerScrollContainer } from '@patternfly/react-table';
 import { ColumnManagementModalProvider } from './ColumnManagementModalContext';
 import {
   DataViewFiltersProvider,
@@ -47,10 +47,8 @@ import { normalizeLegacySortSearchParams } from './utils/normalizeLegacySortSear
 import { SORT_DIR_URL_PARAM, SORT_URL_PARAM } from './constants';
 import useInventoryViewsFeatureFlag from '../../Utilities/useInventoryViewsFeatureFlag';
 import type { Column } from './columns/allColumnDefinitions';
-import type {
-  System,
-  SystemsViewFetchParams,
-} from '../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../InventoryViews/hooks/useHostsQuery';
+import type { SortDirection, SystemsViewFetchParams } from './types';
 import { deriveActiveState } from './utils/deriveActiveState';
 import type { OnInvalidate } from './SystemActionModalsContext';
 import {
@@ -58,7 +56,7 @@ import {
   type ColumnSelector,
 } from './columns/resolveColumnSelector';
 
-export type SortDirection = ISortBy['direction'];
+export type { SortDirection } from './types';
 export type OnSort = (
   _event: React.MouseEvent | React.KeyboardEvent | MouseEvent | undefined,
   newSortBy: string,
@@ -76,7 +74,7 @@ export type SystemsViewDataQueryResult = {
 };
 
 export type UseSystemsViewDataQuery = (
-  params: SystemsViewFetchParams,
+  params: SystemsViewFetchParams<InventoryFilters>,
 ) => SystemsViewDataQueryResult;
 
 export type SystemsViewProps = {
@@ -165,22 +163,14 @@ const SystemsViewInner = ({
   const { direction, onSort } = sort;
 
   const fetchParams = useMemo(
-    (): SystemsViewFetchParams => ({
+    (): SystemsViewFetchParams<InventoryFilters> => ({
       page: pagination.page,
       perPage: pagination.perPage,
       filters: queryFilters,
-      lastSeenCustomRange,
       sortBy,
       direction,
     }),
-    [
-      pagination.page,
-      pagination.perPage,
-      queryFilters,
-      lastSeenCustomRange,
-      sortBy,
-      direction,
-    ],
+    [pagination.page, pagination.perPage, queryFilters, sortBy, direction],
   );
 
   const { data, total, deniedServices, isLoading, isFetching, isError } =

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useMemo } from 'react';
 import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+  type QueryKey,
+  type UseQueryOptions,
+} from '@tanstack/react-query';
+import {
   DataView,
   useDataViewPagination,
   useDataViewSort,
@@ -44,17 +51,21 @@ import { INITIAL_PAGE, NO_HEADER } from '../InventoryViews/constants';
 import { PER_PAGE } from '../../constants';
 import { DEBOUNCE_TIMEOUT_MS } from '../../constants';
 import { normalizeLegacySortSearchParams } from './utils/normalizeLegacySortSearchParams';
-import { SORT_DIR_URL_PARAM, SORT_URL_PARAM } from './constants';
+import {
+  EMPTY_SERVICES,
+  SORT_DIR_URL_PARAM,
+  SORT_URL_PARAM,
+} from './constants';
 import useInventoryViewsFeatureFlag from '../../Utilities/useInventoryViewsFeatureFlag';
 import type { Column } from './columns/allColumnDefinitions';
 import type { System } from '../InventoryViews/hooks/useHostsQuery';
 import type { SortDirection, SystemsViewFetchParams } from './types';
 import { deriveActiveState } from './utils/deriveActiveState';
-import type { OnInvalidate } from './SystemActionModalsContext';
 import {
   resolveColumnSelector,
   type ColumnSelector,
 } from './columns/resolveColumnSelector';
+import useInventoryViewsColumnsRbacFeatureFlag from '../../Utilities/useInventoryViewsColumnsRbacFeatureFlag';
 
 export type { SortDirection } from './types';
 export type OnSort = (
@@ -64,22 +75,29 @@ export type OnSort = (
 ) => void;
 export type Pagination = ReturnType<typeof useDataViewPagination>;
 
-export type SystemsViewDataQueryResult = {
-  data: System[] | undefined;
-  total: number | undefined;
+export type SystemsViewQueryData = {
+  results: System[];
+  total: number;
   deniedServices?: string[];
-  isLoading: boolean;
-  isFetching: boolean;
-  isError: boolean;
 };
 
-export type UseSystemsViewDataQuery = (
+/**
+ * Pure function that turns table fetch params into TanStack Query options.
+ * Pass a named factory (or inline function), not a React hook.
+ * `queryKey` must be a non-empty array whose first element is a stable prefix
+ * used to invalidate every page after mutations (`'hosts'`, `'inventory-views'`).
+ */
+export type SystemsViewQueryOptionsFn = (
   params: SystemsViewFetchParams<InventoryFilters>,
-) => SystemsViewDataQueryResult;
+) => UseQueryOptions<
+  SystemsViewQueryData,
+  Error,
+  SystemsViewQueryData,
+  QueryKey
+>;
 
 export type SystemsViewProps = {
-  useDataQuery: UseSystemsViewDataQuery;
-  onInvalidate: OnInvalidate;
+  queryOptions: SystemsViewQueryOptionsFn;
   /**
    * Selects which columns are available in this view from the full catalog.
    * Stable reference for selectors required! don't define them inline in JSX.
@@ -94,8 +112,7 @@ export type SystemsViewProps = {
 interface SystemsViewInnerProps {
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
-  useDataQuery: UseSystemsViewDataQuery;
-  onInvalidate: OnInvalidate;
+  queryOptions: SystemsViewQueryOptionsFn;
   resolvedDefaultColumns: readonly Column[];
   initialSort?: { sortBy: Column['sortBy']; direction: SortDirection };
   onColumnsChange?: (columns: readonly Column[]) => void;
@@ -104,12 +121,12 @@ interface SystemsViewInnerProps {
 const SystemsViewInner = ({
   searchParams,
   setSearchParams,
-  useDataQuery,
-  onInvalidate,
+  queryOptions,
   resolvedDefaultColumns,
   initialSort,
   onColumnsChange,
 }: SystemsViewInnerProps) => {
+  const queryClient = useQueryClient();
   const { filters, clearAllFilters, hasDefaultFilters, lastSeenCustomRange } =
     useDataViewFiltersContext();
 
@@ -181,10 +198,29 @@ const SystemsViewInner = ({
     ],
   );
 
-  const { data, total, deniedServices, isLoading, isFetching, isError } =
-    useDataQuery(fetchParams);
+  const options = queryOptions(fetchParams);
+  const { data, isLoading, isFetching, isError } = useQuery({
+    placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
+    ...queryOptions(fetchParams),
+  });
+  const rowsData = data?.results;
+  const total = data?.total;
+  const isInventoryViewsRbacEnabled = useInventoryViewsColumnsRbacFeatureFlag();
+  const deniedServices = isInventoryViewsRbacEnabled
+    ? (data?.deniedServices ?? EMPTY_SERVICES)
+    : EMPTY_SERVICES;
+
+  const queryKeyPrefix = options.queryKey?.[0];
+  const onInvalidate = useCallback(() => {
+    if (queryKeyPrefix === undefined) {
+      return;
+    }
+    return queryClient.invalidateQueries({ queryKey: [queryKeyPrefix] });
+  }, [queryClient, queryKeyPrefix]);
+
   const activeState = deriveActiveState({
-    data,
+    data: rowsData,
     isLoading,
     isFetching,
     isError,
@@ -215,10 +251,10 @@ const SystemsViewInner = ({
     [setColumns, onColumnsChange],
   );
 
-  const { hostsWithPermissions } = useHostIdsWithKessel(data);
+  const { hostsWithPermissions } = useHostIdsWithKessel(rowsData);
 
   const rows = mapSystemsToRows({
-    data: hostsWithPermissions ?? data,
+    data: hostsWithPermissions ?? rowsData,
     columns,
     isInventoryViewsEnabled,
   });
@@ -341,8 +377,7 @@ const SystemsViewInner = ({
 };
 
 export const SystemsView = ({
-  useDataQuery,
-  onInvalidate,
+  queryOptions,
   columns,
   defaultFilters,
   initialSort,
@@ -365,8 +400,7 @@ export const SystemsView = ({
       <SystemsViewInner
         searchParams={searchParams}
         setSearchParams={setSearchParams}
-        useDataQuery={useDataQuery}
-        onInvalidate={onInvalidate}
+        queryOptions={queryOptions}
         resolvedDefaultColumns={resolvedDefaultColumns}
         initialSort={initialSort}
         onColumnsChange={onColumnsChange}

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -3,8 +3,6 @@ import {
   keepPreviousData,
   useQuery,
   useQueryClient,
-  type QueryKey,
-  type UseQueryOptions,
 } from '@tanstack/react-query';
 import {
   DataView,
@@ -59,7 +57,12 @@ import {
 import useInventoryViewsFeatureFlag from '../../Utilities/useInventoryViewsFeatureFlag';
 import type { Column } from './columns/allColumnDefinitions';
 import type { System } from '../InventoryViews/hostsQueryOptions';
-import type { SortDirection, SystemsViewFetchParams } from './types';
+import type {
+  SortDirection,
+  SystemsViewFetchData,
+  SystemsViewFetchParams,
+  SystemsViewItem,
+} from './types';
 import { deriveActiveState } from './utils/deriveActiveState';
 import {
   resolveColumnSelector,
@@ -68,6 +71,11 @@ import {
 import useInventoryViewsColumnsRbacFeatureFlag from '../../Utilities/useInventoryViewsColumnsRbacFeatureFlag';
 
 export type { SortDirection } from './types';
+export type {
+  SystemsViewItem,
+  SystemsViewQueryData,
+  SystemsViewFetchData,
+} from './types';
 export type OnSort = (
   _event: React.MouseEvent | React.KeyboardEvent | MouseEvent | undefined,
   newSortBy: string,
@@ -75,57 +83,48 @@ export type OnSort = (
 ) => void;
 export type Pagination = ReturnType<typeof useDataViewPagination>;
 
-export type SystemsViewQueryData = {
-  results: System[];
-  total: number;
-  deniedServices?: string[];
-};
+export type SystemsViewProps<TItem extends SystemsViewItem = SystemsViewItem> =
+  {
+    /**
+     * Unique & stable queryKey prefix (`'hosts'`, `'inventory-views'`). SystemsView keys the
+     * inner query as `[queryKeyPrefix, fetchParams]` and invalidates by this prefix after mutations.
+     */
+    queryKeyPrefix: string;
+    /**
+     * Fetches the data for table. Receives table state for pagination, sorting, and
+     * filtering, and should use those values to fetch from backend.
+     */
+    fetchData: SystemsViewFetchData<TItem, InventoryFilters>;
+    /**
+     * Selects which columns are available in this view from the full catalog.
+     * Stable reference for selectors required! don't define them inline in JSX.
+     */
+    columns?: ColumnSelector;
+    defaultFilters?: Partial<InventoryFilters>;
+    initialSort?: { sortBy: Column['sortBy']; direction: SortDirection };
+    initialFilters?: Partial<InventoryFilters>;
+    onColumnsChange?: (columns: readonly Column[]) => void;
+  };
 
-/**
- * Pure function that turns table fetch params into TanStack Query options.
- * Pass a named factory (or inline function), not a React hook.
- * `queryKey` must be a non-empty array whose first element is a stable prefix
- * used to invalidate every page after mutations (`'hosts'`, `'inventory-views'`).
- */
-export type SystemsViewQueryOptionsFn = (
-  params: SystemsViewFetchParams<InventoryFilters>,
-) => UseQueryOptions<
-  SystemsViewQueryData,
-  Error,
-  SystemsViewQueryData,
-  QueryKey
->;
-
-export type SystemsViewProps = {
-  queryOptions: SystemsViewQueryOptionsFn;
-  /**
-   * Selects which columns are available in this view from the full catalog.
-   * Stable reference for selectors required! don't define them inline in JSX.
-   */
-  columns?: ColumnSelector;
-  defaultFilters?: Partial<InventoryFilters>;
-  initialSort?: { sortBy: Column['sortBy']; direction: SortDirection };
-  initialFilters?: Partial<InventoryFilters>;
-  onColumnsChange?: (columns: readonly Column[]) => void;
-};
-
-interface SystemsViewInnerProps {
+interface SystemsViewInnerProps<TItem extends SystemsViewItem> {
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
-  queryOptions: SystemsViewQueryOptionsFn;
+  queryKeyPrefix: string;
+  fetchData: SystemsViewFetchData<TItem, InventoryFilters>;
   resolvedDefaultColumns: readonly Column[];
   initialSort?: { sortBy: Column['sortBy']; direction: SortDirection };
   onColumnsChange?: (columns: readonly Column[]) => void;
 }
 
-const SystemsViewInner = ({
+function SystemsViewInner<TItem extends SystemsViewItem>({
   searchParams,
   setSearchParams,
-  queryOptions,
+  queryKeyPrefix,
+  fetchData,
   resolvedDefaultColumns,
   initialSort,
   onColumnsChange,
-}: SystemsViewInnerProps) => {
+}: SystemsViewInnerProps<TItem>) {
   const queryClient = useQueryClient();
   const { filters, clearAllFilters, hasDefaultFilters, lastSeenCustomRange } =
     useDataViewFiltersContext();
@@ -152,7 +151,7 @@ const SystemsViewInner = ({
     [filters, debouncedName],
   );
 
-  const selection = useDataViewSelection<SystemsViewTableRow>({
+  const selection = useDataViewSelection<SystemsViewTableRow<TItem>>({
     matchOption: (a, b) => a.id === b.id,
     initialSelected: [],
   });
@@ -198,11 +197,11 @@ const SystemsViewInner = ({
     ],
   );
 
-  const options = queryOptions(fetchParams);
   const { data, isLoading, isFetching, isError } = useQuery({
+    queryKey: [queryKeyPrefix, fetchParams],
+    queryFn: () => fetchData(fetchParams),
     placeholderData: keepPreviousData,
     refetchOnWindowFocus: false,
-    ...queryOptions(fetchParams),
   });
   const rowsData = data?.results;
   const total = data?.total;
@@ -211,11 +210,7 @@ const SystemsViewInner = ({
     ? (data?.deniedServices ?? EMPTY_SERVICES)
     : EMPTY_SERVICES;
 
-  const queryKeyPrefix = options.queryKey?.[0];
   const onInvalidate = useCallback(() => {
-    if (queryKeyPrefix === undefined) {
-      return;
-    }
     return queryClient.invalidateQueries({ queryKey: [queryKeyPrefix] });
   }, [queryClient, queryKeyPrefix]);
 
@@ -251,10 +246,14 @@ const SystemsViewInner = ({
     [setColumns, onColumnsChange],
   );
 
-  const { hostsWithPermissions } = useHostIdsWithKessel(rowsData);
+  // FIXME remove type casting
+  const { hostsWithPermissions } = useHostIdsWithKessel(
+    rowsData as unknown as System[] | undefined,
+  );
 
+  // FIXME remove type casting
   const rows = mapSystemsToRows({
-    data: hostsWithPermissions ?? rowsData,
+    data: (hostsWithPermissions ?? rowsData) as unknown as TItem[] | undefined,
     columns,
     isInventoryViewsEnabled,
   });
@@ -350,7 +349,8 @@ const SystemsViewInner = ({
               filters={<SystemsViewFilters />}
               actions={
                 <SystemsViewBulkActions
-                  selectedSystems={selectedSystems}
+                  // FIXME remove type casting
+                  selectedSystems={selectedSystems as unknown as System[]}
                   activeState={activeState}
                 />
               }
@@ -374,16 +374,17 @@ const SystemsViewInner = ({
       </ColumnManagementModalProvider>
     </SystemActionModalsProvider>
   );
-};
+}
 
-export const SystemsView = ({
-  queryOptions,
+export function SystemsView<TItem extends SystemsViewItem = SystemsViewItem>({
+  queryKeyPrefix,
+  fetchData,
   columns,
   defaultFilters,
   initialSort,
   initialFilters,
   onColumnsChange,
-}: SystemsViewProps) => {
+}: SystemsViewProps<TItem>) {
   const [searchParams, setSearchParams] = useSearchParams();
   const resolvedDefaultColumns = useMemo(
     () => resolveColumnSelector(columns),
@@ -400,13 +401,14 @@ export const SystemsView = ({
       <SystemsViewInner
         searchParams={searchParams}
         setSearchParams={setSearchParams}
-        queryOptions={queryOptions}
+        queryKeyPrefix={queryKeyPrefix}
+        fetchData={fetchData}
         resolvedDefaultColumns={resolvedDefaultColumns}
         initialSort={initialSort}
         onColumnsChange={onColumnsChange}
       />
     </DataViewFiltersProvider>
   );
-};
+}
 
 export default SystemsView;

--- a/src/components/SystemsView/SystemsViewBulkActions.test.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { expect, jest } from '@jest/globals';
 import { SystemActionModalsContext } from './SystemActionModalsContext';
-import type { System } from '../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../InventoryViews/hostsQueryOptions';
 import {
   createSystem,
   mockOpenAddToWorkspaceModal,

--- a/src/components/SystemsView/SystemsViewBulkActions.tsx
+++ b/src/components/SystemsView/SystemsViewBulkActions.tsx
@@ -4,7 +4,7 @@ import {
   ResponsiveActions,
 } from '@patternfly/react-component-groups';
 import { SystemsViewExport } from './SystemsViewExport';
-import type { System } from '../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../InventoryViews/hostsQueryOptions';
 import { useSystemActionModalsContext } from './SystemActionModalsContext';
 import { useColumnManagementModalContext } from './ColumnManagementModalContext';
 import { useKesselMigrationFeatureFlag } from '../../Utilities/hooks/useKesselMigrationFeatureFlag';

--- a/src/components/SystemsView/SystemsViewRowActions.tsx
+++ b/src/components/SystemsView/SystemsViewRowActions.tsx
@@ -1,6 +1,6 @@
 import { ActionsColumn } from '@patternfly/react-table';
 import React from 'react';
-import { System } from '../InventoryViews/hooks/useHostsQuery';
+import { System } from '../InventoryViews/hostsQueryOptions';
 import { useSystemActionModalsContext } from './SystemActionModalsContext';
 import { useKesselMigrationFeatureFlag } from '../../Utilities/hooks/useKesselMigrationFeatureFlag';
 import { useConditionalRBAC } from '../../Utilities/hooks/useConditionalRBAC';

--- a/src/components/SystemsView/TagsModal/SingleHostTagsModal.tsx
+++ b/src/components/SystemsView/TagsModal/SingleHostTagsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { BaseTagsModal } from './BaseTagsModal';
 import TagsModalTable from './TagsModalTable';
-import type { System } from '../../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../../InventoryViews/hostsQueryOptions';
 
 export interface SingleHostTagsModalProps {
   isOpen: boolean;

--- a/src/components/SystemsView/TagsModal/TagsModalTable.tsx
+++ b/src/components/SystemsView/TagsModal/TagsModalTable.tsx
@@ -13,7 +13,7 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 import { BulkSelect } from '../../BulkSelect';
-import { System } from '../../InventoryViews/hooks/useHostsQuery';
+import { System } from '../../InventoryViews/hostsQueryOptions';
 import { INITIAL_PAGE, PER_PAGE } from '../../../constants';
 import { NO_HEADER } from '../../InventoryViews/constants';
 import NoEntitiesFound from '../../InventoryTable/NoEntitiesFound';

--- a/src/components/SystemsView/__fixtures__/systemsViewActionsTestHelpers.ts
+++ b/src/components/SystemsView/__fixtures__/systemsViewActionsTestHelpers.ts
@@ -5,7 +5,7 @@ import {
   GENERAL_HOSTS_WRITE_PERMISSIONS,
 } from '../../../constants';
 import type { SystemWithPermissions } from '../../../Utilities/hooks/useHostIdsWithKessel';
-import type { System } from '../../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../../InventoryViews/hostsQueryOptions';
 
 export const mockUseKesselMigrationFeatureFlag = jest.fn();
 

--- a/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/advisor/columnDefinitions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Column } from '../allColumnDefinitions';
-import { InventoryViewSystem } from '../../../InventoryViews/hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../../InventoryViews/inventoryViewsQueryOptions';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import AdvisorCount from './cells/AdvisorCount';
 

--- a/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
+++ b/src/components/SystemsView/columns/allColumnDefinitions.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import allColumns, { type Column } from './allColumnDefinitions';
-import { InventoryViewSystem } from '../../InventoryViews/hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../InventoryViews/inventoryViewsQueryOptions';
 import {
   DEFAULT_NAME_COLUMN_MIN_WIDTH,
   getColumnMinWidthStyle,

--- a/src/components/SystemsView/columns/allColumnDefinitions.ts
+++ b/src/components/SystemsView/columns/allColumnDefinitions.ts
@@ -2,7 +2,7 @@ import { ColumnManagementModalColumn } from '@patternfly/react-component-groups'
 import inventoryColumns from './inventory/columnDefinitions';
 import complianceColumns from './compliance/columnDefinitions';
 import patchColumns from './content/columnDefinitions';
-import { System } from '../../InventoryViews/hooks/useHostsQuery';
+import { System } from '../../InventoryViews/hostsQueryOptions';
 import { Resolve } from '../../../types/utility-types';
 import advisorColumns from './advisor/columnDefinitions';
 import vulnerabilityColumns from './vulnerability/columnDefinitions';

--- a/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Column } from '../allColumnDefinitions';
-import { InventoryViewSystem } from '../../../InventoryViews/hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../../InventoryViews/inventoryViewsQueryOptions';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import LastComplianceScan from './cells/LastComplianceScan';
 import Policies from './cells/Policies';

--- a/src/components/SystemsView/columns/content/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/content/columnDefinitions.tsx
@@ -2,7 +2,7 @@ import { Column } from '../allColumnDefinitions';
 import React from 'react';
 import InstallableAdvisories from './cells/InstallableAdvisories';
 import Template from './cells/Template';
-import { InventoryViewSystem } from '../../../InventoryViews/hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../../InventoryViews/inventoryViewsQueryOptions';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 
 const APP_NAME = 'content' as const;

--- a/src/components/SystemsView/columns/inventory/cells/Created.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Created.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import CellValue from '../../CellValue';
-import { System } from '../../../../InventoryViews/hooks/useHostsQuery';
+import { System } from '../../../../InventoryViews/hostsQueryOptions';
 
 interface CreatedProps {
   value: System['created'];

--- a/src/components/SystemsView/columns/inventory/cells/DisplayName.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/DisplayName.tsx
@@ -5,7 +5,7 @@ import { Flex, FlexItem, Icon, Popover } from '@patternfly/react-core';
 import { BundleIcon } from '@patternfly/react-icons';
 import FontAwesomeImageIcon from '../../../../FontAwesomeImageIcon';
 import CellValue from '../../CellValue';
-import type { System } from '../../../../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../../../../InventoryViews/hostsQueryOptions';
 
 export type DisplayNameValue = Pick<
   System,

--- a/src/components/SystemsView/columns/inventory/cells/DisplayName.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/DisplayName.tsx
@@ -9,8 +9,10 @@ import type { System } from '../../../../InventoryViews/hostsQueryOptions';
 
 export type DisplayNameValue = Pick<
   System,
-  'id' | 'display_name' | 'system_profile'
->;
+  'display_name' | 'system_profile'
+> & {
+  id?: string;
+};
 
 const isImageBasedSystem = (value: DisplayNameValue) =>
   value.system_profile?.bootc_status?.booted?.image_digest ||

--- a/src/components/SystemsView/columns/inventory/cells/LastSeen.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/LastSeen.tsx
@@ -5,7 +5,7 @@ import { verifyCulledReporter } from '../../../../../Utilities/sharedFunctions';
 import InsightsDisconnected from '../../../../../Utilities/InsightsDisconnected';
 import { REPORTER_PUPTOO } from '../../../../../Utilities/constants';
 import CellValue from '../../CellValue';
-import { System } from '../../../../InventoryViews/hooks/useHostsQuery';
+import { System } from '../../../../InventoryViews/hostsQueryOptions';
 
 type CullingDate = string | number | Date;
 

--- a/src/components/SystemsView/columns/inventory/cells/Status.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Status.tsx
@@ -5,7 +5,7 @@ import {
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
 import CellValue from '../../CellValue';
-import { System } from '../../../../InventoryViews/hooks/useHostsQuery';
+import { System } from '../../../../InventoryViews/hostsQueryOptions';
 
 export type HostStalenessStatus = 'Fresh' | 'Stale' | 'Stale warning';
 

--- a/src/components/SystemsView/columns/inventory/cells/Tags.test.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Tags.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import type { StructuredTag } from '@redhat-cloud-services/host-inventory-client';
 import Tags from './Tags';
 import { SystemActionModalsContext } from '../../../SystemActionModalsContext';
-import type { System } from '../../../../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../../../../InventoryViews/hostsQueryOptions';
 import { NOT_AVAILABLE } from '../../CellValue';
 
 const SYSTEM_ID = 'test-system-id';

--- a/src/components/SystemsView/columns/inventory/cells/Tags.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Tags.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TagCount } from '@redhat-cloud-services/frontend-components/TagCount';
 import { useSystemActionModalsContext } from '../../../SystemActionModalsContext';
-import { System } from '../../../../InventoryViews/hooks/useHostsQuery';
+import { System } from '../../../../InventoryViews/hostsQueryOptions';
 import CellValue from '../../CellValue';
 
 interface TagsProps {

--- a/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
+++ b/src/components/SystemsView/columns/inventory/cells/Workspace.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import CellValue from '../../CellValue';
-import { System } from '../../../../InventoryViews/hooks/useHostsQuery';
+import { System } from '../../../../InventoryViews/hostsQueryOptions';
 
 interface WorkspaceProps {
   value: System['groups'] | undefined;

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -11,10 +11,10 @@ import Vendor from './cells/Vendor';
 import Infrastructure from './cells/Infrastructure';
 import Created from './cells/Created';
 import { LastSeenColumnHeader } from '../../../../Utilities/LastSeenColumnHeader';
-import { System } from '../../../InventoryViews/hooks/useHostsQuery';
+import { System } from '../../../InventoryViews/hostsQueryOptions';
 import type { Column } from '../allColumnDefinitions';
 import { DEFAULT_NAME_COLUMN_MIN_WIDTH } from '../../utils/columnMinWidths';
-import { InventoryViewSystem } from '../../../InventoryViews/hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../../InventoryViews/inventoryViewsQueryOptions';
 
 const APP_NAME = 'inventory' as const;
 

--- a/src/components/SystemsView/columns/malware/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/malware/columnDefinitions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Column } from '../allColumnDefinitions';
-import { InventoryViewSystem } from '../../../InventoryViews/hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../../InventoryViews/inventoryViewsQueryOptions';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import LastMalwareScan from './cells/LastMalwareScan';
 import LastMalwareStatus from './cells/LastMalwareStatus';

--- a/src/components/SystemsView/columns/remediations/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/remediations/columnDefinitions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Column } from '../allColumnDefinitions';
-import { InventoryViewSystem } from '../../../InventoryViews/hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../../InventoryViews/inventoryViewsQueryOptions';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import RemediationPlans from './cells/RemediationPlans';
 

--- a/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Column } from '../allColumnDefinitions';
-import { InventoryViewSystem } from '../../../InventoryViews/hooks/useInventoryViewsQuery';
+import { InventoryViewSystem } from '../../../InventoryViews/inventoryViewsQueryOptions';
 import { ApiHostViewsGetHostViewsOrderByEnum } from '@redhat-cloud-services/host-inventory-client/ApiHostViewsGetHostViews';
 import {
   CVES_WITH_KNOWN_EXPLOITS_SORT_KEY,

--- a/src/components/SystemsView/constants.ts
+++ b/src/components/SystemsView/constants.ts
@@ -121,3 +121,5 @@ export const VULNERABILITY_LINK_SEARCH = {
   cvesWithSecurityRules: `${ADVISORY_AVAILABLE}&${RULE_PRESENCE}`,
   cvesWithKnownExploits: `${ADVISORY_AVAILABLE}&${KNOWN_EXPLOIT}`,
 } as const;
+
+export const EMPTY_SERVICES: string[] = [];

--- a/src/components/SystemsView/filters/SystemsViewFilters.tsx
+++ b/src/components/SystemsView/filters/SystemsViewFilters.tsx
@@ -27,7 +27,7 @@ import {
   useWorkspaceDisplayNames,
 } from '../hooks/useWorkspaceDisplayNames';
 
-export interface InventoryFilters {
+export type InventoryFilters = {
   hostname_or_id: string;
   status: ApiHostGetHostListStalenessEnum[];
   source: ApiHostGetHostListRegisteredWithEnum[];
@@ -38,7 +38,7 @@ export interface InventoryFilters {
   operating_system: string[];
   workloads: string[];
   last_seen: LastSeenKey | '';
-}
+};
 
 export const isToolbarLabel = (
   label: string | ToolbarLabel,

--- a/src/components/SystemsView/hooks/useDeleteSystemsMutation.ts
+++ b/src/components/SystemsView/hooks/useDeleteSystemsMutation.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import { deleteSystemsById } from '../../InventoryTable/utils/api';
 import { getDeleteErrorDescription } from '../../InventoryTable/utils/errorUtils';
-import { type System } from '../../InventoryViews/hooks/useHostsQuery';
+import { type System } from '../../InventoryViews/hostsQueryOptions';
 import { useMemo } from 'react';
 import type { OnInvalidate } from '../SystemActionModalsContext';
 

--- a/src/components/SystemsView/hooks/usePatchSystemsMutation.ts
+++ b/src/components/SystemsView/hooks/usePatchSystemsMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
-import { type System } from '../../InventoryViews/hooks/useHostsQuery';
+import { type System } from '../../InventoryViews/hostsQueryOptions';
 import { useMemo } from 'react';
 import { patchHostById } from '../../../api/hostInventoryApiTyped';
 import { PatchHostIn } from '@redhat-cloud-services/host-inventory-client';

--- a/src/components/SystemsView/index.ts
+++ b/src/components/SystemsView/index.ts
@@ -1,11 +1,10 @@
 export { default } from './SystemsView';
-export type {
-  SystemsViewProps,
-  SystemsViewQueryOptionsFn,
-  SystemsViewQueryData,
-} from './SystemsView';
+export type { SystemsViewProps } from './SystemsView';
 export type {
   SystemsViewFetchParams,
+  SystemsViewItem,
+  SystemsViewQueryData,
+  SystemsViewFetchData,
   SortDirection,
   LastSeenCustomRange,
 } from './types';

--- a/src/components/SystemsView/index.ts
+++ b/src/components/SystemsView/index.ts
@@ -1,8 +1,8 @@
 export { default } from './SystemsView';
 export type {
   SystemsViewProps,
-  UseSystemsViewDataQuery,
-  SystemsViewDataQueryResult,
+  SystemsViewQueryOptionsFn,
+  SystemsViewQueryData,
 } from './SystemsView';
 export type {
   SystemsViewFetchParams,

--- a/src/components/SystemsView/index.ts
+++ b/src/components/SystemsView/index.ts
@@ -3,9 +3,8 @@ export type {
   SystemsViewProps,
   UseSystemsViewDataQuery,
   SystemsViewDataQueryResult,
-  SortDirection,
 } from './SystemsView';
-export type { SystemsViewFetchParams } from '../InventoryViews/hooks/useHostsQuery';
+export type { SystemsViewFetchParams, SortDirection } from './types';
 export type { OnInvalidate } from './SystemActionModalsContext';
 export type { SystemsViewActiveState } from './utils/deriveActiveState';
 export type { Column } from './columns/allColumnDefinitions';

--- a/src/components/SystemsView/index.ts
+++ b/src/components/SystemsView/index.ts
@@ -1,10 +1,9 @@
 export { default } from './SystemsView';
-export type { SystemsViewProps } from './SystemsView';
+export type { SystemsViewProps, SystemsViewFetchData } from './SystemsView';
 export type {
   SystemsViewFetchParams,
   SystemsViewItem,
   SystemsViewQueryData,
-  SystemsViewFetchData,
   SortDirection,
   LastSeenCustomRange,
 } from './types';

--- a/src/components/SystemsView/index.ts
+++ b/src/components/SystemsView/index.ts
@@ -4,7 +4,11 @@ export type {
   UseSystemsViewDataQuery,
   SystemsViewDataQueryResult,
 } from './SystemsView';
-export type { SystemsViewFetchParams, SortDirection } from './types';
+export type {
+  SystemsViewFetchParams,
+  SortDirection,
+  LastSeenCustomRange,
+} from './types';
 export type { OnInvalidate } from './SystemActionModalsContext';
 export type { SystemsViewActiveState } from './utils/deriveActiveState';
 export type { Column } from './columns/allColumnDefinitions';

--- a/src/components/SystemsView/types.ts
+++ b/src/components/SystemsView/types.ts
@@ -17,3 +17,22 @@ export type SystemsViewFetchParams<
   filters: TFilters;
   lastSeenCustomRange: LastSeenCustomRange;
 };
+
+export type SystemsViewItem = {
+  id: string;
+};
+
+export type SystemsViewQueryData<
+  TItem extends SystemsViewItem = SystemsViewItem,
+> = {
+  results: TItem[];
+  total: number;
+  deniedServices?: string[];
+};
+
+export type SystemsViewFetchData<
+  TItem extends SystemsViewItem = SystemsViewItem,
+  TFilters extends Record<string, unknown> = Record<string, unknown>,
+> = (
+  params: SystemsViewFetchParams<TFilters>,
+) => Promise<SystemsViewQueryData<TItem>>;

--- a/src/components/SystemsView/types.ts
+++ b/src/components/SystemsView/types.ts
@@ -2,6 +2,11 @@ import type { ISortBy } from '@patternfly/react-table';
 
 export type SortDirection = ISortBy['direction'];
 
+export type LastSeenCustomRange = {
+  start?: string;
+  end?: string;
+} | null;
+
 export type SystemsViewFetchParams<
   TFilters extends Record<string, unknown> = Record<string, unknown>,
 > = {
@@ -10,4 +15,5 @@ export type SystemsViewFetchParams<
   sortBy: string | undefined;
   direction: SortDirection | undefined;
   filters: TFilters;
+  lastSeenCustomRange: LastSeenCustomRange;
 };

--- a/src/components/SystemsView/types.ts
+++ b/src/components/SystemsView/types.ts
@@ -1,0 +1,13 @@
+import type { ISortBy } from '@patternfly/react-table';
+
+export type SortDirection = ISortBy['direction'];
+
+export type SystemsViewFetchParams<
+  TFilters extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  page: number;
+  perPage: number;
+  sortBy: string | undefined;
+  direction: SortDirection | undefined;
+  filters: TFilters;
+};

--- a/src/components/SystemsView/types.ts
+++ b/src/components/SystemsView/types.ts
@@ -22,17 +22,8 @@ export type SystemsViewItem = {
   id: string;
 };
 
-export type SystemsViewQueryData<
-  TItem extends SystemsViewItem = SystemsViewItem,
-> = {
-  results: TItem[];
+export type SystemsViewQueryData = {
+  results: SystemsViewItem[];
   total: number;
   deniedServices?: string[];
 };
-
-export type SystemsViewFetchData<
-  TItem extends SystemsViewItem = SystemsViewItem,
-  TFilters extends Record<string, unknown> = Record<string, unknown>,
-> = (
-  params: SystemsViewFetchParams<TFilters>,
-) => Promise<SystemsViewQueryData<TItem>>;

--- a/src/components/SystemsView/utils/deriveActiveState.ts
+++ b/src/components/SystemsView/utils/deriveActiveState.ts
@@ -13,10 +13,10 @@ export const deriveActiveState = ({
   isFetching,
   isError,
 }: DeriveActiveStateParams): SystemsViewActiveState =>
-  isLoading || isFetching || data == null
-    ? 'loading'
-    : isError
-      ? 'error'
+  isError
+    ? 'error'
+    : isLoading || isFetching || data == null
+      ? 'loading'
       : data.length === 0
         ? 'empty'
         : 'active';

--- a/src/components/SystemsView/utils/mapSystemsToRows.test.tsx
+++ b/src/components/SystemsView/utils/mapSystemsToRows.test.tsx
@@ -2,7 +2,7 @@ import { isDataViewTdObject } from '@patternfly/react-data-view';
 import { expect, jest } from '@jest/globals';
 import React from 'react';
 import type { Column } from '../columns/allColumnDefinitions';
-import type { System } from '../../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../../InventoryViews/hostsQueryOptions';
 import { DEFAULT_NAME_COLUMN_MIN_WIDTH } from './columnMinWidths';
 import { mapSystemsToRows } from './mapSystemsToRows';
 import { STICKY_ACTIONS_BODY_PROPS } from './stickyActionsColumn';

--- a/src/components/SystemsView/utils/mapSystemsToRows.tsx
+++ b/src/components/SystemsView/utils/mapSystemsToRows.tsx
@@ -8,7 +8,7 @@ import {
 import { STICKY_ACTIONS_BODY_PROPS } from './stickyActionsColumn';
 import { getStickyNameBodyProps } from './stickyNameColumn';
 import type { SystemWithPermissions } from '../../../Utilities/hooks/useHostIdsWithKessel';
-import type { System } from '../../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../../InventoryViews/hostsQueryOptions';
 import { Column } from '../columns/allColumnDefinitions';
 
 /** DataViewTrObject Extension, `meta` points to associated system objects. */

--- a/src/components/SystemsView/utils/mapSystemsToRows.tsx
+++ b/src/components/SystemsView/utils/mapSystemsToRows.tsx
@@ -12,14 +12,12 @@ import { Column } from '../columns/allColumnDefinitions';
 import type { SystemsViewItem } from '../types';
 
 /** DataViewTrObject Extension, `meta` points to associated system objects. */
-export type SystemsViewTableRow<
-  TItem extends SystemsViewItem = SystemsViewItem,
-> = DataViewTrObject & {
-  meta: TItem;
+export type SystemsViewTableRow = DataViewTrObject & {
+  meta: SystemsViewItem;
 };
 
-interface MapSystemsToRowsParams<TItem extends SystemsViewItem> {
-  data?: TItem[];
+interface MapSystemsToRowsParams {
+  data?: SystemsViewItem[];
   columns: readonly Column[];
   /**
    * When true (inventory views feature): sticky Name/actions cells and column min-widths.
@@ -27,12 +25,12 @@ interface MapSystemsToRowsParams<TItem extends SystemsViewItem> {
   isInventoryViewsEnabled: boolean;
 }
 
-export const mapSystemsToRows = <TItem extends SystemsViewItem>({
+export const mapSystemsToRows = ({
   data,
   columns,
   isInventoryViewsEnabled,
-}: MapSystemsToRowsParams<TItem>): SystemsViewTableRow<TItem>[] => {
-  const mapSystemToRow = (system: TItem): SystemsViewTableRow<TItem> => {
+}: MapSystemsToRowsParams): SystemsViewTableRow[] => {
+  const mapSystemToRow = (system: SystemsViewItem): SystemsViewTableRow => {
     const selectableColumnCells = columns
       .filter((col) => col.isShown)
       .map((col) => {

--- a/src/components/SystemsView/utils/mapSystemsToRows.tsx
+++ b/src/components/SystemsView/utils/mapSystemsToRows.tsx
@@ -7,17 +7,19 @@ import {
 } from './columnMinWidths';
 import { STICKY_ACTIONS_BODY_PROPS } from './stickyActionsColumn';
 import { getStickyNameBodyProps } from './stickyNameColumn';
-import type { SystemWithPermissions } from '../../../Utilities/hooks/useHostIdsWithKessel';
 import type { System } from '../../InventoryViews/hostsQueryOptions';
 import { Column } from '../columns/allColumnDefinitions';
+import type { SystemsViewItem } from '../types';
 
 /** DataViewTrObject Extension, `meta` points to associated system objects. */
-export type SystemsViewTableRow = DataViewTrObject & {
-  meta: System | SystemWithPermissions;
+export type SystemsViewTableRow<
+  TItem extends SystemsViewItem = SystemsViewItem,
+> = DataViewTrObject & {
+  meta: TItem;
 };
 
-interface MapSystemsToRowsParams {
-  data?: (System | SystemWithPermissions)[];
+interface MapSystemsToRowsParams<TItem extends SystemsViewItem> {
+  data?: TItem[];
   columns: readonly Column[];
   /**
    * When true (inventory views feature): sticky Name/actions cells and column min-widths.
@@ -25,18 +27,17 @@ interface MapSystemsToRowsParams {
   isInventoryViewsEnabled: boolean;
 }
 
-export const mapSystemsToRows = ({
+export const mapSystemsToRows = <TItem extends SystemsViewItem>({
   data,
   columns,
   isInventoryViewsEnabled,
-}: MapSystemsToRowsParams): SystemsViewTableRow[] => {
-  const mapSystemToRow = (
-    system: System | SystemWithPermissions,
-  ): SystemsViewTableRow => {
+}: MapSystemsToRowsParams<TItem>): SystemsViewTableRow<TItem>[] => {
+  const mapSystemToRow = (system: TItem): SystemsViewTableRow<TItem> => {
     const selectableColumnCells = columns
       .filter((col) => col.isShown)
       .map((col) => {
-        const cell = col.renderCell(system);
+        // FIXME remove type casting
+        const cell = col.renderCell(system as unknown as System);
         if (col.key === 'display_name') {
           if (isInventoryViewsEnabled) {
             return {
@@ -59,7 +60,8 @@ export const mapSystemsToRows = ({
       row: [
         ...selectableColumnCells,
         {
-          cell: <SystemsViewRowActions system={system} />,
+          // FIXME remove type casting
+          cell: <SystemsViewRowActions system={system as unknown as System} />,
           props: isInventoryViewsEnabled
             ? {
                 ...STICKY_ACTIONS_BODY_PROPS,

--- a/src/components/SystemsView/utils/systemHelpers.ts
+++ b/src/components/SystemsView/utils/systemHelpers.ts
@@ -1,4 +1,4 @@
-import type { System } from '../../InventoryViews/hooks/useHostsQuery';
+import type { System } from '../../InventoryViews/hostsQueryOptions';
 
 export const hasWorkspace = (system: System): boolean => {
   const ungrouped = system?.groups?.[0]?.ungrouped;


### PR DESCRIPTION
RHINENG-29491

## What
The way we fetch changed. We still using Tanstack Query, however we don't rely any longer on consumers to build it on their own and pass it. Instead we ask for two necessary parts in order to customize it (for their backend) internally.

useDataQuery prop was exchanged for 2 new props:
- queryKeyPrefix
- fetchData

## Why
With useQueryData Hook parameter we had to abide by the laws of hooks, which made it quite odd to work with. There was also a lots of footguns in setting up data query correctly for table.

Before we ended up with queryKeyPrefix and fetchData props, I've also tried to expose queryOptions as it is common/official way of sharing queries. This however still contained few foot guns for consumers and didn't offer much extra for it.

Hence In the end I've decided to consolidate API props to two which represent the  minimum requirements for custom query setup. This should be sufficient and simple enough and while improving ease of use.

## Testing

The new API is demonstrated in both of ours InventoryHosts and InventoryViews. Tables don't use their own hooks to fetch but setup hook inside SystemsView. 

Please explore UI and verify these tables still work as expected.

## Summary by Sourcery

Simplify SystemsView data loading by replacing consumer-provided query hooks with fetcher-based configuration and internal TanStack Query management.

New Features:
- Allow SystemsView consumers to provide a query key prefix and asynchronous data-fetching function for backend-specific table data.
- Add shared host and inventory-view fetchers that include tags and permission metadata in table results.

Bug Fixes:
- Preserve query errors as error states instead of masking them with loading states during failed or refetching requests.

Enhancements:
- Centralize SystemsView query caching, refetching, and mutation invalidation with TanStack Query.
- Standardize SystemsView fetch parameters and result types while removing consumer-managed query hooks.

Tests:
- Update SystemsView unit and RBAC coverage for promise-based fetching, query states, invalidation, and custom date-range parameters.

## Summary by Sourcery

Simplify SystemsView data loading by replacing consumer-provided query hooks with fetcher-based configuration and internal TanStack Query management.

New Features:
- Allow SystemsView consumers to configure backend data loading with a query key prefix and asynchronous fetch function.
- Provide shared host and inventory-view fetchers that enrich table results with tags and permission metadata.

Bug Fixes:
- Ensure query failures take precedence over loading states so errors are displayed correctly.

Enhancements:
- Centralize SystemsView query caching, refetching, and mutation invalidation with TanStack Query.
- Replace consumer-managed query hooks with standardized fetch parameters, result types, and internal data loading.

Tests:
- Update SystemsView unit and RBAC coverage for promise-based fetching, query states, invalidation, and custom date-range parameters.

Chores:
- Move shared system and fetch-related types out of the removed query hooks.