### PR TITLE
fix(InventoryViews):set All systems on top of menu

### DIFF
--- a/_playwright-tests/test_systems_filter.test.ts
+++ b/_playwright-tests/test_systems_filter.test.ts
@@ -100,7 +100,7 @@ test.describe('Filtering Systems Tests', { tag: ['@systems-table'] }, () => {
       })
       .or(
         page.locator(
-          'td[data-ouia-component-id^="systems-view-table-td-"][data-ouia-component-id$="-1"]',
+          'td[data-ouia-component-id^="systems-view-table-td-"][data-ouia-component-id$="-2"]',
           {
             hasText: workspaceWithSystem.workspaceName,
           },

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -1,5 +1,11 @@
 import { useQueryClient } from '@tanstack/react-query';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useSearchParams } from 'react-router-dom';
 import SystemsView from '../SystemsView/SystemsView';
 import type { SortDirection } from '../SystemsView/SystemsView';
@@ -139,6 +145,20 @@ const InventoryViews = () => {
     () => viewsData?.pages.flatMap((page) => page.results) ?? [],
     [viewsData],
   );
+  const allSystemsViewId = useMemo(
+    () => viewsList.find((v) => v.is_system_view)?.id ?? ALL_SYSTEMS_VIEW_ID,
+    [viewsList],
+  );
+
+  useEffect(() => {
+    if (
+      activeViewId === ALL_SYSTEMS_VIEW_ID &&
+      allSystemsViewId !== ALL_SYSTEMS_VIEW_ID
+    ) {
+      setActiveViewId(allSystemsViewId);
+    }
+  }, [activeViewId, allSystemsViewId]);
+
   const activeView = viewsList.find((v) => v.id === activeViewId);
   const isSystemView = activeView?.is_system_view ?? true;
   const viewsLoaded = !!viewsData;
@@ -263,7 +283,7 @@ const InventoryViews = () => {
   const handleDeleteSuccess = (viewId: string) => {
     setIsDeleteModalOpen(false);
     if (viewId === activeViewId) {
-      setActiveViewId(ALL_SYSTEMS_VIEW_ID);
+      setActiveViewId(allSystemsViewId);
       setSearchParams(new URLSearchParams(), { replace: true });
     }
   };

--- a/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
@@ -120,18 +120,18 @@ export const ManageViewButton = ({
         <DropdownItem key="save-as" onClick={onSaveAs}>
           Save as
         </DropdownItem>
-        <DropdownItem key="rename" onClick={onRename} isDisabled={isSystemView}>
-          Rename
-        </DropdownItem>
-        <DropdownItem key="delete" onClick={onDelete} isDisabled={isSystemView}>
-          Delete
-        </DropdownItem>
         <DropdownItem
           key="save"
           onClick={onSave}
           isDisabled={!isViewDirty || isSystemView || !isOwner}
         >
           Save
+        </DropdownItem>
+        <DropdownItem key="rename" onClick={onRename} isDisabled={isSystemView}>
+          Rename
+        </DropdownItem>
+        <DropdownItem key="delete" onClick={onDelete} isDisabled={isSystemView}>
+          Delete
         </DropdownItem>
       </DropdownList>
     </Dropdown>

--- a/src/components/InventoryViews/ViewsToolbar/ViewSelector.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewSelector.tsx
@@ -9,10 +9,7 @@ import {
   SelectOption,
   Spinner,
 } from '@patternfly/react-core';
-import {
-  ALL_SYSTEMS_VIEW_ID,
-  type ViewOut,
-} from '../../../api/inventoryViewsApi';
+import type { ViewOut } from '../../../api/inventoryViewsApi';
 import { DEFAULT_PAGE_SIZE } from '../hooks/useViewsQuery';
 
 export interface ViewSelectorProps {
@@ -47,10 +44,12 @@ const ViewSelector = ({
     systemViews: ViewOut[];
   }>(
     (acc, view) => {
-      if (view.id === ALL_SYSTEMS_VIEW_ID) {
-        acc.allSystemsView = view;
-      } else if (view.is_system_view) {
-        acc.systemViews.push(view);
+      if (view.is_system_view) {
+        if (!acc.allSystemsView) {
+          acc.allSystemsView = view;
+        } else {
+          acc.systemViews.push(view);
+        }
       } else {
         acc.userViews.push(view);
       }

--- a/src/components/InventoryViews/hooks/useViewDirtyState.ts
+++ b/src/components/InventoryViews/hooks/useViewDirtyState.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import type { ViewConfiguration } from '../../../api/inventoryViewsApi';
-import { ALL_SYSTEMS_VIEW_ID } from '../../../api/inventoryViewsApi';
 import type { InventoryFilters } from '../../SystemsView/filters/SystemsViewFilters';
 import type { Column } from '../../SystemsView/columns/types';
 import {

--- a/src/components/InventoryViews/hooks/useViewsQuery.ts
+++ b/src/components/InventoryViews/hooks/useViewsQuery.ts
@@ -1,10 +1,15 @@
+import { useEffect } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { listViewsApi } from '../../../api/inventoryViewsApi';
 
 export const DEFAULT_PAGE_SIZE = 50;
 
 /**
- * Hook for fetching the list of inventory views visible to the current user, paginated.
+ * Hook for fetching the list of inventory views visible to the current user.
+ *
+ * The views are fetched page by page, but every page is loaded eagerly so the
+ * complete list is always available. This guarantees the "All systems" view is
+ * present regardless of which page it lands on.
  *
  *  @param pageSize number of views to fetch per page
  *  @returns        an infinite query result with `data.pages`, `fetchNextPage`, and `hasNextPage`
@@ -13,7 +18,7 @@ export const DEFAULT_PAGE_SIZE = 50;
  * const viewNames = data?.pages.flatMap((p) => p.results).map((v) => v.name) ?? [];
  */
 export const useViewsQuery = (pageSize = DEFAULT_PAGE_SIZE) => {
-  return useInfiniteQuery({
+  const query = useInfiniteQuery({
     queryKey: ['views', pageSize],
     queryFn: ({ pageParam }) =>
       listViewsApi({ page: pageParam, perPage: pageSize }),
@@ -23,4 +28,14 @@ export const useViewsQuery = (pageSize = DEFAULT_PAGE_SIZE) => {
         ? lastPage.page + 1
         : null,
   });
+
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
+
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return query;
 };


### PR DESCRIPTION
1. Fix All systems view: always present, pinned, and selected by default (_default selection currently falls back to the All systems view. Once the "Set as default" feature (per-user default view API) is introduced, this will be updated to select the user's chosen default instead_)
2. fix menu option order in Manage view

## Summary by Sourcery

Keep the All systems view pinned as the default inventory view and align Manage view actions with the intended order.

Bug Fixes:
- Ensure the All systems view is always available, selected by default, and restored after deleting the active view.
- Correct the Manage view menu option order.

Enhancements:
- Load all inventory view pages eagerly so system views can be identified regardless of pagination.

Tests:
- Update the systems filter test to reflect the revised view ordering.