### PR TITLE
chore(RHINENG-29883): Expose SystemsView as federated module

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -96,6 +96,7 @@ module.exports = {
       ),
       // Inventory modules
       './InventoryTable': resolve(__dirname, '/src/modules/InventoryTable.js'),
+      './SystemsView': resolve(__dirname, '/src/modules/SystemsView.tsx'),
       './AppInfo': resolve(__dirname, '/src/modules/AppInfo.js'),
       './InventoryDetailHead': resolve(
         __dirname,

--- a/src/modules/SystemsView.tsx
+++ b/src/modules/SystemsView.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACProvider';
+import { AccessCheck } from '@project-kessel/react-kessel-access-check';
+import {
+  SystemsView as SystemsViewImpl,
+  type SystemsViewFetchData,
+} from '../components/SystemsView/SystemsView';
+import type { ColumnSelector } from '../components/SystemsView/columns/resolveColumnSelector';
+import type { SystemsViewItem } from '../components/SystemsView/types';
+import { useKesselMigrationFeatureFlag } from '../Utilities/hooks/useKesselMigrationFeatureFlag';
+import { KESSEL_API_PATH } from '../constants';
+
+export type { SystemsViewFetchData } from '../components/SystemsView/SystemsView';
+export type {
+  SystemsViewFetchParams,
+  SystemsViewItem,
+  SystemsViewQueryData,
+} from '../components/SystemsView/types';
+export type { ColumnSelector } from '../components/SystemsView/columns/resolveColumnSelector';
+export type { InventoryFilters } from '../components/SystemsView/filters/SystemsViewFilters';
+
+/**
+ * Public federated contract. Some internal props are not exposed.
+ *
+ * `queryClient` is optional. Pass the host client to share cache (and
+ * `invalidateQueries`). Omit it for an isolated cache owned by this module.
+ * Does not fall back to an ambient `QueryClientProvider`.
+ */
+export type SystemsViewProps<TItem extends SystemsViewItem> = {
+  queryClient?: QueryClient;
+  queryKeyPrefix: string;
+  fetchData: SystemsViewFetchData<TItem>;
+  columns: ColumnSelector<TItem>;
+};
+
+function SystemsView<TItem extends SystemsViewItem>({
+  queryClient,
+  queryKeyPrefix,
+  fetchData,
+  columns,
+}: SystemsViewProps<TItem>) {
+  const [internalQueryClient] = useState(
+    () => queryClient ?? new QueryClient(),
+  );
+  const isKesselMigrationEnabled = useKesselMigrationFeatureFlag();
+
+  const systemsView = (
+    <SystemsViewImpl
+      queryKeyPrefix={queryKeyPrefix}
+      fetchData={fetchData}
+      columns={columns}
+    />
+  );
+
+  return (
+    <QueryClientProvider client={queryClient ?? internalQueryClient}>
+      <AccessCheck.Provider
+        baseUrl={typeof window !== 'undefined' ? window.location.origin : ''}
+        apiPath={KESSEL_API_PATH}
+      >
+        {isKesselMigrationEnabled ? (
+          systemsView
+        ) : (
+          <RBACProvider appName="inventory" checkResourceDefinitions>
+            {systemsView}
+          </RBACProvider>
+        )}
+      </AccessCheck.Provider>
+    </QueryClientProvider>
+  );
+}
+
+export default SystemsView;


### PR DESCRIPTION
RHINENG-29883

## What
Exposing SystemsView shell component as Federated module

## Testing
In case you want to test this as well follow instructions in our README.md file for federated modules. You can use branch below from my repo for quick client setup.

I've managed to render the tested module in patchma-ui Systems, code is on my personal branch:

https://github.com/raswonders/patchman-ui/tree/chore/test-systems-view

## Screenshots/Videos (if applicable)
<img width="1873" height="1497" alt="patchman" src="https://github.com/user-attachments/assets/593ab9b5-c874-4eaa-b520-8545fb672b72" />

## Summary by Sourcery

Expose SystemsView as a federated module for consumption by external hosts.

New Features:
- Expose the SystemsView component as a federated module with a public, typed integration contract.
- Support optional host-provided React Query clients while retaining isolated caching when none is supplied.
- Provide authorization integration through Kessel access checks with RBAC fallback based on the migration feature flag.