### PR TITLE
fix(RHINENG-30483): Prevent duplicate view saves requets from the Save split button

### DIFF
--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -226,10 +226,6 @@ const InventoryViews = () => {
     currentLastSeenCustomRange,
   });
 
-  useEffect(() => {
-    if (isSaving && !isViewDirty) setIsSaving(false);
-  }, [isSaving, isViewDirty]);
-
   const handleSelectView = useCallback(
     (viewId: string) => {
       setActiveViewId(viewId);
@@ -253,9 +249,11 @@ const InventoryViews = () => {
         data: { configuration: getCurrentConfiguration() },
       },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
           setCurrentColumns(undefined);
           setCurrentLastSeenCustomRange(undefined);
+          await queryClient.invalidateQueries({ queryKey: ['views'] });
+          setIsSaving(false);
         },
         onError: () => {
           setIsSaving(false);

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -155,7 +155,6 @@ const InventoryViews = () => {
   const activeView = viewsList.find((v) => v.id === activeViewId);
   const isSystemView = activeView?.is_system_view ?? true;
   const viewsLoaded = !!viewsData;
-  const [isSaving, setIsSaving] = useState(false);
 
   const columnSelector = useMemo(
     () => createViewColumnSelector(activeView?.configuration),
@@ -241,22 +240,16 @@ const InventoryViews = () => {
   };
 
   const handleSave = () => {
-    if (!activeView) return;
-    setIsSaving(true);
+    if (!activeView || updateView.isPending) return;
     updateView.mutate(
       {
         id: activeView.id,
         data: { configuration: getCurrentConfiguration() },
       },
       {
-        onSuccess: async () => {
+        onSuccess: () => {
           setCurrentColumns(undefined);
           setCurrentLastSeenCustomRange(undefined);
-          await queryClient.invalidateQueries({ queryKey: ['views'] });
-          setIsSaving(false);
-        },
-        onError: () => {
-          setIsSaving(false);
         },
       },
     );
@@ -321,7 +314,7 @@ const InventoryViews = () => {
             activeViewId={activeViewId}
             isSystemView={isSystemView}
             isViewDirty={isViewDirty}
-            isSaving={isSaving}
+            isSaving={updateView.isPending}
             isOwner={activeView?.is_owner ?? false}
             onSelectView={handleSelectView}
             onSaveAs={handleSaveAs}

--- a/src/components/InventoryViews/InventoryViews.tsx
+++ b/src/components/InventoryViews/InventoryViews.tsx
@@ -155,6 +155,7 @@ const InventoryViews = () => {
   const activeView = viewsList.find((v) => v.id === activeViewId);
   const isSystemView = activeView?.is_system_view ?? true;
   const viewsLoaded = !!viewsData;
+  const [isSaving, setIsSaving] = useState(false);
 
   const columnSelector = useMemo(
     () => createViewColumnSelector(activeView?.configuration),
@@ -225,6 +226,10 @@ const InventoryViews = () => {
     currentLastSeenCustomRange,
   });
 
+  useEffect(() => {
+    if (isSaving && !isViewDirty) setIsSaving(false);
+  }, [isSaving, isViewDirty]);
+
   const handleSelectView = useCallback(
     (viewId: string) => {
       setActiveViewId(viewId);
@@ -241,6 +246,7 @@ const InventoryViews = () => {
 
   const handleSave = () => {
     if (!activeView) return;
+    setIsSaving(true);
     updateView.mutate(
       {
         id: activeView.id,
@@ -250,6 +256,9 @@ const InventoryViews = () => {
         onSuccess: () => {
           setCurrentColumns(undefined);
           setCurrentLastSeenCustomRange(undefined);
+        },
+        onError: () => {
+          setIsSaving(false);
         },
       },
     );
@@ -314,6 +323,7 @@ const InventoryViews = () => {
             activeViewId={activeViewId}
             isSystemView={isSystemView}
             isViewDirty={isViewDirty}
+            isSaving={isSaving}
             isOwner={activeView?.is_owner ?? false}
             onSelectView={handleSelectView}
             onSaveAs={handleSaveAs}

--- a/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
@@ -85,6 +85,7 @@ export const ManageViewButton = ({
             ref={toggleRef}
             onClick={onToggle}
             isExpanded={isOpen}
+            isDisabled={isSaving}
             aria-label="Manage view actions"
             data-testid="manage-view-toggle"
             splitButtonItems={[

--- a/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ManageViewButton.tsx
@@ -15,6 +15,7 @@ export interface ManageViewButtonProps {
   isSystemView?: boolean;
   /** Whether the view is dirty */
   isViewDirty?: boolean;
+  isSaving?: boolean;
   isOwner?: boolean;
   /** Callback when Save As is clicked */
   onSaveAs: () => void;
@@ -47,6 +48,7 @@ export const ManageViewButton = ({
   currentViewId,
   isSystemView = true,
   isViewDirty = false,
+  isSaving = false,
   isOwner = false,
   onSaveAs,
   onRename,
@@ -88,6 +90,7 @@ export const ManageViewButton = ({
             splitButtonItems={[
               <MenuToggleAction
                 key="primary-action"
+                isDisabled={isSaving}
                 // Stop the click from bubbling into the split button's toggle /
                 // dropdown so the primary action can never open the menu.
                 onClick={(event) => {
@@ -123,7 +126,7 @@ export const ManageViewButton = ({
         <DropdownItem
           key="save"
           onClick={onSave}
-          isDisabled={!isViewDirty || isSystemView || !isOwner}
+          isDisabled={!isViewDirty || isSystemView || !isOwner || isSaving}
         >
           Save
         </DropdownItem>

--- a/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewsToolbar.tsx
@@ -20,6 +20,7 @@ export interface ViewsToolbarProps {
   currentViewId?: string | null;
   isSystemView?: boolean;
   isViewDirty?: boolean;
+  isSaving?: boolean;
   isOwner?: boolean;
   viewsList?: ViewOut[];
   onSelectView: (viewId: string) => void;
@@ -38,6 +39,7 @@ export const ViewsToolbar = ({
   currentViewId,
   isSystemView = true,
   isViewDirty = false,
+  isSaving = false,
   isOwner = false,
   viewsList = [],
   onSelectView,
@@ -85,6 +87,7 @@ export const ViewsToolbar = ({
               currentViewId={currentViewId}
               isSystemView={isSystemView}
               isViewDirty={isViewDirty}
+              isSaving={isSaving}
               isOwner={isOwner}
               onSaveAs={onSaveAs}
               onRename={onRename}

--- a/src/components/InventoryViews/hooks/useUpdateViewMutation.ts
+++ b/src/components/InventoryViews/hooks/useUpdateViewMutation.ts
@@ -10,17 +10,16 @@ export const useUpdateViewMutation = () => {
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: UpdateViewRequest }) =>
       updateViewApi(id, data),
-    onSuccess: (updatedView) => {
+    onSuccess: async (updatedView) => {
       addNotification({
         variant: 'success',
         title: `View "${updatedView.name}" updated successfully`,
         dismissable: true,
       });
-
-      void queryClient.invalidateQueries({ queryKey: ['views'] });
-      void queryClient.invalidateQueries({
-        queryKey: ['view', updatedView.id],
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['views'] }),
+        queryClient.invalidateQueries({ queryKey: ['view', updatedView.id] }),
+      ]);
     },
     onError: (error) => {
       console.error(error);


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-30483

## What

- Prevent duplicate view saves requets from the Save split button
- disable Save split button when `isSaving` is pending

## Why
When dirty state is true user able to click Save multiple times (same multiple PATCH requests are send). The root cause is timing between success save/PATCH request and dirty state verification (the Save is done and dirty state is still `true` -  refetch hasn't landed yet - that re-enables Save button ). 

## How
the Save button now stays disabled until the mutation and its refetch complete, driven by `updateView.isPending`

## Summary by Sourcery

Prevent duplicate view saves by tracking the update request state across the view toolbar.

Bug Fixes:
- Prevent duplicate view updates by blocking repeated Save actions while a save request is in progress.

Enhancements:
- Disable view management controls during saving and wait for view data refreshes to complete after a successful update.