### PR TITLE
chore(RHINENG-30409): Ability to save filters

### DIFF
--- a/_playwright-tests/helpers/views/columnHelpers.ts
+++ b/_playwright-tests/helpers/views/columnHelpers.ts
@@ -16,7 +16,9 @@ export const defaultInventoryColumns = [
   'Last seen',
 ];
 
-// Default columns for All systems view (system view), Tags currently can't be saved to custom views
+// Default columns for All systems view (system view)
+// Note: Tags is excluded from this array because it's a special column that's always visible by default
+// but not included in the minimal set of columns for testing custom views.
 export const allSystemsColumns = ['Name', 'Workspace', 'OS', 'Last seen'];
 
 // Total columns includes checkbox (first) and per-row actions (last)

--- a/_playwright-tests/test_manage_views.test.ts
+++ b/_playwright-tests/test_manage_views.test.ts
@@ -80,7 +80,7 @@ test.describe(
 
     const configurationA = {
       columns: [...vulnerabilityColumns, ...allSystemsColumns],
-      columnsCount: vulnerabilityColumns.length + totalDefaultColumns - 1, // tags columns currenlty not be able to be added to custom view
+      columnsCount: vulnerabilityColumns.length + totalDefaultColumns,
       filters: [
         {
           filter: 'System type',
@@ -97,8 +97,7 @@ test.describe(
       columnsCount:
         vulnerabilityColumns.length +
         malwareColumns.length +
-        totalDefaultColumns -
-        1, // tags columns currenlty not be able to be added to custom view
+        totalDefaultColumns,
       filters: [],
     };
 

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -106,24 +106,13 @@ const getFiltersFromSearchParams = (
   );
 };
 
-// Persists each shown column's `key`, which is what restore matches against
-// (see createViewColumnSelector, which builds its catalog map keyed by col.key).
-// The `typeof c.sortBy === 'string'` filter selects only persistable columns:
-// every sortable column's `key` is a backend-valid order_by value.
-//
-// TODO: Once backend accepts 'tags' column in view configuration API,
-// update this filter to not exclude columns without sortBy.
-// Current issue: Tags column has no sortBy field and gets filtered out,
-// so it cannot be saved to custom views. Backend currently rejects 'tags'
-// as invalid column key (see validation error listing valid keys).
+// Converts visible columns to ViewConfiguration format.
+// Backend validates column keys server-side against its field registry.
 const normalizeViewColumns = (
   columns: readonly Column<InventoryBindableItem>[],
 ): ViewConfiguration['columns'] =>
   columns
-    .filter(
-      (c): c is Column<InventoryBindableItem> & { sortBy: string } =>
-        c.isShown === true && typeof c.sortBy === 'string',
-    )
+    .filter((c) => c.isShown === true && typeof c.key === 'string')
     .map((c) => ({ key: c.key }));
 
 const InventoryViews = () => {

--- a/src/components/InventoryViews/createViewColumnSelector.ts
+++ b/src/components/InventoryViews/createViewColumnSelector.ts
@@ -15,7 +15,7 @@ export const createViewColumnSelector = (
 
   const configColumns = configuration.columns;
 
-  return () => {
+  return (_catalog) => {
     const allColumns = bindInventoryViewColumns();
     const catalogByKey = new Map(allColumns.map((col) => [col.key, col]));
     const matchedKeys = new Set<string>(configColumns.map((col) => col.key));

--- a/src/components/InventoryViews/normalizeViewColumns.test.ts
+++ b/src/components/InventoryViews/normalizeViewColumns.test.ts
@@ -1,0 +1,162 @@
+import type { Column } from '../SystemsView/columns/types';
+import type { InventoryBindableItem } from '../SystemsView/columns/inventory/columnDefinitions';
+import type { ViewConfiguration } from '../../api/inventoryViewsApi';
+
+// This is the function we're testing (extracted from InventoryViews.tsx)
+const normalizeViewColumns = (
+  columns: readonly Column<InventoryBindableItem>[],
+): ViewConfiguration['columns'] =>
+  columns
+    .filter((c) => c.isShown === true && typeof c.key === 'string')
+    .map((c) => ({ key: c.key }));
+
+describe('normalizeViewColumns', () => {
+  it('saves columns with sortBy field', () => {
+    const columns = [
+      {
+        key: 'display_name',
+        sortBy: 'display_name',
+        isShown: true,
+      },
+      {
+        key: 'operating_system',
+        sortBy: 'operating_system',
+        isShown: true,
+      },
+    ] as Column<InventoryBindableItem>[];
+
+    const result = normalizeViewColumns(columns);
+
+    expect(result).toEqual([
+      { key: 'display_name' },
+      { key: 'operating_system' },
+    ]);
+  });
+
+  it('saves columns WITHOUT sortBy field (tags, infrastructure, vendor, workload, created)', () => {
+    const columns = [
+      { key: 'display_name', sortBy: 'display_name', isShown: true },
+      { key: 'tags', isShown: true }, // No sortBy
+      { key: 'operating_system', sortBy: 'operating_system', isShown: true },
+      { key: 'infrastructure', isShown: true }, // No sortBy
+      { key: 'vendor', isShown: true }, // No sortBy
+      { key: 'workload', isShown: true }, // No sortBy
+      { key: 'created', isShown: true }, // No sortBy
+    ] as Column<InventoryBindableItem>[];
+
+    const result = normalizeViewColumns(columns);
+
+    expect(result).toEqual([
+      { key: 'display_name' },
+      { key: 'tags' },
+      { key: 'operating_system' },
+      { key: 'infrastructure' },
+      { key: 'vendor' },
+      { key: 'workload' },
+      { key: 'created' },
+    ]);
+  });
+
+  it('filters out hidden columns (isShown: false)', () => {
+    const columns = [
+      { key: 'display_name', isShown: true },
+      { key: 'tags', isShown: false }, // Hidden
+      { key: 'operating_system', isShown: true },
+      { key: 'infrastructure', isShown: false }, // Hidden
+    ] as Column<InventoryBindableItem>[];
+
+    const result = normalizeViewColumns(columns);
+
+    expect(result).toEqual([
+      { key: 'display_name' },
+      { key: 'operating_system' },
+    ]);
+  });
+
+  it('filters out columns with no key', () => {
+    const columns = [
+      { key: 'display_name', isShown: true },
+      { isShown: true }, // No key
+      { key: 'operating_system', isShown: true },
+    ] as Column<InventoryBindableItem>[];
+
+    const result = normalizeViewColumns(columns);
+
+    expect(result).toEqual([
+      { key: 'display_name' },
+      { key: 'operating_system' },
+    ]);
+  });
+
+  it('preserves column order', () => {
+    const columns = [
+      { key: 'created', isShown: true },
+      { key: 'tags', isShown: true },
+      { key: 'display_name', isShown: true },
+      { key: 'vendor', isShown: true },
+    ] as Column<InventoryBindableItem>[];
+
+    const result = normalizeViewColumns(columns);
+
+    expect(result.map((c) => c.key)).toEqual([
+      'created',
+      'tags',
+      'display_name',
+      'vendor',
+    ]);
+  });
+
+  it('includes app columns (vulnerability, advisor, compliance, etc.)', () => {
+    const columns = [
+      { key: 'display_name', isShown: true },
+      { key: 'vulnerability:critical_cves', isShown: true },
+      { key: 'advisor:critical', isShown: true },
+      { key: 'compliance:policies_count', isShown: true },
+      { key: 'patch:advisories_rhsa_installable', isShown: true },
+    ] as Column<InventoryBindableItem>[];
+
+    const result = normalizeViewColumns(columns);
+
+    expect(result).toEqual([
+      { key: 'display_name' },
+      { key: 'vulnerability:critical_cves' },
+      { key: 'advisor:critical' },
+      { key: 'compliance:policies_count' },
+      { key: 'patch:advisories_rhsa_installable' },
+    ]);
+  });
+
+  it('returns empty array when no visible columns', () => {
+    const columns = [
+      { key: 'display_name', isShown: false },
+      { key: 'tags', isShown: false },
+    ] as Column<InventoryBindableItem>[];
+
+    const result = normalizeViewColumns(columns);
+
+    expect(result).toEqual([]);
+  });
+
+  it('handles mixed sortable and non-sortable columns', () => {
+    const columns = [
+      { key: 'display_name', sortBy: 'display_name', isShown: true }, // Sortable
+      { key: 'tags', isShown: true }, // Non-sortable
+      { key: 'operating_system', sortBy: 'operating_system', isShown: true }, // Sortable
+      { key: 'infrastructure', isShown: true }, // Non-sortable
+      { key: 'last_check_in', sortBy: 'last_check_in', isShown: true }, // Sortable
+      { key: 'vendor', isShown: true }, // Non-sortable
+    ] as Column<InventoryBindableItem>[];
+
+    const result = normalizeViewColumns(columns);
+
+    expect(result).toEqual([
+      { key: 'display_name' },
+      { key: 'tags' },
+      { key: 'operating_system' },
+      { key: 'infrastructure' },
+      { key: 'last_check_in' },
+      { key: 'vendor' },
+    ]);
+    expect(result.length).toBe(6);
+  });
+});

--- a/src/components/InventoryViews/viewColumnRoundtrip.test.ts
+++ b/src/components/InventoryViews/viewColumnRoundtrip.test.ts
@@ -1,0 +1,232 @@
+import { createViewColumnSelector } from './createViewColumnSelector';
+import { bindInventoryViewColumns } from '../SystemsView/columns/inventoryViewColumns';
+import { columnCatalog } from '../SystemsView/columns/catalog';
+import type { Column } from '../SystemsView/columns/types';
+import type { InventoryBindableItem } from '../SystemsView/columns/inventory/columnDefinitions';
+import type { ViewConfiguration } from '../../api/inventoryViewsApi';
+
+// This is the function we're testing (extracted from InventoryViews.tsx)
+const normalizeViewColumns = (
+  columns: readonly Column<InventoryBindableItem>[],
+): ViewConfiguration['columns'] =>
+  columns
+    .filter((c) => c.isShown === true && typeof c.key === 'string')
+    .map((c) => ({ key: c.key }));
+
+describe('View column round-trip (save → restore)', () => {
+  it('round-trips sortable columns correctly', () => {
+    // Start with a selection of sortable columns
+    const originalColumns = bindInventoryViewColumns().map((col) => ({
+      ...col,
+      isShown: ['display_name', 'operating_system', 'last_check_in'].includes(
+        col.key,
+      ),
+      isShownByDefault: [
+        'display_name',
+        'operating_system',
+        'last_check_in',
+      ].includes(col.key),
+    }));
+
+    // Save to ViewConfiguration
+    const savedConfig: ViewConfiguration = {
+      columns: normalizeViewColumns(originalColumns),
+    };
+
+    // Restore from ViewConfiguration
+    const selector = createViewColumnSelector(savedConfig);
+    const restoredColumns = selector!(columnCatalog);
+
+    // Verify: shown columns match
+    const originalShownKeys = originalColumns
+      .filter((c) => c.isShown)
+      .map((c) => c.key);
+    const restoredShownKeys = restoredColumns
+      .filter((c) => c.isShown)
+      .map((c) => c.key);
+
+    expect(restoredShownKeys).toEqual(originalShownKeys);
+  });
+
+  it('round-trips NON-SORTABLE columns correctly (tags, infrastructure, vendor, workload, created)', () => {
+    // Start with a selection that includes non-sortable columns
+    const originalColumns = bindInventoryViewColumns().map((col) => ({
+      ...col,
+      isShown: [
+        'display_name',
+        'tags', // Non-sortable
+        'operating_system',
+        'infrastructure', // Non-sortable
+        'vendor', // Non-sortable
+        'workload', // Non-sortable
+        'created', // Non-sortable
+      ].includes(col.key),
+      isShownByDefault: [
+        'display_name',
+        'tags',
+        'operating_system',
+        'infrastructure',
+        'vendor',
+        'workload',
+        'created',
+      ].includes(col.key),
+    }));
+
+    // Save to ViewConfiguration
+    const savedConfig: ViewConfiguration = {
+      columns: normalizeViewColumns(originalColumns),
+    };
+
+    // Verify: saved config includes non-sortable columns
+    const savedKeys = savedConfig.columns.map((c) => c.key);
+    expect(savedKeys).toContain('tags');
+    expect(savedKeys).toContain('infrastructure');
+    expect(savedKeys).toContain('vendor');
+    expect(savedKeys).toContain('workload');
+    expect(savedKeys).toContain('created');
+
+    // Restore from ViewConfiguration
+    const selector = createViewColumnSelector(savedConfig);
+    const restoredColumns = selector!(columnCatalog);
+
+    // Verify: restored columns match original
+    const originalShownKeys = originalColumns
+      .filter((c) => c.isShown)
+      .map((c) => c.key);
+    const restoredShownKeys = restoredColumns
+      .filter((c) => c.isShown)
+      .map((c) => c.key);
+
+    expect(restoredShownKeys).toEqual(originalShownKeys);
+  });
+
+  it('round-trips app columns correctly (vulnerability, advisor, compliance)', () => {
+    // Start with a selection that includes app columns
+    const originalColumns = bindInventoryViewColumns().map((col) => ({
+      ...col,
+      isShown: [
+        'display_name',
+        'vulnerability:critical_cves',
+        'advisor:critical',
+        'compliance:policies_count',
+      ].includes(col.key),
+      isShownByDefault: [
+        'display_name',
+        'vulnerability:critical_cves',
+        'advisor:critical',
+        'compliance:policies_count',
+      ].includes(col.key),
+    }));
+
+    // Save to ViewConfiguration
+    const savedConfig: ViewConfiguration = {
+      columns: normalizeViewColumns(originalColumns),
+    };
+
+    // Restore from ViewConfiguration
+    const selector = createViewColumnSelector(savedConfig);
+    const restoredColumns = selector!(columnCatalog);
+
+    // Verify: shown columns match
+    const originalShownKeys = originalColumns
+      .filter((c) => c.isShown)
+      .map((c) => c.key);
+    const restoredShownKeys = restoredColumns
+      .filter((c) => c.isShown)
+      .map((c) => c.key);
+
+    expect(restoredShownKeys).toEqual(originalShownKeys);
+  });
+
+  it('round-trips mixed sortable + non-sortable + app columns', () => {
+    // Realistic selection with all types
+    const originalColumns = bindInventoryViewColumns().map((col) => ({
+      ...col,
+      isShown: [
+        'display_name', // Sortable inventory
+        'tags', // Non-sortable inventory
+        'operating_system', // Sortable inventory
+        'infrastructure', // Non-sortable inventory
+        'last_check_in', // Sortable inventory
+        'vendor', // Non-sortable inventory
+        'vulnerability:critical_cves', // App column
+        'advisor:critical', // App column
+      ].includes(col.key),
+      isShownByDefault: [
+        'display_name',
+        'tags',
+        'operating_system',
+        'infrastructure',
+        'last_check_in',
+        'vendor',
+        'vulnerability:critical_cves',
+        'advisor:critical',
+      ].includes(col.key),
+    }));
+
+    // Save to ViewConfiguration
+    const savedConfig: ViewConfiguration = {
+      columns: normalizeViewColumns(originalColumns),
+    };
+
+    // Verify: all 8 columns are in saved config
+    expect(savedConfig.columns).toHaveLength(8);
+
+    // Restore from ViewConfiguration
+    const selector = createViewColumnSelector(savedConfig);
+    const restoredColumns = selector!(columnCatalog);
+
+    // Verify: exact match
+    const originalShownKeys = originalColumns
+      .filter((c) => c.isShown)
+      .map((c) => c.key);
+    const restoredShownKeys = restoredColumns
+      .filter((c) => c.isShown)
+      .map((c) => c.key);
+
+    expect(restoredShownKeys).toEqual(originalShownKeys);
+  });
+
+  it('preserves column order through round-trip', () => {
+    // Custom order: put non-sortable columns first
+    const customOrder = [
+      'tags',
+      'infrastructure',
+      'vendor',
+      'display_name',
+      'operating_system',
+      'last_check_in',
+    ];
+
+    const originalColumns = bindInventoryViewColumns().map((col) => ({
+      ...col,
+      isShown: customOrder.includes(col.key),
+      isShownByDefault: customOrder.includes(col.key),
+    }));
+
+    // Sort by custom order
+    const sortedColumns = [...originalColumns].sort((a, b) => {
+      const aIndex = customOrder.indexOf(a.key);
+      const bIndex = customOrder.indexOf(b.key);
+      if (aIndex === -1) return 1;
+      if (bIndex === -1) return -1;
+      return aIndex - bIndex;
+    });
+
+    // Save to ViewConfiguration
+    const savedConfig: ViewConfiguration = {
+      columns: normalizeViewColumns(sortedColumns.filter((c) => c.isShown)),
+    };
+
+    // Restore from ViewConfiguration
+    const selector = createViewColumnSelector(savedConfig);
+    const restoredColumns = selector!(columnCatalog);
+
+    // Verify: order matches
+    const restoredShownKeys = restoredColumns
+      .filter((c) => c.isShown)
+      .map((c) => c.key);
+
+    expect(restoredShownKeys).toEqual(customOrder);
+  });
+});


### PR DESCRIPTION
## Jira
[RHINENG-30409](https://redhat.atlassian.net/browse/RHINENG-30409)

## What
This PR adds the ability to save all filters to a view's configuration. The backend now allows it and this PR connects it all up.

[RHINENG-30409]: https://redhat.atlassian.net/browse/RHINENG-30409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enable complete persistence of inventory view filters and visible column selections in custom view configurations.

New Features:
- Enable saving and restoring all visible inventory view columns, including non-sortable and application-specific columns, in view configurations.

Bug Fixes:
- Allow previously excluded columns such as tags to persist correctly when custom views are saved and restored.

Enhancements:
- Update view column normalization and selection handling to support complete column configuration round-trips.

Tests:
- Add coverage for column normalization and save-and-restore behavior across sortable, non-sortable, application, mixed, and ordered columns.