### PR TITLE
chore(deps): bump host-inventory-client package from 7.0.0 to 7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@redhat-cloud-services/frontend-components": "^7.10.5",
         "@redhat-cloud-services/frontend-components-notifications": "^6.11.5",
         "@redhat-cloud-services/frontend-components-utilities": "^7.5.3",
-        "@redhat-cloud-services/host-inventory-client": "^7.0.0",
+        "@redhat-cloud-services/host-inventory-client": "^7.1.0",
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.15",
         "@sentry/webpack-plugin": "^2.23.1",
         "@tanstack/react-query": "^5.90.21",
@@ -7822,13 +7822,13 @@
       }
     },
     "node_modules/@redhat-cloud-services/host-inventory-client": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-7.0.0.tgz",
-      "integrity": "sha512-/C0zOYlolPSCgBwH9zAcY03xa4v/JAyseclTx7No2+uuvF5mSPejpD4O68ojkB+ByfVs/WIiaUmZ5iDlmxWeMQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-7.1.0.tgz",
+      "integrity": "sha512-Fe5g95xat86yWM4ztVZJPaLIjvBVv0i4ps6zFMFmo2xGakNCFrG7tlSArDxnk4a6KvHh9K8YMu0VZu6HNvTPEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.5",
-        "axios": "^1.18.1",
+        "axios": "^1.20.0",
         "tslib": "^2.6.2"
       }
     },
@@ -11850,9 +11850,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
-      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@redhat-cloud-services/frontend-components": "^7.10.5",
     "@redhat-cloud-services/frontend-components-notifications": "^6.11.5",
     "@redhat-cloud-services/frontend-components-utilities": "^7.5.3",
-    "@redhat-cloud-services/host-inventory-client": "^7.0.0",
+    "@redhat-cloud-services/host-inventory-client": "^7.1.0",
     "@redhat-cloud-services/javascript-clients-shared": "^2.0.15",
     "@sentry/webpack-plugin": "^2.23.1",
     "@tanstack/react-query": "^5.90.21",


### PR DESCRIPTION
chore(deps): bump host-inventory-client package from 7.0.0 to 7.1.0

## Why
unblock Inventory Views and containerized workloads changes in UI

## Summary by Sourcery

Upgrade the host inventory client to unblock inventory views and containerized workload support in the UI.

Enhancements:
- Update the host inventory client dependency to version 7.1.0 to support the latest inventory views and containerized workload changes.

Chores:
- Refresh the lockfile for the dependency update.