### PR TITLE
feat(RHINENG-30319): Show 4 advisories in installable advisories

### DIFF
--- a/src/components/SystemsView/columns/content/cells/InstallableAdvisories.test.tsx
+++ b/src/components/SystemsView/columns/content/cells/InstallableAdvisories.test.tsx
@@ -7,7 +7,8 @@ import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
 import type { PatchAppData } from '@redhat-cloud-services/host-inventory-client';
 
 const systemId = 'test-system-uuid';
-const PATCH_SYSTEM_PATH = `//patch/systems/${systemId}`;
+const getInventoryPatchPath = (advisoryType: string) =>
+  `//inventory/${systemId}?appName=patch&offset=0&filter[advisory_type_name]=${advisoryType}`;
 
 function renderInstallableAdvisories(appData: PatchAppData | undefined) {
   return render(
@@ -72,32 +73,44 @@ describe('InstallableAdvisories cell', () => {
     expect(screen.getByText(NOT_SET)).toBeInTheDocument();
   });
 
-  it('should render only the security advisory icon and count when rhsa is non-zero', () => {
+  it('should render all advisory types, with only security being non-zero', () => {
     renderInstallableAdvisories(securityOnlyPatchAppData);
 
     expect(screen.queryByText(NOT_SET)).not.toBeInTheDocument();
+    // Non-zero count (security)
     expect(screen.getByText('7')).toBeInTheDocument();
+    // Zero counts (should still be visible)
+    expect(screen.getAllByText('0')).toHaveLength(3); // bug fixes, enhancements, other
   });
 
-  it('should render only the bug fix advisory icon and count when rhba is non-zero', () => {
+  it('should render all advisory types, with only bug fixes being non-zero', () => {
     renderInstallableAdvisories(bugfixesOnlyPatchAppData);
 
     expect(screen.queryByText(NOT_SET)).not.toBeInTheDocument();
+    // Non-zero count (bug fixes)
     expect(screen.getByText('4')).toBeInTheDocument();
+    // Zero counts (should still be visible)
+    expect(screen.getAllByText('0')).toHaveLength(3); // security, enhancements, other
   });
 
-  it('should render only the enhancement advisory icon and count when rhea is non-zero', () => {
+  it('should render all advisory types, with only enhancements being non-zero', () => {
     renderInstallableAdvisories(enhancementsOnlyPatchAppData);
 
     expect(screen.queryByText(NOT_SET)).not.toBeInTheDocument();
+    // Non-zero count (enhancements)
     expect(screen.getByText('2')).toBeInTheDocument();
+    // Zero counts (should still be visible)
+    expect(screen.getAllByText('0')).toHaveLength(3); // security, bug fixes, other
   });
 
-  it('should render only the other advisory icon and count when other is non-zero', () => {
+  it('should render all advisory types, with only other being non-zero', () => {
     renderInstallableAdvisories(otherOnlyPatchAppData);
 
     expect(screen.queryByText(NOT_SET)).not.toBeInTheDocument();
+    // Non-zero count (other)
     expect(screen.getByText('1')).toBeInTheDocument();
+    // Zero counts (should still be visible)
+    expect(screen.getAllByText('0')).toHaveLength(3); // security, bug fixes, enhancements
   });
 
   it('should render all advisory type counts when each installable count is non-zero', () => {
@@ -110,14 +123,44 @@ describe('InstallableAdvisories cell', () => {
     expect(screen.getByText('9')).toBeInTheDocument();
   });
 
-  it('should link each advisory type to the patch system page', () => {
+  it('should link each non-zero advisory type to the filtered patch system page', () => {
     renderInstallableAdvisories(mixedCountsPatchAppData);
 
-    ['5', '11', '3', '9'].forEach((count) => {
-      expect(screen.getByRole('link', { name: count })).toHaveAttribute(
-        'href',
-        PATCH_SYSTEM_PATH,
-      );
-    });
+    // Security advisories (count: 5)
+    expect(screen.getByRole('link', { name: '5' })).toHaveAttribute(
+      'href',
+      getInventoryPatchPath('security'),
+    );
+
+    // Bug fixes (count: 11)
+    expect(screen.getByRole('link', { name: '11' })).toHaveAttribute(
+      'href',
+      getInventoryPatchPath('bugfix'),
+    );
+
+    // Enhancements (count: 3)
+    expect(screen.getByRole('link', { name: '3' })).toHaveAttribute(
+      'href',
+      getInventoryPatchPath('enhancement'),
+    );
+
+    // Other (count: 9)
+    expect(screen.getByRole('link', { name: '9' })).toHaveAttribute(
+      'href',
+      getInventoryPatchPath('other'),
+    );
+  });
+
+  it('should not link zero-count advisory types', () => {
+    renderInstallableAdvisories(securityOnlyPatchAppData);
+
+    // Security (count: 7) should be a link
+    expect(screen.getByRole('link', { name: '7' })).toBeInTheDocument();
+
+    // Zero counts should NOT be links (there should be no links with text '0')
+    expect(screen.queryAllByRole('link', { name: '0' })).toHaveLength(0);
+
+    // But the zero text should still be visible (3 times: bug fixes, enhancements, other)
+    expect(screen.getAllByText('0')).toHaveLength(3);
   });
 });

--- a/src/components/SystemsView/columns/content/cells/InstallableAdvisories.tsx
+++ b/src/components/SystemsView/columns/content/cells/InstallableAdvisories.tsx
@@ -43,6 +43,42 @@ function patchAppDataToInstallableCounts(
   ];
 }
 
+interface AdvisoryIconWithLinkProps {
+  count: number;
+  tooltipText: string;
+  Icon: React.ComponentType;
+  systemId: string;
+  advisoryType: 'security' | 'bugfix' | 'enhancement' | 'other';
+}
+
+const AdvisoryIconWithLink: React.FC<AdvisoryIconWithLinkProps> = ({
+  count,
+  tooltipText,
+  Icon,
+  systemId,
+  advisoryType,
+}) => {
+  const patchSystemLink = {
+    pathname: `/${systemId}`,
+    search: `appName=patch&offset=0&filter[advisory_type_name]=${advisoryType}`,
+  };
+
+  const iconAndCount = (
+    <AdvisoryIcon tooltipText={tooltipText} count={count} Icon={Icon} />
+  );
+
+  // Only link if count > 0
+  if (count > 0) {
+    return (
+      <InsightsLink app="inventory" to={patchSystemLink} preview={false}>
+        {iconAndCount}
+      </InsightsLink>
+    );
+  }
+
+  return iconAndCount;
+};
+
 interface InstallableAdvisoriesProps {
   appData: PatchAppData | undefined;
   systemId: string;
@@ -57,8 +93,25 @@ const InstallableAdvisories = ({
   }
 
   const [rhea, rhba, rhsa, other] = patchAppDataToInstallableCounts(appData);
-  const allZero = [rhea, rhba, rhsa, other].every((item) => item === 0);
-  const patchSystemLink = { pathname: `/systems/${systemId}` };
+
+  // Check if all advisory data is missing (null/undefined)
+  const allMissing = [rhea, rhba, rhsa, other].every(
+    (count) => count === null || count === undefined,
+  );
+
+  if (allMissing) {
+    return <CellValue type="notAvailable" reason={PATCH_DATA_NOT_AVAILABLE} />;
+  }
+
+  // Convert null/undefined to 0 for display (only if we have at least some valid data)
+  const rheaCount = rhea ?? 0;
+  const rhbaCount = rhba ?? 0;
+  const rhsaCount = rhsa ?? 0;
+  const otherCount = other ?? 0;
+
+  const allZero = [rheaCount, rhbaCount, rhsaCount, otherCount].every(
+    (count) => count === 0,
+  );
 
   if (allZero) {
     return <CellValue type="notSet" value={NOT_SET} />;
@@ -69,50 +122,42 @@ const InstallableAdvisories = ({
       type="present"
       value={
         <Flex style={{ display: 'inline-flex', flexWrap: 'nowrap' }}>
-          {rhsa !== 0 && (
-            <FlexItem spacer={{ default: 'spacerXs' }}>
-              <InsightsLink app="patch" to={patchSystemLink} preview={false}>
-                <AdvisoryIcon
-                  tooltipText="Security advisories"
-                  count={rhsa}
-                  Icon={SecurityIcon}
-                />
-              </InsightsLink>
-            </FlexItem>
-          )}
-          {rhba !== 0 && (
-            <FlexItem spacer={{ default: 'spacerXs' }}>
-              <InsightsLink app="patch" to={patchSystemLink} preview={false}>
-                <AdvisoryIcon
-                  tooltipText="Bug fixes"
-                  count={rhba}
-                  Icon={BugIcon}
-                />
-              </InsightsLink>
-            </FlexItem>
-          )}
-          {rhea !== 0 && (
-            <FlexItem spacer={{ default: 'spacerXs' }}>
-              <InsightsLink app="patch" to={patchSystemLink} preview={false}>
-                <AdvisoryIcon
-                  tooltipText="Enhancements"
-                  count={rhea}
-                  Icon={EnhancementIcon}
-                />
-              </InsightsLink>
-            </FlexItem>
-          )}
-          {other !== 0 && (
-            <FlexItem spacer={{ default: 'spacerXs' }}>
-              <InsightsLink app="patch" to={patchSystemLink} preview={false}>
-                <AdvisoryIcon
-                  tooltipText="Other"
-                  count={other}
-                  Icon={FlagIcon}
-                />
-              </InsightsLink>
-            </FlexItem>
-          )}
+          <FlexItem spacer={{ default: 'spacerXs' }}>
+            <AdvisoryIconWithLink
+              tooltipText="Security advisories"
+              count={rhsaCount}
+              Icon={SecurityIcon}
+              systemId={systemId}
+              advisoryType="security"
+            />
+          </FlexItem>
+          <FlexItem spacer={{ default: 'spacerXs' }}>
+            <AdvisoryIconWithLink
+              tooltipText="Bug fixes"
+              count={rhbaCount}
+              Icon={BugIcon}
+              systemId={systemId}
+              advisoryType="bugfix"
+            />
+          </FlexItem>
+          <FlexItem spacer={{ default: 'spacerXs' }}>
+            <AdvisoryIconWithLink
+              tooltipText="Enhancements"
+              count={rheaCount}
+              Icon={EnhancementIcon}
+              systemId={systemId}
+              advisoryType="enhancement"
+            />
+          </FlexItem>
+          <FlexItem spacer={{ default: 'spacerXs' }}>
+            <AdvisoryIconWithLink
+              tooltipText="Other"
+              count={otherCount}
+              Icon={FlagIcon}
+              systemId={systemId}
+              advisoryType="other"
+            />
+          </FlexItem>
         </Flex>
       }
     />


### PR DESCRIPTION
## Jira
[RHINENG-30319](https://redhat.atlassian.net/browse/RHINENG-30319)

## What
The Installable advisories column should show all 4 values, even if one of the values is 0. If the value is 0, there is no link. The links have also been updated to link to the system details page, content table, and filter applied for given advisory. But if there are no advisories at all, it still shows "No installable advisories".

## Screenshots/Videos (if applicable)
<img width="444" height="676" alt="image" src="https://github.com/user-attachments/assets/d80c9742-c846-4100-a4e8-81fde3197a67" />

<img width="293" height="585" alt="image" src="https://github.com/user-attachments/assets/0eacf7a5-a1a7-4e8c-8510-d79d076b5352" />

[RHINENG-30319]: https://redhat.atlassian.net/browse/RHINENG-30319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Show all installable advisory categories while linking only available counts to their corresponding filtered system views.

New Features:
- Display all four installable advisory categories, including zero-valued counts.
- Link non-zero advisory counts to the system’s filtered inventory patch view by advisory type.

Bug Fixes:
- Preserve the no-installable-advisories state when all advisory counts are zero and the unavailable state when advisory data is missing.

Tests:
- Update installable advisory coverage for zero-count visibility, filtered links, and non-linking zero values.