### PR TITLE
[foreman-5.0] Fix CVE-2026-59879: bump immutable to >=5.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15662,9 +15662,9 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "qs": ">=6.14.1",
     "fast-xml-parser": ">=5.3.8",
     "minimatch": ">=10.0.0",
-    "immutable": ">=4.3.8",
+    "immutable": ">=5.1.8",
     "sanitize-html": ">=2.17.6",
     "fast-uri": ">=3.1.4",
     "brace-expansion": ">=5.0.7"


### PR DESCRIPTION
Bumps `immutable` to `>=5.1.8` (resolves to 5.1.9) to patch CVE-2026-59879.

## Summary by Sourcery

Upgrade immutable to a patched release to remediate CVE-2026-59879.

Bug Fixes:
- Update the immutable dependency to a patched 5.1.8-or-later release to address CVE-2026-59879.

Build:
- Refresh the locked dependency version for immutable.