### PR TITLE
fix(RHINENG-29975): update RBAC tooltip phrasing

### DIFF
--- a/_playwright-tests/rbac/test_inventory_views_rbac.test.ts
+++ b/_playwright-tests/rbac/test_inventory_views_rbac.test.ts
@@ -31,7 +31,7 @@ test.describe(
 
       // Viewer account has no vulnerability access — expect lock icons
       const lockCells = page.locator(
-        'td span[aria-label*="do not have the necessary Vulnerability permissions"]',
+        'td span[aria-label*="request Vulnerability read access"]',
       );
       await expect(lockCells.first()).toBeVisible();
     });
@@ -50,7 +50,7 @@ test.describe(
       await modal.open();
 
       const vulnLock = modal.root.locator(
-        'span[aria-label*="do not have the necessary Vulnerability permissions"]',
+        'span[aria-label*="request Vulnerability read access"]',
       );
       await expect(vulnLock.first()).toBeVisible();
 

--- a/src/components/SystemsView/SystemsView.rbac.cy.js
+++ b/src/components/SystemsView/SystemsView.rbac.cy.js
@@ -159,19 +159,20 @@ describe('Per-service RBAC column gating', () => {
     cy.contains('test-host-1.example.com').should('be.visible');
 
     // Verify: vulnerability columns show lock icons (2 rows, both denied)
-    cy.get('td span[aria-label*="do not have the necessary Vulnerability"]')
+    cy.get('td span[aria-label*="request Vulnerability read access"]')
       .should('have.length', 2)
       .first()
       .find('svg')
       .should('exist');
 
     // Verify: compliance columns show lock icons (2 rows, both denied)
-    cy.get(
-      'td span[aria-label*="do not have the necessary Compliance"]',
-    ).should('have.length', 2);
+    cy.get('td span[aria-label*="request Compliance read access"]').should(
+      'have.length',
+      2,
+    );
 
     // Verify: advisor columns show real data (no lock icons)
-    cy.get('td span[aria-label*="do not have the necessary Advisor"]').should(
+    cy.get('td span[aria-label*="request Advisor read access"]').should(
       'not.exist',
     );
 
@@ -194,9 +195,10 @@ describe('Per-service RBAC column gating', () => {
     cy.contains('test-host-1.example.com').should('be.visible');
 
     // Verify: Total CVEs column shows lock icons (denied)
-    cy.get(
-      'td span[aria-label*="do not have the necessary Vulnerability"]',
-    ).should('have.length', 2);
+    cy.get('td span[aria-label*="request Vulnerability read access"]').should(
+      'have.length',
+      2,
+    );
 
     // Verify: sort has automatically fallen back to Name (display_name) ascending
     // The useEffect in useColumns.tsx detects the locked column and resets to FALLBACK_SORT
@@ -214,9 +216,7 @@ describe('Per-service RBAC column gating', () => {
     cy.contains('test-host-1.example.com').should('be.visible');
 
     // Verify: no lock icons anywhere
-    cy.get('td span[aria-label*="do not have the necessary"]').should(
-      'not.exist',
-    );
+    cy.get('td span[aria-label*="To view this data"]').should('not.exist');
 
     // Verify real vulnerability data is shown
     cy.contains('td', '12').should('be.visible'); // total_cves for host 1
@@ -244,16 +244,18 @@ describe('Per-service RBAC column gating', () => {
     cy.contains('test-host-1.example.com').should('be.visible');
 
     // Verify: all app-data columns show lock icons
-    cy.get('td span[aria-label*="do not have the necessary Advisor"]').should(
+    cy.get('td span[aria-label*="request Advisor read access"]').should(
       'have.length',
       2,
     );
-    cy.get(
-      'td span[aria-label*="do not have the necessary Vulnerability"]',
-    ).should('have.length', 2);
-    cy.get(
-      'td span[aria-label*="do not have the necessary Compliance"]',
-    ).should('have.length', 2);
+    cy.get('td span[aria-label*="request Vulnerability read access"]').should(
+      'have.length',
+      2,
+    );
+    cy.get('td span[aria-label*="request Compliance read access"]').should(
+      'have.length',
+      2,
+    );
 
     // Verify: inventory columns show real data
     cy.contains('th', 'Name').should('be.visible');

--- a/src/components/SystemsView/columns/CellValue.test.tsx
+++ b/src/components/SystemsView/columns/CellValue.test.tsx
@@ -35,7 +35,7 @@ describe('CellValue', () => {
       render(<CellValue type="noPermission" appName="vulnerability" />);
       expect(
         screen.getByLabelText(
-          'You do not have the necessary Vulnerability permissions to view this data. Contact your organization administrator to request Vulnerability read access.',
+          'To view this data, contact your Organization Administrator to request Vulnerability read access.',
         ),
       ).toBeInTheDocument();
     });
@@ -44,7 +44,7 @@ describe('CellValue', () => {
       render(<CellValue type="noPermission" appName="advisor" />);
       expect(
         screen.getByLabelText(
-          'You do not have the necessary Advisor permissions to view this data. Contact your organization administrator to request Advisor read access.',
+          'To view this data, contact your Organization Administrator to request Advisor read access.',
         ),
       ).toBeInTheDocument();
     });

--- a/src/constants.js
+++ b/src/constants.js
@@ -312,7 +312,7 @@ export const NO_MODIFY_HOST_KESSEL_TOOLTIP_MESSAGE =
 export const NO_MANAGE_USER_ACCESS_TOOLTIP_MESSAGE =
   'You must be an organization administrator to modify User Access configuration.';
 export const noServicePermissionTooltip = (appName) =>
-  `You do not have the necessary ${appName} permissions to view this data. Contact your organization administrator to request ${appName} read access.`;
+  `To view this data, contact your Organization Administrator to request ${appName} read access.`;
 const REMEDIATIONS_DISPLAY = 'Automation Toolkit > Remediations';
 const REMEDIATIONS_LINK = (
   <InsightsLink aria-label="rhc-remediations-link" to={'/'} app="remediations">


### PR DESCRIPTION
RHINENG-29975

## What
Update the RBAC permission tooltip message phrasing across Inventory Views table cells and column management modal.

- **From:** `You do not have the necessary ${appName} permissions to view this data. Contact your organization administrator to request ${appName} read access.`
- **To:** `To view this data, contact your Organization Administrator to request ${appName} read access.`

## Why
Standardizes the permission tooltip phrasing per UX review on RHINENG-29975 / RHINENG-28774.

## Testing
- Unit tests in `src/components/SystemsView/columns/CellValue.test.tsx` updated and passing
- E2E selector in `_playwright-tests/rbac/test_inventory_views_rbac.test.ts` updated
- Full unit test suite and lint/type checks passing

## Summary by Sourcery

Standardize RBAC permission tooltip phrasing across Inventory Views and update related test expectations.

Bug Fixes:
- Update RBAC permission tooltip messaging to use the standardized Organization Administrator phrasing across Inventory Views.

Tests:
- Update unit, Cypress, and Playwright coverage to validate the revised RBAC tooltip text and selectors.