### PR TITLE
test(GloablTagfilter): update locators due global tag filter disabling

### DIFF
--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -59,9 +59,7 @@ export const filterSystemsWithConditionalFilter = async (
     // TODO: Implement logic to select the Status filter option.
     // Logic not implemented yet. Test continues without filtering.
   } else if (filterName === 'Tags') {
-    const inputLocator = isLegacyInventoryTableEnabled
-      ? page.getByPlaceholder('Filter by tags').nth(1)
-      : page.getByPlaceholder('Filter by tags');
+    const inputLocator = page.getByPlaceholder('Filter by tags');
     await inputLocator.click();
     await inputLocator.fill(option);
 
@@ -84,7 +82,6 @@ export const filterSystemsWithConditionalFilter = async (
   } else if (filterName === 'Operating system') {
     await page
       .getByRole('button', { name: 'Group filter' })
-      .nth(1)
       .or(
         page.locator(
           '[data-ouia-component-id="SystemsViewOperatingSystemsFilter"]',

--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -12,7 +12,6 @@ import {
   TAG,
   isSystemsViewEnabled,
   isInventoryViewsEnabled,
-  isLegacyInventoryTableEnabled,
 } from './helpers/constants';
 import { scrollColumnIntoView } from './helpers/columnHelpers';
 
@@ -207,9 +206,7 @@ test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
 
     await test.step('Verify Tags Modal has expected tag', async () => {
       // TODO: Remove when RHINENG-22581 is fixed
-      const inputLocator = isLegacyInventoryTableEnabled
-        ? page.getByPlaceholder('Filter by tags').nth(1)
-        : page.getByPlaceholder('Filter by tags');
+      const inputLocator = page.getByPlaceholder('Filter by tags');
       await inputLocator.fill('');
 
       // get name of system we check the tags to verify tags modal title


### PR DESCRIPTION
Update test locator due global tag filter disabling

Should fix Legacy Table CI

## Summary by Sourcery

Update systems filter test locators to support the global tag filter configuration.

Bug Fixes:
- Update systems filtering test locators to work when the global tag filter is disabled, fixing Legacy Table CI failures.

Enhancements:
- Simplify tag and operating-system filter locator handling by removing legacy-table-specific selection logic.

Tests:
- Adjust systems filtering tests to use the current tag filter locator.