### PR TITLE
fix(InventoryViews): Stop query all pages for views on page load

### DIFF
--- a/src/components/InventoryViews/ViewsToolbar/ViewSelector.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewSelector.tsx
@@ -121,19 +121,19 @@ const ViewSelector = ({
                 {view.name}
               </SelectOption>
             ))}
-            {canShowMore && (
-              <SelectOption
-                value={LOADER_ID}
-                isLoadButton={!isFetchingNextPage}
-                isLoading={isFetchingNextPage}
-                isDisabled={isFetchingNextPage}
-                style={{ overflow: 'visible' }}
-                onClick={onShowMoreClick}
-              >
-                {isFetchingNextPage ? <Spinner size="lg" /> : 'Show more'}
-              </SelectOption>
-            )}
           </>
+        )}
+        {canShowMore && (
+          <SelectOption
+            value={LOADER_ID}
+            isLoadButton={!isFetchingNextPage}
+            isLoading={isFetchingNextPage}
+            isDisabled={isFetchingNextPage}
+            style={{ overflow: 'visible' }}
+            onClick={onShowMoreClick}
+          >
+            {isFetchingNextPage ? <Spinner size="lg" /> : 'Show more'}
+          </SelectOption>
         )}
         {systemViews.length > 0 && (
           <>

--- a/src/components/InventoryViews/hooks/useViewsQuery.ts
+++ b/src/components/InventoryViews/hooks/useViewsQuery.ts
@@ -5,11 +5,7 @@ import { listViewsApi } from '../../../api/inventoryViewsApi';
 export const DEFAULT_PAGE_SIZE = 50;
 
 /**
- * Hook for fetching the list of inventory views visible to the current user.
- *
- * The views are fetched page by page, but every page is loaded eagerly so the
- * complete list is always available. This guarantees the "All systems" view is
- * present regardless of which page it lands on.
+ * Hook for fetching the list of inventory views visible to the current user, paginated.
  *
  *  @param pageSize number of views to fetch per page
  *  @returns        an infinite query result with `data.pages`, `fetchNextPage`, and `hasNextPage`
@@ -18,7 +14,7 @@ export const DEFAULT_PAGE_SIZE = 50;
  * const viewNames = data?.pages.flatMap((p) => p.results).map((v) => v.name) ?? [];
  */
 export const useViewsQuery = (pageSize = DEFAULT_PAGE_SIZE) => {
-  const query = useInfiniteQuery({
+  return useInfiniteQuery({
     queryKey: ['views', pageSize],
     queryFn: ({ pageParam }) =>
       listViewsApi({ page: pageParam, perPage: pageSize }),
@@ -28,14 +24,4 @@ export const useViewsQuery = (pageSize = DEFAULT_PAGE_SIZE) => {
         ? lastPage.page + 1
         : null,
   });
-
-  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
-
-  useEffect(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      void fetchNextPage();
-    }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  return query;
 };

--- a/src/components/InventoryViews/hooks/useViewsQuery.ts
+++ b/src/components/InventoryViews/hooks/useViewsQuery.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { listViewsApi } from '../../../api/inventoryViewsApi';
 


### PR DESCRIPTION
## What
Stop query all pages for views on page load

## Why
Backend is fixed: Prioritize system views ahead of user views in the views listing  https://github.com/RedHatInsights/insights-host-inventory/pull/4887


## Testing
- When fisrt time Systems page is visited in network tab only 1 request for views is visble
<img width="832" height="197" alt="image" src="https://github.com/user-attachments/assets/14c5365b-2afd-460f-9aa1-4b43214daa23" />
- The "All systems" option is on top

## Screenshots/Videos (if applicable)
Before qe-u-inventory account:
<img width="538" height="252" alt="image" src="https://github.com/user-attachments/assets/1ef336d0-b8f8-4d7a-939b-18f8d0056f95" />

## Summary by Sourcery

Load the initial inventory views page only and fetch additional pages when requested.

Bug Fixes:
- Prevent inventory views from eagerly fetching every page when the view selector loads.

Enhancements:
- Keep view pagination on demand while preserving the ability to load additional views from the selector.