### PR TITLE
chore(RHINENG-30676): Adjust InvViews column widths

### DIFF
--- a/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/compliance/columnDefinitions.tsx
@@ -22,7 +22,7 @@ const policiesSpec: ColumnSpec<ComplianceAppData | undefined> = {
   appName: APP_NAME,
   title: 'Policies',
   key: ApiHostViewsGetHostViewsOrderByEnum.CompliancepoliciesCount,
-  minWidth: '7rem',
+  minWidth: '9rem',
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.CompliancepoliciesCount,
   renderCell: (value) => <Policies appData={value} />,
 };

--- a/src/components/SystemsView/columns/content/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/content/columnDefinitions.tsx
@@ -29,6 +29,7 @@ const templateSpec: ColumnSpec<PatchAppData | undefined> = {
   title: 'Template',
   key: ApiHostViewsGetHostViewsOrderByEnum.PatchtemplateName,
   sortBy: ApiHostViewsGetHostViewsOrderByEnum.PatchtemplateName,
+  minWidth: '9rem',
   renderCell: (value) => <Template appData={value} />,
 };
 

--- a/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/inventory/columnDefinitions.tsx
@@ -72,7 +72,7 @@ export const tagsSpec: ColumnSpec<TagsValue> = {
   appName: APP_NAME,
   title: 'Tags',
   key: 'tags',
-  minWidth: '6rem',
+  minWidth: '7rem',
   renderCell: (value) => <Tags value={value} />,
 };
 
@@ -89,7 +89,7 @@ export const lastSeenSpec: ColumnSpec<LastSeenValue> = {
   appName: APP_NAME,
   title: <LastSeenColumnHeader />,
   key: ApiOrderByEnum.LastCheckIn,
-  minWidth: '9rem',
+  minWidth: '10rem',
   sortBy: ApiOrderByEnum.LastCheckIn,
   renderCell: (value) => <LastSeen value={value} />,
 };
@@ -107,6 +107,7 @@ export const infrastructureSpec: ColumnSpec<string | undefined> = {
   appName: APP_NAME,
   title: 'Infrastructure',
   key: 'infrastructure',
+  minWidth: '9rem',
   renderCell: (value) => <Infrastructure value={value} />,
 };
 
@@ -114,6 +115,7 @@ export const vendorSpec: ColumnSpec<string | undefined> = {
   appName: APP_NAME,
   title: 'Vendor',
   key: 'vendor',
+  minWidth: '9rem',
   renderCell: (value) => <Vendor value={value} />,
 };
 
@@ -121,6 +123,7 @@ export const workloadSpec: ColumnSpec<SystemProfileWorkloads | undefined> = {
   appName: APP_NAME,
   title: 'Workload',
   key: 'workload',
+  minWidth: '9rem',
   renderCell: (value) => <Workload value={value} />,
 };
 
@@ -128,6 +131,7 @@ export const createdSpec: ColumnSpec<CreatedValue> = {
   appName: APP_NAME,
   title: 'Created',
   key: 'created',
+  minWidth: '9rem',
   renderCell: (value) => <Created value={value} />,
 };
 
@@ -137,6 +141,7 @@ export const dataCollectorSpec: ColumnSpec<
   appName: APP_NAME,
   title: 'Data collector',
   key: 'per_reporter_staleness',
+  minWidth: '9rem',
   renderCell: (value) => <DataCollector value={value} />,
 };
 

--- a/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
+++ b/src/components/SystemsView/columns/vulnerability/columnDefinitions.tsx
@@ -77,7 +77,7 @@ const importantCvesSpec: ColumnSpec<VulnerabilityCountValue> = {
   appName: APP_NAME,
   title: 'Important CVEs',
   key: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilityimportantCves,
-  minWidth: '10rem',
+  minWidth: '12rem',
   sortBy: IMPORTANT_CVES_SORT_KEY,
   renderCell: (value) => (
     <VulnerabilityCount
@@ -93,7 +93,7 @@ const cvesWithSecurityRulesSpec: ColumnSpec<VulnerabilityCountValue> = {
   appName: APP_NAME,
   title: 'CVEs with security rules',
   key: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitycvesWithSecurityRules,
-  minWidth: '10rem',
+  minWidth: '12rem',
   sortBy: CVES_WITH_SECURITY_RULES_SORT_KEY,
   renderCell: (value) => (
     <VulnerabilityCount
@@ -109,7 +109,7 @@ const cvesWithKnownExploitsSpec: ColumnSpec<VulnerabilityCountValue> = {
   appName: APP_NAME,
   title: 'CVEs with known exploits',
   key: ApiHostViewsGetHostViewsOrderByEnum.VulnerabilitycvesWithKnownExploits,
-  minWidth: '10rem',
+  minWidth: '12rem',
   sortBy: CVES_WITH_KNOWN_EXPLOITS_SORT_KEY,
   renderCell: (value) => (
     <VulnerabilityCount


### PR DESCRIPTION
## Jira
[RHINENG-30676](https://redhat.atlassian.net/browse/RHINENG-30676)

## What
This PR adjusts column widths in Inventory views to allow most column headers to avoid truncation. Some longer headers will still be truncated.

## Screenshots/Videos (if applicable)
<img width="3351" height="1311" alt="image" src="https://github.com/user-attachments/assets/efb3bab2-f96c-4ed3-bd10-81cc973616ca" />

<img width="1614" height="1287" alt="image" src="https://github.com/user-attachments/assets/57a368dc-249e-4c00-bb1f-0d59a25d95fb" />

[RHINENG-30676]: https://redhat.atlassian.net/browse/RHINENG-30676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Increase minimum widths for Inventory view columns to improve header readability and reduce truncation across compliance, content, inventory, and vulnerability views.