### PR TITLE
fix(RHINENG-30575): validate view names

### DIFF
--- a/src/components/InventoryViews/Modals/ValidationErrorText.tsx
+++ b/src/components/InventoryViews/Modals/ValidationErrorText.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import { VIEW_NAME_VALIDATION_ERRORS } from '../constants';
+import type { ViewNameValidationError } from '../hooks/useViewNameValidation';
+
+interface ValidationErrorTextProps {
+  error: ViewNameValidationError | null;
+}
+
+export const ValidationErrorText = ({ error }: ValidationErrorTextProps) => {
+  const errorMessage = error ? VIEW_NAME_VALIDATION_ERRORS[error] : null;
+
+  if (!errorMessage) {
+    return null;
+  }
+
+  return (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem variant="error">{errorMessage}</HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  );
+};

--- a/src/components/InventoryViews/Modals/ViewRenameModal.test.tsx
+++ b/src/components/InventoryViews/Modals/ViewRenameModal.test.tsx
@@ -27,13 +27,44 @@ jest.mock(
   }),
 );
 
-let mockValidation: { isDuplicate: boolean; validated: 'default' | 'error' } = {
-  isDuplicate: false,
-  validated: 'default',
+let mockValidation: {
+  isValid: boolean;
+  validated: 'default' | 'error' | 'success';
+  error:
+    | 'INVALID_CHARACTERS'
+    | 'NO_ALPHANUMERIC'
+    | 'TOO_LONG'
+    | 'DUPLICATE'
+    | null;
+} = {
+  isValid: true,
+  validated: 'success',
+  error: null,
 };
 
 jest.mock('../hooks/useViewNameValidation', () => ({
   validateViewName: () => mockValidation,
+  VIEW_NAME_VALIDATION_ERRORS: {
+    INVALID_CHARACTERS:
+      'View name must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes.',
+    NO_ALPHANUMERIC: 'View name must contain at least one letter or number.',
+    TOO_LONG: 'View name must be 255 characters or less.',
+    DUPLICATE: 'A view with this name already exists.',
+  },
+}));
+
+jest.mock('./ValidationErrorText', () => ({
+  ValidationErrorText: ({ error }: { error: string | null }) => {
+    if (!error) return null;
+    const messages = {
+      INVALID_CHARACTERS:
+        'View name must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes.',
+      NO_ALPHANUMERIC: 'View name must contain at least one letter or number.',
+      TOO_LONG: 'View name must be 255 characters or less.',
+      DUPLICATE: 'A view with this name already exists.',
+    };
+    return <div>{messages[error as keyof typeof messages]}</div>;
+  },
 }));
 
 const createTestQueryClient = () =>
@@ -65,7 +96,11 @@ function renderRenameModal(props = {}) {
 
 describe('ViewRenameModal', () => {
   beforeEach(() => {
-    mockValidation = { isDuplicate: false, validated: 'default' as const };
+    mockValidation = {
+      isValid: true,
+      validated: 'success' as const,
+      error: null,
+    };
   });
 
   it('should render the modal when open', () => {
@@ -109,7 +144,11 @@ describe('ViewRenameModal', () => {
   });
 
   it('should disable Save and show error when name is a duplicate', async () => {
-    mockValidation = { isDuplicate: true, validated: 'error' as const };
+    mockValidation = {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'DUPLICATE',
+    };
 
     const user = userEvent.setup();
     renderRenameModal({ currentName: 'My View' });
@@ -125,7 +164,11 @@ describe('ViewRenameModal', () => {
   });
 
   it('should not call mutate when name is a duplicate', async () => {
-    mockValidation = { isDuplicate: true, validated: 'error' as const };
+    mockValidation = {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'DUPLICATE',
+    };
 
     const user = userEvent.setup();
     const onSuccess = jest.fn();

--- a/src/components/InventoryViews/Modals/ViewRenameModal.tsx
+++ b/src/components/InventoryViews/Modals/ViewRenameModal.tsx
@@ -3,9 +3,6 @@ import {
   Button,
   Form,
   FormGroup,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
   Modal,
   ModalBody,
   ModalFooter,
@@ -15,6 +12,7 @@ import {
 import type { ViewOut } from '../../../api/inventoryViewsApi';
 import { useUpdateViewMutation } from '../hooks/useUpdateViewMutation';
 import { validateViewName } from '../hooks/useViewNameValidation';
+import { ValidationErrorText } from './ValidationErrorText';
 
 export interface ViewRenameModalProps {
   isOpen: boolean;
@@ -36,7 +34,7 @@ const ViewRenameModal = ({
   const [viewName, setViewName] = useState(currentName);
   const updateView = useUpdateViewMutation();
   const trimmedName = viewName.trim();
-  const { isDuplicate, validated } = validateViewName(viewsList, trimmedName, {
+  const validation = validateViewName(viewsList, trimmedName, {
     excludeViewId: viewId,
   });
 
@@ -46,7 +44,7 @@ const ViewRenameModal = ({
 
   const isLoading = updateView.isPending;
   const isUnchanged = trimmedName === currentName.trim();
-  const canSave = !!trimmedName && !isDuplicate && !isLoading && !isUnchanged;
+  const canSave = validation.isValid && !isLoading && !isUnchanged;
 
   const handleSave = () => {
     if (!canSave) {
@@ -92,18 +90,10 @@ const ViewRenameModal = ({
               value={viewName}
               onChange={(_event, value) => setViewName(value)}
               isDisabled={isLoading}
-              validated={validated}
+              validated={validation.validated}
               autoFocus
             />
-            {isDuplicate && (
-              <FormHelperText>
-                <HelperText>
-                  <HelperTextItem variant="error">
-                    A view with this name already exists.
-                  </HelperTextItem>
-                </HelperText>
-              </FormHelperText>
-            )}
+            <ValidationErrorText error={validation.error} />
           </FormGroup>
         </Form>
       </ModalBody>

--- a/src/components/InventoryViews/Modals/ViewSaveAsModal.test.tsx
+++ b/src/components/InventoryViews/Modals/ViewSaveAsModal.test.tsx
@@ -29,13 +29,44 @@ jest.mock(
   }),
 );
 
-let mockValidation: { isDuplicate: boolean; validated: 'default' | 'error' } = {
-  isDuplicate: false,
-  validated: 'default',
+let mockValidation: {
+  isValid: boolean;
+  validated: 'default' | 'error' | 'success';
+  error:
+    | 'INVALID_CHARACTERS'
+    | 'NO_ALPHANUMERIC'
+    | 'TOO_LONG'
+    | 'DUPLICATE'
+    | null;
+} = {
+  isValid: true,
+  validated: 'success',
+  error: null,
 };
 
 jest.mock('../hooks/useViewNameValidation', () => ({
   validateViewName: () => mockValidation,
+  VIEW_NAME_VALIDATION_ERRORS: {
+    INVALID_CHARACTERS:
+      'View name must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes.',
+    NO_ALPHANUMERIC: 'View name must contain at least one letter or number.',
+    TOO_LONG: 'View name must be 255 characters or less.',
+    DUPLICATE: 'A view with this name already exists.',
+  },
+}));
+
+jest.mock('./ValidationErrorText', () => ({
+  ValidationErrorText: ({ error }: { error: string | null }) => {
+    if (!error) return null;
+    const messages = {
+      INVALID_CHARACTERS:
+        'View name must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes.',
+      NO_ALPHANUMERIC: 'View name must contain at least one letter or number.',
+      TOO_LONG: 'View name must be 255 characters or less.',
+      DUPLICATE: 'A view with this name already exists.',
+    };
+    return <div>{messages[error as keyof typeof messages]}</div>;
+  },
 }));
 
 const createTestQueryClient = () =>
@@ -77,7 +108,11 @@ function renderSaveAsModal(props = {}) {
 
 describe('SaveAsModal', () => {
   beforeEach(() => {
-    mockValidation = { isDuplicate: false, validated: 'default' as const };
+    mockValidation = {
+      isValid: true,
+      validated: 'success' as const,
+      error: null,
+    };
   });
 
   it('should render the modal when open', () => {
@@ -95,6 +130,12 @@ describe('SaveAsModal', () => {
   });
 
   it('should have Save button disabled when name is empty', () => {
+    mockValidation = {
+      isValid: false,
+      validated: 'default' as const,
+      error: null,
+    };
+
     renderSaveAsModal();
 
     const saveButton = screen.getByRole('button', { name: 'Save' });
@@ -175,7 +216,11 @@ describe('SaveAsModal', () => {
   });
 
   it('should disable Save and show error when name is a duplicate', async () => {
-    mockValidation = { isDuplicate: true, validated: 'error' as const };
+    mockValidation = {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'DUPLICATE',
+    };
 
     const user = userEvent.setup();
     renderSaveAsModal();
@@ -190,7 +235,11 @@ describe('SaveAsModal', () => {
   });
 
   it('should not call mutate when name is a duplicate', async () => {
-    mockValidation = { isDuplicate: true, validated: 'error' as const };
+    mockValidation = {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'DUPLICATE',
+    };
 
     const user = userEvent.setup();
     const onSuccess = jest.fn();
@@ -203,5 +252,62 @@ describe('SaveAsModal', () => {
     await user.click(saveButton);
 
     expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should show error when name contains invalid characters', async () => {
+    mockValidation = {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'INVALID_CHARACTERS',
+    };
+
+    const user = userEvent.setup();
+    renderSaveAsModal();
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'Invalid@Name!');
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(
+      screen.getByText(
+        'View name must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should show error when name has no alphanumeric characters', async () => {
+    mockValidation = {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'NO_ALPHANUMERIC',
+    };
+
+    const user = userEvent.setup();
+    renderSaveAsModal();
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, '...');
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(
+      screen.getByText('View name must contain at least one letter or number.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should accept name with periods and apostrophes', async () => {
+    mockValidation = {
+      isValid: true,
+      validated: 'success' as const,
+      error: null,
+    };
+
+    const user = userEvent.setup();
+    renderSaveAsModal();
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, "Bob's RHEL 9.4");
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeEnabled();
   });
 });

--- a/src/components/InventoryViews/Modals/ViewSaveAsModal.tsx
+++ b/src/components/InventoryViews/Modals/ViewSaveAsModal.tsx
@@ -3,9 +3,6 @@ import {
   Button,
   Form,
   FormGroup,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
   Modal,
   ModalBody,
   ModalFooter,
@@ -18,6 +15,7 @@ import type {
 } from '../../../api/inventoryViewsApi';
 import { useCreateViewMutation } from '../hooks/useCreateViewMutation';
 import { validateViewName } from '../hooks/useViewNameValidation';
+import { ValidationErrorText } from './ValidationErrorText';
 
 export interface ViewSaveAsModalProps {
   isOpen: boolean;
@@ -36,10 +34,10 @@ const ViewSaveAsModal = ({
 }: ViewSaveAsModalProps) => {
   const [viewName, setViewName] = useState('');
   const createView = useCreateViewMutation();
-  const { isDuplicate, validated } = validateViewName(viewsList, viewName);
+  const validation = validateViewName(viewsList, viewName);
 
   const handleSave = () => {
-    if (!viewName.trim() || isDuplicate) {
+    if (!validation.isValid) {
       return;
     }
 
@@ -64,7 +62,7 @@ const ViewSaveAsModal = ({
   };
 
   const isLoading = createView.isPending;
-  const isSaveDisabled = !viewName.trim() || isDuplicate || isLoading;
+  const isSaveDisabled = !validation.isValid || isLoading;
 
   return (
     <Modal
@@ -86,18 +84,10 @@ const ViewSaveAsModal = ({
               value={viewName}
               onChange={(_event, value) => setViewName(value)}
               isDisabled={isLoading}
-              validated={validated}
+              validated={validation.validated}
               autoFocus
             />
-            {isDuplicate && (
-              <FormHelperText>
-                <HelperText>
-                  <HelperTextItem variant="error">
-                    A view with this name already exists.
-                  </HelperTextItem>
-                </HelperText>
-              </FormHelperText>
-            )}
+            <ValidationErrorText error={validation.error} />
           </FormGroup>
         </Form>
       </ModalBody>

--- a/src/components/InventoryViews/constants.tsx
+++ b/src/components/InventoryViews/constants.tsx
@@ -3,3 +3,16 @@ import React from 'react';
 export const INITIAL_PAGE = 1;
 
 export const NO_HEADER = <></>;
+
+// View name validation constants
+export const VIEW_NAME_PATTERN = /^[a-zA-Z0-9 _.'-]+$/;
+export const VIEW_NAME_ALPHANUMERIC_PATTERN = /.*[a-zA-Z0-9].*/;
+export const MAX_VIEW_NAME_LENGTH = 255; // Backend enforced limit
+
+export const VIEW_NAME_VALIDATION_ERRORS = {
+  INVALID_CHARACTERS:
+    'View name must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes.',
+  NO_ALPHANUMERIC: 'View name must contain at least one letter or number.',
+  TOO_LONG: 'View name must be 255 characters or less.',
+  DUPLICATE: 'A view with this name already exists.',
+} as const;

--- a/src/components/InventoryViews/hooks/useViewNameValidation.ts
+++ b/src/components/InventoryViews/hooks/useViewNameValidation.ts
@@ -1,4 +1,12 @@
 import type { ViewOut } from '../../../api/inventoryViewsApi';
+import {
+  VIEW_NAME_PATTERN,
+  VIEW_NAME_ALPHANUMERIC_PATTERN,
+  MAX_VIEW_NAME_LENGTH,
+  VIEW_NAME_VALIDATION_ERRORS,
+} from '../constants';
+
+export type ViewNameValidationError = keyof typeof VIEW_NAME_VALIDATION_ERRORS;
 
 export const validateViewName = (
   viewsList: ViewOut[],
@@ -6,15 +14,61 @@ export const validateViewName = (
   options?: { excludeViewId?: string },
 ) => {
   const trimmedName = name.trim();
-  const isDuplicate =
-    trimmedName.length > 0 &&
-    viewsList.some(
-      (v) =>
-        v.name.toLowerCase() === trimmedName.toLowerCase() &&
-        v.id !== options?.excludeViewId,
-    );
 
-  const validated = isDuplicate ? ('error' as const) : ('default' as const);
+  // Check if name is empty
+  if (trimmedName.length === 0) {
+    return {
+      isValid: false,
+      validated: 'default' as const,
+      error: null,
+    };
+  }
 
-  return { isDuplicate, validated };
+  // Check max length (backend limit is 255)
+  if (trimmedName.length > MAX_VIEW_NAME_LENGTH) {
+    return {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'TOO_LONG' as ViewNameValidationError,
+    };
+  }
+
+  // Check for invalid characters
+  if (!VIEW_NAME_PATTERN.test(trimmedName)) {
+    return {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'INVALID_CHARACTERS' as ViewNameValidationError,
+    };
+  }
+
+  // Check for at least one alphanumeric character
+  if (!VIEW_NAME_ALPHANUMERIC_PATTERN.test(trimmedName)) {
+    return {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'NO_ALPHANUMERIC' as ViewNameValidationError,
+    };
+  }
+
+  // Check for duplicate names
+  const isDuplicate = viewsList.some(
+    (v) =>
+      v.name.toLowerCase() === trimmedName.toLowerCase() &&
+      v.id !== options?.excludeViewId,
+  );
+
+  if (isDuplicate) {
+    return {
+      isValid: false,
+      validated: 'error' as const,
+      error: 'DUPLICATE' as ViewNameValidationError,
+    };
+  }
+
+  return {
+    isValid: true,
+    validated: 'success' as const,
+    error: null,
+  };
 };

--- a/src/components/InventoryViews/hooks/validateViewName.test.ts
+++ b/src/components/InventoryViews/hooks/validateViewName.test.ts
@@ -16,81 +16,259 @@ const makeView = (id: string, name: string): ViewOut => ({
 });
 
 describe('validateViewName', () => {
-  it('should not flag an empty name as duplicate', () => {
-    const views = [makeView('1', 'My View')];
-    const result = validateViewName(views, '');
+  describe('empty names', () => {
+    it('should invalidate an empty name', () => {
+      const views = [makeView('1', 'My View')];
+      const result = validateViewName(views, '');
 
-    expect(result.isDuplicate).toBe(false);
-    expect(result.validated).toBe('default');
-  });
-
-  it('should not flag a whitespace-only name as duplicate', () => {
-    const views = [makeView('1', 'My View')];
-    const result = validateViewName(views, '   ');
-
-    expect(result.isDuplicate).toBe(false);
-    expect(result.validated).toBe('default');
-  });
-
-  it('should not flag a unique name as duplicate', () => {
-    const views = [makeView('1', 'Existing View')];
-    const result = validateViewName(views, 'New View');
-
-    expect(result.isDuplicate).toBe(false);
-    expect(result.validated).toBe('default');
-  });
-
-  it('should flag an exact duplicate name', () => {
-    const views = [makeView('1', 'My View')];
-    const result = validateViewName(views, 'My View');
-
-    expect(result.isDuplicate).toBe(true);
-    expect(result.validated).toBe('error');
-  });
-
-  it('should be case-insensitive', () => {
-    const views = [makeView('1', 'My View')];
-    const result = validateViewName(views, 'my view');
-
-    expect(result.isDuplicate).toBe(true);
-    expect(result.validated).toBe('error');
-  });
-
-  it('should trim whitespace before comparing', () => {
-    const views = [makeView('1', 'My View')];
-    const result = validateViewName(views, '  My View  ');
-
-    expect(result.isDuplicate).toBe(true);
-    expect(result.validated).toBe('error');
-  });
-
-  it('should exclude a view by ID (for Rename modal)', () => {
-    const views = [makeView('view-1', 'My View')];
-    const result = validateViewName(views, 'My View', {
-      excludeViewId: 'view-1',
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('default');
+      expect(result.error).toBeNull();
     });
 
-    expect(result.isDuplicate).toBe(false);
-    expect(result.validated).toBe('default');
+    it('should invalidate a whitespace-only name', () => {
+      const views = [makeView('1', 'My View')];
+      const result = validateViewName(views, '   ');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('default');
+      expect(result.error).toBeNull();
+    });
   });
 
-  it('should still flag duplicates when excludeViewId does not match', () => {
-    const views = [
-      makeView('view-1', 'My View'),
-      makeView('view-2', 'Other View'),
-    ];
-    const result = validateViewName(views, 'My View', {
-      excludeViewId: 'view-2',
+  describe('length validation', () => {
+    it('should accept names at max length (255 characters)', () => {
+      const maxLengthName = 'a'.repeat(255);
+      const result = validateViewName([], maxLengthName);
+
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
     });
 
-    expect(result.isDuplicate).toBe(true);
-    expect(result.validated).toBe('error');
+    it('should reject names longer than 255 characters', () => {
+      const tooLongName = 'a'.repeat(256);
+      const result = validateViewName([], tooLongName);
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('TOO_LONG');
+    });
+
+    it('should reject names much longer than max length', () => {
+      const wayTooLongName = 'a'.repeat(500);
+      const result = validateViewName([], wayTooLongName);
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('TOO_LONG');
+    });
   });
 
-  it('should handle an empty views list', () => {
-    const result = validateViewName([], 'Any Name');
+  describe('character validation', () => {
+    it('should accept names with letters, numbers, and allowed characters', () => {
+      const result = validateViewName([], "Bob's RHEL 9.4 view_test-123");
 
-    expect(result.isDuplicate).toBe(false);
-    expect(result.validated).toBe('default');
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
+    });
+
+    it('should accept names with periods', () => {
+      const result = validateViewName([], 'RHEL 9.4');
+
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
+    });
+
+    it('should accept names with apostrophes', () => {
+      const result = validateViewName([], "Bob's View");
+
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
+    });
+
+    it('should accept names with hyphens and underscores', () => {
+      const result = validateViewName([], 'my-view_2024');
+
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
+    });
+
+    it('should reject names with invalid special characters (@)', () => {
+      const result = validateViewName([], 'my@view');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('INVALID_CHARACTERS');
+    });
+
+    it('should reject names with invalid special characters (!)', () => {
+      const result = validateViewName([], 'my!view');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('INVALID_CHARACTERS');
+    });
+
+    it('should reject names with invalid special characters (#)', () => {
+      const result = validateViewName([], 'view#123');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('INVALID_CHARACTERS');
+    });
+
+    it('should reject names with invalid special characters ($)', () => {
+      const result = validateViewName([], 'view$name');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('INVALID_CHARACTERS');
+    });
+  });
+
+  describe('alphanumeric requirement', () => {
+    it('should reject names with only punctuation (periods)', () => {
+      const result = validateViewName([], '...');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('NO_ALPHANUMERIC');
+    });
+
+    it('should reject names with only punctuation (hyphens)', () => {
+      const result = validateViewName([], '---');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('NO_ALPHANUMERIC');
+    });
+
+    it('should reject names with only punctuation (apostrophes)', () => {
+      const result = validateViewName([], "'''");
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('NO_ALPHANUMERIC');
+    });
+
+    it('should reject names with only spaces and punctuation', () => {
+      const result = validateViewName([], '  - . -  ');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('NO_ALPHANUMERIC');
+    });
+
+    it('should accept names with at least one letter', () => {
+      const result = validateViewName([], 'a...');
+
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
+    });
+
+    it('should accept names with at least one number', () => {
+      const result = validateViewName([], '...1');
+
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe('duplicate detection', () => {
+    it('should validate a unique name', () => {
+      const views = [makeView('1', 'Existing View')];
+      const result = validateViewName(views, 'New View');
+
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
+    });
+
+    it('should flag an exact duplicate name', () => {
+      const views = [makeView('1', 'My View')];
+      const result = validateViewName(views, 'My View');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('DUPLICATE');
+    });
+
+    it('should be case-insensitive for duplicates', () => {
+      const views = [makeView('1', 'My View')];
+      const result = validateViewName(views, 'my view');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('DUPLICATE');
+    });
+
+    it('should trim whitespace before comparing duplicates', () => {
+      const views = [makeView('1', 'My View')];
+      const result = validateViewName(views, '  My View  ');
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('DUPLICATE');
+    });
+
+    it('should exclude a view by ID (for Rename modal)', () => {
+      const views = [makeView('view-1', 'My View')];
+      const result = validateViewName(views, 'My View', {
+        excludeViewId: 'view-1',
+      });
+
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
+    });
+
+    it('should still flag duplicates when excludeViewId does not match', () => {
+      const views = [
+        makeView('view-1', 'My View'),
+        makeView('view-2', 'Other View'),
+      ];
+      const result = validateViewName(views, 'My View', {
+        excludeViewId: 'view-2',
+      });
+
+      expect(result.isValid).toBe(false);
+      expect(result.validated).toBe('error');
+      expect(result.error).toBe('DUPLICATE');
+    });
+
+    it('should handle an empty views list', () => {
+      const result = validateViewName([], 'Any Name');
+
+      expect(result.isValid).toBe(true);
+      expect(result.validated).toBe('success');
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe('validation order', () => {
+    it('should check invalid characters before duplicates', () => {
+      const views = [makeView('1', 'valid@name')];
+      const result = validateViewName(views, 'valid@name');
+
+      // Should fail on invalid characters, not duplicates
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('INVALID_CHARACTERS');
+    });
+
+    it('should check alphanumeric requirement before duplicates', () => {
+      const views = [makeView('1', '---')];
+      const result = validateViewName(views, '---');
+
+      // Should fail on alphanumeric requirement, not duplicates
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('NO_ALPHANUMERIC');
+    });
   });
 });


### PR DESCRIPTION
## Jira
[RHINENG-30575](https://redhat.atlassian.net/browse/RHINENG-30575)

## What
This PR validates view names in the "Save As" and "Rename" modals as dictated by the backend
(https://github.com/RedHatInsights/insights-host-inventory/pull/4902/changes). So now we allow alphanumeric characters, spaces, underscores, periods, and hyphens.

Also noteworthy, we don't allow names over 255 characters, or names like "..." or "---", etc.

[RHINENG-30575]: https://redhat.atlassian.net/browse/RHINENG-30575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enforce backend-compatible view-name validation when creating or renaming views.

New Features:
- Validate view names in Save As and Rename modals against supported characters, length, alphanumeric content, and duplicate names.
- Display specific validation messages and prevent saving invalid view names.

Enhancements:
- Centralize view-name validation rules and error presentation for both view naming workflows.

Tests:
- Expand validation and modal tests to cover length limits, allowed characters, punctuation-only names, duplicates, and accepted names.