### PR TITLE
fix(RHCLOUD-50431): gate getUserPermissions('inventory') calls

### DIFF
--- a/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
+++ b/src/components/InventoryGroups/Modals/AddSelectedHostsToGroupModal.js
@@ -9,6 +9,7 @@ import { CreateGroupButton } from '../SmallComponents/CreateGroupButton';
 import { addHostSchema } from './ModalSchemas/schemes';
 import CreateGroupModal from './CreateGroupModal';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useKesselMigrationFeatureFlag } from '../../../Utilities/hooks/useKesselMigrationFeatureFlag';
 
 const AddSelectedHostsToGroupModal = ({
   isModalOpen,
@@ -18,6 +19,7 @@ const AddSelectedHostsToGroupModal = ({
 }) => {
   const chrome = useChrome();
   const apiWithToast = useApiWithToast();
+  const isKesselEnabled = useKesselMigrationFeatureFlag();
   const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false);
   const handleAddDevices = (values) => {
     const group = JSON.parse(values.group); // parse is a workaround for https://github.com/data-driven-forms/react-forms/issues/1401
@@ -52,7 +54,7 @@ const AddSelectedHostsToGroupModal = ({
           closeModal={() => setIsModalOpen(false)}
           title="Add to workspace"
           submitLabel="Add"
-          schema={addHostSchema(hosts, chrome)}
+          schema={addHostSchema(hosts, chrome, isKesselEnabled)}
           additionalMappers={{
             'create-group-btn': {
               component: CreateGroupButton,

--- a/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
+++ b/src/components/InventoryGroups/Modals/ModalSchemas/schemes.js
@@ -106,11 +106,13 @@ const createDescription = (hosts) => {
 //it allows to create custom item types in the modal
 
 const loadOptions = awesomeDebouncePromise(
-  async (searchValue, chrome) => {
+  async (searchValue, chrome, isKesselEnabled) => {
     const fetchedGroups = await getWritableGroups(
       searchValue,
       { page: 1, per_page: 100 }, // TODO: make the list paginated
-      () => chrome.getUserPermissions('inventory'),
+      isKesselEnabled
+        ? undefined
+        : () => chrome.getUserPermissions('inventory'),
     );
 
     return fetchedGroups.map(({ name, id }) => ({
@@ -122,7 +124,7 @@ const loadOptions = awesomeDebouncePromise(
   { onlyResolvesLast: false },
 );
 
-export const addHostSchema = (hosts, chrome) => ({
+export const addHostSchema = (hosts, chrome, isKesselEnabled = false) => ({
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,
@@ -138,7 +140,8 @@ export const addHostSchema = (hosts, chrome) => ({
       isRequired: true,
       isClearable: true,
       placeholder: 'Type or click to select a workspace',
-      loadOptions: (searchValue) => loadOptions(searchValue, chrome),
+      loadOptions: (searchValue) =>
+        loadOptions(searchValue, chrome, isKesselEnabled),
       options: [],
       validate: [{ type: validatorTypes.REQUIRED }],
       updatingMessage: 'Loading workspaces...',


### PR DESCRIPTION
## Jira
[RHCLOUD-50431](https://redhat.atlassian.net/browse/RHCLOUD-50431)

## What
This PR gates the `chrome.getUserPermissions('inventory')` calls so they're only called when the kessel migration feature flag returns false.

[RHCLOUD-50431]: https://redhat.atlassian.net/browse/RHCLOUD-50431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Prevent inventory permission lookups when Kessel migration is enabled.

Bug Fixes:
- Gate inventory user-permission requests during workspace selection when the Kessel migration feature flag is enabled.

Enhancements:
- Pass the Kessel migration state through the add-host modal and workspace-loading flow to avoid unnecessary permission checks.