### PR TITLE
feat(RHINENG-30337): Combine vulnerability severities into one column

### DIFF
--- a/_playwright-tests/helpers/views/columnHelpers.ts
+++ b/_playwright-tests/helpers/views/columnHelpers.ts
@@ -87,9 +87,9 @@ export const malwareColumns = [
 ];
 
 export const vulnerabilityColumns = [
-  'Total CVEs',
-  'Important CVEs',
+  'Vulnerabilities',
   'Critical CVEs',
+  'Important CVEs',
   'CVEs with security rules',
   'CVEs with known exploits',
 ];
@@ -253,9 +253,9 @@ const COLUMN_VALIDATIONS: Record<string, ColumnValidationConfig> = {
     type: 'numeric',
     ignoreValues: [NOT_AVAILABLE],
   },
-  'Total CVEs': {
+  Vulnerabilities: {
     type: 'numeric',
-    ignoreValues: [NOT_AVAILABLE],
+    ignoreValues: [NOT_AVAILABLE, 'No vulnerabilities'],
   },
   'Critical CVEs': {
     type: 'numeric',
@@ -341,6 +341,8 @@ export async function validateDataColumnSortOrder(
       validateInstallableAdvisoriesOrder(columnValues, direction);
     } else if (columnName === 'Recommendations') {
       validateRecommendationsOrder(columnValues, direction);
+    } else if (columnName === 'Vulnerabilities') {
+      validateVulnerabilitiesOrder(columnValues, direction);
     } else {
       validateNumericOrder(columnValues, direction);
     }
@@ -454,6 +456,30 @@ function validateRecommendationsOrder(
 ) {
   // For the new multi-icon Recommendations column, the displayed values don't directly
   // correspond to the sort key (critical count), so we just verify the column is sortable
+  // by checking that not all values are identical
+  const uniqueValues = new Set(values);
+  expect(uniqueValues.size).toBeGreaterThan(1);
+}
+
+/**
+ * Validates Vulnerabilities column order.
+ * The column displays severity icons (Critical, Important, Moderate, Low) but sorts by Critical CVE count.
+ * Since icons display multiple values and may include fallback values (--), we skip detailed validation
+ * and just verify the data changes across rows (not all the same value).
+ *
+ * TODO: Once backend provides moderate_cves and low_cves data and implements proper sorting,
+ * update this to do full numeric validation by parsing the critical CVE count from the composite display.
+ *
+ *  @param {string[]} values    - Array of values from the table.
+ *  @param {string}   direction - Sort direction ('ascending' or 'descending').
+ */
+function validateVulnerabilitiesOrder(
+  values: string[],
+  direction: 'ascending' | 'descending',
+) {
+  // TODO: Temporary validation - replace with proper numeric validation once backend is ready.
+  // For the new multi-icon Vulnerabilities column, the displayed values don't directly
+  // correspond to the sort key (critical CVE count), so we just verify the column is sortable
   // by checking that not all values are identical
   const uniqueValues = new Set(values);
   expect(uniqueValues.size).toBeGreaterThan(1);

--- a/_playwright-tests/rbac/test_inventory_views_rbac.test.ts
+++ b/_playwright-tests/rbac/test_inventory_views_rbac.test.ts
@@ -66,17 +66,17 @@ test.describe(
 
       const modal = columnManagementModal(page);
       await modal.open();
-      await modal.enableColumn('Total CVEs');
+      await modal.enableColumn('Critical CVEs');
       await modal.save();
 
-      const totalCvesHeader = page.getByRole('columnheader', {
-        name: 'Total CVEs',
+      const criticalCvesHeader = page.getByRole('columnheader', {
+        name: 'Critical CVEs',
       });
-      await expect(totalCvesHeader).toBeVisible();
-      await expect(totalCvesHeader).not.toHaveAttribute('aria-sort');
+      await expect(criticalCvesHeader).toBeVisible();
+      await expect(criticalCvesHeader).not.toHaveAttribute('aria-sort');
 
-      await totalCvesHeader.click();
-      await expect(totalCvesHeader).not.toHaveAttribute('aria-sort');
+      await criticalCvesHeader.click();
+      await expect(criticalCvesHeader).not.toHaveAttribute('aria-sort');
     });
   },
 );

--- a/_playwright-tests/test_inventory_views.test.ts
+++ b/_playwright-tests/test_inventory_views.test.ts
@@ -85,11 +85,11 @@ test.describe('Inventory Views application columns', () => {
     },
     {
       name: 'Vulnerability',
-      appColumns: [
-        { name: 'Total CVEs' },
-        { name: 'Critical CVEs' },
-        { name: 'Important CVEs' },
-      ],
+      // 'Vulnerabilities' is intentionally omitted: it shares a sortBy field
+      // with 'Critical CVEs' (Phase 1), so its sort caret is ambiguous until
+      // composite sorting lands. Sort validation uses columns with distinct
+      // sortBy fields.
+      appColumns: [{ name: 'Critical CVEs' }, { name: 'Important CVEs' }],
     },
   ];
 

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -106,12 +106,16 @@ const getFiltersFromSearchParams = (
   );
 };
 
+// Persists each shown column's `key`, which is what restore matches against
+// (see createViewColumnSelector, which builds its catalog map keyed by col.key).
+// The `typeof c.sortBy === 'string'` filter selects only persistable columns:
+// every sortable column's `key` is a backend-valid order_by value.
+//
 // TODO: Once backend accepts 'tags' column in view configuration API,
-// update this function to not filter out columns without sortBy.
+// update this filter to not exclude columns without sortBy.
 // Current issue: Tags column has no sortBy field and gets filtered out,
 // so it cannot be saved to custom views. Backend currently rejects 'tags'
 // as invalid column key (see validation error listing valid keys).
-// Future fix: Change filter to use c.key instead of c.sortBy
 const normalizeViewColumns = (
   columns: readonly Column<InventoryBindableItem>[],
 ): ViewConfiguration['columns'] =>
@@ -120,7 +124,7 @@ const normalizeViewColumns = (
       (c): c is Column<InventoryBindableItem> & { sortBy: string } =>
         c.isShown === true && typeof c.sortBy === 'string',
     )
-    .map((c) => ({ key: c.sortBy }));
+    .map((c) => ({ key: c.key }));
 
 const InventoryViews = () => {
   const { isReady, defaultFilters } = useAnsibleWorkloadDefault();

--- a/src/components/InventoryViews/createViewColumnSelector.test.ts
+++ b/src/components/InventoryViews/createViewColumnSelector.test.ts
@@ -23,7 +23,7 @@ describe('createViewColumnSelector', () => {
       columns: [
         { key: 'display_name' },
         { key: 'operating_system' },
-        { key: 'vulnerability:total_cves' },
+        { key: 'vulnerability:important_cves' },
       ],
     });
     const result = selector!(columnCatalog);
@@ -32,7 +32,7 @@ describe('createViewColumnSelector', () => {
     expect(shownKeys).toEqual([
       'display_name',
       'operating_system',
-      'vulnerability:total_cves',
+      'vulnerability:important_cves',
     ]);
   });
 
@@ -74,7 +74,7 @@ describe('createViewColumnSelector', () => {
     const selector = createViewColumnSelector({
       columns: [
         { key: 'last_check_in' },
-        { key: 'vulnerability:total_cves' },
+        { key: 'vulnerability:important_cves' },
         { key: 'display_name' },
       ],
     });
@@ -83,7 +83,7 @@ describe('createViewColumnSelector', () => {
     const firstThree = result.slice(0, 3).map((c) => c.key);
     expect(firstThree).toEqual([
       'last_check_in',
-      'vulnerability:total_cves',
+      'vulnerability:important_cves',
       'display_name',
     ]);
   });

--- a/src/components/SystemsView/SystemsView.rbac.cy.js
+++ b/src/components/SystemsView/SystemsView.rbac.cy.js
@@ -12,7 +12,7 @@ const selectTestColumns = () => {
     'operating_system',
     'last_check_in',
     'advisor:critical', // Changed from advisor:recommendations due to RHINENG-30055
-    'vulnerability:total_cves',
+    'vulnerability:important_cves',
     'compliance:policies_count',
   ];
   const showKeys = new Set(columnsToShow);
@@ -183,19 +183,19 @@ describe('Per-service RBAC column gating', () => {
   });
 
   it('automatically falls back to display_name sort when sorted column is denied', () => {
-    // Mount with URL params that set sort to vulnerability:total_cves
+    // Mount with URL params that set sort to vulnerability:important_cves
     // AND with vulnerability denied - the useEffect should detect the locked
     // sort column on mount and automatically fall back to display_name ascending
     mountSystemsView(['vulnerability'], {
       routerProps: {
-        initialEntries: ['/?sort=vulnerability:total_cves&sort_dir=desc'],
+        initialEntries: ['/?sort=vulnerability:important_cves&sort_dir=desc'],
       },
     });
 
     // Wait for table to load
     cy.contains('test-host-1.example.com').should('be.visible');
 
-    // Verify: Total CVEs column shows lock icons (denied)
+    // Verify: Important CVEs column shows lock icons (denied)
     cy.get('td span[aria-label*="request Vulnerability read access"]').should(
       'have.length',
       2,
@@ -220,8 +220,8 @@ describe('Per-service RBAC column gating', () => {
     cy.get('td span[aria-label*="To view this data"]').should('not.exist');
 
     // Verify real vulnerability data is shown
-    cy.contains('td', '12').should('be.visible'); // total_cves for host 1
-    cy.contains('td', '8').should('be.visible'); // total_cves for host 2
+    cy.contains('td', '3').should('be.visible'); // important_cves for host 1
+    cy.contains('td', '2').should('be.visible'); // important_cves for host 2
 
     // Verify real advisor data is shown (individual severity counts)
     cy.contains('td', '2').should('be.visible'); // important/moderate counts

--- a/src/components/SystemsView/columns/vulnerability/cells/SeverityIcon/SeverityIcon.test.tsx
+++ b/src/components/SystemsView/columns/vulnerability/cells/SeverityIcon/SeverityIcon.test.tsx
@@ -1,0 +1,147 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import SeverityIcon from './SeverityIcon';
+import { TestWrapper } from '../../../../../../Utilities/TestingUtilities';
+import { SeverityCriticalIcon } from '@patternfly/react-icons';
+
+const TEST_SYSTEM_ID = 'test-system-123';
+const TEST_TOOLTIP = 'Critical';
+const TEST_COLOR_VAR =
+  'var(--pf-t--global--icon--color--severity--critical--default)';
+const TEST_SEARCH = 'impact=7';
+
+function renderSeverityIcon(
+  count: number | null | undefined,
+  showFallback = false,
+) {
+  return render(
+    <TestWrapper>
+      <SeverityIcon
+        count={count}
+        tooltipText={TEST_TOOLTIP}
+        Icon={SeverityCriticalIcon}
+        colorVar={TEST_COLOR_VAR}
+        systemId={TEST_SYSTEM_ID}
+        search={TEST_SEARCH}
+        showFallback={showFallback}
+      />
+    </TestWrapper>,
+  );
+}
+
+describe('SeverityIcon component', () => {
+  describe('display values', () => {
+    it('should display the count when count is a number', () => {
+      renderSeverityIcon(5);
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
+    it('should display 0 when count is 0', () => {
+      renderSeverityIcon(0);
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('should display 0 when count is null and showFallback is false', () => {
+      renderSeverityIcon(null, false);
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('should display 0 when count is undefined and showFallback is false', () => {
+      renderSeverityIcon(undefined, false);
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('should display "--" when count is null and showFallback is true', () => {
+      renderSeverityIcon(null, true);
+      expect(screen.getByText('--')).toBeInTheDocument();
+    });
+
+    it('should display "--" when count is undefined and showFallback is true', () => {
+      renderSeverityIcon(undefined, true);
+      expect(screen.getByText('--')).toBeInTheDocument();
+    });
+
+    it('should display count when count is a number even if showFallback is true', () => {
+      renderSeverityIcon(3, true);
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.queryByText('--')).not.toBeInTheDocument();
+    });
+
+    it('should handle large numbers', () => {
+      renderSeverityIcon(999);
+      expect(screen.getByText('999')).toBeInTheDocument();
+    });
+  });
+
+  describe('linking behavior', () => {
+    it('should render a link when count is greater than 0', () => {
+      renderSeverityIcon(5);
+      const link = screen.getByRole('link');
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute(
+        'href',
+        expect.stringContaining(TEST_SYSTEM_ID),
+      );
+      expect(link).toHaveAttribute(
+        'href',
+        expect.stringContaining(TEST_SEARCH),
+      );
+    });
+
+    it('should not render a link when count is 0', () => {
+      renderSeverityIcon(0);
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('should not render a link when showing fallback value', () => {
+      renderSeverityIcon(null, true);
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('should not render a link when count is null without fallback', () => {
+      renderSeverityIcon(null, false);
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('should include appName=vulnerabilities in the link', () => {
+      renderSeverityIcon(3);
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute(
+        'href',
+        expect.stringContaining('appName=vulnerabilities'),
+      );
+    });
+
+    it('should use the provided systemId in the link pathname', () => {
+      renderSeverityIcon(1);
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute(
+        'href',
+        expect.stringContaining(`/${TEST_SYSTEM_ID}`),
+      );
+    });
+  });
+
+  describe('tooltip', () => {
+    it('should render with tooltip text', () => {
+      renderSeverityIcon(5);
+      // The tooltip content is rendered but may not be visible until hover
+      // We can verify the Tooltip component is present by checking for the trigger
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle count of 1', () => {
+      renderSeverityIcon(1);
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getByRole('link')).toBeInTheDocument();
+    });
+
+    it('should handle very large counts', () => {
+      renderSeverityIcon(10000);
+      expect(screen.getByText('10000')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/SystemsView/columns/vulnerability/cells/SeverityIcon/SeverityIcon.tsx
+++ b/src/components/SystemsView/columns/vulnerability/cells/SeverityIcon/SeverityIcon.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Flex, FlexItem, Icon, Tooltip } from '@patternfly/react-core';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+
+export interface SeverityIconProps {
+  count: number | null | undefined;
+  tooltipText: string;
+  Icon: React.ComponentType;
+  colorVar: string;
+  systemId: string;
+  search: string;
+  showFallback?: boolean;
+}
+
+const SeverityIcon: React.FC<SeverityIconProps> = ({
+  count,
+  tooltipText,
+  Icon: IconComponent,
+  colorVar,
+  systemId,
+  search,
+  showFallback = false,
+}) => {
+  const vulnerabilitySystemLink = {
+    pathname: `/${systemId}`,
+    search: `appName=vulnerabilities&${search}`,
+  };
+
+  // TODO: Phase 1 temporary fallback - remove once backend provides moderate_cves and low_cves data.
+  // Phase 1: Show fallback for moderate and low if backend data not available
+  const displayValue =
+    showFallback && (count === null || count === undefined)
+      ? '--'
+      : (count ?? 0);
+
+  const iconAndCount = (
+    <Tooltip content={tooltipText}>
+      <Flex style={{ display: 'inline-flex', flexWrap: 'nowrap' }}>
+        <FlexItem spacer={{ default: 'spacerSm' }}>
+          <Icon
+            isInline
+            style={
+              {
+                '--pf-v6-c-icon__content--Color': colorVar,
+              } as React.CSSProperties
+            }
+          >
+            <IconComponent />
+          </Icon>
+        </FlexItem>
+        <FlexItem spacer={{ default: 'spacerSm' }}>{displayValue}</FlexItem>
+      </Flex>
+    </Tooltip>
+  );
+
+  // Only link if count > 0 and not a fallback value
+  if (typeof displayValue === 'number' && displayValue > 0) {
+    return (
+      <InsightsLink
+        app="inventory"
+        to={vulnerabilitySystemLink}
+        preview={false}
+      >
+        {iconAndCount}
+      </InsightsLink>
+    );
+  }
+
+  return iconAndCount;
+};
+
+export default SeverityIcon;

--- a/src/components/SystemsView/columns/vulnerability/cells/SeverityIcon/index.ts
+++ b/src/components/SystemsView/columns/vulnerability/cells/SeverityIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SeverityIcon';
+export type { SeverityIconProps } from './SeverityIcon';

--- a/src/components/SystemsView/columns/vulnerability/cells/VulnerabilityCves.test.tsx
+++ b/src/components/SystemsView/columns/vulnerability/cells/VulnerabilityCves.test.tsx
@@ -1,0 +1,315 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import VulnerabilityCves, { NOT_SET } from './VulnerabilityCves';
+import { TestWrapper } from '../../../../../Utilities/TestingUtilities';
+import type { VulnerabilityAppData } from '@redhat-cloud-services/host-inventory-client';
+import { NOT_AVAILABLE } from '../../CellValue';
+
+const TEST_SYSTEM_ID = 'test-system-123';
+
+type VulnerabilityAppDataExtended = VulnerabilityAppData & {
+  important_cves?: number | null;
+  moderate_cves?: number | null;
+  low_cves?: number | null;
+};
+
+function renderVulnerabilityCves(
+  appData: VulnerabilityAppDataExtended | undefined,
+  systemId: string = TEST_SYSTEM_ID,
+) {
+  return render(
+    <TestWrapper>
+      <VulnerabilityCves appData={appData} systemId={systemId} />
+    </TestWrapper>,
+  );
+}
+
+describe('VulnerabilityCves cell', () => {
+  describe('when data is not available', () => {
+    it(`should show ${NOT_AVAILABLE} when appData is undefined`, () => {
+      renderVulnerabilityCves(undefined);
+
+      expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+    });
+
+    it(`should show ${NOT_AVAILABLE} when all severity counts are null`, () => {
+      renderVulnerabilityCves({
+        critical_cves: null,
+        important_cves: null,
+        moderate_cves: null,
+        low_cves: null,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+    });
+
+    it(`should show ${NOT_AVAILABLE} when all severity counts are undefined`, () => {
+      renderVulnerabilityCves({} as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+    });
+
+    it(`should show ${NOT_AVAILABLE} when severity counts are mixed null and undefined`, () => {
+      renderVulnerabilityCves({
+        critical_cves: null,
+        important_cves: undefined,
+        moderate_cves: null,
+        low_cves: undefined,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText(NOT_AVAILABLE)).toBeInTheDocument();
+    });
+  });
+
+  describe('when no vulnerabilities exist', () => {
+    it(`should show "${NOT_SET}" when all counts are 0`, () => {
+      renderVulnerabilityCves({
+        critical_cves: 0,
+        important_cves: 0,
+        moderate_cves: 0,
+        low_cves: 0,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText(NOT_SET)).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it(`should show "${NOT_SET}" when counts are mix of 0 and null (with at least one valid 0)`, () => {
+      renderVulnerabilityCves({
+        critical_cves: 0,
+        important_cves: null,
+        moderate_cves: 0,
+        low_cves: undefined,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText(NOT_SET)).toBeInTheDocument();
+    });
+  });
+
+  describe('when vulnerabilities exist', () => {
+    it('should render all four severity icons with their counts', () => {
+      renderVulnerabilityCves({
+        critical_cves: 5,
+        important_cves: 3,
+        moderate_cves: 2,
+        low_cves: 1,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
+
+    it('should render all severity icons when counts are present', () => {
+      renderVulnerabilityCves({
+        critical_cves: 1,
+        important_cves: 1,
+        moderate_cves: 1,
+        low_cves: 1,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      // All four severity counts should be visible
+      const counts = screen.getAllByText('1');
+      expect(counts).toHaveLength(4);
+    });
+
+    it('should show fallback "--" for moderate and low when data is null (Phase 1)', () => {
+      renderVulnerabilityCves({
+        critical_cves: 5,
+        important_cves: 3,
+        moderate_cves: null,
+        low_cves: null,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+      // Should show fallback for moderate and low
+      const fallbacks = screen.getAllByText('--');
+      expect(fallbacks).toHaveLength(2);
+    });
+
+    it('should show fallback "--" for moderate and low when data is undefined (Phase 1)', () => {
+      renderVulnerabilityCves({
+        critical_cves: 2,
+        important_cves: 1,
+        moderate_cves: undefined,
+        low_cves: undefined,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument();
+      const fallbacks = screen.getAllByText('--');
+      expect(fallbacks).toHaveLength(2);
+    });
+
+    it('should render links for counts greater than 0', () => {
+      renderVulnerabilityCves({
+        critical_cves: 3,
+        important_cves: 0,
+        moderate_cves: 0,
+        low_cves: 0,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(1);
+      expect(links[0]).toHaveAttribute(
+        'href',
+        expect.stringContaining(TEST_SYSTEM_ID),
+      );
+      expect(links[0]).toHaveAttribute(
+        'href',
+        expect.stringContaining('impact=7'),
+      );
+    });
+
+    it('should not render links for counts of 0', () => {
+      renderVulnerabilityCves({
+        critical_cves: 0,
+        important_cves: 0,
+        moderate_cves: 0,
+        low_cves: 1,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      // Only one link for the low count
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(1);
+    });
+
+    it('should not render links for fallback values', () => {
+      renderVulnerabilityCves({
+        critical_cves: 2,
+        important_cves: 3,
+        moderate_cves: null,
+        low_cves: null,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      // Only two links for critical and important
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(2);
+    });
+
+    it('should render multiple links when multiple counts are greater than 0', () => {
+      renderVulnerabilityCves({
+        critical_cves: 2,
+        important_cves: 3,
+        moderate_cves: 1,
+        low_cves: 1,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(4);
+      links.forEach((link) => {
+        expect(link).toHaveAttribute(
+          'href',
+          expect.stringContaining(TEST_SYSTEM_ID),
+        );
+      });
+    });
+
+    it('should use the correct impact filter for each severity level', () => {
+      renderVulnerabilityCves({
+        critical_cves: 1,
+        important_cves: 1,
+        moderate_cves: 1,
+        low_cves: 1,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      const links = screen.getAllByRole('link');
+      expect(links[0]).toHaveAttribute(
+        'href',
+        expect.stringContaining('impact=7'),
+      ); // Critical
+      expect(links[1]).toHaveAttribute(
+        'href',
+        expect.stringContaining('impact=5'),
+      ); // Important
+      expect(links[2]).toHaveAttribute(
+        'href',
+        expect.stringContaining('impact=4'),
+      ); // Moderate
+      expect(links[3]).toHaveAttribute(
+        'href',
+        expect.stringContaining('impact=2'),
+      ); // Low
+    });
+
+    it('should use the provided systemId in links', () => {
+      const customSystemId = 'custom-system-456';
+      renderVulnerabilityCves(
+        {
+          critical_cves: 1,
+          important_cves: 0,
+          moderate_cves: 0,
+          low_cves: 0,
+        } as unknown as VulnerabilityAppDataExtended,
+        customSystemId,
+      );
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute(
+        'href',
+        expect.stringContaining(customSystemId),
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle only critical vulnerabilities', () => {
+      renderVulnerabilityCves({
+        critical_cves: 10,
+        important_cves: 0,
+        moderate_cves: 0,
+        low_cves: 0,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText('10')).toBeInTheDocument();
+      expect(screen.getAllByRole('link')).toHaveLength(1);
+    });
+
+    it('should handle only low vulnerabilities', () => {
+      renderVulnerabilityCves({
+        critical_cves: 0,
+        important_cves: 0,
+        moderate_cves: 0,
+        low_cves: 5,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getAllByRole('link')).toHaveLength(1);
+    });
+
+    it('should handle large numbers', () => {
+      renderVulnerabilityCves({
+        critical_cves: 999,
+        important_cves: 888,
+        moderate_cves: 777,
+        low_cves: 666,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText('999')).toBeInTheDocument();
+      expect(screen.getByText('888')).toBeInTheDocument();
+      expect(screen.getByText('777')).toBeInTheDocument();
+      expect(screen.getByText('666')).toBeInTheDocument();
+    });
+
+    it('should handle mix of real data and fallback values', () => {
+      renderVulnerabilityCves({
+        critical_cves: 5,
+        important_cves: 3,
+        moderate_cves: null,
+        low_cves: 2,
+      } as unknown as VulnerabilityAppDataExtended);
+
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('--')).toBeInTheDocument(); // Moderate fallback
+      expect(screen.getByText('2')).toBeInTheDocument();
+
+      // Three links: critical, important, and low (not moderate)
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(3);
+    });
+  });
+});

--- a/src/components/SystemsView/columns/vulnerability/cells/VulnerabilityCves.tsx
+++ b/src/components/SystemsView/columns/vulnerability/cells/VulnerabilityCves.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import {
+  SeverityCriticalIcon,
+  SeverityImportantIcon,
+  SeverityModerateIcon,
+  SeverityMinorIcon,
+} from '@patternfly/react-icons';
+import { VulnerabilityAppData } from '@redhat-cloud-services/host-inventory-client';
+import CellValue from '../../CellValue';
+import SeverityIcon from './SeverityIcon';
+
+const APP_NAME = 'vulnerability' as const;
+
+const VULNERABILITY_DATA_NOT_AVAILABLE =
+  'Vulnerability data has not been collected for this system';
+export const NOT_SET = 'No vulnerabilities';
+
+/**
+ * TODO(host-inventory-client): remove important_cves once it ships on VulnerabilityAppData.
+ */
+type VulnerabilityAppDataExtended = VulnerabilityAppData & {
+  important_cves?: number | null;
+  moderate_cves?: number | null;
+  low_cves?: number | null;
+};
+
+interface VulnerabilityCvesProps {
+  appData: VulnerabilityAppDataExtended | undefined;
+  systemId: string;
+}
+
+const VulnerabilityCves = ({ appData, systemId }: VulnerabilityCvesProps) => {
+  if (!appData) {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason={VULNERABILITY_DATA_NOT_AVAILABLE}
+      />
+    );
+  }
+
+  // Check if all severity data is missing (null/undefined)
+  const allMissing = [
+    appData.critical_cves,
+    appData.important_cves,
+    appData.moderate_cves,
+    appData.low_cves,
+  ].every((count) => count === null || count === undefined);
+
+  if (allMissing) {
+    return (
+      <CellValue
+        type="notAvailable"
+        reason={VULNERABILITY_DATA_NOT_AVAILABLE}
+      />
+    );
+  }
+
+  // TODO: Phase 1 temporary behavior - remove once backend provides moderate_cves and low_cves.
+  // Phase 1: Critical and Important use real data; Moderate and Low show fallback
+  const critical = appData.critical_cves ?? 0;
+  const important = appData.important_cves ?? 0;
+  const moderate = appData.moderate_cves;
+  const low = appData.low_cves;
+
+  // Check if we have any CVEs at all (counting only real data: critical + important)
+  const hasCves = critical > 0 || important > 0;
+
+  // If no CVEs exist (and moderate/low are also null/0), show "No vulnerabilities"
+  const moderateIsZero =
+    moderate === 0 || moderate === null || moderate === undefined;
+  const lowIsZero = low === 0 || low === null || low === undefined;
+
+  if (critical === 0 && important === 0 && moderateIsZero && lowIsZero) {
+    return <CellValue type="notSet" value={NOT_SET} />;
+  }
+
+  return (
+    <CellValue
+      type="present"
+      value={
+        <Flex style={{ display: 'inline-flex', flexWrap: 'nowrap' }}>
+          <FlexItem spacer={{ default: 'spacerXs' }}>
+            <SeverityIcon
+              tooltipText="Critical"
+              count={critical}
+              Icon={SeverityCriticalIcon}
+              colorVar="var(--pf-t--global--icon--color--severity--critical--default)"
+              systemId={systemId}
+              search="impact=7"
+            />
+          </FlexItem>
+          <FlexItem spacer={{ default: 'spacerXs' }}>
+            <SeverityIcon
+              tooltipText="Important"
+              count={important}
+              Icon={SeverityImportantIcon}
+              colorVar="var(--pf-t--global--icon--color--severity--important--default)"
+              systemId={systemId}
+              search="impact=5"
+            />
+          </FlexItem>
+          <FlexItem spacer={{ default: 'spacerXs' }}>
+            <SeverityIcon
+              tooltipText="Moderate"
+              count={moderate}
+              Icon={SeverityModerateIcon}
+              colorVar="var(--pf-t--global--icon--color--severity--moderate--default)"
+              systemId={systemId}
+              search="impact=4"
+              showFallback={true} // TODO: Remove once backend provides moderate_cves
+            />
+          </FlexItem>
+          <FlexItem spacer={{ default: 'spacerXs' }}>
+            <SeverityIcon
+              tooltipText="Low"
+              count={low}
+              Icon={SeverityMinorIcon}
+              colorVar="var(--pf-t--global--icon--color--severity--minor--default)"
+              systemId={systemId}
+              search="impact=2"
+              showFallback={true} // TODO: Remove once backend provides low_cves
+            />
+          </FlexItem>
+        </Flex>
+      }
+    />
+  );
+};
+
+export default VulnerabilityCves;

--- a/src/components/SystemsView/columns/vulnerability/columnDefinitions.test.tsx
+++ b/src/components/SystemsView/columns/vulnerability/columnDefinitions.test.tsx
@@ -1,0 +1,40 @@
+import { bindVulnerabilityColumns } from './columnDefinitions';
+
+describe('bindVulnerabilityColumns', () => {
+  it('returns columns with unique keys', () => {
+    const columns = bindVulnerabilityColumns();
+    const keys = columns.map((col) => col.key);
+
+    // Check for duplicates
+    const uniqueKeys = new Set(keys);
+    expect(uniqueKeys.size).toBe(keys.length);
+
+    // Verify expected keys are present
+    expect(keys).toContain('vulnerability:total_cves');
+    expect(keys).toContain('vulnerability:critical_cves');
+    expect(keys).toContain('vulnerability:important_cves');
+    expect(keys).toContain('vulnerability:cves_with_security_rules');
+    expect(keys).toContain('vulnerability:cves_with_known_exploits');
+  });
+
+  it('returns 5 vulnerability columns in correct order', () => {
+    const columns = bindVulnerabilityColumns();
+
+    expect(columns).toHaveLength(5);
+
+    // Verify export order
+    expect(columns[0].title).toBe('Vulnerabilities');
+    expect(columns[1].title).toBe('Critical CVEs');
+    expect(columns[2].title).toBe('Important CVEs');
+    expect(columns[3].title).toBe('CVEs with security rules');
+    expect(columns[4].title).toBe('CVEs with known exploits');
+  });
+
+  it('sets appName to "vulnerability" for all columns', () => {
+    const columns = bindVulnerabilityColumns();
+
+    columns.forEach((col) => {
+      expect(col.appName).toBe('vulnerability');
+    });
+  });
+});

--- a/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
@@ -11,11 +11,14 @@ import {
   VULNERABILITY_LINK_SEARCH,
 } from '../../constants';
 import VulnerabilityCount from './cells/VulnerabilityCount';
+import VulnerabilityCves from './cells/VulnerabilityCves';
 
 const APP_NAME = 'vulnerability' as const;
 
 type VulnerabilityAppDataExtended = VulnerabilityAppData & {
   important_cves?: number | null;
+  moderate_cves?: number | null;
+  low_cves?: number | null;
 };
 
 type VulnerabilityCountValue = {
@@ -35,19 +38,22 @@ const bindVulnerabilityCountColumn = <TItem extends InventoryBindableItem>(
     }),
   });
 
-const totalCvesSpec: ColumnSpec<VulnerabilityCountValue> = {
+const vulnerabilitiesSpec: ColumnSpec<VulnerabilityCountValue> = {
   appName: APP_NAME,
-  title: 'Total CVEs',
+  title: 'Vulnerabilities',
+  // Distinct, backend-valid key so this composite column persists to and
+  // restores from saved views independently of the Critical CVEs column
+  // (which uses `vulnerability:critical_cves`). Its `sortBy` still shares the
+  // critical CVEs sort key for Phase 1 (see below).
   key: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitytotalCves,
-  minWidth: '10rem',
-  sortBy: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitytotalCves,
+  minWidth: '12rem',
+  // Phase 1: Sorts by critical CVEs (same as Critical CVEs column).
+  // Known issue: When both columns are visible, sort indicator appears on
+  // whichever column is exported first (this one). Will be fixed in Phase 2
+  // with proper composite sorting when all severity data is available.
+  sortBy: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitycriticalCves,
   renderCell: (value) => (
-    <VulnerabilityCount
-      appData={value.appData}
-      systemId={value.systemId}
-      countField="total_cves"
-      search={VULNERABILITY_LINK_SEARCH.totalCves}
-    />
+    <VulnerabilityCves appData={value.appData} systemId={value.systemId} />
   ),
 };
 
@@ -118,7 +124,7 @@ const cvesWithKnownExploitsSpec: ColumnSpec<VulnerabilityCountValue> = {
 export const bindVulnerabilityColumns = <
   TItem extends InventoryBindableItem,
 >(): Column<TItem>[] => [
-  bindVulnerabilityCountColumn<TItem>(totalCvesSpec),
+  bindVulnerabilityCountColumn<TItem>(vulnerabilitiesSpec),
   bindVulnerabilityCountColumn<TItem>(criticalCvesSpec),
   bindVulnerabilityCountColumn<TItem>(importantCvesSpec),
   bindVulnerabilityCountColumn<TItem>(cvesWithSecurityRulesSpec),


### PR DESCRIPTION
## Jira
[RHINENG-30337](https://redhat.atlassian.net/browse/RHINENG-30337)

## What
This PR combines Critical, Important, Moderate, and Low severity CVE counts into a single column (similar to Advisor Recommendations). We're not currently getting counts for Moderate and Low, so we're filling them with -- for now. With this, we have also removed the Total CVEs column. The Vulnerabilities column is sorted by Critical CVEs until we get a special sort for the column from the backend. That means, if you include the Critical column with the Vulnerabilities column, you'll get a sort on both columns. This is a temporary trade-off for the upcoming customer demo.

Side note: Now we have 3 composite columns. I'm thinking we can create a shared component that handles these scenarios. I'll take care of this in a future PR.

## Screenshots/Videos (if applicable)
<img width="907" height="585" alt="image" src="https://github.com/user-attachments/assets/96d9547c-5665-41b5-a576-874ad08903b1" />

[RHINENG-30337]: https://redhat.atlassian.net/browse/RHINENG-30337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Replace the Total CVEs vulnerability column with a composite severity breakdown while maintaining inventory view persistence and coverage for the new behavior.

New Features:
- Combine vulnerability severity counts into a single Vulnerabilities column with severity-specific icons, counts, links, and temporary placeholders for unavailable Moderate and Low data.

Bug Fixes:
- Preserve custom view column selections using stable column keys when saving and restoring inventory views.

Enhancements:
- Use Critical CVE counts as the temporary sort key for the composite Vulnerabilities column and handle its display validation separately.

Tests:
- Update inventory, RBAC, and column helper coverage for the revised vulnerability columns and sorting behavior.
- Add component tests covering severity display, fallback values, links, and vulnerability cell states.