### PR TITLE
feat(RHINENG-30641): Add typeahead to view selector

### DIFF
--- a/_playwright-tests/helpers/views/manageViewsHelper.ts
+++ b/_playwright-tests/helpers/views/manageViewsHelper.ts
@@ -4,6 +4,7 @@ import { Page, Locator, expect } from '@playwright/test';
 export type ManageViewHelper = {
   manageViewToggle: Locator;
   selectedView: Locator;
+  selectedViewInput: Locator;
   selectedViewMenu: Locator;
   selectView: (view: string) => Promise<void>;
   saveAs: (view: string) => Promise<void>;
@@ -25,13 +26,16 @@ export type ManageViewHelper = {
 export function manageViewHelper(page: Page): ManageViewHelper {
   const manageViewToggle = page.getByTestId('manage-view-toggle');
   const selectedView = page.getByTestId('manage-view-select-view');
+  // The active view name is rendered as the typeahead input's value (not text
+  // content), so assertions must read the value rather than the element text.
+  const selectedViewInput = selectedView.getByRole('textbox');
   const selectedViewMenu = page.getByTestId('manage-view-select-view-dropdown');
 
   const verifyActiveView = async (
     expectedViewName: string,
     { timeout = 5000 }: { timeout?: number } = {},
   ): Promise<void> => {
-    await expect(selectedView).toContainText(expectedViewName, {
+    await expect(selectedViewInput).toHaveValue(expectedViewName, {
       timeout,
     });
   };
@@ -39,6 +43,7 @@ export function manageViewHelper(page: Page): ManageViewHelper {
   return {
     manageViewToggle,
     selectedView,
+    selectedViewInput,
     selectedViewMenu,
 
     /**
@@ -125,7 +130,7 @@ export function manageViewHelper(page: Page): ManageViewHelper {
 
       // The UI falls back to another view after deletion; the title can take a
       // moment to update, so give this a longer timeout than the default.
-      await expect(selectedView).not.toContainText(view, {
+      await expect(selectedViewInput).not.toHaveValue(view, {
         timeout: 10000,
       });
     },

--- a/_playwright-tests/test_manage_views.test.ts
+++ b/_playwright-tests/test_manage_views.test.ts
@@ -54,7 +54,7 @@ test.describe(
       });
 
       await test.step(`Verifies active view now is default view after deletion`, async () => {
-        await expect(manageView.selectedView).toContainText(ALL_SYSTEMS_VIEW);
+        await manageView.verifyActiveView(ALL_SYSTEMS_VIEW);
       });
     });
   },

--- a/src/components/InventoryViews/ViewsToolbar/ViewSelector.test.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewSelector.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import ViewSelector from './ViewSelector';
@@ -20,14 +20,14 @@ describe('ViewSelector', () => {
   it('should render the active view name in the toggle', () => {
     renderViewSelector();
 
-    expect(screen.getByText('All systems')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('All systems')).toBeInTheDocument();
   });
 
   it('should show dropdown options when clicked', async () => {
     const user = userEvent.setup();
     renderViewSelector();
 
-    await user.click(screen.getByRole('button', { name: 'Select a view' }));
+    await user.click(screen.getByRole('textbox'));
 
     const listbox = screen.getByRole('listbox');
     for (const view of MOCK_VIEWS) {
@@ -40,7 +40,7 @@ describe('ViewSelector', () => {
     const onSelectView = jest.fn();
     renderViewSelector({ onSelectView });
 
-    await user.click(screen.getByRole('button', { name: 'Select a view' }));
+    await user.click(screen.getByRole('textbox'));
     await user.click(screen.getByText('Production view'));
 
     expect(onSelectView).toHaveBeenCalledWith('view-production');
@@ -50,8 +50,8 @@ describe('ViewSelector', () => {
     const user = userEvent.setup();
     renderViewSelector();
 
-    const toggle = screen.getByRole('button', { name: 'Select a view' });
-    await user.click(toggle);
+    const toggle = screen.getByRole('button', { name: 'Menu toggle' });
+    await user.click(screen.getByRole('textbox'));
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
 
     await user.click(screen.getByText('Production view'));
@@ -62,14 +62,14 @@ describe('ViewSelector', () => {
   it('should show the selected view name in the toggle', () => {
     renderViewSelector({ activeViewId: 'view-production' });
 
-    expect(screen.getByText('Production view')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Production view')).toBeInTheDocument();
   });
 
   it('should render dividers between sections', async () => {
     const user = userEvent.setup();
     renderViewSelector();
 
-    await user.click(screen.getByRole('button', { name: 'Select a view' }));
+    await user.click(screen.getByRole('textbox'));
 
     const dividers = screen.getAllByRole('separator');
     expect(dividers.length).toBeGreaterThanOrEqual(2);
@@ -79,9 +79,64 @@ describe('ViewSelector', () => {
     const user = userEvent.setup();
     renderViewSelector();
 
-    await user.click(screen.getByRole('button', { name: 'Select a view' }));
+    await user.click(screen.getByRole('textbox'));
 
     const systemLabels = screen.getAllByText('System');
     expect(systemLabels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should filter views based on search input', async () => {
+    const user = userEvent.setup();
+    renderViewSelector();
+
+    const searchInput = screen.getByRole('textbox');
+    await user.click(searchInput);
+    await user.type(searchInput, 'Production');
+
+    await waitFor(() => {
+      const listbox = screen.getByRole('listbox');
+      expect(within(listbox).getByText('Production view')).toBeInTheDocument();
+      expect(
+        within(listbox).queryByText('RHEL 9 staging'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show "No matching views" when search returns no results', async () => {
+    const user = userEvent.setup();
+    renderViewSelector();
+
+    const searchInput = screen.getByRole('textbox');
+    await user.click(searchInput);
+    await user.type(searchInput, 'NonexistentView');
+
+    await waitFor(() => {
+      expect(screen.getByText('No matching views')).toBeInTheDocument();
+    });
+  });
+
+  it('should hide "All systems" view when filtering', async () => {
+    const user = userEvent.setup();
+    renderViewSelector();
+
+    const searchInput = screen.getByRole('textbox');
+    await user.click(searchInput);
+
+    // "All systems" option should be visible in the dropdown without search
+    const listbox = screen.getByRole('listbox');
+    expect(within(listbox).getByText('All systems')).toBeInTheDocument();
+
+    // Clear the input and type a search term
+    await user.clear(searchInput);
+    await user.type(searchInput, 'Production');
+
+    await waitFor(() => {
+      // "All systems" should be hidden when filtering
+      expect(
+        within(listbox).queryByText('All systems'),
+      ).not.toBeInTheDocument();
+      // But matching views should still show
+      expect(within(listbox).getByText('Production view')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/InventoryViews/ViewsToolbar/ViewSelector.tsx
+++ b/src/components/InventoryViews/ViewsToolbar/ViewSelector.tsx
@@ -1,8 +1,7 @@
-import React, { Ref, useState } from 'react';
+import React, { Ref, useState, useMemo } from 'react';
 import {
   Divider,
   Label,
-  MenuToggle,
   MenuToggleElement,
   Select,
   SelectList,
@@ -11,6 +10,9 @@ import {
 } from '@patternfly/react-core';
 import type { ViewOut } from '../../../api/inventoryViewsApi';
 import { DEFAULT_PAGE_SIZE } from '../hooks/useViewsQuery';
+import { TypeaheadMenuToggle } from '../../SystemsView/filters/TypeaheadMenuToggle';
+import { useDebouncedValue } from '../../../Utilities/hooks/useDebouncedValue';
+import { DEBOUNCE_TIMEOUT_MS } from '../../../constants';
 
 export interface ViewSelectorProps {
   views: ViewOut[];
@@ -34,38 +36,63 @@ const ViewSelector = ({
 }: ViewSelectorProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [visibleSize, setVisibleSize] = useState(PAGE_SIZE);
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebouncedValue(search, DEBOUNCE_TIMEOUT_MS);
 
   const activeView = views.find((v) => v.id === activeViewId);
   const toggleLabel = activeView?.name ?? 'All systems';
 
-  const { allSystemsView, userViews, systemViews } = views.reduce<{
-    allSystemsView: ViewOut | undefined;
-    userViews: ViewOut[];
-    systemViews: ViewOut[];
-  }>(
-    (acc, view) => {
-      if (view.is_system_view) {
-        if (!acc.allSystemsView) {
-          acc.allSystemsView = view;
-        } else {
-          acc.systemViews.push(view);
+  // Group and filter views based on search
+  const { allSystemsView, userViews, systemViews } = useMemo(() => {
+    const searchLower = debouncedSearch.toLowerCase();
+
+    return views.reduce<{
+      allSystemsView: ViewOut | undefined;
+      userViews: ViewOut[];
+      systemViews: ViewOut[];
+    }>(
+      (acc, view) => {
+        // Identify "All systems" view by name before filtering
+        const isAllSystemsView = view.name === 'All systems';
+
+        // Filter by search term
+        const matchesSearch =
+          !searchLower || view.name.toLowerCase().includes(searchLower);
+
+        if (!matchesSearch) {
+          return acc;
         }
-      } else {
-        acc.userViews.push(view);
-      }
-      return acc;
-    },
-    { allSystemsView: undefined, userViews: [], systemViews: [] },
-  );
+
+        if (isAllSystemsView) {
+          // Hide "All systems" view when filtering, similar to "Ungrouped Hosts" in WorkspaceFilter
+          if (!debouncedSearch) {
+            acc.allSystemsView = view;
+          }
+        } else if (view.is_system_view) {
+          acc.systemViews.push(view);
+        } else {
+          acc.userViews.push(view);
+        }
+        return acc;
+      },
+      { allSystemsView: undefined, userViews: [], systemViews: [] },
+    );
+  }, [views, debouncedSearch]);
 
   const onToggleClick = () => {
-    setIsOpen((prev) => !prev);
+    if (!isOpen) {
+      setIsOpen(true);
+    } else {
+      setIsOpen(false);
+      setSearch('');
+    }
   };
 
   const onSelect = (_event: unknown, value: string | undefined) => {
     if (!value || value === LOADER_ID) return;
     onSelectView(value);
     setIsOpen(false);
+    setSearch('');
   };
 
   const visibleUserViews = userViews.slice(0, visibleSize);
@@ -82,15 +109,16 @@ const ViewSelector = ({
   };
 
   const toggle = (toggleRef: Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={onToggleClick}
+    <TypeaheadMenuToggle
+      toggleRef={toggleRef}
       isExpanded={isOpen}
-      aria-label="Select a view"
+      onToggleClick={onToggleClick}
+      searchValue={isOpen ? search : toggleLabel}
+      onSearchChange={setSearch}
+      placeholder={isOpen ? 'Search views...' : ''}
+      inputId="view-selector-typeahead-input"
       data-testid="manage-view-select-view"
-    >
-      {toggleLabel}
-    </MenuToggle>
+    />
   );
 
   return (
@@ -100,7 +128,10 @@ const ViewSelector = ({
       onSelect={onSelect}
       onOpenChange={(open) => {
         setIsOpen(open);
-        if (!open) setVisibleSize(PAGE_SIZE);
+        if (!open) {
+          setVisibleSize(PAGE_SIZE);
+          setSearch('');
+        }
       }}
       toggle={toggle}
       data-testid="manage-view-select-view-dropdown"
@@ -108,6 +139,12 @@ const ViewSelector = ({
       isScrollable
     >
       <SelectList>
+        {!allSystemsView &&
+          userViews.length === 0 &&
+          systemViews.length === 0 &&
+          debouncedSearch && (
+            <SelectOption isDisabled>No matching views</SelectOption>
+          )}
         {allSystemsView && (
           <SelectOption key={allSystemsView.id} value={allSystemsView.id}>
             {allSystemsView.name}
@@ -115,7 +152,7 @@ const ViewSelector = ({
         )}
         {userViews.length > 0 && (
           <>
-            <Divider />
+            {allSystemsView && <Divider />}
             {visibleUserViews.map((view) => (
               <SelectOption key={view.id} value={view.id}>
                 {view.name}
@@ -137,7 +174,7 @@ const ViewSelector = ({
         )}
         {systemViews.length > 0 && (
           <>
-            <Divider />
+            {(allSystemsView || userViews.length > 0) && <Divider />}
             {systemViews.map((view) => (
               <SelectOption
                 key={view.id}

--- a/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
+++ b/src/components/SystemsView/filters/OperatingSystemsFilter.tsx
@@ -1,15 +1,13 @@
-import React, { Ref, useId, useMemo, useState, useEffect, useRef } from 'react';
+import React, { Ref, useId, useMemo, useState, useRef } from 'react';
 import {
   Checkbox,
-  MenuToggle,
   Select,
   SelectList,
   SelectOption,
   Spinner,
   MenuToggleElement,
-  TextInputGroup,
-  TextInputGroupMain,
 } from '@patternfly/react-core';
+import { TypeaheadMenuToggle } from './TypeaheadMenuToggle';
 import { css } from '@patternfly/react-styles';
 import menuStyles from '@patternfly/react-styles/css/components/Menu/menu';
 import xor from 'lodash/xor';
@@ -122,13 +120,6 @@ export const OperatingSystemsFilter = ({
       .filter((group): group is NonNullable<typeof group> => group !== null);
   }, [groups, debouncedSearch]);
 
-  // Auto-open when user starts typing (if closed)
-  useEffect(() => {
-    if (search && !isOpen) {
-      setIsOpen(true);
-    }
-  }, [search, isOpen]);
-
   const onToggleClick = () => {
     // Toggle button should open/close the dropdown
     if (!isOpen) {
@@ -142,36 +133,16 @@ export const OperatingSystemsFilter = ({
   };
 
   const toggle = (toggleRef: Ref<MenuToggleElement>) => (
-    <MenuToggle
-      variant="typeahead"
-      onClick={onToggleClick}
-      innerRef={toggleRef}
+    <TypeaheadMenuToggle
+      toggleRef={toggleRef}
       isExpanded={isOpen}
-    >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          ref={textInputRef}
-          value={search}
-          onClick={(e) => {
-            // Clicks in the input should only open the menu, not toggle it closed
-            e.stopPropagation();
-            setIsOpen(true);
-          }}
-          onChange={(_event, value) => {
-            setSearch(value);
-          }}
-          onFocus={() => {
-            // Open dropdown when input gains focus
-            if (!isOpen) {
-              setIsOpen(true);
-            }
-          }}
-          id={`${idPrefix}-os-filter-typeahead-input`}
-          autoComplete="off"
-          placeholder={placeholder ?? 'Filter by operating system'}
-        />
-      </TextInputGroup>
-    </MenuToggle>
+      onToggleClick={onToggleClick}
+      searchValue={search}
+      onSearchChange={setSearch}
+      placeholder={placeholder ?? 'Filter by operating system'}
+      inputId={`${idPrefix}-os-filter-typeahead-input`}
+      inputRef={textInputRef}
+    />
   );
 
   const notifyChange = (next: string[]) => {

--- a/src/components/SystemsView/filters/TypeaheadMenuToggle.test.tsx
+++ b/src/components/SystemsView/filters/TypeaheadMenuToggle.test.tsx
@@ -1,0 +1,167 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { createRef } from 'react';
+import { MenuToggleElement } from '@patternfly/react-core';
+import { TypeaheadMenuToggle } from './TypeaheadMenuToggle';
+
+describe('TypeaheadMenuToggle', () => {
+  const defaultProps = {
+    toggleRef: createRef<MenuToggleElement>(),
+    isExpanded: false,
+    onToggleClick: jest.fn(),
+    searchValue: '',
+    onSearchChange: jest.fn(),
+    placeholder: 'Search...',
+    inputId: 'test-input',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with correct placeholder', () => {
+    render(<TypeaheadMenuToggle {...defaultProps} />);
+
+    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+  });
+
+  it('should render with search value', () => {
+    render(<TypeaheadMenuToggle {...defaultProps} searchValue="test query" />);
+
+    expect(screen.getByDisplayValue('test query')).toBeInTheDocument();
+  });
+
+  it('should call onToggleClick when menu toggle button is clicked', async () => {
+    const user = userEvent.setup();
+    const onToggleClick = jest.fn();
+
+    render(
+      <TypeaheadMenuToggle {...defaultProps} onToggleClick={onToggleClick} />,
+    );
+
+    const toggleButton = screen.getByRole('button', { name: 'Menu toggle' });
+    await user.click(toggleButton);
+
+    expect(onToggleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onSearchChange when typing in input', async () => {
+    const user = userEvent.setup();
+    const onSearchChange = jest.fn();
+
+    render(
+      <TypeaheadMenuToggle {...defaultProps} onSearchChange={onSearchChange} />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'test');
+
+    expect(onSearchChange).toHaveBeenCalledWith('t');
+    expect(onSearchChange).toHaveBeenCalledWith('e');
+    expect(onSearchChange).toHaveBeenCalledWith('s');
+    expect(onSearchChange).toHaveBeenCalledWith('t');
+  });
+
+  it('should call onToggleClick when clicking input while closed', async () => {
+    const user = userEvent.setup();
+    const onToggleClick = jest.fn();
+
+    render(
+      <TypeaheadMenuToggle
+        {...defaultProps}
+        isExpanded={false}
+        onToggleClick={onToggleClick}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+
+    // Called twice: once from onClick, once from onFocus
+    expect(onToggleClick).toHaveBeenCalled();
+  });
+
+  it('should NOT call onToggleClick when clicking input while already open', async () => {
+    const user = userEvent.setup();
+    const onToggleClick = jest.fn();
+
+    render(
+      <TypeaheadMenuToggle
+        {...defaultProps}
+        isExpanded={true}
+        onToggleClick={onToggleClick}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+
+    // Input click should NOT toggle when already open (stopPropagation behavior)
+    expect(onToggleClick).not.toHaveBeenCalled();
+  });
+
+  it('should call onToggleClick when input receives focus while closed', () => {
+    const onToggleClick = jest.fn();
+
+    render(
+      <TypeaheadMenuToggle
+        {...defaultProps}
+        isExpanded={false}
+        onToggleClick={onToggleClick}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    input.focus();
+
+    expect(onToggleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT call onToggleClick when input receives focus while already open', () => {
+    const onToggleClick = jest.fn();
+
+    render(
+      <TypeaheadMenuToggle
+        {...defaultProps}
+        isExpanded={true}
+        onToggleClick={onToggleClick}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    input.focus();
+
+    // Focus should NOT toggle when already open
+    expect(onToggleClick).not.toHaveBeenCalled();
+  });
+
+  it('should render textbox input', () => {
+    render(<TypeaheadMenuToggle {...defaultProps} />);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should attach inputRef to the input element', () => {
+    const inputRef = createRef<HTMLInputElement>();
+
+    render(<TypeaheadMenuToggle {...defaultProps} inputRef={inputRef} />);
+
+    expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
+    expect(inputRef.current).toBe(screen.getByRole('textbox'));
+  });
+
+  it('should render with aria-expanded true when expanded', () => {
+    render(<TypeaheadMenuToggle {...defaultProps} isExpanded={true} />);
+
+    const toggleButton = screen.getByRole('button', { name: 'Menu toggle' });
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('should render with aria-expanded false when collapsed', () => {
+    render(<TypeaheadMenuToggle {...defaultProps} isExpanded={false} />);
+
+    const toggleButton = screen.getByRole('button', { name: 'Menu toggle' });
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/src/components/SystemsView/filters/TypeaheadMenuToggle.tsx
+++ b/src/components/SystemsView/filters/TypeaheadMenuToggle.tsx
@@ -1,0 +1,61 @@
+import React, { Ref } from 'react';
+import {
+  MenuToggle,
+  MenuToggleElement,
+  TextInputGroup,
+  TextInputGroupMain,
+} from '@patternfly/react-core';
+
+export interface TypeaheadMenuToggleProps {
+  toggleRef: Ref<MenuToggleElement>;
+  isExpanded: boolean;
+  onToggleClick: () => void;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  placeholder?: string;
+  inputId?: string;
+  inputRef?: React.RefObject<HTMLInputElement>;
+  'data-testid'?: string;
+}
+
+export const TypeaheadMenuToggle = ({
+  toggleRef,
+  isExpanded,
+  onToggleClick,
+  searchValue,
+  onSearchChange,
+  placeholder,
+  inputId,
+  inputRef,
+  'data-testid': dataTestId,
+}: TypeaheadMenuToggleProps) => (
+  <MenuToggle
+    variant="typeahead"
+    onClick={onToggleClick}
+    innerRef={toggleRef}
+    isExpanded={isExpanded}
+    data-testid={dataTestId}
+  >
+    <TextInputGroup isPlain>
+      <TextInputGroupMain
+        ref={inputRef}
+        value={searchValue}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (!isExpanded) {
+            onToggleClick();
+          }
+        }}
+        onChange={(_event, val) => onSearchChange(val)}
+        onFocus={() => {
+          if (!isExpanded) {
+            onToggleClick();
+          }
+        }}
+        id={inputId}
+        autoComplete="off"
+        placeholder={placeholder}
+      />
+    </TextInputGroup>
+  </MenuToggle>
+);

--- a/src/components/SystemsView/filters/WorkspaceFilter.tsx
+++ b/src/components/SystemsView/filters/WorkspaceFilter.tsx
@@ -8,9 +8,6 @@ import React, {
   Ref,
 } from 'react';
 import {
-  MenuToggle,
-  TextInputGroup,
-  TextInputGroupMain,
   Select,
   SelectList,
   SelectOption,
@@ -21,6 +18,7 @@ import {
   Flex,
   FlexItem,
 } from '@patternfly/react-core';
+import { TypeaheadMenuToggle } from './TypeaheadMenuToggle';
 import xor from 'lodash/xor';
 import { useDebouncedValue } from '../../../Utilities/hooks/useDebouncedValue';
 import { useWorkspaceGroupsInfiniteQuery } from '../../filters/useWorkspaceGroupsInfiniteQuery';
@@ -109,13 +107,6 @@ export const WorkspaceFilter = ({
     setFocusedOption(visibleSize);
   };
 
-  // Auto-open when user starts typing (if closed)
-  useEffect(() => {
-    if (search && !isOpen) {
-      setIsOpen(true);
-    }
-  }, [search, isOpen]);
-
   useEffect(() => {
     focusedOptionRef.current?.focus();
   }, [visibleSize]);
@@ -125,25 +116,15 @@ export const WorkspaceFilter = ({
   };
 
   const toggle = (toggleRef: Ref<MenuToggleElement>) => (
-    <MenuToggle
-      variant="typeahead"
-      onClick={onToggleClick}
-      innerRef={toggleRef}
+    <TypeaheadMenuToggle
+      toggleRef={toggleRef}
       isExpanded={isOpen}
-    >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          value={search}
-          onClick={onToggleClick}
-          onChange={(_event, value) => {
-            setSearch(value);
-          }}
-          id="multi-typeahead-select-input"
-          autoComplete="off"
-          placeholder={placeholder ?? ''}
-        />
-      </TextInputGroup>
-    </MenuToggle>
+      onToggleClick={onToggleClick}
+      searchValue={search}
+      onSearchChange={setSearch}
+      placeholder={placeholder ?? ''}
+      inputId="multi-typeahead-select-input"
+    />
   );
 
   return (


### PR DESCRIPTION
## Jira
[RHINENG-30641](https://redhat.atlassian.net/browse/RHINENG-30641)

## What
This PR creates a shared typeahead menu toggle for the workspace filter, operating system filter, and view selector dropdown.


[RHINENG-30641]: https://redhat.atlassian.net/browse/RHINENG-30641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add shared typeahead controls and searchable filtering to view selection and related inventory filters.

New Features:
- Add searchable typeahead behavior to the view selector, including debounced filtering and an empty-results message.

Enhancements:
- Introduce a shared typeahead menu toggle for the view selector, workspace filter, and operating-system filter with consistent open, focus, and input behavior.

Tests:
- Add coverage for the shared typeahead toggle and view selector filtering, empty results, and conditional view visibility.