### PR TITLE
test(e2e): fix E2E workspaces tests

### DIFF
--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -58,16 +58,16 @@ setup.describe('Setup', () => {
     await authenticateUser(page, admin);
   });
 
-  if (!isProd) {
-    setup('Ensure RBAC ENV variables exist', async () => {
-      expect(() => throwIfMissingRbacEnvVariables()).not.toThrow();
-    });
+  // if (!isProd) {
+  //   setup('Ensure RBAC ENV variables exist', async () => {
+  //     expect(() => throwIfMissingRbacEnvVariables()).not.toThrow();
+  //   });
 
-    for (const user of getRbacUsersForSetup()) {
-      setup(`Authenticate as ${user.role}`, async ({ page }) => {
-        setup.setTimeout(120_000);
-        await authenticateUser(page, user);
-      });
-    }
-  }
+  //   for (const user of getRbacUsersForSetup()) {
+  //     setup(`Authenticate as ${user.role}`, async ({ page }) => {
+  //       setup.setTimeout(120_000);
+  //       await authenticateUser(page, user);
+  //     });
+  //   }
+  // }
 });

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -58,16 +58,16 @@ setup.describe('Setup', () => {
     await authenticateUser(page, admin);
   });
 
-  // if (!isProd) {
-  //   setup('Ensure RBAC ENV variables exist', async () => {
-  //     expect(() => throwIfMissingRbacEnvVariables()).not.toThrow();
-  //   });
+  if (!isProd) {
+    setup('Ensure RBAC ENV variables exist', async () => {
+      expect(() => throwIfMissingRbacEnvVariables()).not.toThrow();
+    });
 
-  //   for (const user of getRbacUsersForSetup()) {
-  //     setup(`Authenticate as ${user.role}`, async ({ page }) => {
-  //       setup.setTimeout(120_000);
-  //       await authenticateUser(page, user);
-  //     });
-  //   }
-  // }
+    for (const user of getRbacUsersForSetup()) {
+      setup(`Authenticate as ${user.role}`, async ({ page }) => {
+        setup.setTimeout(120_000);
+        await authenticateUser(page, user);
+      });
+    }
+  }
 });

--- a/_playwright-tests/helpers/cleanup.ts
+++ b/_playwright-tests/helpers/cleanup.ts
@@ -1,11 +1,22 @@
 import fs from 'fs';
 import path from 'path';
 import { MANIFEST_PATH, RUN_ID, GLOBAL_DATA_PATH } from './constants';
+import { deleteWorkspaceById } from './apiHelpers';
 
 interface ArchiveEntry {
   archiveName: string;
   workingDir: string;
 }
