### PR TITLE
feat(RHINENG-28356): Save current table state to view configuration

### DIFF
--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -20,7 +20,13 @@ import {
   type ViewConfiguration,
 } from '../../api/inventoryViewsApi';
 import { createViewColumnSelector } from './createViewColumnSelector';
-import { parseViewConfigFilters } from './utils/viewConfigFilters';
+import { SORT_URL_PARAM, SORT_DIR_URL_PARAM } from '../SystemsView/constants';
+import { INITIAL_SORT } from '../SystemsView/hooks/useColumns';
+import type { Column } from '../SystemsView/columns/allColumnDefinitions';
+import {
+  buildViewConfigFilters,
+  parseViewConfigFilters,
+} from './utils/viewConfigFilters';
 
 const filtersToSearchParams = (
   filters?: Partial<Record<string, string | string[]>>,
@@ -38,6 +44,46 @@ const filtersToSearchParams = (
   }
   return params;
 };
+
+const getSortFromSearchParams = (
+  searchParams: URLSearchParams,
+): ViewConfiguration['sort'] => {
+  const key =
+    searchParams.get(SORT_URL_PARAM) ?? INITIAL_SORT.sortBy ?? 'last_check_in';
+
+  const direction =
+    (searchParams.get(SORT_DIR_URL_PARAM) as 'asc' | 'desc') ??
+    INITIAL_SORT.direction;
+
+  return { key, direction };
+};
+
+const getFiltersFromSearchParams = (
+  searchParams: URLSearchParams,
+): ViewConfiguration['filters'] | undefined => {
+  return buildViewConfigFilters({
+    operating_system: searchParams.getAll('operating_system'),
+    workloads: searchParams.getAll('workloads'),
+    rhcStatus: searchParams.getAll('rhcStatus'),
+    system_type: searchParams.getAll('system_type'),
+  });
+};
+
+// TODO: Once backend accepts 'tags' column in view configuration API,
+// update this function to not filter out columns without sortBy.
+// Current issue: Tags column has no sortBy field and gets filtered out,
+// so it cannot be saved to custom views. Backend currently rejects 'tags'
+// as invalid column key (see validation error listing valid keys).
+// Future fix: Change filter to use c.key instead of c.sortBy
+const normalizeViewColumns = (
+  columns: readonly Column[],
+): ViewConfiguration['columns'] =>
+  columns
+    .filter(
+      (c): c is Column & { sortBy: string } =>
+        c.isShown === true && typeof c.sortBy === 'string',
+    )
+    .map((c) => ({ key: c.sortBy }));
 
 const InventoryViews = () => {
   const { isReady, defaultFilters } = useAnsibleWorkloadDefault();
@@ -57,6 +103,13 @@ const InventoryViews = () => {
 
   const viewConfiguration =
     activeView?.configuration ?? ALL_SYSTEMS_CONFIGURATION;
+
+  const [currentColumns, setCurrentColumns] =
+    useState<ViewConfiguration['columns']>();
+
+  const handleColumnsChange = useCallback((columns: readonly Column[]) => {
+    setCurrentColumns(normalizeViewColumns(columns));
+  }, []);
 
   const columnSelector = useMemo(
     () => createViewColumnSelector(viewConfiguration)!,
@@ -117,12 +170,15 @@ const InventoryViews = () => {
     }
   };
 
-  // TODO: Replace with actual table state when available
   const getCurrentConfiguration = (): ViewConfiguration => {
+    const sort = getSortFromSearchParams(searchParams);
+    const filters = getFiltersFromSearchParams(searchParams);
+    const columns = currentColumns ?? activeView?.configuration?.columns ?? [];
+
     return {
-      columns: [],
-      sort: { key: 'display_name', direction: 'asc' },
-      filters: {},
+      columns,
+      sort,
+      ...(filters && { filters }),
     };
   };
 
@@ -176,6 +232,7 @@ const InventoryViews = () => {
         columns={columnSelector}
         initialSort={initialSort}
         initialFilters={initialFilters}
+        onColumnsChange={handleColumnsChange}
         useDataQuery={useInventoryViewsQuery}
         defaultFilters={defaultFilters}
         onInvalidate={() =>

--- a/src/components/SystemsView/SystemsView.tsx
+++ b/src/components/SystemsView/SystemsView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   DataView,
   useDataViewPagination,
@@ -90,6 +90,7 @@ export type SystemsViewProps = {
   defaultFilters?: Partial<InventoryFilters>;
   initialSort?: { sortBy: Column['sortBy']; direction: SortDirection };
   initialFilters?: Partial<InventoryFilters>;
+  onColumnsChange?: (columns: readonly Column[]) => void;
 };
 
 interface SystemsViewInnerProps {
@@ -99,6 +100,7 @@ interface SystemsViewInnerProps {
   onInvalidate: OnInvalidate;
   resolvedDefaultColumns: readonly Column[];
   initialSort?: { sortBy: Column['sortBy']; direction: SortDirection };
+  onColumnsChange?: (columns: readonly Column[]) => void;
 }
 
 const SystemsViewInner = ({
@@ -108,6 +110,7 @@ const SystemsViewInner = ({
   onInvalidate,
   resolvedDefaultColumns,
   initialSort,
+  onColumnsChange,
 }: SystemsViewInnerProps) => {
   const { filters, clearAllFilters, hasDefaultFilters, lastSeenCustomRange } =
     useDataViewFiltersContext();
@@ -201,6 +204,19 @@ const SystemsViewInner = ({
       deniedServices: deniedServices ?? [],
     });
 
+  // Wrapper to call both setColumns and onColumnsChange when user applies columns in modal.
+  // Note: ColumnManagementModal always calls this with direct column array, never with updater function.
+  const handleApplyColumns = useCallback(
+    (newColumns: React.SetStateAction<readonly Column[]>) => {
+      setColumns(newColumns);
+      // Only notify parent when columns are directly provided (modal always does this)
+      if (typeof newColumns !== 'function') {
+        onColumnsChange?.(newColumns);
+      }
+    },
+    [setColumns, onColumnsChange],
+  );
+
   const { hostsWithPermissions } = useHostIdsWithKessel(data);
 
   const rows = mapSystemsToRows({
@@ -265,7 +281,7 @@ const SystemsViewInner = ({
       <ColumnManagementModalProvider
         columns={columns}
         defaultColumns={annotatedDefaults}
-        setColumns={setColumns}
+        setColumns={handleApplyColumns}
       >
         <DataView selection={selection} activeState={activeState}>
           <PageSection hasBodyWrapper={false}>
@@ -333,6 +349,7 @@ export const SystemsView = ({
   defaultFilters,
   initialSort,
   initialFilters,
+  onColumnsChange,
 }: SystemsViewProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const resolvedDefaultColumns = useMemo(
@@ -354,6 +371,7 @@ export const SystemsView = ({
         onInvalidate={onInvalidate}
         resolvedDefaultColumns={resolvedDefaultColumns}
         initialSort={initialSort}
+        onColumnsChange={onColumnsChange}
       />
     </DataViewFiltersProvider>
   );


### PR DESCRIPTION
## Jira
[RHINENG-28356](https://redhat.atlassian.net/browse/RHINENG-28356)

## What
Capture current columns, sort, and filters from the table and persist them when saving a view. Wire onColumnsChange callback through SystemsView to track column state for getCurrentConfiguration.

Note: because of backend limitations, we can currently only save operating system, workload, and system type filters.

[RHINENG-28356]: https://redhat.atlassian.net/browse/RHINENG-28356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Save the current inventory table state as part of view configurations.

New Features:
- Persist the table’s current visible columns, sorting, and supported filters when saving inventory views.
- Track column changes from SystemsView and propagate them to view configuration saving.

Enhancements:
- Use existing table URL state and active view configuration as fallbacks when constructing saved configurations.