### PR TITLE
feat(RHINENG-29875): Add information about containerized workloads to Inventory UI

### DIFF
--- a/src/components/GeneralInfo/SystemCard/SystemCard.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.js
@@ -117,6 +117,7 @@ const SystemCard = ({
                 handleClick={handleClick}
                 workloadsData={workloadsData}
                 workloadsTypes={workloadsTypes}
+                entity={entity}
               />
             ),
           },

--- a/src/components/GeneralInfo/SystemCard/SystemCard.test.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCard.test.js
@@ -505,6 +505,7 @@ describe('SystemCard', () => {
         workloads,
         expectedClickTitle,
         expectedData,
+        expectedVariant,
       }) => {
         const handleClick = jest.fn();
 
@@ -539,6 +540,7 @@ describe('SystemCard', () => {
         expect(handleClick).toHaveBeenCalledWith(
           expectedClickTitle,
           expectedData,
+          ...(expectedVariant ? [expectedVariant] : []),
         );
       },
     );

--- a/src/components/GeneralInfo/SystemCard/SystemCardConfigs.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCardConfigs.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import { generalMapper, workloadsDataMapper } from '../dataMapper';
-import { Icon, Tooltip } from '@patternfly/react-core';
+import { Icon, ModalVariant, Tooltip } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
+import {
+  AnsibleWorkloadsContent,
+  SatelliteWorkloadsContent,
+} from './WorkloadsModalContent';
 
-export const workloadConfigs = (handleClick, workloadsData) => [
+export const workloadConfigs = (handleClick, workloadsData, entity) => [
   {
     type: 'sap',
     title: 'SAP',
@@ -23,21 +27,15 @@ export const workloadConfigs = (handleClick, workloadsData) => [
     onClick: () =>
       handleClick(
         'Ansible Automation Platform',
-        workloadsDataMapper({
-          data: [workloadsData.ansible],
-          fieldKeys: [
-            'catalog_worker_version',
-            'controller_version',
-            'hub_version',
-            'sso_version',
-          ],
-          columnTitles: [
-            'Catalog worker version',
-            'Controller version',
-            'Hub version',
-            'SSO version',
-          ],
-        }),
+        {
+          content: (
+            <AnsibleWorkloadsContent
+              ansible={workloadsData.ansible}
+              entity={entity}
+            />
+          ),
+        },
+        ModalVariant.medium,
       ),
     target: 'ansible',
   },
@@ -145,11 +143,15 @@ export const workloadConfigs = (handleClick, workloadsData) => [
     onClick: () =>
       handleClick(
         'Satellite',
-        workloadsDataMapper({
-          data: [workloadsData.satellite],
-          fieldKeys: ['type', 'version'],
-          columnTitles: ['Type', 'Version'],
-        }),
+        {
+          content: (
+            <SatelliteWorkloadsContent
+              satellite={workloadsData.satellite}
+              entity={entity}
+            />
+          ),
+        },
+        ModalVariant.medium,
       ),
     target: 'satellite',
   },

--- a/src/components/GeneralInfo/SystemCard/SystemCardTestsFixtures.js
+++ b/src/components/GeneralInfo/SystemCard/SystemCardTestsFixtures.js
@@ -34,23 +34,29 @@ export const workloadClickTestCases = [
       },
     },
     expectedClickTitle: 'Ansible Automation Platform',
-    expectedData: {
-      cells: [
-        { title: 'Catalog worker version' },
-        { title: 'Controller version' },
-        { title: 'Hub version' },
-        { title: 'SSO version' },
-      ],
-      filters: [{ type: 'text' }],
-      rows: [
-        [
-          '9.8.7, banana.42, 0.0.abc',
-          'x.1.2, foo.bar, 3.3.3',
-          'abc.def, 123.456, xyz.789',
-          'preview-1, glitch.9.9, zz-top.7',
+    expectedData: { content: expect.anything() },
+    expectedVariant: 'medium',
+  },
+  {
+    name: 'Satellite',
+    linkText: /Satellite/i,
+    workloads: {
+      satellite: {
+        type: 'server',
+        version: '6.19.0',
+        foremanctl_version: '1.1.0',
+        containers: [
+          {
+            name: 'satellite',
+            image: 'registry.redhat.io/satellite/satellite-rhel9:6.16.0',
+            state: 'running',
+          },
         ],
-      ],
+      },
     },
+    expectedClickTitle: 'Satellite',
+    expectedData: { content: expect.anything() },
+    expectedVariant: 'medium',
   },
   {
     name: 'RHEL AI',

--- a/src/components/GeneralInfo/SystemCard/Workloads.js
+++ b/src/components/GeneralInfo/SystemCard/Workloads.js
@@ -3,12 +3,17 @@ import PropTypes from 'prop-types';
 import { workloadConfigs } from './SystemCardConfigs';
 import { Clickable } from '../LoadingCard/LoadingCard';
 
-const WorkloadsSection = ({ handleClick, workloadsData, workloadsTypes }) => {
+const WorkloadsSection = ({
+  handleClick,
+  workloadsData,
+  workloadsTypes,
+  entity,
+}) => {
   const filteredConfigs = useMemo(() => {
-    return workloadConfigs(handleClick, workloadsData).filter(({ type }) =>
-      workloadsTypes.includes(type),
+    return workloadConfigs(handleClick, workloadsData, entity).filter(
+      ({ type }) => workloadsTypes.includes(type),
     );
-  }, [handleClick, workloadsData, workloadsTypes]);
+  }, [handleClick, workloadsData, workloadsTypes, entity]);
 
   return filteredConfigs.map(
     ({ type, title, onClick, target, customRender }, index) => {
@@ -40,6 +45,7 @@ WorkloadsSection.propTypes = {
   handleClick: PropTypes.func.isRequired,
   workloadsData: PropTypes.object.isRequired,
   workloadsTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+  entity: PropTypes.object,
 };
 
 export default React.memo(WorkloadsSection);

--- a/src/components/GeneralInfo/SystemCard/WorkloadsModalContent.test.tsx
+++ b/src/components/GeneralInfo/SystemCard/WorkloadsModalContent.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import type {
+  SystemProfileAnsible,
+  SystemProfileWorkloadsSatellite,
+} from '@redhat-cloud-services/host-inventory-client';
+import {
+  AnsibleWorkloadsContent,
+  SatelliteWorkloadsContent,
+  type WorkloadsEntity,
+} from './WorkloadsModalContent';
+
+const ansible: SystemProfileAnsible = {
+  controller_version: '2.40',
+  hub_version: '2.4.0',
+  receptor_version: '1.4.1',
+  containers: [
+    {
+      name: 'automation-controller',
+      image: 'registry.redhat.io/ansible-automation-platform/controller:2.4',
+      state: 'running',
+    },
+  ],
+};
+
+const satellite: SystemProfileWorkloadsSatellite = {
+  type: 'server',
+  version: '6.19.0',
+  foremanctl_version: '1.1.0',
+  containers: [
+    {
+      name: 'satellite',
+      image: 'registry.redhat.io/satellite/satellite-rhel9:6.16.0',
+      state: 'running',
+    },
+  ],
+};
+
+const entity: WorkloadsEntity = {
+  per_reporter_staleness: {
+    puptoo: { last_check_in: '2024-02-19T09:19:00.000Z' },
+    'yupana-canary': { last_check_in: '2024-02-20T09:19:00.000Z' },
+  },
+};
+
+const getRowValue = (label: string) =>
+  screen.getByRole('definition', { name: `${label} value` }).textContent;
+
+describe('AnsibleWorkloadsContent', () => {
+  it('shows the most recent check-in across reporters as "Last seen"', () => {
+    render(<AnsibleWorkloadsContent ansible={ansible} entity={entity} />);
+
+    expect(getRowValue('Last seen')).toMatch(/20 Feb 2024/);
+  });
+
+  it('falls back when no reporter has checked in', () => {
+    render(<AnsibleWorkloadsContent ansible={ansible} entity={{}} />);
+
+    expect(getRowValue('Last seen')).toContain('Not available');
+  });
+
+  it('renders reported RPM versions and placeholders for the rest', () => {
+    render(<AnsibleWorkloadsContent ansible={ansible} entity={entity} />);
+
+    expect(getRowValue('Controller RPM')).toContain('2.40');
+    expect(getRowValue('Hub RPM')).toContain('2.4.0');
+    expect(getRowValue('Receptor RPM')).toContain('1.4.1');
+    // Not reported by this system
+    expect(getRowValue('Runner RPM')).toContain('--');
+    expect(getRowValue('Gateway RPM')).toContain('--');
+  });
+
+  it('renders the containers table', () => {
+    render(<AnsibleWorkloadsContent ansible={ansible} entity={entity} />);
+
+    const table = screen.getByRole('grid', {
+      name: 'Containerized Ansible workloads',
+    });
+    expect(
+      within(table).getByRole('columnheader', { name: 'Name' }),
+    ).toBeVisible();
+    expect(within(table).getByText('automation-controller')).toBeVisible();
+    expect(within(table).getByText('Running')).toBeVisible();
+  });
+
+  it('omits the containers section when none are reported', () => {
+    render(
+      <AnsibleWorkloadsContent
+        ansible={{ controller_version: '2.40' }}
+        entity={entity}
+      />,
+    );
+
+    expect(
+      screen.queryByText('Containerized Ansible workloads'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('omits the RPM section when no version is reported', () => {
+    render(
+      <AnsibleWorkloadsContent
+        ansible={{ containers: ansible.containers }}
+        entity={entity}
+      />,
+    );
+
+    expect(screen.queryByText('RPM package versions')).not.toBeInTheDocument();
+  });
+
+  it('renders without workload data', () => {
+    render(<AnsibleWorkloadsContent />);
+
+    expect(getRowValue('Last seen')).toContain('Not available');
+    expect(screen.queryByText('RPM package versions')).not.toBeInTheDocument();
+  });
+});
+
+describe('SatelliteWorkloadsContent', () => {
+  it('renders the capitalized server type', () => {
+    render(<SatelliteWorkloadsContent satellite={satellite} />);
+
+    expect(getRowValue('Type')).toContain('Server');
+  });
+
+  it('falls back when no reporter has checked in', () => {
+    render(<SatelliteWorkloadsContent satellite={satellite} entity={{}} />);
+
+    expect(getRowValue('Last seen')).toContain('Not available');
+  });
+
+  it('renders the capitalized capsule type', () => {
+    render(<SatelliteWorkloadsContent satellite={{ type: 'capsule' }} />);
+
+    expect(getRowValue('Type')).toContain('Capsule');
+  });
+
+  it('renders RPM versions', () => {
+    render(<SatelliteWorkloadsContent satellite={satellite} />);
+
+    expect(getRowValue('Satellite RPM')).toContain('6.19.0');
+    expect(getRowValue('foremanctl RPM')).toContain('1.1.0');
+  });
+
+  it('renders the containers table', () => {
+    render(<SatelliteWorkloadsContent satellite={satellite} />);
+
+    const table = screen.getByRole('grid', {
+      name: 'Containerized Satellite workloads',
+    });
+    expect(within(table).getByText('satellite')).toBeVisible();
+    expect(
+      within(table).getByText(
+        'registry.redhat.io/satellite/satellite-rhel9:6.16.0',
+      ),
+    ).toBeVisible();
+    expect(within(table).getByText('Running')).toBeVisible();
+  });
+
+  it('keeps the RPM section when only one version is reported', () => {
+    render(<SatelliteWorkloadsContent satellite={{ version: '6.19.0' }} />);
+
+    expect(getRowValue('Satellite RPM')).toContain('6.19.0');
+    expect(getRowValue('foremanctl RPM')).toContain('--');
+  });
+
+  it('renders without workload data', () => {
+    render(<SatelliteWorkloadsContent />);
+
+    expect(getRowValue('Type')).toContain('--');
+    expect(screen.queryByText('RPM package versions')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Containerized Satellite workloads'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/GeneralInfo/SystemCard/WorkloadsModalContent.tsx
+++ b/src/components/GeneralInfo/SystemCard/WorkloadsModalContent.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import {
+  Content,
+  ContentVariants,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import type {
+  HostOut,
+  SystemProfileAnsible,
+  SystemProfileContainer,
+  SystemProfileWorkloadsSatellite,
+} from '@redhat-cloud-services/host-inventory-client';
+
+const NOT_AVAILABLE = '--';
+
+interface RpmField {
+  label: string;
+  value?: string;
+}
+
+export type WorkloadsEntity = Pick<HostOut, 'per_reporter_staleness'>;
+
+const ansibleRpmFields = (ansible?: SystemProfileAnsible): RpmField[] => [
+  { label: 'Controller RPM', value: ansible?.controller_version },
+  { label: 'Hub RPM', value: ansible?.hub_version },
+  { label: 'Receptor RPM', value: ansible?.receptor_version },
+  { label: 'Runner RPM', value: ansible?.runner_version },
+  { label: 'Catalog worker RPM', value: ansible?.catalog_worker_version },
+  { label: 'SSO RPM', value: ansible?.sso_version },
+  { label: 'EDA controller RPM', value: ansible?.eda_controller_version },
+  { label: 'Gateway RPM', value: ansible?.gateway_version },
+];
+
+const satelliteRpmFields = (
+  satellite?: SystemProfileWorkloadsSatellite,
+): RpmField[] => [
+  { label: 'Satellite RPM', value: satellite?.version },
+  { label: 'foremanctl RPM', value: satellite?.foremanctl_version },
+];
+
+const capitalize = (value?: string) =>
+  value ? value.charAt(0).toUpperCase() + value.slice(1) : undefined;
+
+/**
+ * Most recent check-in across all reporters - the same value the
+ * System status card shows as "Last seen".
+ *  @param entity - Host entity
+ *  @returns      ISO timestamp, or undefined when no reporter has checked in
+ */
+const getLastCheckIn = (entity?: WorkloadsEntity): string | undefined =>
+  Object.values(entity?.per_reporter_staleness ?? {})
+    .map((reporter) => reporter.last_check_in)
+    .filter((checkIn): checkIn is string => Boolean(checkIn))
+    .sort()
+    .reverse()[0];
+
+const DescriptionRow = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <DescriptionListGroup>
+    <DescriptionListTerm>{label}</DescriptionListTerm>
+    <DescriptionListDescription aria-label={`${label} value`}>
+      {children}
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+);
+
+const SummarySection = ({
+  items,
+}: {
+  items: Array<{ label: string; value: React.ReactNode }>;
+}) => (
+  <StackItem>
+    <DescriptionList columnModifier={{ default: '2Col' }}>
+      {items.map(({ label, value }) => (
+        <DescriptionRow key={label} label={label}>
+          {value}
+        </DescriptionRow>
+      ))}
+    </DescriptionList>
+  </StackItem>
+);
+
+const lastSeenValue = (entity?: WorkloadsEntity): React.ReactNode => {
+  const lastCheckIn = getLastCheckIn(entity);
+  return lastCheckIn ? (
+    <DateFormat date={lastCheckIn} type="exact" />
+  ) : (
+    'Not available'
+  );
+};
+
+const RpmVersionsSection = ({ fields }: { fields: RpmField[] }) => {
+  if (!fields.some(({ value }) => value)) {
+    return null;
+  }
+
+  return (
+    <StackItem>
+      <Content component={ContentVariants.h3}>RPM package versions</Content>
+      <DescriptionList columnModifier={{ default: '2Col' }}>
+        {fields.map(({ label, value }) => (
+          <DescriptionRow key={label} label={label}>
+            {value || NOT_AVAILABLE}
+          </DescriptionRow>
+        ))}
+      </DescriptionList>
+    </StackItem>
+  );
+};
+
+const ContainersSection = ({
+  title,
+  containers = [],
+}: {
+  title: string;
+  containers?: SystemProfileContainer[];
+}) => {
+  if (containers.length === 0) {
+    return null;
+  }
+
+  return (
+    <StackItem>
+      <Content component={ContentVariants.h3}>{title}</Content>
+      <Table aria-label={title} variant="compact">
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Image</Th>
+            <Th>State</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {containers.map(({ name, image, state }, index) => (
+            <Tr key={`${name || 'container'}-${index}`}>
+              <Td dataLabel="Name">{name || NOT_AVAILABLE}</Td>
+              <Td dataLabel="Image">{image || NOT_AVAILABLE}</Td>
+              <Td dataLabel="State">{capitalize(state) || NOT_AVAILABLE}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </StackItem>
+  );
+};
+
+export interface AnsibleWorkloadsContentProps {
+  ansible?: SystemProfileAnsible;
+  entity?: WorkloadsEntity;
+}
+
+export const AnsibleWorkloadsContent = ({
+  ansible,
+  entity,
+}: AnsibleWorkloadsContentProps) => (
+  <Stack hasGutter>
+    <SummarySection
+      items={[{ label: 'Last seen', value: lastSeenValue(entity) }]}
+    />
+    <RpmVersionsSection fields={ansibleRpmFields(ansible)} />
+    <ContainersSection
+      title="Containerized Ansible workloads"
+      containers={ansible?.containers}
+    />
+  </Stack>
+);
+
+export interface SatelliteWorkloadsContentProps {
+  satellite?: SystemProfileWorkloadsSatellite;
+  entity?: WorkloadsEntity;
+}
+
+export const SatelliteWorkloadsContent = ({
+  satellite,
+  entity,
+}: SatelliteWorkloadsContentProps) => (
+  <Stack hasGutter>
+    <SummarySection
+      items={[
+        { label: 'Type', value: capitalize(satellite?.type) || NOT_AVAILABLE },
+        { label: 'Last seen', value: lastSeenValue(entity) },
+      ]}
+    />
+    <RpmVersionsSection fields={satelliteRpmFields(satellite)} />
+    <ContainersSection
+      title="Containerized Satellite workloads"
+      containers={satellite?.containers}
+    />
+  </Stack>
+);

--- a/src/components/SystemDetails/SystemDetailsModal.tsx
+++ b/src/components/SystemDetails/SystemDetailsModal.tsx
@@ -18,6 +18,7 @@ export interface ModalData {
     type?: string;
     options?: Array<{ value?: React.ReactNode; label?: React.ReactNode }>;
   }>;
+  content?: React.ReactNode;
 }
 
 export interface SystemDetailsModalProps {
@@ -58,13 +59,15 @@ const SystemDetailsModal = ({
         }
       />
       <ModalBody>
-        <InfoTable
-          cells={modalData.cells as []}
-          rows={modalData.rows as []}
-          expandable={modalData.expandable}
-          onSort={onSort as undefined}
-          filters={modalData.filters as []}
-        />
+        {modalData.content ?? (
+          <InfoTable
+            cells={modalData.cells as []}
+            rows={modalData.rows as []}
+            expandable={modalData.expandable}
+            onSort={onSort as undefined}
+            filters={modalData.filters as []}
+          />
+        )}
       </ModalBody>
       <ModalFooter>
         <Button

--- a/src/components/SystemDetails/hooks/useModalState.js
+++ b/src/components/SystemDetails/hooks/useModalState.js
@@ -56,14 +56,15 @@ const useModalState = (navigate) => {
    *  @param {string} modalTitle      - Title to display in modal header
    *  @param {object} data            - Modal data object containing cells, rows, expandable, filters
    *  @param          data.cells
-   *  @param          data.rows
+   *  @param {Array}  data.rows       - Array of row data for the modal table
    *  @param {string} modalVariant    - Modal size variant (small, medium, large)
    *  @param          data.expandable
    *  @param          data.filters
+   *  @param          data.content    - Custom body rendered instead of the default table
    */
   const handleModalToggle = (
     modalTitle = '',
-    { cells, rows, expandable, filters } = {},
+    { cells, rows, expandable, filters, content } = {},
     modalVariant = ModalVariant.small,
   ) => {
     if (isModalOpen) {
@@ -78,6 +79,7 @@ const useModalState = (navigate) => {
       rows,
       expandable,
       filters,
+      content,
     });
 
     // Auto-sort rows when modal opens with data


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/RHINENG-29875

## What
Add information about containerized workloads to Inventory UI for Ansible and Satellite workloads

## Why
As Satellite and AAP move to containerized deployments https://redhat.atlassian.net/browse/RHINENG-28030, HBI now fingerprints container-deployed workloads - these modals had no way to show them.

## How

- `ModalData` gained an optional `content` node, rendered instead of `InfoTable` - other modals still get the table. New `WorkloadsModalContent.tsx` supplies it:
  - **Ansible** - Last seen, all 8 RPM versions, containers table
  - **Satellite** - Type, Last seen, both RPM versions, containers table
- Sections with nothing to report are hidden 
- missing values inside a shown section render as `--`
- "Last seen" comes from `per_reporter_staleness`



## Testing
Mocks: https://inventory-views-5cb498.pages.redhat.com/system/cacao
1. log in `qe-ui-inventory`
2. systems details to test updated modal for Ansible and Satellite

- No rpm versions https://stage.foo.redhat.com:1337/insights/inventory/c9bca316-1c11-4047-abe9-79ab8add6c7c
- RPM versions + containers https://stage.foo.redhat.com:1337/insights/inventory/c4b5e843-f965-4246-894f-ca7499860fde
- Only containers https://stage.foo.redhat.com:1337/insights/inventory/c9bca316-1c11-4047-abe9-79ab8add6c7c
- To test ansible/satellite without containers data use `insights-qa` account 


## Screenshots/Videos (if applicable)
<img width="859" height="655" alt="image" src="https://github.com/user-attachments/assets/73bc5c10-96a0-4fae-a0ae-fe5e86f91241" />
<img width="841" height="1011" alt="image" src="https://github.com/user-attachments/assets/f9b10189-8f25-41f0-b975-d22006561462" />


## Summary by Sourcery

Show containerized Ansible and Satellite workload information in the Inventory UI.

New Features:
- Display Ansible and Satellite workload details, including last-seen status, RPM versions, and containerized workloads, in dedicated modal content.

Enhancements:
- Hide empty RPM and container sections while showing placeholders for missing values in populated sections.
- Support custom modal body content while retaining the existing table-based modal behavior for other workloads.
- Add sorting, filtering, and pagination support for container workload tables.

Tests:
- Add coverage for workload summaries, missing data handling, container tables, sorting/filtering, and modal variants.