+
+interface WorkspaceEntry {
+  id: string;
+  name: string;
+}
+
+const WORKSPACE_MANIFEST_PATH = path.resolve(
+  __dirname,
+  `../.workspace-manifest-${RUN_ID}.jsonl`,
+);
 
 /**
  * Records archive metadata to a local JSON manifest for tracking and cleanup.
@@ -59,6 +70,68 @@ export function cleanupAllArchives() {
     fs.unlinkSync(MANIFEST_PATH);
   } catch (error) {
     console.error('Error during cleanupAllArchives:', error);
+  }
+}
+
+/**
+ * Records a workspace created by a test so teardown can delete it.
+ * Only session-created workspaces belong here - reusable fixture workspaces
+ * must survive the run.
+ *  @param entry
+ */
+export function recordWorkspaceToManifest(entry: WorkspaceEntry) {
+  try {
+    fs.appendFileSync(WORKSPACE_MANIFEST_PATH, `${JSON.stringify(entry)}\n`);
+  } catch (error) {
+    console.error('Failed to record workspace for cleanup:', error);
+  }
+}
+
+/**
+ * Deletes every workspace created during this run, then removes the manifest.
+ */
+export async function cleanupSessionWorkspaces() {
+  if (!fs.existsSync(WORKSPACE_MANIFEST_PATH)) {
+    console.log(`No workspaces created in run ${RUN_ID}. Skipping...`);
+    return;
+  }
+
+  let entries: WorkspaceEntry[] = [];
+  try {
+    entries = fs
+      .readFileSync(WORKSPACE_MANIFEST_PATH, 'utf-8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line) as WorkspaceEntry);
+  } catch (error) {
+    console.error('Error reading the workspace manifest:', error);
+    return;
+  }
+
+  // Dedupe: a retried test records the same workspace more than once.
+  const uniqueEntries = [...new Map(entries.map((e) => [e.id, e])).values()];
+  let deleted = 0;
+
+  for (const entry of uniqueEntries) {
+    try {
+      await deleteWorkspaceById(entry.id);
+      deleted++;
+    } catch (error) {
+      console.warn(
+        `Failed to delete workspace "${entry.name}" (${entry.id}):`,
+        error,
+      );
+    }
+  }
+
+  console.log(
+    `Deleted ${deleted}/${uniqueEntries.length} workspaces created in this run.`,
+  );
+
+  try {
+    fs.unlinkSync(WORKSPACE_MANIFEST_PATH);
+  } catch (error) {
+    console.error('Error removing the workspace manifest:', error);
   }
 }
 

--- a/_playwright-tests/helpers/filterHelpers.ts
+++ b/_playwright-tests/helpers/filterHelpers.ts
@@ -146,10 +146,17 @@ export const expectAllRowsHaveText = async (
  * @example
  * await searchByName(page, 'my-system-name');
  */
-export const searchByName = async (page: Page, name: string): Promise<void> => {
+export const searchByName = async (
+  page: Page,
+  name: string,
+  isWorkspacesPage: boolean = false,
+): Promise<void> => {
   const searchInput = page.locator('input[placeholder="Filter by name"]');
   await page.reload({
-    waitUntil: isLegacyInventoryTableEnabled ? 'networkidle' : 'load',
+    waitUntil:
+      isLegacyInventoryTableEnabled || isWorkspacesPage
+        ? 'networkidle'
+        : 'load',
   });
   await expect(searchInput).toBeVisible({ timeout: 30000 });
   await searchInput.fill(name);

--- a/_playwright-tests/helpers/globalTeardown.ts
+++ b/_playwright-tests/helpers/globalTeardown.ts
@@ -1,10 +1,15 @@
 // _playwright-tests/helpers/globalTeardown.ts
 import { FullConfig } from '@playwright/test';
-import { cleanupAllArchives, cleanupGlobalTestData } from './cleanup';
+import {
+  cleanupAllArchives,
+  cleanupGlobalTestData,
+  cleanupSessionWorkspaces,
+} from './cleanup';
 
 async function globalTeardown(config: FullConfig) {
   console.log('\n--- Starting Global Teardown ---');
 
+  await cleanupSessionWorkspaces();
   cleanupAllArchives();
   cleanupGlobalTestData();
 

--- a/_playwright-tests/helpers/workspaceHelpers.ts
+++ b/_playwright-tests/helpers/workspaceHelpers.ts
@@ -1,5 +1,6 @@
 import { Response, expect, type Page } from '@playwright/test';
 import { INVENTORY_API_BASE } from './apiHelpers';
+import { recordWorkspaceToManifest } from './cleanup';
 
 /**
  * Locator for the workspace details page header "Actions" menu toggle (not table bulk Actions).
@@ -89,7 +90,11 @@ export const generateUniqueWorkspaceName = async () => {
 };
 
 /**
- * Help function to create a new workspace via the UI modal
+ * Help function to create a new workspace via the UI modal.
+ *
+ * The id from the create response is recorded so global teardown can delete
+ * the workspace at the end of the run. Tracking by id rather than name keeps
+ * cleanup working for tests that rename the workspace afterwards.
  *
  *  @param                   page - The Playwright Page object for interaction.
  *  @param                   name - The unique name to be given to the new workspace.
@@ -102,7 +107,22 @@ export const createNewWorkspace = async (page: Page, name: string) => {
   const dialog = page.locator('[role="dialog"]');
   await expect(dialog).toBeVisible({ timeout: 100000 });
   await dialog.locator('input').first().fill(name);
+
+  // never fail the test just because the id could not be read.
+  const createResponse = page
+    .waitForResponse(isWorkspaceResponse('POST'), { timeout: 60000 })
+    .catch(() => null);
   await dialog.getByRole('button', { name: 'Create' }).click();
+
+  const response = await createResponse;
+  const body = await response?.json().catch(() => null);
+  if (body?.id) {
+    recordWorkspaceToManifest({ id: body.id, name });
+  } else {
+    console.warn(
+      `Could not capture id for workspace "${name}"; skipping cleanup.`,
+    );
+  }
 };
 
 type Method = 'GET' | 'POST' | 'DELETE' | 'PATCH';

--- a/_playwright-tests/test_workspace.test.ts
+++ b/_playwright-tests/test_workspace.test.ts
@@ -20,6 +20,8 @@ import {
 } from './helpers/constants';
 import { isSystemsViewEnabled } from './helpers/constants';
 
+const isWorkspacesPage = true; // Used to determine if the searchByName function is being called from the Workspaces page or not
+
 test.describe('Workspace CRUD - Details Page', () => {
   test('User can create, rename, and delete a workspace from Workspace Details page', async ({
     page,
@@ -45,11 +47,7 @@ test.describe('Workspace CRUD - Details Page', () => {
     const renamedWorkspace = `${workspaceName}_Renamed`;
 
     await test.step('Create a new workspace', async () => {
-      await page.click('button:has-text("Create workspace")');
-      const dialog = page.locator('[role="dialog"]');
-      await expect(dialog).toBeVisible({ timeout: 100000 });
-      await dialog.locator('input').first().fill(workspaceName);
-      await dialog.getByRole('button', { name: 'Create' }).click();
+      await createNewWorkspace(page, workspaceName);
     });
 
     await test.step('Search and open newly created workspace', async () => {
@@ -191,7 +189,7 @@ test.describe('Workspace CRUD - List Page', () => {
 
     await test.step('Search for empty workspaces and bulk delete', async () => {
       await expect(searchInput).toBeVisible();
-      await searchByName(page, 'empty');
+      await searchByName(page, 'empty', isWorkspacesPage);
 
       const bulkSelectCheckbox = page.locator(
         '[data-ouia-component-id="BulkSelectCheckbox"]',
@@ -247,7 +245,7 @@ test.describe('Workspace CRUD - List Page', () => {
       await navigateToWorkspacesFunc(page);
       await createNewWorkspace(page, workspaceName);
       // search for workspace and via 'Name' column make sure only 1 workspace is found
-      await searchByName(page, workspaceName);
+      await searchByName(page, workspaceName, isWorkspacesPage);
       await expect(nameCell).toHaveCount(1, { timeout: 10000 });
       await expect(nameCell).toHaveText(workspaceName);
     });
@@ -255,7 +253,7 @@ test.describe('Workspace CRUD - List Page', () => {
     await test.step('Rename workspace via per-row action from Workspaces page and verify renaming via search', async () => {
       await expect(async () => {
         await page.reload({ waitUntil: 'load' });
-        await searchByName(page, workspaceName);
+        await searchByName(page, workspaceName, isWorkspacesPage);
         const kebab = await waitForTableKebabReady(
           page,
           new RegExp(workspaceName, 'i'),
@@ -275,7 +273,7 @@ test.describe('Workspace CRUD - List Page', () => {
       await dialogModal.getByRole('button', { name: 'Save' }).click();
 
       // search for the new name to confirm rename worked
-      await searchByName(page, renamedWorkspace);
+      await searchByName(page, renamedWorkspace, isWorkspacesPage);
       await expect(nameCell).toHaveCount(1, { timeout: 10000 });
       await expect(nameCell).toHaveText(renamedWorkspace);
     });
@@ -283,7 +281,7 @@ test.describe('Workspace CRUD - List Page', () => {
     await test.step('Delete workspace via per-row action from Workspaces page and verify deletion via search', async () => {
       await expect(async () => {
         await page.reload({ waitUntil: 'load' });
-        await searchByName(page, renamedWorkspace);
+        await searchByName(page, renamedWorkspace, isWorkspacesPage);
         const kebab = await waitForTableKebabReady(
           page,
           new RegExp(renamedWorkspace, 'i'),
@@ -302,7 +300,7 @@ test.describe('Workspace CRUD - List Page', () => {
       await dialogModal.getByRole('button', { name: 'Delete' }).click();
 
       // search for the workspace to confirm workspace is removed
-      await searchByName(page, renamedWorkspace);
+      await searchByName(page, renamedWorkspace, isWorkspacesPage);
       await expect(
         page.locator('text=No matching workspaces found'),
       ).toBeVisible();
@@ -334,7 +332,7 @@ test.describe('Workspace System Management', () => {
       await navigateToWorkspacesFunc(page);
       await createNewWorkspace(page, workspaceName);
 
-      await searchByName(page, workspaceName);
+      await searchByName(page, workspaceName, isWorkspacesPage);
       const nameCell = page.locator('td[data-label="Name"]');
       await expect(nameCell).toHaveCount(1);
 
@@ -391,7 +389,7 @@ test.describe('Workspace System Management', () => {
 
     await test.step('Verify workspace has 1 system', async () => {
       await navigateToWorkspacesFunc(page);
-      await searchByName(page, workspaceName);
+      await searchByName(page, workspaceName, isWorkspacesPage);
       const workspaceNameCell = page.locator('td[data-label="Name"]');
       await expect(workspaceNameCell).toHaveCount(1);
 
@@ -551,7 +549,7 @@ test.describe('Workspace Navigation', () => {
   test('User can navigate to Workspace Info Tab', async ({ page }) => {
     await test.step('Navigate to existing workspace', async () => {
       await navigateToWorkspacesFunc(page);
-      await searchByName(page, WORKSPACE_WITH_SYSTEMS);
+      await searchByName(page, WORKSPACE_WITH_SYSTEMS, isWorkspacesPage);
       const workspaceLink = page.getByRole('link', {
         name: WORKSPACE_WITH_SYSTEMS,
       });
@@ -616,7 +614,7 @@ test.describe('Workspace Sorting', () => {
         });
 
         await test.step('Filter to show only test workspaces', async () => {
-          await searchByName(page, column.searchTerm);
+          await searchByName(page, column.searchTerm, isWorkspacesPage);
 
           // Wait for the filter to be applied
           await expect(async () => {


### PR DESCRIPTION
fix E2E workspaces tests

## Summary by Sourcery

Stabilize workspace E2E tests and ensure test-created workspaces are cleaned up after each run.

Bug Fixes:
- Fix E2E workspace tests by ensuring workspace-page searches wait for complete data loading and by making workspace creation and cleanup reliable across test runs.

Enhancements:
- Track workspaces created during a test run and remove them during global teardown without affecting reusable fixture workspaces.
- Reuse the workspace creation helper in CRUD tests and capture created workspace identifiers for cleanup.

Tests:
- Update workspace E2E coverage to use the corrected search behavior and shared workspace creation flow.